### PR TITLE
Make the nikonlook v2 switch reviewable, reproducible, and actually scored

### DIFF
--- a/app/ScanStudio/PARITY.md
+++ b/app/ScanStudio/PARITY.md
@@ -65,36 +65,67 @@ a completely different color pipeline than `nikonlook_core.py`'s
 `load_bundle` / `estimate_gains` / `apply` model that Phase 14 ports to
 Rust. **`_positive.tif` is therefore not usable as a nikonlook parity
 reference.** The real reference is
-`acceptance_slotNN_reference_color_nikonlook-v1.tif`, freshly rendered by
+`acceptance_slotNN_reference_color_{bundle_version}.tif`, freshly rendered by
 `render_references.py` (this plan, Task 3) by literally invoking
 `nikonlook_core.load_bundle` / `estimate_gains` / `apply` against each
 slot's own raw `.tif` capture — not copied or derived from `_positive.tif`.
 
-`render_references.py` lives in the separately managed bridge checkout's
-`tools/` directory (GPL reference code stays outside this repository). Run
-it with:
+**`{bundle_version}` is not a fixed literal.** `bin/parity.rs`'s `score_color`
+derives it from `processing::nikonlook::load_bundle().bundle_version` —
+whichever bundle version is actually compiled into the engine build running
+`make parity` — so a candidate rendered against bundle X is only ever
+compared to bundle X's own reference. As of the nikonlook-v2 switch,
+`load_bundle()` returns `nikonlook-v2` by default, so the filename `make
+parity` looks for today is `acceptance_slotNN_reference_color_nikonlook-v2.tif`,
+not `..._nikonlook-v1.tif`. The `nikonlook-v1`-named references described
+below in this section were generated and validated before that switch, on
+`load_bundle_v1()`'s bundle; they remain useful for `load_bundle_v1()`-based
+comparison tooling but are no longer what a default `make parity` run looks
+for. If the reference file `score_color` expects doesn't exist,
+`bin/parity.rs` reports `no_reference` with a message naming the exact
+expected filename and the command to produce it, rather than silently
+falling back to a differently-versioned reference.
+
+`render_references.py` lives in this repository's own `bridge/tools/`
+directory. Run it with:
 
 ```sh
-BRIDGE_REPO=/path/to/scanstudio-bridge
-python3 "$BRIDGE_REPO/tools/render_references.py" --corpus "$SCANSTUDIO_PARITY_CORPUS"
+python3 bridge/tools/render_references.py \
+  --corpus "$SCANSTUDIO_PARITY_CORPUS" \
+  --bundle /path/to/nikonlook-v2
 ```
 
-By default it writes the six reference TIFFs next to the corpus (exactly
-where `bin/parity.rs` looks for them: `{corpus}/acceptance_slotNN_reference_color_nikonlook-v1.tif`).
+`--bundle` defaults to this checkout's own vendored `nikonlook-v2`
+resources (`app/ScanStudio/engine/resources/nikonlook-v2/` — the exact
+model.json/layer_a.json/manifest.json bytes the Rust engine embeds via
+`include_str!`; see the script's own `--help`), so an unqualified run
+already matches whichever bundle version `load_bundle()` currently returns
+without pointing at any private, maintainer-specific checkout. Pass
+`--bundle` explicitly only to render against a *different* bundle version —
+e.g. a `nikonlook-v1` checkout, for `load_bundle_v1()`-based comparison
+tooling. `--negfit-path` has no default and must always be passed: negfit
+is GPL-labeled reference code that stays external to this repository (see
+the script's own module docstring). By default the script writes the
+reference TIFFs next to the corpus, named
+`acceptance_slotNN_reference_color_<bundle-directory-name>.tif` (exactly
+where `bin/parity.rs` looks for them).
 
 **Validation reference location.** The corpus used for the original
-validation was read-only, so the six generated TIFFs were written to an
-operator-chosen sibling directory rather than into the corpus. All six files
-were verified (`acceptance_slot01..06_reference_color_nikonlook-v1.tif`,
+(nikonlook-v1) validation was read-only, so the six generated TIFFs were
+written to an operator-chosen sibling directory rather than into the
+corpus. All six files were verified (`acceptance_slot01..06_reference_color_nikonlook-v1.tif`,
 each `(3946, 5959, 3)` uint16). **Because they are not colocated with that
 corpus, `make parity` reports `color` as `no_reference`, not
 `no_candidate`** — this is an honest, environment-driven gap, not a code
 bug: `bin/parity.rs` looks for the reference at
-`{SCANSTUDIO_PARITY_CORPUS}/acceptance_slotNN_reference_color_nikonlook-v1.tif`
+`{SCANSTUDIO_PARITY_CORPUS}/acceptance_slotNN_reference_color_{bundle_version}.tif`
 exactly, by design (see §6). To make `make parity` see external references,
 either re-run `render_references.py` without `--output-dir` once the corpus
 location is writable, copy the files into the corpus, or set `SCANSTUDIO_PARITY_REFS`
-to the directory containing the reference TIFFs (see §7).
+to the directory containing the reference TIFFs (see §7). A fresh
+nikonlook-v2 validation run needs its own `render_references.py --bundle
+.../nikonlook-v2` pass — the v1 references already on disk will not satisfy
+a v2 `make parity` run.
 
 **ICE.** The corpus's `acceptance_slotNN_repaired_SYNTH.png` disclosure
 mask was produced in `hybrid` (ML-assisted) mode (`digital-fauxice`
@@ -260,7 +291,7 @@ see them.
 
 | Module | Reference status | Notes |
 |--------|------------------|-------|
-| Color | Real reference rendered (`render_references.py`, bundle `nikonlook-v1`); real Rust candidate available via `make render-color-candidates` (Phase 14, `processing::nikonlook`) | Reference not colocated with this corpus snapshot in this environment — see §3's read-only caveat; set `SCANSTUDIO_PARITY_REFS`. With `SCANSTUDIO_PARITY_REFS` and `SCANSTUDIO_PARITY_CANDIDATES` (see §7) both set and candidates rendered, `make parity` reports `pass` for all six slots. |
+| Color | Real reference rendered (`render_references.py`, bundle-derived filename — see §3; production default is now `nikonlook-v2`); real Rust candidate available via `make render-color-candidates` (Phase 14, `processing::nikonlook`) | Reference not colocated with this corpus snapshot in this environment — see §3's read-only caveat; set `SCANSTUDIO_PARITY_REFS`. With `SCANSTUDIO_PARITY_REFS` and `SCANSTUDIO_PARITY_CANDIDATES` (see §7) both set and candidates rendered for the SAME bundle version, `make parity` reports `pass` for all six slots. |
 | Autocrop | Real reference rendered (`render_geometry_references.py`, Phase 15); real Rust candidate available via `make render-geometry-candidates` (`processing::geometry::autocrop_roi`) | `make parity`'s `autocrop` row reports **Image mode (AUTO_FRAME_EDGE)** only — NegPy's own default; `ModuleKind::Autocrop` (Phase 13's report schema) is not split into separate Film/Image variants for this. **Film mode (AUTO_FILM_BORDER) is fully ported and independently proven against the real corpus** via a corpus-gated `cargo test` (`film_mode_iou_matches_reference` in `engine/tests/geometry_candidates.rs`), not this table — both modes are implemented and both are proven, just through two different mechanisms. With `SCANSTUDIO_PARITY_REFS`/`SCANSTUDIO_PARITY_CANDIDATES` set and candidates rendered, all six slots report `pass` (`AUTOCROP_IOU_THRESHOLD = 0.93` — see §5). |
 | Deskew | Real reference rendered (`render_geometry_references.py`, Phase 15); real Rust candidate available via `make render-geometry-candidates` (`processing::geometry::apply_fine_rotation`) | `make parity`'s `deskew` row is a **rotation-matrix angle-provenance check**, not a full geometric-correctness proof: both sides decompose `rotation_matrix_2x3`'s own closed-form output (`atan2(m[0][1], m[0][0])`) at the same fixed, documented test angle (`1.75` degrees — see §3), so it verifies matrix-construction correctness (sign convention, degrees-to-radians conversion, center-point formula) but cannot by itself detect a resampling bug. **The real pixel-level regression protection for the bilinear-resample step lives in a separate corpus-gated `cargo test`** (`deskew_pixel_fidelity_within_tolerance` in `engine/tests/geometry_candidates.rs`), which compares actual candidate/reference rotated TIFFs pixel-by-pixel. With `SCANSTUDIO_PARITY_REFS`/`SCANSTUDIO_PARITY_CANDIDATES` set and candidates rendered, all six slots report `pass` (`DESKEW_ANGLE_EPSILON_DEGREES = 0.05`, unchanged — measured agreement is ~2.22e-16 on all six slots). |
 | ICE | Legacy-only reference freshly rendered (`render_ice_references.py`, external, real `portable_digital_ice` v0.3.1); real Rust candidate available via `make render-ice-candidates` (Phase 16, `processing::ice::repair_frame`) | Reference-mask investigation **resolved with real measured evidence** — see §3: the corpus-bundled hybrid mask is structurally unrepresentative (Jaccard ~0.000176 against the Legacy port on slot 1); `score_ice()` now prefers the Legacy-only reference, falling back to the hybrid mask only when no Legacy-only reference exists. With `SCANSTUDIO_PARITY_REFS`/`SCANSTUDIO_PARITY_CANDIDATES` set and candidates rendered, **all six slots report `pass`, Jaccard `1.000000` exactly** (`ICE_MASK_AGREEMENT_THRESHOLD = 0.85` — see §5), independently re-verified pixel-by-pixel outside the Rust binary. |
@@ -280,10 +311,17 @@ reader doesn't need to open the Rust source):
   is well under the ~1.0 "just noticeable difference" convention,
   appropriate when comparing two implementations of the same algorithm on
   the same input rather than measuring perceptual accuracy against ground
-  truth. Separately and importantly: the `nikonlook-v1` bundle's own
-  `manifest.json` documents that it does **not** numerically pass its own
-  skin ΔE00 quality gate — best oracle-gain holdout result is 3.55 ΔE00
-  against a ≤1.0 target. That is a known, owner-documented property of the
+  truth — which only holds when candidate and reference actually are the
+  same bundle version. `bin/parity.rs`'s `score_color` derives the
+  reference filename from the loaded bundle's own `bundle_version` (never a
+  fixed literal) specifically so this threshold can never end up silently
+  scoring one bundle version's candidate against another's reference; see
+  §3. Separately and importantly: the nikonlook bundles' own
+  `manifest.json` (Layer B — shared, unchanged across bundle versions)
+  documents that it does **not** numerically pass its own skin ΔE00 quality
+  gate — best oracle-gain holdout result is 3.55 ΔE00 against a ≤1.0
+  target, identical in both the `nikonlook-v1` and `nikonlook-v2`
+  manifests. That is a known, owner-documented property of the
   nikonlook algorithm itself (real-world color accuracy), completely
   orthogonal to `COLOR_DELTA_E76_TOLERANCE`, which only measures whether a
   Rust port reproduces the *same* (imperfect) Python algorithm faithfully.
@@ -368,8 +406,9 @@ fabricated pass or fail.
 
 Color reference TIFFs rendered by `render_references.py` can live in a
 separate directory from the corpus. When `bin/parity.rs` doesn't find
-`acceptance_slotNN_reference_color_nikonlook-v1.tif` colocated with the
-corpus, it falls back to `$SCANSTUDIO_PARITY_REFS/acceptance_slotNN_reference_color_nikonlook-v1.tif`.
+`acceptance_slotNN_reference_color_{bundle_version}.tif` (`{bundle_version}`
+per §3 — `nikonlook-v2` by default) colocated with the corpus, it falls back
+to `$SCANSTUDIO_PARITY_REFS/acceptance_slotNN_reference_color_{bundle_version}.tif`.
 Set the env var when references are stored elsewhere — for the
 read-only-corpus scenario described in §3:
 

--- a/app/ScanStudio/PARITY.md
+++ b/app/ScanStudio/PARITY.md
@@ -178,8 +178,8 @@ framework, this real evidence (not a forced or assumed conclusion) means
 the bundled mask is not usable as a reference for this port, and a
 Legacy-only reference was generated instead.
 
-`render_ice_references.py` lives in the separately managed bridge checkout's
-`tools/` directory, mirroring `render_references.py`/
+`render_ice_references.py` lives in this repository's own `bridge/tools/`
+directory, mirroring `render_references.py`/
 `render_geometry_references.py`'s exact shape — argparse
 `--corpus`/`--output-dir`, `sys.executable`-based dependency probe,
 `.expanduser().resolve()` on path-like defaults. It invokes
@@ -209,8 +209,7 @@ needs.
 Run it via the scratchpad venv that has the real package installed:
 
 ```sh
-BRIDGE_REPO=/path/to/scanstudio-bridge
-/path/to/ice-venv/bin/python3 "$BRIDGE_REPO/tools/render_ice_references.py" \
+/path/to/ice-venv/bin/python3 bridge/tools/render_ice_references.py \
   --corpus "$SCANSTUDIO_PARITY_CORPUS" \
   --output-dir /path/to/reference-output/ice-refs
 ```
@@ -257,13 +256,11 @@ by `render_geometry_references.py` (plan 15-02), by literally invoking the
 real `negpy.features.geometry.logic.get_autocrop_coords` (both Film and
 Image modes) and `apply_fine_rotation` against each slot's own raw `.tif`
 capture, exactly mirroring how `render_references.py` produced the color
-reference. `render_geometry_references.py` lives in the separately managed
-bridge checkout's `tools/` directory (GPL reference code stays external).
-Run it with:
+reference. `render_geometry_references.py` lives in this repository's own
+`bridge/tools/` directory. Run it with:
 
 ```sh
-BRIDGE_REPO=/path/to/scanstudio-bridge
-python3 "$BRIDGE_REPO/tools/render_geometry_references.py" --corpus "$SCANSTUDIO_PARITY_CORPUS"
+python3 bridge/tools/render_geometry_references.py --corpus "$SCANSTUDIO_PARITY_CORPUS"
 ```
 
 Unlike color, deskew has no automatic-detection ground truth to reproduce:
@@ -294,7 +291,7 @@ see them.
 | Color | Real reference rendered (`render_references.py`, bundle-derived filename — see §3; production default is now `nikonlook-v2`); real Rust candidate available via `make render-color-candidates` (Phase 14, `processing::nikonlook`) | Reference not colocated with this corpus snapshot in this environment — see §3's read-only caveat; set `SCANSTUDIO_PARITY_REFS`. With `SCANSTUDIO_PARITY_REFS` and `SCANSTUDIO_PARITY_CANDIDATES` (see §7) both set and candidates rendered for the SAME bundle version, `make parity` reports `pass` for all six slots. |
 | Autocrop | Real reference rendered (`render_geometry_references.py`, Phase 15); real Rust candidate available via `make render-geometry-candidates` (`processing::geometry::autocrop_roi`) | `make parity`'s `autocrop` row reports **Image mode (AUTO_FRAME_EDGE)** only — NegPy's own default; `ModuleKind::Autocrop` (Phase 13's report schema) is not split into separate Film/Image variants for this. **Film mode (AUTO_FILM_BORDER) is fully ported and independently proven against the real corpus** via a corpus-gated `cargo test` (`film_mode_iou_matches_reference` in `engine/tests/geometry_candidates.rs`), not this table — both modes are implemented and both are proven, just through two different mechanisms. With `SCANSTUDIO_PARITY_REFS`/`SCANSTUDIO_PARITY_CANDIDATES` set and candidates rendered, all six slots report `pass` (`AUTOCROP_IOU_THRESHOLD = 0.93` — see §5). |
 | Deskew | Real reference rendered (`render_geometry_references.py`, Phase 15); real Rust candidate available via `make render-geometry-candidates` (`processing::geometry::apply_fine_rotation`) | `make parity`'s `deskew` row is a **rotation-matrix angle-provenance check**, not a full geometric-correctness proof: both sides decompose `rotation_matrix_2x3`'s own closed-form output (`atan2(m[0][1], m[0][0])`) at the same fixed, documented test angle (`1.75` degrees — see §3), so it verifies matrix-construction correctness (sign convention, degrees-to-radians conversion, center-point formula) but cannot by itself detect a resampling bug. **The real pixel-level regression protection for the bilinear-resample step lives in a separate corpus-gated `cargo test`** (`deskew_pixel_fidelity_within_tolerance` in `engine/tests/geometry_candidates.rs`), which compares actual candidate/reference rotated TIFFs pixel-by-pixel. With `SCANSTUDIO_PARITY_REFS`/`SCANSTUDIO_PARITY_CANDIDATES` set and candidates rendered, all six slots report `pass` (`DESKEW_ANGLE_EPSILON_DEGREES = 0.05`, unchanged — measured agreement is ~2.22e-16 on all six slots). |
-| ICE | Legacy-only reference freshly rendered (`render_ice_references.py`, external, real `portable_digital_ice` v0.3.1); real Rust candidate available via `make render-ice-candidates` (Phase 16, `processing::ice::repair_frame`) | Reference-mask investigation **resolved with real measured evidence** — see §3: the corpus-bundled hybrid mask is structurally unrepresentative (Jaccard ~0.000176 against the Legacy port on slot 1); `score_ice()` now prefers the Legacy-only reference, falling back to the hybrid mask only when no Legacy-only reference exists. With `SCANSTUDIO_PARITY_REFS`/`SCANSTUDIO_PARITY_CANDIDATES` set and candidates rendered, **all six slots report `pass`, Jaccard `1.000000` exactly** (`ICE_MASK_AGREEMENT_THRESHOLD = 0.85` — see §5), independently re-verified pixel-by-pixel outside the Rust binary. |
+| ICE | Legacy-only reference freshly rendered (`render_ice_references.py`, real `portable_digital_ice` v0.3.1); real Rust candidate available via `make render-ice-candidates` (Phase 16, `processing::ice::repair_frame`) | Reference-mask investigation **resolved with real measured evidence** — see §3: the corpus-bundled hybrid mask is structurally unrepresentative (Jaccard ~0.000176 against the Legacy port on slot 1); `score_ice()` now prefers the Legacy-only reference, falling back to the hybrid mask only when no Legacy-only reference exists. With `SCANSTUDIO_PARITY_REFS`/`SCANSTUDIO_PARITY_CANDIDATES` set and candidates rendered, **all six slots report `pass`, Jaccard `1.000000` exactly** (`ICE_MASK_AGREEMENT_THRESHOLD = 0.85` — see §5), independently re-verified pixel-by-pixel outside the Rust binary. |
 
 ## 5. Threshold rationale
 

--- a/app/ScanStudio/engine/Cargo.toml
+++ b/app/ScanStudio/engine/Cargo.toml
@@ -7,5 +7,14 @@ edition = "2021"
 image = { version = "0.25.10", default-features = false, features = ["tiff", "png", "jpeg"] }
 imageproc = { version = "0.27", default-features = false }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# float_roundtrip: without it, serde_json's default float parser can be off
+# by 1 ULP on some literal-JSON-text inputs (fast best-effort parsing, not
+# exact) -- manifest.rs's persist_frame_receipt/read_manifest round trips
+# ScanReceipt through real JSON text on disk (not an in-memory
+# serde_json::Value, which never loses precision either way), so a receipt
+# field carrying a "nasty" enough decimal (e.g. NikonlookProvenance.gains)
+# could silently drift by 1 ULP on every read -- confirmed empirically via
+# manifest.rs's persist_frame_receipt_round_trips_nikonlook_provenance_through_disk.
+# A receipt is supposed to be an exact record.
+serde_json = { version = "1", features = ["float_roundtrip"] }
 sha2 = "0.10"

--- a/app/ScanStudio/engine/src/bin/parity.rs
+++ b/app/ScanStudio/engine/src/bin/parity.rs
@@ -14,6 +14,7 @@ use scanstudio_engine::parity::image_io;
 use scanstudio_engine::parity::scoring;
 use scanstudio_engine::parity::{CorpusSlot, ModuleKind, ModuleScore, ModuleStatus, ParityReport};
 use scanstudio_engine::processing::geometry;
+use scanstudio_engine::processing::nikonlook;
 
 struct Args {
     json: bool,
@@ -84,9 +85,21 @@ fn main() {
         std::process::exit(1);
     }
 
+    // Load once: the color module's reference filename is derived from
+    // whichever bundle version is actually loaded here, not hardcoded, so
+    // this harness can never compare a candidate against a different
+    // model's reference render (Finding 1 -- see score_color's own doc
+    // comment). This is the exact same `load_bundle()` call
+    // `render_color_candidates`/`parity::candidates::render_color_candidate`
+    // use to render the candidates being scored.
+    let bundle = match nikonlook::load_bundle() {
+        Ok(bundle) => bundle,
+        Err(err) => fatal(&format!("failed to load nikonlook bundle: {err}")),
+    };
+
     let mut scores = Vec::new();
     for slot in &manifest.slots {
-        scores.push(score_color(slot, &root, args.candidate_dir.as_deref()));
+        scores.push(score_color(slot, &root, args.candidate_dir.as_deref(), &bundle.bundle_version));
         scores.push(score_ice(slot, &root, args.candidate_dir.as_deref()));
         scores.push(score_autocrop(slot, &root, args.candidate_dir.as_deref()));
         scores.push(score_deskew(slot, &root, args.candidate_dir.as_deref()));
@@ -109,29 +122,44 @@ fn main() {
     std::process::exit(if report.has_any_failure() { 1 } else { 0 });
 }
 
-/// Color module: reference is `{root}/acceptance_slot{NN}_reference_color_nikonlook-v1.tif`
-/// (the naming convention Task 3's `render_references.py` writes), with a
-/// fallback to `$SCANSTUDIO_PARITY_REFS/acceptance_slot{NN}_reference_color_nikonlook-v1.tif`
-/// when the colocated file doesn't exist.
-fn score_color(slot: &CorpusSlot, root: &Path, candidate_dir: Option<&Path>) -> ModuleScore {
-    let reference_path = resolve_reference_path(
-        root,
-        &format!("acceptance_slot{:02}_reference_color_nikonlook-v1.tif", slot.slot),
-    );
+/// Color module: reference is
+/// `{root}/acceptance_slot{NN}_reference_color_{bundle_version}.tif`, with a
+/// fallback to
+/// `$SCANSTUDIO_PARITY_REFS/acceptance_slot{NN}_reference_color_{bundle_version}.tif`
+/// when the colocated file doesn't exist. `bundle_version` is
+/// `main`'s own loaded `nikonlook::load_bundle().bundle_version` —
+/// never hardcoded — because `render_color_candidates`/
+/// `parity::candidates::render_color_candidate` render the candidate this
+/// row scores with that exact same `load_bundle()` call. `COLOR_DELTA_E76_TOLERANCE`
+/// (`scoring.rs`) is a port-fidelity tolerance: it exists to prove the Rust
+/// port reproduces the Python reference of the SAME bundle, not to compare
+/// two different models' output. Deriving the filename from the bundle
+/// actually in use, instead of a fixed `nikonlook-v1` literal, is what
+/// keeps that guarantee true after a bundle upgrade (e.g. `load_bundle()`
+/// switching from `nikonlook-v1` to `nikonlook-v2`): a v2 candidate now
+/// only ever looks for a v2 reference, and reports `no_reference` — not a
+/// mismatched pass or fail — when that reference doesn't exist yet.
+fn score_color(slot: &CorpusSlot, root: &Path, candidate_dir: Option<&Path>, bundle_version: &str) -> ModuleScore {
+    let reference_filename = format!("acceptance_slot{:02}_reference_color_{bundle_version}.tif", slot.slot);
+    let reference_path = resolve_reference_path(root, &reference_filename);
 
     let Some(reference_path) = reference_path else {
         return no_reference_score(
             ModuleKind::Color,
             slot.slot,
             "delta_e76",
-            "no nikonlook reference render found; run render_references.py (see PARITY.md)",
+            &format!(
+                "no {bundle_version} reference render found (expected {reference_filename:?}, \
+                 colocated with the corpus or under $SCANSTUDIO_PARITY_REFS); produce it with \
+                 `bridge/tools/render_references.py --bundle <path-to-{bundle_version}-bundle> \
+                 --corpus <corpus>` — see PARITY.md"
+            ),
         );
     };
 
-    let reference_provenance = Some(
-        "freshly rendered via render_references.py from nikonlook_core.py (bundle nikonlook-v1) — see PARITY.md"
-            .to_string(),
-    );
+    let reference_provenance = Some(format!(
+        "freshly rendered via render_references.py from nikonlook_core.py (bundle {bundle_version}) — see PARITY.md"
+    ));
 
     let candidate_path = candidate_dir
         .map(|dir| dir.join("color").join(format!("acceptance_slot{:02}.tif", slot.slot)))
@@ -551,6 +579,30 @@ fn print_human_table(report: &ParityReport) {
         println!(
             "{}\t{}\t{}\t{}\t{}\t{}\t{}",
             score.module, score.slot, status_str, score.metric_name, metric_value, threshold, note
+        );
+    }
+
+    // A per-row `no_reference`/`fail` in a long table is easy to scan past.
+    // `report.has_any_failure()` is what actually decides this run's exit
+    // code (see its own doc comment — `no_reference` counts), so the
+    // summary below must count exactly the same statuses it does, or a
+    // human reading this table could see "FAILED" without the row that
+    // caused it, or see silence and miss a nonzero exit.
+    if report.has_any_failure() {
+        let fail_count = report
+            .scores
+            .iter()
+            .filter(|score| matches!(score.status, ModuleStatus::Fail))
+            .count();
+        let no_reference_count = report
+            .scores
+            .iter()
+            .filter(|score| matches!(score.status, ModuleStatus::NoReference { .. }))
+            .count();
+        println!(
+            "\nFAILED: {fail_count} fail, {no_reference_count} no_reference (a module reporting \
+             no_reference was never actually compared — see PARITY.md §3/§7 for how to render \
+             the missing reference)"
         );
     }
 }

--- a/app/ScanStudio/engine/src/domain.rs
+++ b/app/ScanStudio/engine/src/domain.rs
@@ -552,6 +552,41 @@ pub struct WrittenOutputs {
     pub preview_path: Option<String>,
 }
 
+/// Which of nikonlook v2's Layer-A gain-estimation paths a rendered C41
+/// frame actually used. `Blind` covers both v1's only method
+/// (`percentile-stopgap-v1`, which never accepts exposure metadata at all)
+/// and v2's scored raw-feature fallback (`log-ridge-raw-features-v1`) --
+/// telling those two apart requires reading `NikonlookProvenance.bundle_version`
+/// alongside this field. `HardwareExposure` is only reachable on a v2
+/// bundle whose caller supplied a usable `exposure_10ns` (see
+/// `processing::nikonlook::estimate_gains`'s doc comment for exactly what
+/// "usable" means and why an unusable value is treated as absent rather
+/// than erroring or clamping a meaningless ratio).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum NikonlookLayerAPath {
+    Blind,
+    HardwareExposure,
+}
+
+/// Per-frame nikonlook provenance for a rendered C41 positive: the bundle
+/// version, which Layer-A path ran, and the exact per-channel gains
+/// `processing::nikonlook::apply` actually used. These materially change
+/// the rendered output (see PARITY.md and
+/// `resources/nikonlook-v2/PROVENANCE.md`) but were previously
+/// unrecoverable from a receipt alone. `None` on every non-C41 frame
+/// (Positive/Kodachrome pass the raw pixels through unchanged; BwNegative
+/// inverts a neutral RGB average) -- nikonlook never runs for those.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NikonlookProvenance {
+    pub bundle_version: String,
+    pub layer_a_path: NikonlookLayerAPath,
+    /// R, G, B order -- the exact `k` `estimate_gains` returned and `apply`
+    /// multiplied into the raw pixels before the shared matrix+curves model.
+    pub gains: [f64; 3],
+}
+
 // ---------------------------------------------------------------------
 // Metadata (META-01)
 // ---------------------------------------------------------------------
@@ -886,6 +921,11 @@ pub struct ScanReceipt {
     pub meter_rgbi_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hardware_telemetry: Option<HardwareTelemetry>,
+    /// `None` for every non-C41 frame and for any C41 frame rendered before
+    /// this field existed (legacy receipts predate it) -- never a
+    /// fabricated value. See `NikonlookProvenance`'s own doc comment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nikonlook: Option<NikonlookProvenance>,
 }
 
 // ---------------------------------------------------------------------
@@ -1300,6 +1340,7 @@ mod tests {
             storage_transform: None,
             meter_rgbi_path: None,
             hardware_telemetry: None,
+            nikonlook: None,
         };
         round_trip(&ProjectFrame {
             index: 1,
@@ -1532,8 +1573,61 @@ mod tests {
             storage_transform: None,
             meter_rgbi_path: None,
             hardware_telemetry: None,
+            nikonlook: None,
         };
         round_trip(&receipt);
+    }
+
+    #[test]
+    fn scan_receipt_with_nikonlook_provenance_matches_documented_camelcase_shape() {
+        // Same base receipt literal as `scan_receipt_matches_golden_fixture_shape`
+        // above, but with `nikonlook: Some(...)` -- the one field neither
+        // existing ScanReceipt round-trip test exercises (both use `None`),
+        // so nothing previously proved this field's `Some` side reaches the
+        // wire in its documented camelCase shape (PROTOCOL.md) rather than
+        // being silently dropped by `skip_serializing_if`.
+        let receipt = ScanReceipt {
+            job_id: "job-1".into(),
+            frame_index: 1,
+            started_at: "2026-07-22T09:00:00Z".into(),
+            duration_ms: 1900,
+            passes: 2,
+            resolution_dpi: 4000,
+            bit_depth: 16,
+            channels: "rgbi".into(),
+            engine_version: "0.1.0".into(),
+            device_id: "sim-ls5000-0".into(),
+            simulated: true,
+            settings_fingerprint: "1a3d265e0b54bbd2".into(),
+            processing: None,
+            output: None,
+            outputs: None,
+            rgb_path: None,
+            ir_path: None,
+            storage_transform: None,
+            meter_rgbi_path: None,
+            hardware_telemetry: None,
+            nikonlook: Some(NikonlookProvenance {
+                bundle_version: "nikonlook-v2".into(),
+                layer_a_path: NikonlookLayerAPath::HardwareExposure,
+                gains: [0.5764822683598294, 0.22818411954519974, 0.2620541212542383],
+            }),
+        };
+        let value = serde_json::to_value(&receipt).unwrap();
+        assert_eq!(
+            value["nikonlook"],
+            json!({
+                "bundleVersion": "nikonlook-v2",
+                "layerAPath": "hardwareExposure",
+                "gains": [0.5764822683598294, 0.22818411954519974, 0.2620541212542383],
+            })
+        );
+        round_trip(&receipt);
+
+        // The fallback path's own wire value -- what a malformed or absent
+        // exposure_10ns labels (see processing::nikonlook::exposure_is_usable
+        // and render::render_positive).
+        assert_eq!(serde_json::to_value(NikonlookLayerAPath::Blind).unwrap(), json!("blind"));
     }
 
     #[test]

--- a/app/ScanStudio/engine/src/exiftool.rs
+++ b/app/ScanStudio/engine/src/exiftool.rs
@@ -464,6 +464,7 @@ mod tests {
             storage_transform: None,
             meter_rgbi_path: None,
             hardware_telemetry: None,
+            nikonlook: None,
         });
         let targets = resolve_targets(&project, 1).expect("derivative-only receipt resolves");
         assert_eq!(targets, vec![

--- a/app/ScanStudio/engine/src/manifest.rs
+++ b/app/ScanStudio/engine/src/manifest.rs
@@ -627,6 +627,7 @@ mod tests {
             storage_transform: None,
             meter_rgbi_path: None,
             hardware_telemetry: None,
+            nikonlook: None,
         };
         let project = ScanProject {
             schema_version: CURRENT_SCHEMA_VERSION,
@@ -1123,6 +1124,7 @@ mod tests {
             storage_transform: None,
             meter_rgbi_path: None,
             hardware_telemetry: None,
+            nikonlook: None,
         }
     }
 
@@ -1145,6 +1147,45 @@ mod tests {
         assert_eq!(read_back.frames[0].receipts.len(), 1);
         assert_eq!(read_back.frames[0].receipts[0], receipt);
         assert!(read_back.frames[1].receipts.is_empty());
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn persist_frame_receipt_round_trips_nikonlook_provenance_through_disk() {
+        // Backend-level proof that a written receipt actually carries the
+        // nikonlook field: `sample_receipt` (used by most tests in this
+        // module) always sets `nikonlook: None`, so nothing else exercises
+        // this field through the real write-to-JSON-then-read-back path
+        // both the sim and real backends funnel through via
+        // `persist_frame_receipt`.
+        let dir = temp_project_dir();
+        let (project, _dir) = create_project(
+            "Nikonlook Receipt Persistence",
+            MediaCarrier::Strip6,
+            2,
+            FilmProcess::C41ColorNegative,
+            Some(&dir),
+        )
+        .expect("create_project should succeed");
+
+        let receipt = ScanReceipt {
+            nikonlook: Some(crate::domain::NikonlookProvenance {
+                bundle_version: "nikonlook-v2".to_string(),
+                layer_a_path: crate::domain::NikonlookLayerAPath::HardwareExposure,
+                gains: [0.5764822683598294, 0.22818411954519974, 0.2620541212542383],
+            }),
+            ..sample_receipt(&project.id, 1)
+        };
+        persist_frame_receipt(&dir, 1, &receipt).expect("persist frame 1 receipt");
+
+        let read_back = read_manifest(&dir).expect("read back manifest");
+        assert_eq!(read_back.frames[0].receipts.len(), 1);
+        assert_eq!(
+            read_back.frames[0].receipts[0].nikonlook, receipt.nikonlook,
+            "nikonlook provenance must survive a real write-to-disk/read-back round trip"
+        );
+        assert_eq!(read_back.frames[0].receipts[0], receipt);
 
         cleanup(&dir);
     }

--- a/app/ScanStudio/engine/src/parity/scoring.rs
+++ b/app/ScanStudio/engine/src/parity/scoring.rs
@@ -16,16 +16,23 @@ use crate::parity::types::ParityError;
 /// reference and a future Rust port of the *same* nikonlook algorithm,
 /// tight enough to catch a real logic bug. This measures Rust-port
 /// fidelity to the Python `nikonlook_core` reference render, not
-/// real-world accuracy against true Nikon Scan color — the nikonlook-v1
-/// bundle's own `manifest.json` documents a 3.55 ΔE00 gap against true
-/// Nikon color at best (see PARITY.md from plan 13-02), which is a
-/// separate, orthogonal quality question this threshold does not address.
+/// real-world accuracy against true Nikon Scan color — the nikonlook
+/// bundles' own `manifest.json` (Layer B: shared, unchanged across bundle
+/// versions) documents a 3.55 ΔE00 gap against true Nikon color at best
+/// (see PARITY.md from plan 13-02), which is a separate, orthogonal
+/// quality question this threshold does not address.
 pub const COLOR_PER_CHANNEL_TOLERANCE_U16: u16 = 8;
 
 /// Same port-fidelity framing as `COLOR_PER_CHANNEL_TOLERANCE_U16`; 0.5 is
 /// well under the ~1.0 "just noticeable difference" convention, appropriate
 /// when comparing two implementations of the same algorithm on the same
 /// input rather than measuring perceptual accuracy against ground truth.
+/// That framing only holds when candidate and reference actually ARE the
+/// same algorithm/bundle — `bin/parity.rs`'s `score_color` derives the
+/// reference filename from the loaded bundle's own `bundle_version` rather
+/// than a fixed literal specifically so this threshold can never end up
+/// silently comparing two different bundle versions' output against each
+/// other (see that function's own doc comment).
 pub const COLOR_DELTA_E76_TOLERANCE: f64 = 0.5;
 
 /// Validated against the real six-slot corpus by plan 15-02 (see

--- a/app/ScanStudio/engine/src/parity/types.rs
+++ b/app/ScanStudio/engine/src/parity/types.rs
@@ -66,7 +66,15 @@ impl std::fmt::Display for ModuleKind {
 pub enum ModuleStatus {
     Pass,
     Fail,
+    /// A reference artifact this slot needs to be scored at all does not
+    /// exist yet (not colocated with the corpus, and not found under the
+    /// configured fallback directory either) -- this module/slot was never
+    /// actually compared against ground truth. `ParityReport::has_any_failure`
+    /// treats this as a failure; see that method's own doc comment for why.
     NoReference { reason: String },
+    /// The reference exists (this slot COULD be scored) but this port's own
+    /// candidate output hasn't been rendered yet -- a normal mid-development
+    /// state, not an incomplete or broken setup. Not a failure.
     NoCandidate { reason: String },
 }
 
@@ -93,12 +101,47 @@ pub struct ParityReport {
 }
 
 impl ParityReport {
-    /// `true` iff any score's status is `Fail`. `NoReference`/`NoCandidate`
-    /// are not failures — used by plan 13-02's binary for its exit code.
+    /// `true` iff any score's status is `Fail` or `NoReference` — used by
+    /// plan 13-02's binary for its exit code.
+    ///
+    /// `NoReference` counts as a failure here, deliberately, not as a
+    /// softer "informational" outcome. A module reporting `NoReference` was
+    /// never actually compared against ground truth for that slot, which is
+    /// worse than a `Fail`: `Fail` is at least loud about a real
+    /// discrepancy, while an uncompared module sitting next to passing ones
+    /// in the same report is a silent gap that looks green from a distance
+    /// (this is exactly how a bundle-version mismatch between candidates
+    /// and on-disk references once made `make parity` exit 0 with color
+    /// never actually scored). The alternative this method could have
+    /// implemented instead — a narrower "expected-but-absent" carve-out for
+    /// modules that legitimately have no reference concept — does not apply
+    /// to anything in this codebase today: `bin/parity.rs`'s
+    /// `score_color`/`score_autocrop`/`score_deskew`/`score_ice` all
+    /// construct `NoReference` through the same shared `no_reference_score`
+    /// helper, for the same reason every time (the module's
+    /// reference-rendering script hasn't been run yet, or its output isn't
+    /// colocated with the corpus or pointed at by `SCANSTUDIO_PARITY_REFS`)
+    /// — an incomplete-setup problem, not a designed-in gap. `score_ice`
+    /// even absorbs the one case that could have argued for a real carve-out
+    /// (a missing Legacy-only reference, with the corpus-bundled hybrid mask
+    /// still available as a fallback) INSIDE its own two-tier resolution,
+    /// before ever constructing `NoReference` — so by the time any module
+    /// reaches this status, for any slot, there is genuinely nothing to
+    /// score against. The narrow rule and the global rule are therefore the
+    /// same rule; this implements the simpler of two equivalent options.
+    /// PARITY.md §7 has documented exactly this contract since before this
+    /// fix ("The binary still hard-fails if neither location has the file
+    /// (exit 1, `no_reference` status)") — this method is what makes that
+    /// documented behavior true instead of aspirational.
+    ///
+    /// `NoCandidate` stays non-failing: the reference exists (this slot
+    /// COULD be scored) but this port's own candidate output hasn't been
+    /// rendered yet (`make render-*-candidates` not run) — a normal
+    /// mid-development state, not a broken or incomplete setup.
     pub fn has_any_failure(&self) -> bool {
-        self.scores
-            .iter()
-            .any(|score| matches!(score.status, ModuleStatus::Fail))
+        self.scores.iter().any(|score| {
+            matches!(score.status, ModuleStatus::Fail | ModuleStatus::NoReference { .. })
+        })
     }
 }
 
@@ -159,7 +202,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn has_any_failure_is_true_only_when_a_score_is_fail() {
+    fn has_any_failure_is_true_for_fail_and_no_reference_but_not_pass_or_no_candidate() {
         let make_score = |status: ModuleStatus| ModuleScore {
             module: ModuleKind::Color,
             slot: 1,
@@ -170,19 +213,36 @@ mod tests {
             reference_provenance: Some("freshly-generated".to_string()),
         };
 
+        // Pass + NoCandidate (nothing rendered to compare yet -- a normal
+        // mid-development state) must stay green.
         let no_failures = ParityReport {
             corpus_root: PathBuf::from("/tmp/corpus"),
             scores: vec![
                 make_score(ModuleStatus::Pass),
-                make_score(ModuleStatus::NoReference {
-                    reason: "no reference render yet".to_string(),
-                }),
                 make_score(ModuleStatus::NoCandidate {
                     reason: "module not ported yet".to_string(),
                 }),
             ],
         };
         assert!(!no_failures.has_any_failure());
+
+        // Regression guard for the bug this method's fix closes: a module
+        // that was supposed to be scored but had no reference to score
+        // against must NOT be green, even when every other module in the
+        // same report passes -- this exact shape (v1-named references on
+        // disk, v2 candidates rendered, color's own NoReference sitting
+        // next to three passing modules) is what let `make parity` exit 0
+        // with color never actually compared.
+        let missing_reference = ParityReport {
+            corpus_root: PathBuf::from("/tmp/corpus"),
+            scores: vec![
+                make_score(ModuleStatus::Pass),
+                make_score(ModuleStatus::NoReference {
+                    reason: "no reference render yet".to_string(),
+                }),
+            ],
+        };
+        assert!(missing_reference.has_any_failure());
 
         let with_failure = ParityReport {
             corpus_root: PathBuf::from("/tmp/corpus"),

--- a/app/ScanStudio/engine/src/processing/nikonlook.rs
+++ b/app/ScanStudio/engine/src/processing/nikonlook.rs
@@ -145,6 +145,29 @@ const LAYER_A_V2_QUANTILES: [f64; 13] =
 /// to narrowest) — mirrors `LAYER_A_V2_SPAN_INDEX_PAIRS` (line 107) exactly.
 const LAYER_A_V2_SPAN_INDEX_PAIRS: [(usize, usize); 3] = [(0, 12), (1, 11), (2, 10)];
 
+/// The frozen v2 blind feature name schema, R then G then B, 13 quantile
+/// names then 3 span names per channel (48 total) — mirrors
+/// `nikonlook_core.py::_layer_a_v2_feature_names()`'s generated output
+/// exactly (verified against the vendored `resources/nikonlook-v2/layer_a.json`'s
+/// own `blind_fallback.feature_names` array). Hardcoded rather than
+/// generated from `LAYER_A_V2_QUANTILES` at validation time, consistent
+/// with this module's existing frozen-literal style for Layer-A schema tags
+/// (see the method/schema consts above) — a bundle's `feature_names` must
+/// match this list exactly or `_validate_layer_a`'s Rust port
+/// (`build_layer_a_v2`) rejects it, the same "fail loudly on schema drift"
+/// contract every other schema tag in this module already enforces.
+const LAYER_A_V2_FEATURE_NAMES: [&str; LAYER_A_V2_FEATURE_COUNT] = [
+    "log_R_q1", "log_R_q2", "log_R_q5", "log_R_q10", "log_R_q20", "log_R_q35", "log_R_q50",
+    "log_R_q65", "log_R_q80", "log_R_q90", "log_R_q95", "log_R_q98", "log_R_q99",
+    "log_R_span_q1_q99", "log_R_span_q2_q98", "log_R_span_q5_q95",
+    "log_G_q1", "log_G_q2", "log_G_q5", "log_G_q10", "log_G_q20", "log_G_q35", "log_G_q50",
+    "log_G_q65", "log_G_q80", "log_G_q90", "log_G_q95", "log_G_q98", "log_G_q99",
+    "log_G_span_q1_q99", "log_G_span_q2_q98", "log_G_span_q5_q95",
+    "log_B_q1", "log_B_q2", "log_B_q5", "log_B_q10", "log_B_q20", "log_B_q35", "log_B_q50",
+    "log_B_q65", "log_B_q80", "log_B_q90", "log_B_q95", "log_B_q98", "log_B_q99",
+    "log_B_span_q1_q99", "log_B_span_q2_q98", "log_B_span_q5_q95",
+];
+
 // ---------------------------------------------------------------------
 // Bundle
 // ---------------------------------------------------------------------
@@ -243,7 +266,14 @@ struct LayerADto {
     hi_pct: f64,
     rail_lo_fraction: f64,
     rail_hi_fraction: f64,
-    gain_bounds: Vec<f64>,
+    // `#[serde(default)]` (-> None) rather than a required field — mirrors
+    // `nikonlook_core.py`'s `layer_a.get("gain_bounds", GAIN_BOUNDS)`: an
+    // absent field defaults to `DEFAULT_GAIN_BOUNDS` rather than failing to
+    // parse (see `validated_gain_bounds_or_default`), while a
+    // present-but-malformed array must still fail validation, so `None`
+    // here means "key absent," never conflated with a present empty array.
+    #[serde(default)]
+    gain_bounds: Option<Vec<f64>>,
     reference_lo: Vec<f64>,
     reference_hi: Vec<f64>,
     reference_k: Vec<f64>,
@@ -270,17 +300,43 @@ struct MetadataEstimatorDto {
     method: String,
     reference_exposure_10ns: Vec<f64>,
     reference_gain: Vec<f64>,
-    gain_bounds: Vec<f64>,
+    // `#[serde(default)]` (-> None) — mirrors `nikonlook_core.py`'s
+    // `metadata.get("gain_bounds", GAIN_BOUNDS)`; see `LayerADto.gain_bounds`'s
+    // own doc comment for why `None` means "key absent," not "empty array."
+    #[serde(default)]
+    gain_bounds: Option<Vec<f64>>,
+    // Optional in both the real bundle's own schema and
+    // `nikonlook_core.py::_validate_layer_a` (only checked `if
+    // "gain_exposure_product" in metadata`) — absent entirely rather than
+    // defaulting to a placeholder, so `#[serde(default)]` (-> None) mirrors
+    // Python's `metadata.get(...)` returning `None` exactly.
+    #[serde(default)]
+    gain_exposure_product: Option<Vec<f64>>,
 }
 
 #[derive(Deserialize)]
 struct BlindFallbackDto {
     method: String,
     feature_schema: String,
+    // `#[serde(default)]` (-> empty Vec) rather than a required field: an
+    // absent `feature_names` must fail the same explicit, named
+    // schema-mismatch check a present-but-wrong array would (mirrors
+    // `nikonlook_core.py`'s `blind.get("feature_names") != ...` — `None !=
+    // [...]` is simply another mismatch to Python, not a separate
+    // missing-field error), not the generic `serde_json::Error` a required
+    // field's absence would raise here.
+    #[serde(default)]
+    feature_names: Vec<String>,
     sample_stride: usize,
     rail_lo_fraction: f64,
     rail_hi_fraction: f64,
-    gain_bounds: Vec<f64>,
+    alpha: f64,
+    target_kind: String,
+    // `#[serde(default)]` (-> None) — mirrors `nikonlook_core.py`'s
+    // `blind.get("gain_bounds", GAIN_BOUNDS)`; see `LayerADto.gain_bounds`'s
+    // own doc comment for why `None` means "key absent," not "empty array."
+    #[serde(default)]
+    gain_bounds: Option<Vec<f64>>,
     feature_mean: Vec<f64>,
     feature_scale: Vec<f64>,
     log_gain_intercept: Vec<f64>,
@@ -397,22 +453,7 @@ fn parse_bundle(
 
     let layer_a = if method == LAYER_A_V1_METHOD {
         let layer_a_dto: LayerADto = serde_json::from_str(layer_a_json)?;
-
-        let reference_lo = fixed3(&layer_a_dto.reference_lo, "layer_a.json:reference_lo")?;
-        let reference_hi = fixed3(&layer_a_dto.reference_hi, "layer_a.json:reference_hi")?;
-        let reference_k = fixed3(&layer_a_dto.reference_k, "layer_a.json:reference_k")?;
-        let gain_bounds = fixed2(&layer_a_dto.gain_bounds, "layer_a.json:gain_bounds")?;
-
-        LayerA::V1(LayerAV1 {
-            lo_pct: layer_a_dto.lo_pct,
-            hi_pct: layer_a_dto.hi_pct,
-            rail_lo_fraction: layer_a_dto.rail_lo_fraction,
-            rail_hi_fraction: layer_a_dto.rail_hi_fraction,
-            reference_lo,
-            reference_hi,
-            reference_k,
-            gain_bounds: (gain_bounds[0], gain_bounds[1]),
-        })
+        LayerA::V1(build_layer_a_v1(layer_a_dto)?)
     } else {
         let layer_a_dto: LayerAV2Dto = serde_json::from_str(layer_a_json)?;
         LayerA::V2(build_layer_a_v2(layer_a_dto)?)
@@ -425,30 +466,6 @@ fn parse_bundle(
         quality_tier: manifest.quality_tier,
         bundle_version: manifest.bundle_version,
     })
-}
-
-/// Validates a field's value slice has exactly 3 elements, converting into
-/// a fixed-size array — `NikonlookError::Invalid` with a clear message
-/// (naming the field) on any shape mismatch.
-fn fixed3(values: &[f64], field: &str) -> Result<[f64; 3], NikonlookError> {
-    if values.len() != 3 {
-        return Err(NikonlookError::Invalid(format!(
-            "{field}: expected 3 values, got {}",
-            values.len()
-        )));
-    }
-    Ok([values[0], values[1], values[2]])
-}
-
-/// Same as `fixed3` but for 2-element fields (e.g. `gain_bounds`).
-fn fixed2(values: &[f64], field: &str) -> Result<[f64; 2], NikonlookError> {
-    if values.len() != 2 {
-        return Err(NikonlookError::Invalid(format!(
-            "{field}: expected 2 values, got {}",
-            values.len()
-        )));
-    }
-    Ok([values[0], values[1]])
 }
 
 // ---------------------------------------------------------------------
@@ -497,6 +514,44 @@ fn validated_gain_bounds(values: &[f64], field: &str) -> Result<(f64, f64), Niko
     Ok((lo, hi))
 }
 
+/// Mirrors `nikonlook_core.py`'s own module-level `GAIN_BOUNDS = (0.02,
+/// 100.0)` — the value `layer_a.get("gain_bounds", GAIN_BOUNDS)` /
+/// `metadata.get("gain_bounds", GAIN_BOUNDS)` / `blind.get("gain_bounds",
+/// GAIN_BOUNDS)` (`_validate_layer_a`, lines 373/401/432) fall back to when
+/// a bundle omits the field entirely.
+const DEFAULT_GAIN_BOUNDS: (f64, f64) = (0.02, 100.0);
+
+/// `validated_gain_bounds`, but `None` (an omitted `gain_bounds` key —
+/// every caller passes `dto_field.as_deref()`, and `#[serde(default)]`
+/// makes an absent key deserialize to `None`, never a present empty array;
+/// see e.g. `LayerADto.gain_bounds`'s own doc comment) resolves to
+/// `DEFAULT_GAIN_BOUNDS` instead of erroring, exactly like Python's
+/// `.get(name, GAIN_BOUNDS)` default. A bundle that DOES include the key —
+/// even as `[]` or some other malformed shape — still has to pass
+/// `validated_gain_bounds`'s full check; only true absence gets the
+/// default, matching Python's `dict.get` semantics exactly (a present
+/// `null`/wrong-shape value is not the same as an absent key to `.get`
+/// either).
+fn validated_gain_bounds_or_default(values: Option<&[f64]>, field: &str) -> Result<(f64, f64), NikonlookError> {
+    match values {
+        None => Ok(DEFAULT_GAIN_BOUNDS),
+        Some(values) => validated_gain_bounds(values, field),
+    }
+}
+
+/// Mirrors `_finite_scalar`, itself `_finite_array([value], (1,), field)[0]`
+/// — a single finite value. Python's `_finite_scalar` never takes a
+/// `positive` flag (every one of its own call sites -- `lo_pct`, `hi_pct`,
+/// both rail fractions, `alpha` -- checks positivity, if at all, via a
+/// separate explicit comparison afterward, e.g. `if alpha <= 0.0: raise
+/// ...`), so this port doesn't carry one either -- see this function's own
+/// call sites in `build_layer_a_v1`/`build_layer_a_v2` for the same
+/// separate-comparison pattern.
+fn finite_scalar(value: f64, field: &str) -> Result<f64, NikonlookError> {
+    finite_slice(&[value], 1, field, false)?;
+    Ok(value)
+}
+
 /// Validates v2's `coefficients` field: exactly `rows` rows, each exactly 3
 /// finite values — mirrors `_finite_array`'s `(LAYER_A_V2_FEATURE_COUNT, 3)`
 /// shape check.
@@ -517,6 +572,58 @@ fn finite_matrix_rows3(values: &[Vec<f64>], rows: usize, field: &str) -> Result<
         out.push([row[0], row[1], row[2]]);
     }
     Ok(out)
+}
+
+/// Validates and constructs v1's Layer A from its parsed DTO — mirrors
+/// `nikonlook_core.py::_validate_layer_a`'s v1 branch (lines 362-374)
+/// field-for-field: `reference_lo`/`reference_hi`/`reference_k` finite
+/// (`reference_k` additionally positive, matching Python's
+/// `positive=name == "reference_k"`), `lo_pct`/`hi_pct`/both rail fractions
+/// finite scalars subject to the same two ordering constraints Python
+/// checks (`0 <= lo_pct < hi_pct <= 100`, `0 <= rail_lo_fraction <
+/// rail_hi_fraction <= 1`), and `gain_bounds` defaulting to
+/// `DEFAULT_GAIN_BOUNDS` when the bundle omits it. Shares the same
+/// validation primitives `build_layer_a_v2` below uses
+/// (`finite_array3`/`finite_scalar`/`validated_gain_bounds_or_default`) —
+/// this port previously validated v1 through separate, weaker,
+/// length-only helpers (`fixed3`/`fixed2`) that checked shape but not
+/// finiteness, positivity, or either ordering constraint; closing that gap
+/// is what makes v1 and v2 equally strict, as PARITY.md and this module's
+/// own doc comment already claimed.
+fn build_layer_a_v1(dto: LayerADto) -> Result<LayerAV1, NikonlookError> {
+    const PREFIX: &str = "layer_a.json";
+
+    let reference_lo = finite_array3(&dto.reference_lo, &format!("{PREFIX}:reference_lo"), false)?;
+    let reference_hi = finite_array3(&dto.reference_hi, &format!("{PREFIX}:reference_hi"), false)?;
+    let reference_k = finite_array3(&dto.reference_k, &format!("{PREFIX}:reference_k"), true)?;
+
+    let lo_pct = finite_scalar(dto.lo_pct, &format!("{PREFIX}:lo_pct"))?;
+    let hi_pct = finite_scalar(dto.hi_pct, &format!("{PREFIX}:hi_pct"))?;
+    let rail_lo_fraction = finite_scalar(dto.rail_lo_fraction, &format!("{PREFIX}:rail_lo_fraction"))?;
+    let rail_hi_fraction = finite_scalar(dto.rail_hi_fraction, &format!("{PREFIX}:rail_hi_fraction"))?;
+    if !(0.0 <= lo_pct && lo_pct < hi_pct && hi_pct <= 100.0) {
+        return Err(NikonlookError::Invalid(format!(
+            "{PREFIX}: expected 0 <= lo_pct < hi_pct <= 100"
+        )));
+    }
+    if !(0.0 <= rail_lo_fraction && rail_lo_fraction < rail_hi_fraction && rail_hi_fraction <= 1.0) {
+        return Err(NikonlookError::Invalid(format!(
+            "{PREFIX}: expected 0 <= rail_lo_fraction < rail_hi_fraction <= 1"
+        )));
+    }
+    let gain_bounds =
+        validated_gain_bounds_or_default(dto.gain_bounds.as_deref(), &format!("{PREFIX}:gain_bounds"))?;
+
+    Ok(LayerAV1 {
+        lo_pct,
+        hi_pct,
+        rail_lo_fraction,
+        rail_hi_fraction,
+        reference_lo,
+        reference_hi,
+        reference_k,
+        gain_bounds,
+    })
 }
 
 /// Validates and constructs v2's Layer A from its parsed DTO — mirrors
@@ -540,10 +647,34 @@ fn build_layer_a_v2(dto: LayerAV2Dto) -> Result<LayerAV2, NikonlookError> {
         &format!("{PREFIX}:metadata_estimator.reference_gain"),
         true,
     )?;
-    let metadata_gain_bounds = validated_gain_bounds(
-        &dto.metadata_estimator.gain_bounds,
+    let metadata_gain_bounds = validated_gain_bounds_or_default(
+        dto.metadata_estimator.gain_bounds.as_deref(),
         &format!("{PREFIX}:metadata_estimator.gain_bounds"),
     )?;
+    // Optional consistency check, only when the bundle carries the
+    // (optional) derived field at all — mirrors `_validate_layer_a`'s `if
+    // "gain_exposure_product" in metadata`. `np.allclose(product, ref_exp *
+    // ref_gain, rtol=1e-12, atol=1e-9)` is `|a - b| <= atol + rtol*|b|`
+    // elementwise; replicated per-channel below so a mismatch names the
+    // offending index instead of Python's single blanket message.
+    if let Some(product_field) = &dto.metadata_estimator.gain_exposure_product {
+        let product = finite_array3(
+            product_field,
+            &format!("{PREFIX}:metadata_estimator.gain_exposure_product"),
+            true,
+        )?;
+        for c in 0..3 {
+            let expected = reference_exposure_10ns[c] * reference_gain[c];
+            let tolerance = 1e-9 + 1e-12 * expected.abs();
+            if (product[c] - expected).abs() > tolerance {
+                return Err(NikonlookError::Invalid(format!(
+                    "{PREFIX}:metadata_estimator.gain_exposure_product: inconsistent with \
+                     reference_gain * reference_exposure_10ns at index {c} (got {}, expected {expected})",
+                    product[c]
+                )));
+            }
+        }
+    }
 
     if dto.blind_fallback.method != LAYER_A_V2_BLIND_METHOD {
         return Err(NikonlookError::Invalid(format!(
@@ -555,6 +686,16 @@ fn build_layer_a_v2(dto: LayerAV2Dto) -> Result<LayerAV2, NikonlookError> {
         return Err(NikonlookError::Invalid(format!(
             "{PREFIX}: unsupported blind feature schema {:?}",
             dto.blind_fallback.feature_schema
+        )));
+    }
+    // `!=` against the frozen 48-name list mirrors `_validate_layer_a`
+    // treating a missing `feature_names` the same as a wrong one (both
+    // become "does not match" here) — see `BlindFallbackDto.feature_names`'s
+    // own `#[serde(default)]` doc comment for why absence doesn't fail
+    // earlier, as a bare deserialize error, instead.
+    if dto.blind_fallback.feature_names.iter().map(String::as_str).ne(LAYER_A_V2_FEATURE_NAMES) {
+        return Err(NikonlookError::Invalid(format!(
+            "{PREFIX}: blind feature_names do not match the frozen feature schema"
         )));
     }
     if dto.blind_fallback.sample_stride < 1 {
@@ -569,8 +710,26 @@ fn build_layer_a_v2(dto: LayerAV2Dto) -> Result<LayerAV2, NikonlookError> {
             "{PREFIX}: expected blind rail fractions to satisfy 0 <= lo < hi <= 1"
         )));
     }
-    let blind_gain_bounds = validated_gain_bounds(
-        &dto.blind_fallback.gain_bounds,
+    // `alpha` (the training-time ridge regularization strength) and
+    // `target_kind` (the training target convention) are training metadata
+    // carried into the bundle for provenance/debugging; frozen-schema
+    // agreement on `feature_names` above proves the FEATURE side matches,
+    // these two prove the TRAINING side is present and not obviously
+    // corrupt, matching `_validate_layer_a`'s own `alpha`/`target_kind`
+    // checks exactly.
+    let alpha = finite_scalar(dto.blind_fallback.alpha, &format!("{PREFIX}:blind_fallback.alpha"))?;
+    if alpha <= 0.0 {
+        return Err(NikonlookError::Invalid(format!(
+            "{PREFIX}:blind_fallback.alpha: must be finite and positive, got {alpha}"
+        )));
+    }
+    if dto.blind_fallback.target_kind.is_empty() {
+        return Err(NikonlookError::Invalid(format!(
+            "{PREFIX}:blind_fallback.target_kind: must be a non-empty string"
+        )));
+    }
+    let blind_gain_bounds = validated_gain_bounds_or_default(
+        dto.blind_fallback.gain_bounds.as_deref(),
         &format!("{PREFIX}:blind_fallback.gain_bounds"),
     )?;
     finite_slice(
@@ -744,6 +903,20 @@ fn layer_a_v2_features(raw: &[[f64; 3]], width: usize, blind: &BlindFallbackV1) 
 // hybrid-exposure-ridge-v2)
 // ---------------------------------------------------------------------
 
+/// True if every component of a candidate hardware-exposure triple is
+/// finite and strictly positive — the bar `estimate_gains` requires before
+/// its `LayerA::V2` branch will trust `exposure_10ns` rather than falling
+/// back to the blind estimator (see that function's own doc comment for
+/// the fail-closed rationale). No magnitude/plausibility bound beyond
+/// finite-and-positive is imposed here: this module has no principled
+/// source for a "too large"/"too small" exposure threshold, and the
+/// resulting gain is clamped to the bundle's own `gain_bounds` regardless,
+/// so an implausible-but-finite-and-positive value cannot escape that
+/// clamp even when this check accepts it.
+pub fn exposure_is_usable(exposure_10ns: [f64; 3]) -> bool {
+    exposure_10ns.iter().all(|&value| value.is_finite() && value > 0.0)
+}
+
 /// Per-frame exposure gain estimate ("Layer A"), dispatched by the loaded
 /// bundle's method (see this module's doc comment). `raw` is scanner-linear
 /// RGB in [0,1] (16-bit raw counts / 65535), one [R,G,B] triple per pixel,
@@ -752,15 +925,32 @@ fn layer_a_v2_features(raw: &[[f64; 3]], width: usize, blind: &BlindFallbackV1) 
 ///
 /// `exposure_10ns` is the caller's per-channel hardware exposure duration
 /// in 10ns ticks (mirrors nikonlook_core.py's `meta["exposure_10ns"]`),
-/// `None` when unavailable. `LayerA::V2` uses it when present (the
-/// `inverse-hardware-exposure-v1` path — the caller must guarantee each
-/// component is finite and > 0; only `debug_assert!`-checked, since this is
-/// a hot per-frame call and the bundle's own gain_bounds clamp already
-/// contains a bad ratio's blast radius); otherwise v2 falls back to
-/// `log-ridge-raw-features-v1`, its scored blind estimator, which is the
-/// only path that can return `Err` (a degenerate `raw`/`width` pairing —
-/// see `layer_a_v2_features` — unreachable for real engine data, which is
-/// always an exact (H,W,3) raster).
+/// `None` when unavailable. `LayerA::V2` uses it only when
+/// [`exposure_is_usable`] accepts it (the `inverse-hardware-exposure-v1`
+/// path); any other value — non-finite, zero, negative — is treated
+/// exactly like `None` and routed to `log-ridge-raw-features-v1`, v2's
+/// scored blind estimator, instead. This is a deliberate design choice, not
+/// an oversight: a bad exposure value silently divided into the gain ratio
+/// and then clamped to `gain_bounds` would still land inside a "plausible"
+/// range and pass every downstream sanity check while being numerically
+/// meaningless — exactly the failure this function must not produce. The
+/// blind estimator never reads `exposure_10ns` at all, so it cannot inherit
+/// the bad value's error, and this bundle's own measured evidence (see
+/// `resources/nikonlook-v2/PROVENANCE.md`) is that the blind path is
+/// generally the stronger estimator anyway, so falling back to it is not a
+/// degraded result. `real_backend.rs`'s `nikonlook_exposure_10ns_from_receipt`
+/// already declines to build an `exposure_10ns` argument at all from a
+/// degenerate bridge receipt (defense in depth, checked before this
+/// function ever sees the value); this function enforces the same
+/// finite-and-positive bar unconditionally so every other caller — tests,
+/// parity tooling, future integrations — gets the same guarantee without
+/// having to duplicate the check. A caller that needs to know in advance
+/// which path a given call will take (e.g. render provenance) can call
+/// [`exposure_is_usable`] itself rather than requiring this function to
+/// fail loudly or report it out-of-band. Only the blind path can return
+/// `Err` (a degenerate `raw`/`width` pairing — see `layer_a_v2_features` —
+/// unreachable for real engine data, which is always an exact (H,W,3)
+/// raster).
 ///
 /// Returns (3,) gain, clamped to the active method's own gain_bounds.
 pub fn estimate_gains(
@@ -792,11 +982,7 @@ pub fn estimate_gains(
             Ok(k)
         }
         LayerA::V2(la) => {
-            if let Some(exposure) = exposure_10ns {
-                debug_assert!(
-                    exposure.iter().all(|&value| value.is_finite() && value > 0.0),
-                    "exposure_10ns components must be finite and positive"
-                );
+            if let Some(exposure) = exposure_10ns.filter(|&value| exposure_is_usable(value)) {
                 let mut gain = [0.0f64; 3];
                 for c in 0..3 {
                     gain[c] =
@@ -1351,15 +1537,31 @@ mod tests {
 
     // Group O -- v2 validation failures (Group-G style, tamper one field) --
 
+    /// The frozen 48-name list, JSON-array-element-formatted -- shared by
+    /// the baseline fixture below and the missing-feature_names tamper test,
+    /// so the two can never accidentally drift apart.
+    fn feature_names_json_array() -> String {
+        LAYER_A_V2_FEATURE_NAMES
+            .iter()
+            .map(|name| format!("{name:?}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
     /// A minimal, otherwise-valid v2 layer_a.json fixture, so each test
     /// below tampers exactly one field via a single targeted string
     /// replacement -- mirrors Group G's `.replacen(...)` style.
     /// `feature_mean_len` lets the length-mismatch test build a
     /// structurally different array without a second bespoke literal.
+    /// `gain_exposure_product` ([10.0, 20.0, 30.0]) is self-consistent with
+    /// `reference_exposure_10ns * reference_gain` ([10,20,30] * [1,1,1]) so
+    /// the baseline stays valid with the optional field present -- the
+    /// dedicated tamper test below replaces it with an inconsistent value.
     fn minimal_v2_layer_a_json(feature_mean_len: usize) -> String {
         let feature_mean = vec!["0.0".to_string(); feature_mean_len].join(", ");
         let feature_scale = vec!["1.0".to_string(); LAYER_A_V2_FEATURE_COUNT].join(", ");
         let coefficients = vec!["[0.01, 0.02, 0.03]".to_string(); LAYER_A_V2_FEATURE_COUNT].join(", ");
+        let feature_names = feature_names_json_array();
         format!(
             r#"{{
                 "method": "hybrid-exposure-ridge-v2",
@@ -1367,14 +1569,18 @@ mod tests {
                     "method": "inverse-hardware-exposure-v1",
                     "reference_exposure_10ns": [10.0, 20.0, 30.0],
                     "reference_gain": [1.0, 1.0, 1.0],
+                    "gain_exposure_product": [10.0, 20.0, 30.0],
                     "gain_bounds": [0.02, 100.0]
                 }},
                 "blind_fallback": {{
                     "method": "log-ridge-raw-features-v1",
                     "feature_schema": "raw-rail-quantiles-log-v1",
+                    "feature_names": [{feature_names}],
                     "sample_stride": 16,
                     "rail_lo_fraction": 0.003,
                     "rail_hi_fraction": 0.99,
+                    "alpha": 1.0,
+                    "target_kind": "test-target",
                     "gain_bounds": [0.02, 100.0],
                     "feature_mean": [{feature_mean}],
                     "feature_scale": [{feature_scale}],
@@ -1439,5 +1645,313 @@ mod tests {
         let json = minimal_v2_layer_a_json(LAYER_A_V2_FEATURE_COUNT)
             .replacen("\"reference_gain\": [1.0, 1.0, 1.0]", "\"reference_gain\": [1.0, -1.0, 1.0]", 1);
         assert_v2_fixture_invalid(&json, "reference_gain");
+    }
+
+    // Group O continued -- Finding 4's missing v2 validations: feature-name
+    // schema agreement, blind alpha/target_kind training metadata, and the
+    // gain_exposure_product consistency check (nikonlook_core.py's
+    // _validate_layer_a, lines 404-431).
+
+    #[test]
+    fn group_o_rejects_wrong_feature_names() {
+        let json = minimal_v2_layer_a_json(LAYER_A_V2_FEATURE_COUNT)
+            .replacen("\"log_R_q1\"", "\"totally_wrong_feature\"", 1);
+        assert_v2_fixture_invalid(&json, "feature_names");
+    }
+
+    #[test]
+    fn group_o_rejects_missing_feature_names() {
+        let json = minimal_v2_layer_a_json(LAYER_A_V2_FEATURE_COUNT)
+            .replacen(&format!("\"feature_names\": [{}],", feature_names_json_array()), "", 1);
+        assert_v2_fixture_invalid(&json, "feature_names");
+    }
+
+    #[test]
+    fn group_o_rejects_non_positive_alpha() {
+        let json = minimal_v2_layer_a_json(LAYER_A_V2_FEATURE_COUNT)
+            .replacen("\"alpha\": 1.0", "\"alpha\": -1.0", 1);
+        assert_v2_fixture_invalid(&json, "alpha");
+    }
+
+    #[test]
+    fn group_o_rejects_non_finite_alpha() {
+        // Unlike the sign check above, this can't be driven through a JSON
+        // fixture: `serde_json` itself rejects both a bare `NaN`/`Infinity`
+        // token and an out-of-range numeric literal (e.g. `1e400`) as a
+        // parse error, so a non-finite `f64` can never reach this module's
+        // own validation via real JSON text -- confirmed empirically (an
+        // earlier version of this test tried `"alpha": 1e400` and got
+        // `Json(Error("number out of range"))`, not `Invalid`). This calls
+        // `finite_scalar` directly instead, unit-testing the primitive
+        // `build_layer_a_v2` relies on rather than the unreachable
+        // JSON-round-trip path.
+        let result = finite_scalar(f64::NAN, "layer_a.json:blind_fallback.alpha");
+        match result {
+            Ok(_) => panic!("expected Err(NikonlookError::Invalid) for a NaN alpha, got Ok(_)"),
+            Err(NikonlookError::Invalid(message)) => {
+                assert!(message.contains("alpha"), "error message should name the field: {message}");
+            }
+            Err(other) => panic!("expected NikonlookError::Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn group_o_rejects_empty_target_kind() {
+        let json = minimal_v2_layer_a_json(LAYER_A_V2_FEATURE_COUNT)
+            .replacen("\"target_kind\": \"test-target\"", "\"target_kind\": \"\"", 1);
+        assert_v2_fixture_invalid(&json, "target_kind");
+    }
+
+    #[test]
+    fn group_o_rejects_inconsistent_gain_exposure_product() {
+        let json = minimal_v2_layer_a_json(LAYER_A_V2_FEATURE_COUNT)
+            .replacen("\"gain_exposure_product\": [10.0, 20.0, 30.0]", "\"gain_exposure_product\": [10.0, 20.0, 999.0]", 1);
+        assert_v2_fixture_invalid(&json, "gain_exposure_product");
+    }
+
+    // Group O continued -- Finding 4's other missing v2 validation: a bundle
+    // that OMITS gain_bounds entirely (nikonlook_core.py's
+    // `metadata.get("gain_bounds", GAIN_BOUNDS)` / `blind.get("gain_bounds",
+    // GAIN_BOUNDS)`, lines 401/432) must default to DEFAULT_GAIN_BOUNDS, not
+    // fail to parse. `remove_key` edits real parsed JSON rather than
+    // text-surgering the fixture string, so this doesn't depend on getting
+    // brace/comma whitespace exactly right by hand.
+
+    /// Removes `key` from the named top-level sub-object (`"metadata_estimator"`
+    /// or `"blind_fallback"`) of a `minimal_v2_layer_a_json`-shaped fixture --
+    /// via real JSON parsing, not text surgery, so the result is guaranteed
+    /// syntactically valid even though (unlike every other Group O tamper,
+    /// which replaces a VALUE) this removes a KEY.
+    fn remove_key(json: &str, object_path: &str, key: &str) -> String {
+        let mut value: serde_json::Value = serde_json::from_str(json).expect("fixture must be valid JSON");
+        value[object_path]
+            .as_object_mut()
+            .expect("expected an object at this path")
+            .remove(key);
+        serde_json::to_string(&value).expect("re-serialize")
+    }
+
+    #[test]
+    fn group_o_v2_metadata_estimator_gain_bounds_defaults_when_omitted() {
+        let json = remove_key(&minimal_v2_layer_a_json(LAYER_A_V2_FEATURE_COUNT), "metadata_estimator", "gain_bounds");
+        let bundle = parse_bundle(MODEL_JSON_V2, &json, MANIFEST_JSON_V2)
+            .expect("an omitted gain_bounds must default, not fail to parse");
+        let la = match &bundle.layer_a {
+            LayerA::V2(la) => la,
+            LayerA::V1(_) => panic!("expected LayerA::V2"),
+        };
+        assert_eq!(la.metadata.gain_bounds, DEFAULT_GAIN_BOUNDS);
+    }
+
+    #[test]
+    fn group_o_v2_blind_fallback_gain_bounds_defaults_when_omitted() {
+        let json = remove_key(&minimal_v2_layer_a_json(LAYER_A_V2_FEATURE_COUNT), "blind_fallback", "gain_bounds");
+        let bundle = parse_bundle(MODEL_JSON_V2, &json, MANIFEST_JSON_V2)
+            .expect("an omitted gain_bounds must default, not fail to parse");
+        let la = match &bundle.layer_a {
+            LayerA::V2(la) => la,
+            LayerA::V1(_) => panic!("expected LayerA::V2"),
+        };
+        assert_eq!(la.blind.gain_bounds, DEFAULT_GAIN_BOUNDS);
+    }
+
+    // Group P -- Finding 5: a malformed exposure_10ns must fall back to the
+    // blind estimator, never panic and never silently clamp a meaningless
+    // ratio into something that merely looks like a valid gain.
+
+    #[test]
+    fn group_p_exposure_is_usable_accepts_only_finite_positive_triples() {
+        assert!(exposure_is_usable([127992.0, 312892.0, 259345.0]));
+        assert!(!exposure_is_usable([f64::NAN, 312892.0, 259345.0]));
+        assert!(!exposure_is_usable([127992.0, f64::INFINITY, 259345.0]));
+        assert!(!exposure_is_usable([127992.0, 312892.0, f64::NEG_INFINITY]));
+        assert!(!exposure_is_usable([0.0, 312892.0, 259345.0]));
+        assert!(!exposure_is_usable([127992.0, -312892.0, 259345.0]));
+        assert!(!exposure_is_usable([-0.0, 312892.0, 259345.0]), "-0.0 is not > 0.0");
+    }
+
+    #[test]
+    fn group_p_v2_malformed_exposure_falls_back_to_blind_not_panic_not_clamped_nonsense() {
+        let bundle = load_bundle().expect("real v2 bundle must load");
+        let large = synthetic_image(640, 528);
+        let k_blind = estimate_gains(&large, 528, None, &bundle).expect("blind path never fails on real data");
+
+        let malformed_cases: [[f64; 3]; 6] = [
+            [f64::NAN, 312892.0, 259345.0],
+            [127992.0, f64::INFINITY, 259345.0],
+            [127992.0, 312892.0, f64::NEG_INFINITY],
+            [0.0, 312892.0, 259345.0],
+            [127992.0, -312892.0, 259345.0],
+            [-0.0, 312892.0, 259345.0],
+        ];
+        for exposure in malformed_cases {
+            let k = estimate_gains(&large, 528, Some(exposure), &bundle)
+                .expect("a malformed exposure_10ns must fall back to the blind estimator, never fail");
+            assert_eq!(
+                k, k_blind,
+                "malformed exposure {exposure:?} must fall back to exactly the blind gain, \
+                 proving the bad value was never divided into the ratio"
+            );
+        }
+    }
+
+    #[test]
+    fn group_p_v2_usable_exposure_still_takes_the_hardware_exposure_path() {
+        // Regression guard for the fallback logic itself: a genuinely
+        // usable exposure must NOT be routed to blind -- same exposure
+        // literal and expected gain as Group J.
+        let bundle = load_bundle().expect("real v2 bundle must load");
+        let zeros = vec![[0.0f64; 3]; 16];
+        let k = estimate_gains(&zeros, 4, Some([127992.0, 312892.0, 259345.0]), &bundle)
+            .expect("exposure path never fails");
+        assert_triple_close(k, [0.5764822683598294, 0.22818411954519974, 0.2620541212542383], "group P usable exposure");
+    }
+
+    // Group Q -- Finding 4: v1's validation was length-only (`fixed3`/`fixed2`)
+    // where Python's `_validate_layer_a` (lines 362-374) also checks
+    // finiteness, `reference_k`'s positivity, and two ordering constraints
+    // (`0 <= lo_pct < hi_pct <= 100`, `0 <= rail_lo_fraction <
+    // rail_hi_fraction <= 1`). `build_layer_a_v1` now shares v2's own
+    // validation primitives instead of those separate, weaker helpers --
+    // this group proves each newly-enforced constraint independently,
+    // Group-G/-O style (tamper one field in an otherwise-minimal fixture).
+
+    /// A minimal, otherwise-valid v1 layer_a.json fixture -- mirrors
+    /// `minimal_v2_layer_a_json`'s "one field, one targeted tamper" style.
+    /// Values are not the real bundle's own (only the shape/domain
+    /// constraints `build_layer_a_v1` checks matter here) but do satisfy
+    /// every one of them, so `group_q_minimal_v1_fixture_is_actually_valid`
+    /// below passes before any test tampers it.
+    fn minimal_v1_layer_a_json() -> String {
+        r#"{
+            "method": "percentile-stopgap-v1",
+            "lo_pct": 1.0,
+            "hi_pct": 99.0,
+            "rail_lo_fraction": 0.003,
+            "rail_hi_fraction": 0.99,
+            "gain_bounds": [0.02, 100.0],
+            "reference_lo": [0.1, 0.1, 0.1],
+            "reference_hi": [0.5, 0.5, 0.5],
+            "reference_k": [1.0, 1.0, 1.0]
+        }"#
+        .to_string()
+    }
+
+    /// Removes a top-level key from a `minimal_v1_layer_a_json`-shaped
+    /// fixture via real JSON parsing -- see Group O's own `remove_key`,
+    /// this is that same technique for v1's flat (non-nested) shape.
+    fn remove_top_level_key(json: &str, key: &str) -> String {
+        let mut value: serde_json::Value = serde_json::from_str(json).expect("fixture must be valid JSON");
+        value.as_object_mut().expect("expected a JSON object").remove(key);
+        serde_json::to_string(&value).expect("re-serialize")
+    }
+
+    fn assert_v1_fixture_invalid(json: &str, needle: &str) {
+        match parse_bundle(MODEL_JSON_V1, json, MANIFEST_JSON_V1) {
+            Ok(_) => panic!("expected Err(NikonlookError::Invalid) naming {needle:?}, got Ok(_)"),
+            Err(NikonlookError::Invalid(message)) => {
+                assert!(
+                    message.contains(needle),
+                    "expected message to contain {needle:?}, got {message:?}"
+                );
+            }
+            Err(other) => panic!("expected NikonlookError::Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn group_q_minimal_v1_fixture_is_actually_valid() {
+        // Sanity check for the tamper tests below -- see
+        // group_o_minimal_v2_fixture_is_actually_valid's own rationale.
+        parse_bundle(MODEL_JSON_V1, &minimal_v1_layer_a_json(), MANIFEST_JSON_V1)
+            .expect("untampered minimal v1 fixture must load");
+    }
+
+    #[test]
+    fn group_q_rejects_non_positive_reference_k() {
+        let json = minimal_v1_layer_a_json()
+            .replacen("\"reference_k\": [1.0, 1.0, 1.0]", "\"reference_k\": [1.0, -1.0, 1.0]", 1);
+        assert_v1_fixture_invalid(&json, "reference_k");
+    }
+
+    #[test]
+    fn group_q_rejects_wrong_length_reference_lo() {
+        // reference_lo/reference_hi are NOT positive=true in Python (only
+        // reference_k is), so this exercises the shape check alone --
+        // proving finite_array3 kept the length coverage fixed3 used to
+        // provide, not just added strictness on top.
+        let json = minimal_v1_layer_a_json()
+            .replacen("\"reference_lo\": [0.1, 0.1, 0.1]", "\"reference_lo\": [0.1, 0.1]", 1);
+        assert_v1_fixture_invalid(&json, "reference_lo");
+    }
+
+    #[test]
+    fn group_q_rejects_lo_pct_hi_pct_out_of_order() {
+        let json = minimal_v1_layer_a_json().replacen("\"lo_pct\": 1.0", "\"lo_pct\": 99.5", 1);
+        assert_v1_fixture_invalid(&json, "lo_pct");
+    }
+
+    #[test]
+    fn group_q_rejects_hi_pct_above_100() {
+        let json = minimal_v1_layer_a_json().replacen("\"hi_pct\": 99.0", "\"hi_pct\": 100.5", 1);
+        assert_v1_fixture_invalid(&json, "hi_pct");
+    }
+
+    #[test]
+    fn group_q_rejects_rail_fractions_out_of_order() {
+        let json = minimal_v1_layer_a_json()
+            .replacen("\"rail_lo_fraction\": 0.003", "\"rail_lo_fraction\": 0.995", 1);
+        assert_v1_fixture_invalid(&json, "rail_lo_fraction");
+    }
+
+    #[test]
+    fn group_q_accepts_omitted_gain_bounds_and_applies_the_default() {
+        let json = remove_top_level_key(&minimal_v1_layer_a_json(), "gain_bounds");
+        let bundle = parse_bundle(MODEL_JSON_V1, &json, MANIFEST_JSON_V1)
+            .expect("an omitted gain_bounds must default, not fail to parse");
+        let la = match &bundle.layer_a {
+            LayerA::V1(la) => la,
+            LayerA::V2(_) => panic!("expected LayerA::V1"),
+        };
+        assert_eq!(la.gain_bounds, DEFAULT_GAIN_BOUNDS);
+    }
+
+    #[test]
+    fn group_q_rejects_present_but_empty_gain_bounds() {
+        // The Some(vec![])-vs-None distinction actually matters: an
+        // EXPLICIT empty array must still fail validation, exactly like
+        // Python's `.get("gain_bounds", GAIN_BOUNDS)` only supplies the
+        // default when the KEY itself is absent, never when it's present
+        // with a wrong-shape value.
+        let json = minimal_v1_layer_a_json().replacen("\"gain_bounds\": [0.02, 100.0]", "\"gain_bounds\": []", 1);
+        assert_v1_fixture_invalid(&json, "gain_bounds");
+    }
+
+    #[test]
+    fn group_q_finite_array3_rejects_non_finite_and_non_positive_values() {
+        // NaN/Infinity can't be driven through real JSON text (serde_json
+        // itself rejects both as a parse error before this module's own
+        // validation ever runs -- see group_o_rejects_non_finite_alpha's
+        // own rationale for the identical constraint), so this unit-tests
+        // the shared primitive build_layer_a_v1's reference_lo/reference_hi/
+        // reference_k checks (and several of build_layer_a_v2's) all rely
+        // on, directly.
+        let non_finite = finite_array3(&[1.0, f64::NAN, 1.0], "test:field", false);
+        assert!(
+            matches!(non_finite, Err(NikonlookError::Invalid(_))),
+            "NaN must be rejected regardless of `positive`: {non_finite:?}"
+        );
+
+        let non_positive = finite_array3(&[1.0, -1.0, 1.0], "test:field", true);
+        assert!(
+            matches!(non_positive, Err(NikonlookError::Invalid(_))),
+            "a negative value must be rejected when positive=true: {non_positive:?}"
+        );
+
+        let negative_allowed = finite_array3(&[1.0, -1.0, 1.0], "test:field", false);
+        assert!(
+            negative_allowed.is_ok(),
+            "a negative value must be accepted when positive=false (reference_lo/reference_hi's own case): {negative_allowed:?}"
+        );
     }
 }

--- a/app/ScanStudio/engine/src/real_backend.rs
+++ b/app/ScanStudio/engine/src/real_backend.rs
@@ -2882,9 +2882,12 @@ fn nikonlook_exposure_meta_enabled() -> bool {
 /// own exposure telemetry (µs -> 10ns ticks, RGB order), gated by
 /// `nikonlook_exposure_meta_enabled`. `None` whenever the gate is off, or
 /// whenever any of the three channels isn't a finite positive value —
-/// `estimate_gains`'s exposure path requires all three (see its own
-/// `debug_assert!`), and a partially-populated or degenerate receipt should
-/// fall back to the blind estimator rather than feed it a bad ratio.
+/// `estimate_gains`'s exposure path only trusts a value that passes
+/// `processing::nikonlook::exposure_is_usable` (finite and > 0 on every
+/// channel), routing anything else to its blind fallback instead of
+/// asserting or erroring (see that function's own doc comment), so a
+/// partially-populated or degenerate receipt is caught here too rather than
+/// relying solely on that downstream fallback.
 fn nikonlook_exposure_10ns_from_receipt(exposure: &BridgeExposureVector) -> Option<[f64; 3]> {
     if !nikonlook_exposure_meta_enabled() {
         return None;
@@ -2996,6 +2999,11 @@ fn build_real_receipt(
             focus_detail: map_focus_detail_telemetry(&bridge_receipt.focus_detail),
             transport_smear: map_transport_smear_assessment(&bridge_receipt.transport_smear),
         }),
+        // Derivative rendering (and thus nikonlook) hasn't run yet at this
+        // point -- mirrors `outputs: None` above. Patched in alongside
+        // `outputs` once `render_derivative_from_archive_with_processing`
+        // actually completes, from its own `WrittenPaths.nikonlook`.
+        nikonlook: None,
     }
 }
 
@@ -4574,6 +4582,10 @@ fn run_real_scan_job_inner(
                                         .preview_path
                                         .map(|path| path.display().to_string()),
                                 });
+                                // Which nikonlook bundle/path/gains actually
+                                // rendered this frame -- see build_real_receipt's
+                                // own `nikonlook: None` comment above.
+                                receipt.nikonlook = written.nikonlook;
                                 if let Ok(mut evidence) = shared_evidence.lock() {
                                     if let Some(frame) = evidence.iter_mut().rev().find(|value| value.frame_index == frame_completed.slot) {
                                         frame.engine_receipt["receipt"] = serde_json::to_value(&receipt)

--- a/app/ScanStudio/engine/src/render.rs
+++ b/app/ScanStudio/engine/src/render.rs
@@ -1621,12 +1621,23 @@ fn metadata_date_tokens(date: Option<&domain::PartialDate>) -> (String, String, 
 /// `real_backend.rs`), `None` otherwise (simulator, or the exposure path
 /// opted out), which routes v2 to its blind fallback instead of the
 /// hardware-exposure inverse.
+///
+/// Returns the rendered positive plus, for a C41 frame, the nikonlook
+/// provenance (bundle version, which Layer-A path actually ran, the exact
+/// gains applied) so a caller can surface it in the frame's receipt — see
+/// `domain::NikonlookProvenance`. `None` for every non-C41 process, which
+/// never touches nikonlook at all. `exposure_10ns.is_some()` alone is NOT
+/// enough to determine which path ran: `estimate_gains` silently falls
+/// back to blind on an unusable exposure value (Finding 5), so the actual
+/// path is derived here via `nikonlook::exposure_is_usable` — the same
+/// predicate `estimate_gains` itself gates on — rather than assumed from
+/// the caller's input.
 fn render_positive(
     film_process: domain::FilmProcess,
     raw: &[[f64; 3]],
     width: usize,
     exposure_10ns: Option<[f64; 3]>,
-) -> Result<Vec<[f64; 3]>, domain::EngineError> {
+) -> Result<(Vec<[f64; 3]>, Option<domain::NikonlookProvenance>), domain::EngineError> {
     match film_process {
         domain::FilmProcess::C41ColorNegative => {
             let bundle = crate::processing::nikonlook::load_bundle().map_err(|err| {
@@ -1642,16 +1653,29 @@ fn render_positive(
                         format!("nikonlook gain estimation failed: {err}"),
                     )
                 })?;
-            Ok(crate::processing::nikonlook::apply(raw, k, &bundle))
+            let positive = crate::processing::nikonlook::apply(raw, k, &bundle);
+            let layer_a_path = if exposure_10ns.is_some_and(crate::processing::nikonlook::exposure_is_usable) {
+                domain::NikonlookLayerAPath::HardwareExposure
+            } else {
+                domain::NikonlookLayerAPath::Blind
+            };
+            let provenance = domain::NikonlookProvenance {
+                bundle_version: bundle.bundle_version.clone(),
+                layer_a_path,
+                gains: k,
+            };
+            Ok((positive, Some(provenance)))
         }
-        domain::FilmProcess::BwNegative => Ok(raw
-            .iter()
-            .map(|pixel| {
-                let inverted = 1.0 - (pixel[0] + pixel[1] + pixel[2]) / 3.0;
-                [inverted, inverted, inverted]
-            })
-            .collect()),
-        domain::FilmProcess::Positive | domain::FilmProcess::Kodachrome => Ok(raw.to_vec()),
+        domain::FilmProcess::BwNegative => Ok((
+            raw.iter()
+                .map(|pixel| {
+                    let inverted = 1.0 - (pixel[0] + pixel[1] + pixel[2]) / 3.0;
+                    [inverted, inverted, inverted]
+                })
+                .collect(),
+            None,
+        )),
+        domain::FilmProcess::Positive | domain::FilmProcess::Kodachrome => Ok((raw.to_vec(), None)),
     }
 }
 
@@ -1896,6 +1920,7 @@ pub fn render_derivative_from_archive_with_processing(
             archive_path: recipes.archive.enabled.then(|| archive_rgb_path.to_path_buf()),
             positive_path: None,
             preview_path: None,
+            nikonlook: None,
         });
     }
 
@@ -1966,7 +1991,8 @@ pub fn render_derivative_from_archive_with_processing(
         .collect();
     drop(raw_image);
 
-    let positive_full = render_positive(processing.film_process, &raw_linear, width as usize, exposure_10ns)?;
+    let (positive_full, nikonlook) =
+        render_positive(processing.film_process, &raw_linear, width as usize, exposure_10ns)?;
     drop(raw_linear);
     let positive_full = if processing.film_process == domain::FilmProcess::BwNegative
         && processing.software_dust_removal_bw
@@ -2033,6 +2059,7 @@ pub fn render_derivative_from_archive_with_processing(
         archive_path,
         positive_path,
         preview_path,
+        nikonlook,
     })
 }
 
@@ -2385,6 +2412,10 @@ pub struct WrittenPaths {
     pub archive_path: Option<std::path::PathBuf>,
     pub positive_path: Option<std::path::PathBuf>,
     pub preview_path: Option<std::path::PathBuf>,
+    /// See `render_positive`'s own doc comment. `None` whenever no
+    /// positive/preview was rendered this call, or the rendered frame
+    /// wasn't C41.
+    pub nikonlook: Option<domain::NikonlookProvenance>,
 }
 
 /// Renders one frame's deterministic simulated pixel data and writes the
@@ -2437,13 +2468,16 @@ pub fn render_and_write_frame_with_processing(
 
     let mut positive_path: Option<std::path::PathBuf> = None;
     let mut preview_path: Option<std::path::PathBuf> = None;
+    let mut nikonlook_provenance: Option<domain::NikonlookProvenance> = None;
 
     if recipes.positive.enabled || recipes.preview.enabled {
         // Computed once -- both derivatives share it rather than each
         // calling render_positive (and thus reloading/re-estimating
         // nikonlook) independently. The simulator has no hardware exposure
         // to report, so nikonlook v2 always uses its blind fallback here.
-        let positive_raw_full = render_positive(processing.film_process, &raw, width as usize, None)?;
+        let (positive_raw_full, provenance) =
+            render_positive(processing.film_process, &raw, width as usize, None)?;
+        nikonlook_provenance = provenance;
         let positive_raw_full = if processing.film_process == domain::FilmProcess::BwNegative
             && processing.software_dust_removal_bw
         {
@@ -2489,6 +2523,7 @@ pub fn render_and_write_frame_with_processing(
         archive_path,
         positive_path,
         preview_path,
+        nikonlook: nikonlook_provenance,
     })
 }
 
@@ -3252,19 +3287,99 @@ mod tests {
     #[test]
     fn render_positive_actually_transforms_c41_color_negative() {
         let raw = generate_sim_frame("sim-ls5000-0", 1, 8, 6);
-        let out = render_positive(domain::FilmProcess::C41ColorNegative, &raw, 8, None)
+        let (out, provenance) = render_positive(domain::FilmProcess::C41ColorNegative, &raw, 8, None)
             .expect("nikonlook bundle must load and apply");
         assert_ne!(out, raw, "nikonlook must actually transform the data");
+
+        // Finding 2: a C41 render must surface its nikonlook provenance --
+        // no exposure metadata supplied, so the blind path must have run.
+        let provenance = provenance.expect("a C41 render must report nikonlook provenance");
+        assert_eq!(provenance.bundle_version, "nikonlook-v2");
+        assert_eq!(provenance.layer_a_path, domain::NikonlookLayerAPath::Blind);
+        assert!(
+            provenance.gains.iter().all(|value| value.is_finite() && *value > 0.0),
+            "reported gains must be the real, finite, positive values estimate_gains returned: {:?}",
+            provenance.gains
+        );
+
+        // The reported gains must be exactly what produced `out`, not a
+        // separately-computed or stale value: re-applying them from scratch
+        // against a freshly loaded bundle must reproduce the actual render.
+        let bundle = crate::processing::nikonlook::load_bundle().expect("real v2 bundle must load");
+        let reapplied = crate::processing::nikonlook::apply(&raw, provenance.gains, &bundle);
+        assert_eq!(
+            reapplied, out,
+            "apply()'d output using the reported gains must equal the actual render"
+        );
+    }
+
+    /// Same literal as `processing::nikonlook`'s own Group J/N tests and
+    /// `tests/nikonlook_v2_fixture.rs`'s `EXPOSURE_10NS_FRAME5` -- a real,
+    /// usable exposure triple.
+    const USABLE_EXPOSURE_10NS: [f64; 3] = [127992.0, 312892.0, 259345.0];
+
+    #[test]
+    fn render_positive_c41_with_usable_exposure_labels_hardware_exposure() {
+        let raw = generate_sim_frame("sim-ls5000-0", 1, 8, 6);
+        let (out, provenance) = render_positive(
+            domain::FilmProcess::C41ColorNegative,
+            &raw,
+            8,
+            Some(USABLE_EXPOSURE_10NS),
+        )
+        .expect("nikonlook bundle must load and apply");
+
+        let provenance = provenance.expect("a C41 render must report nikonlook provenance");
+        assert_eq!(provenance.bundle_version, "nikonlook-v2");
+        assert_eq!(
+            provenance.layer_a_path,
+            domain::NikonlookLayerAPath::HardwareExposure,
+            "a usable exposure_10ns must route to the hardware-exposure path, not fall back to blind"
+        );
+
+        let bundle = crate::processing::nikonlook::load_bundle().expect("real v2 bundle must load");
+        let expected_gains =
+            crate::processing::nikonlook::estimate_gains(&raw, 8, Some(USABLE_EXPOSURE_10NS), &bundle)
+                .expect("exposure path never fails");
+        assert_eq!(
+            provenance.gains, expected_gains,
+            "reported gains must equal estimate_gains' own output for this exposure"
+        );
+        let reapplied = crate::processing::nikonlook::apply(&raw, provenance.gains, &bundle);
+        assert_eq!(reapplied, out, "apply()'d output using the reported gains must equal the actual render");
+    }
+
+    #[test]
+    fn render_positive_c41_with_malformed_exposure_falls_back_to_blind() {
+        let raw = generate_sim_frame("sim-ls5000-0", 1, 8, 6);
+        // Non-finite, zero, and negative components are all "unusable" --
+        // see processing::nikonlook::exposure_is_usable. One representative
+        // case here; that predicate's own exhaustive cases are covered by
+        // Group P in processing/nikonlook.rs.
+        let malformed = [f64::NAN, 312892.0, 259345.0];
+
+        let (_, provenance) =
+            render_positive(domain::FilmProcess::C41ColorNegative, &raw, 8, Some(malformed))
+                .expect("a malformed exposure must fall back to blind, never fail");
+
+        let provenance = provenance.expect("a C41 render must report nikonlook provenance");
+        assert_eq!(
+            provenance.layer_a_path,
+            domain::NikonlookLayerAPath::Blind,
+            "a malformed exposure_10ns must be treated like None, not silently divided into a gain"
+        );
     }
 
     #[test]
     fn render_positive_passthroughs_positive_kodachrome_and_neutral_inverts_bw_negative() {
         let raw = generate_sim_frame("sim-ls5000-0", 1, 8, 6);
         for process in [domain::FilmProcess::Positive, domain::FilmProcess::Kodachrome] {
-            let out = render_positive(process, &raw, 8, None).expect("passthrough never fails");
+            let (out, provenance) = render_positive(process, &raw, 8, None).expect("passthrough never fails");
             assert_eq!(out, raw, "{process:?} must be an exact passthrough");
+            assert!(provenance.is_none(), "{process:?} never runs nikonlook, so provenance must be None");
         }
-        let bw = render_positive(domain::FilmProcess::BwNegative, &raw, 8, None).unwrap();
+        let (bw, bw_provenance) = render_positive(domain::FilmProcess::BwNegative, &raw, 8, None).unwrap();
+        assert!(bw_provenance.is_none(), "BwNegative never runs nikonlook, so provenance must be None");
         for (source, rendered) in raw.iter().zip(bw) {
             let expected = 1.0 - (source[0] + source[1] + source[2]) / 3.0;
             assert_eq!(rendered, [expected; 3]);
@@ -3327,6 +3442,64 @@ mod tests {
         let positive = image_io::read_rgb16(written.positive_path.as_ref().unwrap())
             .expect("positive is a readable RGB16 TIFF");
         assert_eq!((positive.width, positive.height), (8, 6));
+
+        // This is the exact function real_backend.rs's `run_real_scan_job_inner`
+        // calls (`render_derivative_from_archive` is a thin exposure_10ns=None
+        // wrapper around `render_derivative_from_archive_with_processing`) --
+        // its `WrittenPaths.nikonlook` is copied verbatim into
+        // `ScanReceipt.nikonlook` there (`receipt.nikonlook = written.nikonlook;`).
+        // Proving it here, written for a real archive file on disk, is the
+        // closest feasible proof of that patch-in short of standing up a
+        // fake bridge subprocess to drive `run_real_scan_job_inner` itself.
+        let provenance = written.nikonlook.expect("a C41 archive render must report nikonlook provenance");
+        assert_eq!(provenance.bundle_version, "nikonlook-v2");
+        assert_eq!(
+            provenance.layer_a_path,
+            domain::NikonlookLayerAPath::Blind,
+            "render_derivative_from_archive supplies no exposure_10ns, so blind must have run"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn real_archive_derivative_nikonlook_provenance_tracks_exposure_usability() {
+        let dir = unique_test_dir();
+        let archive_path = dir.join("Archive").join("Archive_0001.tif");
+        write_small_rgb16_tiff(&archive_path, 8, 6);
+
+        let mut recipes = domain::OutputRecipe::default();
+        recipes.preview.enabled = false;
+        let processing = domain::ProcessingRecipe {
+            film_process: domain::FilmProcess::C41ColorNegative,
+            ..domain::ProcessingRecipe::default()
+        };
+
+        // A usable exposure -- the real_backend.rs path opted into it and
+        // the bridge supplied a finite, positive triple.
+        recipes.positive.destination = dir.join("Hardware").display().to_string();
+        let written_hardware = render_derivative_from_archive_with_processing(
+            &archive_path, 1, &processing, &recipes, Some(STORAGE_TRANSFORM_SWAPAXES01),
+            None, None, None, Some(USABLE_EXPOSURE_10NS),
+        )
+        .expect("render real derivatives");
+        let hardware_provenance = written_hardware
+            .nikonlook
+            .expect("a C41 archive render must report nikonlook provenance");
+        assert_eq!(hardware_provenance.layer_a_path, domain::NikonlookLayerAPath::HardwareExposure);
+
+        // A malformed exposure -- must fall back to blind, never fail or
+        // silently divide a meaningless ratio into the gain.
+        recipes.positive.destination = dir.join("Malformed").display().to_string();
+        let written_malformed = render_derivative_from_archive_with_processing(
+            &archive_path, 1, &processing, &recipes, Some(STORAGE_TRANSFORM_SWAPAXES01),
+            None, None, None, Some([f64::NAN, 312892.0, 259345.0]),
+        )
+        .expect("a malformed exposure must fall back to blind, never fail");
+        let malformed_provenance = written_malformed
+            .nikonlook
+            .expect("a C41 archive render must report nikonlook provenance");
+        assert_eq!(malformed_provenance.layer_a_path, domain::NikonlookLayerAPath::Blind);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/app/ScanStudio/engine/src/server.rs
+++ b/app/ScanStudio/engine/src/server.rs
@@ -2536,6 +2536,7 @@ mod tests {
                     texture_span: Some(0.15),
                 },
             }),
+            nikonlook: None,
         }
     }
 
@@ -2653,6 +2654,7 @@ mod tests {
             storage_transform: None,
             meter_rgbi_path: None,
             hardware_telemetry: None,
+            nikonlook: None,
         }
     }
 
@@ -3068,6 +3070,7 @@ mod tests {
             storage_transform: None,
             meter_rgbi_path: None,
             hardware_telemetry: None,
+            nikonlook: None,
         };
         // Attach the receipt both to the on-disk manifest (the production
         // path) and to the in-memory project state so the subsequent

--- a/app/ScanStudio/engine/src/sim.rs
+++ b/app/ScanStudio/engine/src/sim.rs
@@ -826,6 +826,7 @@ fn build_receipt(
         storage_transform: None,
         meter_rgbi_path: None,
         hardware_telemetry: None,
+        nikonlook: written.nikonlook.clone(),
     }
 }
 
@@ -1390,6 +1391,45 @@ mod tests {
             channels: Channels::Rgbi,
         };
         assert_eq!(settings_fingerprint(&recipe), "1a3d265e0b54bbd2");
+    }
+
+    #[test]
+    fn build_receipt_carries_written_nikonlook_provenance_through_unchanged() {
+        // The one line this test exists to guard: `build_receipt`'s
+        // `nikonlook: written.nikonlook.clone()` (unlike real_backend.rs's
+        // two-phase `None`-then-patch, the simulator has its
+        // `WrittenPaths` in hand before it ever constructs a receipt, so it
+        // wires the field directly). Deleting that line and replacing it
+        // with `None` would compile fine and, before this test, break
+        // nothing else.
+        let recipe = CaptureRecipe::default();
+        let processing = ProcessingRecipe {
+            film_process: FilmProcess::C41ColorNegative,
+            ..ProcessingRecipe::default()
+        };
+        let output = OutputRecipe::default();
+        let provenance = crate::domain::NikonlookProvenance {
+            bundle_version: "nikonlook-v2".to_string(),
+            layer_a_path: crate::domain::NikonlookLayerAPath::Blind,
+            gains: [0.7767985641162477, 0.49546023790785987, 0.2824666578885106],
+        };
+        let written = crate::render::WrittenPaths {
+            archive_path: None,
+            positive_path: None,
+            preview_path: None,
+            nikonlook: Some(provenance.clone()),
+        };
+
+        let receipt = build_receipt("job-1", 1, 1000, &recipe, &processing, &output, DEVICE_ID, &written);
+        assert_eq!(receipt.nikonlook, Some(provenance));
+
+        // The `None` side must also pass through unchanged -- a C41 render
+        // is not guaranteed to have provenance either (e.g. a legacy
+        // pre-Fix-2 written struct), and build_receipt must not fabricate one.
+        let written_none = crate::render::WrittenPaths { nikonlook: None, ..written };
+        let receipt_none =
+            build_receipt("job-1", 1, 1000, &recipe, &processing, &output, DEVICE_ID, &written_none);
+        assert_eq!(receipt_none.nikonlook, None);
     }
 
     #[test]

--- a/app/ScanStudio/engine/tests/memory_ceiling.rs
+++ b/app/ScanStudio/engine/tests/memory_ceiling.rs
@@ -77,6 +77,22 @@ unsafe impl GlobalAlloc for CountingAllocator {
 /// the counter is only ever read as a clean baseline.
 static SERIALIZE: Mutex<()> = Mutex::new(());
 
+/// Acquires `SERIALIZE`, recovering the guard even if a previous holder
+/// panicked while it was held, instead of propagating that as a
+/// `PoisonError` here. `SERIALIZE` protects mutual exclusion between these
+/// two tests' bodies only (see its own doc comment) -- it guards no shared
+/// data of its own (`Mutex<()>`, not e.g. `Mutex<Vec<...>>`), so a poisoned
+/// lock here reflects a previous TEST failing its own assertions, never
+/// data left in an inconsistent state by a panic mid-mutation. Propagating
+/// the poison anyway is exactly how one test's panic used to cascade into
+/// a second, unrelated failure for whichever test happened to run next in
+/// the same process (confirmed empirically: `cargo test --release
+/// --test-threads=1` before this fix failed BOTH tests, the second one
+/// only on `PoisonError`, never reaching its own logic at all).
+fn acquire_serialize() -> std::sync::MutexGuard<'static, ()> {
+    SERIALIZE.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// How often to sample `CURRENT` while waiting for it to go quiet.
 const QUIESCENCE_POLL_INTERVAL: Duration = Duration::from_millis(2);
 
@@ -135,7 +151,7 @@ fn wait_for_allocator_quiescence() {
 
 #[test]
 fn counting_allocator_tracks_a_known_allocation() {
-    let _guard = SERIALIZE.lock().unwrap();
+    let _guard = acquire_serialize();
 
     // Whichever test acquires SERIALIZE first, treat the shared counter as
     // untrustworthy until it has held still for a while -- see the
@@ -148,6 +164,20 @@ fn counting_allocator_tracks_a_known_allocation() {
     let layout = Layout::from_size_align(known_size, 1).unwrap();
     let ptr = unsafe { std::alloc::alloc(layout) };
     assert!(!ptr.is_null(), "known-size allocation should succeed");
+
+    // In `--release`, a raw alloc/dealloc pair with nothing observably done
+    // to the memory in between is exactly the "dead allocation" pattern
+    // LLVM is free to remove outright, regardless of what the registered
+    // `#[global_allocator]` does on the side -- confirmed empirically: this
+    // probe's 10 MB `alloc` produced zero movement in `CURRENT` under
+    // `--release` before this write/read existed (`baseline == current`).
+    // A volatile write followed by a `black_box`ed volatile read is a real,
+    // non-elidable use of `ptr` sitting between the alloc and dealloc
+    // calls, so the compiler can no longer prove the pair has no effect --
+    // in both profiles, not just debug.
+    unsafe { std::ptr::write_volatile(ptr, 0xABu8) };
+    let observed = std::hint::black_box(unsafe { std::ptr::read_volatile(ptr) });
+    assert_eq!(observed, 0xAB, "the volatile probe write must read back before the counter check below");
 
     let current = CURRENT.load(Ordering::SeqCst);
     assert!(
@@ -165,7 +195,7 @@ fn counting_allocator_tracks_a_known_allocation() {
 
 #[test]
 fn sim_batch_scan_peak_memory_stays_within_a_few_frames_worth_not_the_whole_roll() {
-    let _guard = SERIALIZE.lock().unwrap();
+    let _guard = acquire_serialize();
 
     let dir = std::env::temp_dir().join(format!(
         "scanstudio-memtest-{}-{}",

--- a/app/ScanStudio/engine/tests/nikonlook_v2_fixture.rs
+++ b/app/ScanStudio/engine/tests/nikonlook_v2_fixture.rs
@@ -2,13 +2,28 @@
 //! archive and its registered Nikon Scan reference render — following
 //! `tests/real_derivative_backfill.rs`'s env-gated pattern (`#[ignore]`d by
 //! default; normal `cargo test` runs never depend on files this test
-//! needs). Proves the numbers cited in `resources/nikonlook-v2/
-//! PROVENANCE.md` and the module doc comment in
-//! `src/processing/nikonlook.rs`: v2's blind path measures materially
-//! closer to Nikon Scan's own render than v1 did, on the same live frame.
+//! needs).
+//!
+//! What this test actually proves, on one real frame ("SCANSTUDIO5"):
+//! it renders all three Layer-A paths `nikonlook_core.py`/`nikonlook.rs`
+//! support — v1's `percentile-stopgap-v1`, v2's blind
+//! `log-ridge-raw-features-v1`, and v2's `inverse-hardware-exposure-v1` —
+//! through the real `estimate_gains` -> `apply` chain, diffs each render's
+//! interior pixels against the registered Nikon Scan reference on the same
+//! sampling grid, and asserts v2's blind path is MATERIALLY closer than
+//! v1's (not just under a loose ceiling): this is the actual comparison
+//! `resources/nikonlook-v2/PROVENANCE.md` and `src/processing/nikonlook.rs`'s
+//! module doc comment cite, not merely a single-path sanity check dressed
+//! up as one. Before any of that: it verifies the archive and Nikon
+//! reference files it was pointed at are the exact ones this test's
+//! frame-specific literals were harvested from, via a content hash of each
+//! file's decoded pixels — so pointing the path env vars at an unrelated
+//! file fails loudly on that check, not on a confusing downstream number
+//! mismatch (or, worse, a coincidental pass).
 
 use scanstudio_engine::parity::image_io::{read_rgb16, Rgb16Image};
 use scanstudio_engine::processing::nikonlook;
+use sha2::{Digest, Sha256};
 
 /// Same literal as the frame-5 hardware exposure ticks used by
 /// `nikonlook.rs`'s in-module Group J test — the exposure path is
@@ -25,11 +40,32 @@ const K_EXPOSURE_SCANSTUDIO5: [f64; 3] = [0.5764822683598294, 0.2281841195451997
 /// (`Bundle.curves` is a private field), so this is hardcoded against the
 /// vendored, never-hand-edited nikonlook-v2 model.json (see
 /// `resources/nikonlook-v2/PROVENANCE.md` — Layer B is byte-identical to
-/// v1's, so this is also Group F's/Group A's pinned v1 literal).
+/// v1's, so this is also Group F's/Group A's pinned v1 literal, and the
+/// same floor applies to a v1 render just as much as a v2 one).
 const R_CURVE_GRID_Y0: f64 = 0.8745168478139992;
 
 const MARGIN: u32 = 200;
 const STEP: u32 = 5;
+
+/// Regression ceilings, DN (16-bit full-scale), with headroom over the
+/// 2026-07-28 measured values in `resources/nikonlook-v2/PROVENANCE.md`'s
+/// table (v2 blind [3565, 6682, 3340]; v2 exposure [9560, 8064, 3454]) —
+/// tight enough to catch a real regression, loose enough to absorb
+/// legitimate measurement noise (float accumulation order, a different
+/// but equally valid registration dy/dx). These are a supplementary
+/// regression guard; the comparative assertion against a genuinely
+/// rendered v1 (below) is the primary proof of "v2 is materially better."
+const V2_BLIND_CEILING_DN: [f64; 3] = [4300.0, 8000.0, 4000.0];
+const V2_EXPOSURE_CEILING_DN: [f64; 3] = [12500.0, 10500.0, 4500.0];
+
+/// How much lower v2's median |delta| must be than v1's, per channel, to
+/// count as "materially" closer rather than a coincidental few-DN
+/// improvement. 0.75 (v2 must be at least 25% better) is deliberately
+/// generous: the measured ratios are far larger (v2 blind is roughly
+/// 2x-5x better than v1 across channels per PROVENANCE.md), so this bar
+/// has wide headroom while still catching a real regression that erodes
+/// most of v2's advantage.
+const MATERIALLY_LOWER_RATIO: f64 = 0.75;
 
 fn to_raw_linear(image: &Rgb16Image) -> Vec<[f64; 3]> {
     image
@@ -58,6 +94,135 @@ fn median(mut values: Vec<f64>) -> f64 {
     }
 }
 
+// ---------------------------------------------------------------------
+// Input-identity guard (Finding 3): a content hash of each decoded image
+// (dimensions + pixels, not the raw file bytes -- a lossless re-save under
+// different TIFF compression settings still matches), checked against an
+// operator-pinned expected value before any frame-specific numeric
+// assertion runs.
+// ---------------------------------------------------------------------
+
+fn content_hash(image: &Rgb16Image) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(image.width.to_le_bytes());
+    hasher.update(image.height.to_le_bytes());
+    for pixel in &image.pixels {
+        for channel in pixel {
+            hasher.update(channel.to_le_bytes());
+        }
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// `expected` is already resolved from an env var by the caller (kept as a
+/// plain parameter, not read here, so this function is a pure panic/no-panic
+/// decision and can be unit-tested without touching global process state).
+/// Panics on a mismatch (wrong file — names the field, shows both hashes)
+/// or on `None` (not yet pinned — shows the computed hash so a first run
+/// can bootstrap the expected value); never silently proceeds either way.
+fn assert_expected_content_hash(actual: &str, expected: Option<&str>, env_var_name: &str, label: &str) {
+    match expected {
+        Some(expected) if expected == actual => {}
+        Some(expected) => panic!(
+            "{label} content hash mismatch: {env_var_name}={expected:?} but the file at the \
+             configured path decodes to {actual:?}. This test's frame-specific literals \
+             (K_BLIND_SCANSTUDIO5, K_EXPOSURE_SCANSTUDIO5, the regression ceilings) were \
+             harvested from ONE specific frame -- pointing the path env var at a different \
+             file must fail here, not produce a coincidental pass or a confusing downstream \
+             number mismatch."
+        ),
+        None => panic!(
+            "{env_var_name} is not set. Refusing to run frame-specific assertions against an \
+             unpinned {label} file. This run's file decodes to content hash {actual:?} -- if \
+             this is the expected SCANSTUDIO5 frame, set {env_var_name}={actual} and re-run."
+        ),
+    }
+}
+
+#[test]
+fn assert_expected_content_hash_accepts_match_and_rejects_mismatch_or_missing() {
+    assert_expected_content_hash("abc123", Some("abc123"), "SCANSTUDIO_TEST_EXAMPLE_SHA256", "example");
+
+    let mismatch = std::panic::catch_unwind(|| {
+        assert_expected_content_hash("abc123", Some("def456"), "SCANSTUDIO_TEST_EXAMPLE_SHA256", "example")
+    });
+    assert!(mismatch.is_err(), "a wrong expected hash must panic, not silently pass");
+
+    let missing = std::panic::catch_unwind(|| {
+        assert_expected_content_hash("abc123", None, "SCANSTUDIO_TEST_EXAMPLE_SHA256", "example")
+    });
+    assert!(missing.is_err(), "an unset expected-hash env var must panic, not silently pass");
+}
+
+// ---------------------------------------------------------------------
+// Registered-grid agreement measurement, shared by all three rendered
+// paths below so the loop logic isn't tripled.
+// ---------------------------------------------------------------------
+
+struct Agreement {
+    /// Per-channel median absolute difference, in DN (16-bit full-scale).
+    median_abs_diff_dn: [f64; 3],
+    /// Fraction of sampled pixels whose R channel is pinned at the R
+    /// curve's floor (`R_CURVE_GRID_Y0`) -- a proxy for "how often this
+    /// path pushes the gain low enough to underflow the curve," which
+    /// PROVENANCE.md's table also reports per path.
+    r_pinned_fraction: f64,
+    sampled: usize,
+}
+
+/// Registered interior grid: sample every STEP-th pixel at least MARGIN
+/// from the archive's own edges, mapping each archive (y, x) to the Nikon
+/// reference's (y + dy, x + dx) -- the fixed registration shift between
+/// the two rasters. Points whose shifted coordinate falls outside the
+/// reference are skipped rather than clamped, so a wrong dy/dx cannot
+/// silently compare the wrong pixels.
+fn measure_agreement(
+    rendered: &[[f64; 3]],
+    archive_width: u32,
+    archive_height: u32,
+    nikon_ref: &Rgb16Image,
+    dy: i64,
+    dx: i64,
+) -> Agreement {
+    let mut abs_diff: [Vec<f64>; 3] = [Vec::new(), Vec::new(), Vec::new()];
+    let mut r_pinned = 0usize;
+    let mut sampled = 0usize;
+
+    let y_end = archive_height.saturating_sub(MARGIN);
+    let x_end = archive_width.saturating_sub(MARGIN);
+    let mut y = MARGIN;
+    while y < y_end {
+        let mut x = MARGIN;
+        while x < x_end {
+            let ref_y = y as i64 + dy;
+            let ref_x = x as i64 + dx;
+            if ref_y >= 0 && ref_x >= 0 && (ref_y as u32) < nikon_ref.height && (ref_x as u32) < nikon_ref.width {
+                let rendered_px = rendered[(y * archive_width + x) as usize];
+                let ref_px = nikon_ref.pixels[(ref_y as u32 * nikon_ref.width + ref_x as u32) as usize];
+                for c in 0..3 {
+                    let rendered_dn = rendered_px[c] * 65535.0;
+                    let ref_dn = ref_px[c] as f64;
+                    abs_diff[c].push((rendered_dn - ref_dn).abs());
+                }
+                if (rendered_px[0] * 65535.0 - R_CURVE_GRID_Y0 * 65535.0).abs() < 1.0 {
+                    r_pinned += 1;
+                }
+                sampled += 1;
+            }
+            x += STEP;
+        }
+        y += STEP;
+    }
+    assert!(sampled > 0, "registration grid produced zero in-bounds sample points -- check dy/dx");
+
+    let [d0, d1, d2] = abs_diff;
+    Agreement {
+        median_abs_diff_dn: [median(d0), median(d1), median(d2)],
+        r_pinned_fraction: r_pinned as f64 / sampled as f64,
+        sampled,
+    }
+}
+
 #[test]
 #[ignore = "requires explicit real-archive environment variables"]
 fn nikonlook_v2_blind_render_tracks_the_nikon_reference_on_a_real_frame() {
@@ -77,11 +242,39 @@ fn nikonlook_v2_blind_render_tracks_the_nikon_reference_on_a_real_frame() {
     let archive = read_rgb16(std::path::Path::new(&archive_path)).expect("archive TIF must decode");
     let nikon_ref =
         read_rgb16(std::path::Path::new(&nikon_ref_path)).expect("Nikon reference TIF must decode");
+
+    // Input-identity guard -- must run before any frame-specific numeric
+    // assertion below (see this module's doc comment and Finding 3).
+    assert_expected_content_hash(
+        &content_hash(&archive),
+        std::env::var("SCANSTUDIO_TEST_ARCHIVE_SHA256").ok().as_deref(),
+        "SCANSTUDIO_TEST_ARCHIVE_SHA256",
+        "archive",
+    );
+    assert_expected_content_hash(
+        &content_hash(&nikon_ref),
+        std::env::var("SCANSTUDIO_TEST_NIKON_REF_SHA256").ok().as_deref(),
+        "SCANSTUDIO_TEST_NIKON_REF_SHA256",
+        "Nikon reference",
+    );
+
     let raw_linear = to_raw_linear(&archive);
+    let bundle_v2 = nikonlook::load_bundle().expect("real v2 bundle must load");
+    let bundle_v1 = nikonlook::load_bundle_v1().expect("real v1 bundle must load");
 
-    let bundle = nikonlook::load_bundle().expect("real v2 bundle must load");
+    // -- v1: percentile-stopgap-v1. No exact gain literal to pin (this
+    // fixture's original author never harvested one), so this path is
+    // proven purely by the comparative assertions below, not an exact
+    // number -- inventing an unverifiable literal would be worse than not
+    // having one.
+    let k_v1 = nikonlook::estimate_gains(&raw_linear, archive.width as usize, None, &bundle_v1)
+        .expect("v1 estimate_gains never fails");
+    let rendered_v1 = nikonlook::apply(&raw_linear, k_v1, &bundle_v1);
+    let agreement_v1 = measure_agreement(&rendered_v1, archive.width, archive.height, &nikon_ref, dy, dx);
 
-    let k_blind = nikonlook::estimate_gains(&raw_linear, archive.width as usize, None, &bundle)
+    // -- v2 blind: log-ridge-raw-features-v1 (the production default path
+    // when no exposure metadata is supplied).
+    let k_blind = nikonlook::estimate_gains(&raw_linear, archive.width as usize, None, &bundle_v2)
         .expect("blind gain estimation must succeed on a real archive");
     for c in 0..3 {
         let diff = (k_blind[c] - K_BLIND_SCANSTUDIO5[c]).abs();
@@ -92,12 +285,17 @@ fn nikonlook_v2_blind_render_tracks_the_nikon_reference_on_a_real_frame() {
             k_blind[c]
         );
     }
+    let rendered_blind = nikonlook::apply(&raw_linear, k_blind, &bundle_v2);
+    let agreement_blind = measure_agreement(&rendered_blind, archive.width, archive.height, &nikon_ref, dy, dx);
 
+    // -- v2 exposure: inverse-hardware-exposure-v1. Previously computed but
+    // never actually rendered or compared against the reference (Finding
+    // 3) -- now genuinely proven like the other two paths.
     let k_exposure = nikonlook::estimate_gains(
         &raw_linear,
         archive.width as usize,
         Some(EXPOSURE_10NS_FRAME5),
-        &bundle,
+        &bundle_v2,
     )
     .expect("exposure gain estimation never fails");
     for c in 0..3 {
@@ -109,64 +307,90 @@ fn nikonlook_v2_blind_render_tracks_the_nikon_reference_on_a_real_frame() {
             k_exposure[c]
         );
     }
+    let rendered_exposure = nikonlook::apply(&raw_linear, k_exposure, &bundle_v2);
+    let agreement_exposure =
+        measure_agreement(&rendered_exposure, archive.width, archive.height, &nikon_ref, dy, dx);
 
-    let rendered = nikonlook::apply(&raw_linear, k_blind, &bundle);
+    // Not `sampled > 0` -- `measure_agreement` already asserts that
+    // internally on every call (see its own doc comment), so repeating it
+    // here could never fail regardless of what this test's logic actually
+    // did. What isn't already guaranteed: all three renders share the same
+    // archive dimensions and the same fixed dy/dx, so their in-bounds
+    // sample counts must be identical to each other (a future edit that
+    // accidentally passed mismatched dimensions to one of the three
+    // `measure_agreement` calls would silently compare each render against
+    // a different-sized sample without this); and the shared count must be
+    // large enough for the median-based comparisons below to mean anything
+    // -- a technically-nonzero but tiny sample would make those medians
+    // noise, not signal.
+    assert_eq!(
+        agreement_v1.sampled, agreement_blind.sampled,
+        "v1 and v2-blind must sample the identical registration grid"
+    );
+    assert_eq!(
+        agreement_v1.sampled, agreement_exposure.sampled,
+        "v1 and v2-exposure must sample the identical registration grid"
+    );
+    assert!(
+        agreement_v1.sampled >= 1000,
+        "registration grid sampled only {} points -- too few for the median-based \
+         comparisons below to be statistically meaningful",
+        agreement_v1.sampled
+    );
 
-    // Registered interior grid: sample every STEP-th pixel at least MARGIN
-    // from the archive's own edges, mapping each archive (y, x) to the
-    // Nikon reference's (y + dy, x + dx) -- the fixed registration shift
-    // between the two rasters. Points whose shifted coordinate falls
-    // outside the reference are skipped rather than clamped, so a wrong
-    // dy/dx cannot silently compare the wrong pixels.
-    let mut abs_diff: [Vec<f64>; 3] = [Vec::new(), Vec::new(), Vec::new()];
-    let mut r_pinned = 0usize;
-    let mut sampled = 0usize;
-
-    let y_end = archive.height.saturating_sub(MARGIN);
-    let x_end = archive.width.saturating_sub(MARGIN);
-    let mut y = MARGIN;
-    while y < y_end {
-        let mut x = MARGIN;
-        while x < x_end {
-            let ref_y = y as i64 + dy;
-            let ref_x = x as i64 + dx;
-            if ref_y >= 0 && ref_x >= 0 && (ref_y as u32) < nikon_ref.height && (ref_x as u32) < nikon_ref.width {
-                let rendered_px = rendered[(y * archive.width + x) as usize];
-                let ref_px = nikon_ref.pixels[(ref_y as u32 * nikon_ref.width + ref_x as u32) as usize];
-                for c in 0..3 {
-                    let rendered_dn = rendered_px[c] * 65535.0;
-                    let ref_dn = ref_px[c] as f64;
-                    abs_diff[c].push((rendered_dn - ref_dn).abs());
-                }
-                if (rendered_px[0] * 65535.0 - R_CURVE_GRID_Y0 * 65535.0).abs() < 1.0 {
-                    r_pinned += 1;
-                }
-                sampled += 1;
-            }
-            x += STEP;
-        }
-        y += STEP;
-    }
-    assert!(sampled > 0, "registration grid produced zero in-bounds sample points -- check dy/dx");
-
-    let [d0, d1, d2] = abs_diff;
-    let med_abs = [median(d0), median(d1), median(d2)];
-    // Measured 2026-07-28: medAbs [3565, 6682, 3340], pinned R 0.0553.
-    // Thresholds below have headroom but would catch a v1-style
-    // regression ([19463, 14040, 17347] / 0.165).
-    let thresholds = [6000.0, 8000.0, 6000.0];
+    // Primary proof: v2 blind is MATERIALLY closer to the Nikon reference
+    // than v1, per channel -- not just under a loose absolute ceiling. This
+    // is the actual "v1-vs-v2 comparison table" this module's doc comment
+    // and PROVENANCE.md describe.
     for c in 0..3 {
+        let v1 = agreement_v1.median_abs_diff_dn[c];
+        let v2 = agreement_blind.median_abs_diff_dn[c];
         assert!(
-            med_abs[c] <= thresholds[c],
-            "channel {c} median |delta| {} DN exceeds threshold {} DN",
-            med_abs[c],
-            thresholds[c]
+            v2 <= v1 * MATERIALLY_LOWER_RATIO,
+            "channel {c}: v2 blind median |delta| {v2} DN is not materially lower than v1's {v1} DN \
+             (required <= {}% of v1)",
+            MATERIALLY_LOWER_RATIO * 100.0
+        );
+    }
+    assert!(
+        agreement_blind.r_pinned_fraction < agreement_v1.r_pinned_fraction,
+        "v2 blind R-pinned fraction {} must be lower than v1's {}",
+        agreement_blind.r_pinned_fraction,
+        agreement_v1.r_pinned_fraction
+    );
+
+    // v2 exposure must also materially beat v1 (PROVENANCE.md measured it
+    // as an improvement over v1 on every channel, just not as large a one
+    // as blind) -- proves the exposure path isn't silently broken, without
+    // requiring it to beat blind (it measurably doesn't, on B).
+    for c in 0..3 {
+        let v1 = agreement_v1.median_abs_diff_dn[c];
+        let exposure = agreement_exposure.median_abs_diff_dn[c];
+        assert!(
+            exposure <= v1 * MATERIALLY_LOWER_RATIO,
+            "channel {c}: v2 exposure median |delta| {exposure} DN is not materially lower than v1's {v1} DN"
         );
     }
 
-    let r_pinned_fraction = r_pinned as f64 / sampled as f64;
+    // Supplementary absolute regression ceilings (secondary to the
+    // comparative proof above -- see the constants' own doc comment).
+    for c in 0..3 {
+        assert!(
+            agreement_blind.median_abs_diff_dn[c] <= V2_BLIND_CEILING_DN[c],
+            "channel {c}: v2 blind median |delta| {} DN exceeds ceiling {} DN",
+            agreement_blind.median_abs_diff_dn[c],
+            V2_BLIND_CEILING_DN[c]
+        );
+        assert!(
+            agreement_exposure.median_abs_diff_dn[c] <= V2_EXPOSURE_CEILING_DN[c],
+            "channel {c}: v2 exposure median |delta| {} DN exceeds ceiling {} DN",
+            agreement_exposure.median_abs_diff_dn[c],
+            V2_EXPOSURE_CEILING_DN[c]
+        );
+    }
     assert!(
-        r_pinned_fraction <= 0.08,
-        "R pinned-at-floor fraction {r_pinned_fraction} exceeds 0.08 ({r_pinned}/{sampled} sampled pixels)"
+        agreement_blind.r_pinned_fraction <= 0.08,
+        "v2 blind R-pinned-at-floor fraction {} exceeds 0.08",
+        agreement_blind.r_pinned_fraction
     );
 }

--- a/app/ScanStudio/protocol/PROTOCOL.md
+++ b/app/ScanStudio/protocol/PROTOCOL.md
@@ -194,13 +194,15 @@ HardwareTelemetry    {exposure: ExposureVector, clipping: ClippingTelemetry,
                       focusDetail: FocusDetailTelemetry, transportSmear: TransportSmearAssessment}
 FrameIdleSample      {frameIndex: u32, idleMs: u64}
 DutyCycleReport      {perFrameIdleMs: [FrameIdleSample], meanIdleMs: number, maxIdleMs: u64}
+NikonlookProvenance  {bundleVersion: string, layerAPath: "blind"|"hardwareExposure",
+                      gains: [number, number, number]}
 ScanReceipt     {jobId, frameIndex, startedAt: ISO-8601 UTC string, durationMs: u64,
                  passes: u32, resolutionDpi: u32, bitDepth: u32, channels: string,
                  engineVersion: string, deviceId: string, simulated: true,
                  settingsFingerprint: 16-hex-char string,
                  processing?: ProcessingRecipe, output?: OutputRecipe, outputs?: WrittenOutputs,
                  rgbPath?: string, irPath?: string, meterRgbiPath?: string,
-                 hardwareTelemetry?: HardwareTelemetry}
+                 hardwareTelemetry?: HardwareTelemetry, nikonlook?: NikonlookProvenance}
 FrameAlignment  {offsetRows: i64, approved: bool}
 MetadataSet     {camera?: string, lens?: string, filmStock?: string,
                  process?: "positive"|"c41ColorNegative"|"bwNegative"|"kodachrome",
@@ -245,6 +247,8 @@ ApplyMetadataResult {success: bool, exitCode: i32, stdout: string, stderr: strin
 `ArchiveRecipe.enabled` defaults to `true` when omitted, preserving older projects. At least one retained output (`archive`, positive TIFF, or positive JPEG) is required for every effective frame recipe. When archive retention is disabled, `WrittenOutputs.archivePath` is absent; the real backend still reports bridge provenance in `rgbPath`/`irPath` while routing the mandatory physical capture into an engine-owned private working directory. That temporary capture is cleaned only after the observed bridge terminal closure and successful derivative completion; otherwise it is recovery-held and never represented as a user output.
 
 `ScanReceipt.rgbPath`/`irPath`/`meterRgbiPath`/`hardwareTelemetry` are populated only by a real backend, forwarding BRIDGE.md's `ScanReceipt.rgbPath`/`irPath`/`meterRgbiPath` and `exposure`/`clipping`/`focusDetail`/`transportSmear` telemetry verbatim (mirrored field-for-field under `HardwareTelemetry`'s `ExposureVector`/`ClippingTelemetry`/`FocusDetailTelemetry`/`TransportSmearAssessment`). `rgbPath`/`irPath` are bridge-written capture-file locations, deliberately distinct from `outputs`/`WrittenOutputs` (engine-rendered retained files) — the two are never merged. The simulator omits all four (it has no bridge-sourced capture-file locations or hardware telemetry to report).
+
+`ScanReceipt.nikonlook` records which nikonlook color pipeline actually rendered a C41 frame's positive: `bundleVersion` (the loaded bundle's own version string, e.g. `"nikonlook-v2"`), `layerAPath` (`"blind"` or `"hardwareExposure"` — which Layer-A gain estimator ran; see PARITY.md and `resources/nikonlook-v2/PROVENANCE.md` for why these can render materially different output on the same frame), and `gains` (the exact per-channel `[R, G, B]` multiplier `apply()` used). Present on both real and simulated receipts for a C41 frame once its positive/preview has rendered — this is engine-rendering provenance, not bridge-sourced hardware telemetry, so it is not restricted to real backends the way `hardwareTelemetry` is. Absent (not `null`) for every non-C41 frame (nikonlook never runs for Positive/Kodachrome/BwNegative) and for any receipt written before this field existed.
 
 `settingsFingerprint` = lowercase hex of FNV-1a 64 over the ASCII string `"{resolutionDpi}:{bitDepth}:{multisamplePasses}:{channels}"`. Golden value: `"4000:16:2:rgbi"` → `1a3d265e0b54bbd2` (as in fixture 09).
 

--- a/bridge/tools/render_geometry_references.py
+++ b/bridge/tools/render_geometry_references.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 """render_geometry_references.py -- renders fresh autocrop + fine-deskew
-geometry reference files for Scan Studio's parity harness
-(nikon-coolscan4-software-archaeology, phase 15-geometry-port, plan 15-02)
-by invoking the real `negpy.features.geometry.logic` module directly
-against each corpus slot's own raw RGB capture.
+geometry reference files for Scan Studio's parity harness (phase
+15-geometry-port, plan 15-02) by invoking the real
+`negpy.features.geometry.logic` module directly against each corpus slot's
+own raw RGB capture.
 
-This script lives OUTSIDE the nikon-coolscan4-software-archaeology repo (GPL
-reference code stays external -- see that repo's CLAUDE.md licensing
-constraint) and is never copied into it. By default it writes reference
-files next to the corpus, which is what
+This script is vendored in this repository, at `bridge/tools/`. The GPL
+reference code it CALLS -- negpy-src -- is the thing that must stay
+external so this repository's MIT licence is not entangled; this script
+itself is MIT-licensed like the rest of this repository and has always been
+intended to ship with it. Point --negpy-src-path at a checkout of that
+external negpy-src (no default -- see that flag's own --help). By default
+it writes reference files next to the corpus, which is what
 app/ScanStudio/engine/src/bin/parity.rs looks for as the geometry modules'
 references. Pass --output-dir to write elsewhere instead (e.g. when the
 corpus directory itself must stay read-only) -- see PARITY.md for the
@@ -79,11 +82,13 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--negpy-src-path",
-        default="~/Downloads/digital-ice-2026/negpy-src",
+        default=None,
         help=(
             "Path to negpy-src's directory, added to sys.path so "
-            "negpy.features.geometry.logic can be imported (default: "
-            "~/Downloads/digital-ice-2026/negpy-src)"
+            "negpy.features.geometry.logic can be imported. Required -- "
+            "negpy-src is GPL-labeled reference code that stays external to "
+            "this repository (see this file's own module docstring), so "
+            "there is no in-checkout path to default to."
         ),
     )
     parser.add_argument(
@@ -102,6 +107,11 @@ def parse_args() -> argparse.Namespace:
     if not args.corpus:
         parser.error(
             "--corpus not given and SCANSTUDIO_PARITY_CORPUS is not set in the environment"
+        )
+    if not args.negpy_src_path:
+        parser.error(
+            "--negpy-src-path is required (no default -- see --help): point it at a checkout "
+            "of negpy-src's GPL-licensed source"
         )
     return args
 

--- a/bridge/tools/render_ice_references.py
+++ b/bridge/tools/render_ice_references.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """render_ice_references.py -- renders a fresh Legacy-only (classical, no
 Hybrid/ML) ICE defect-mask reference for Scan Studio's parity harness
-(nikon-coolscan4-software-archaeology, phase 16-legacy-ice, plan 16-03) by
-invoking the real, installed `portable_digital_ice` v0.3.1 package's own
-detection primitives directly against each corpus slot's own raw RGB+IR
-capture.
+(phase 16-legacy-ice, plan 16-03) by invoking the real, installed
+`portable_digital_ice` v0.3.1 package's own detection primitives directly
+against each corpus slot's own raw RGB+IR capture.
 
 WHY THIS SCRIPT EXISTS (read this before trusting a score). Phase 13's
 `bin/parity.rs` originally had `score_ice()` compare the Rust Legacy-ICE
@@ -27,16 +26,19 @@ neighborhood than the pixel-level defect footprint), the bundled disclosure
 mask is not a meaningful reference for scoring a Legacy-only port. This
 script generates the missing Legacy-only reference instead.
 
-WHY THIS SCRIPT LIVES OUTSIDE nikon-coolscan4-software-archaeology. Unlike
-`render_references.py`/`render_geometry_references.py` (which MUST live
-externally -- their upstream sources are GPL-labeled/unlicensed, and the
-target repo is MIT), `portable-digital-ice` is ALREADY MIT, same owner
-(Rohan Pandula) as nikon-coolscan4-software-archaeology. Keeping this
-script here too is a CONSISTENCY choice (every other reference-rendering
-script in this project already lives in this directory; keeping a one-off
-Python dependency out of the primary Swift/Rust app repo), NOT a licensing
-requirement -- do not mistake this for a GPL boundary. See
-app/ScanStudio/PARITY.md in nikon-coolscan4-software-archaeology for the
+WHY THIS SCRIPT NEVER NEEDED A GPL BOUNDARY. This script is vendored in this
+repository, at `bridge/tools/`, same as `render_references.py`/
+`render_geometry_references.py`. Those two depend on upstream sources
+(negfit, negpy-src) that are GPL-labeled and must stay external to this
+MIT-licensed repository -- callers pass a checkout path in via
+--negfit-path/--negpy-src-path, with no in-repo default, so this
+repository's MIT licence is not entangled. `portable-digital-ice` is ALREADY MIT,
+same owner (Rohan Pandula) as this repository, so this script never had
+that constraint -- it depends on portable_digital_ice being installed
+(pip), not on a separately-checked-out source tree. Living in this same
+directory alongside the other two reference-rendering scripts is a
+CONSISTENCY choice, not a licensing requirement -- do not mistake this for
+a GPL boundary. See this repository's own app/ScanStudio/PARITY.md for the
 full writeup.
 
 WHAT THIS SCRIPT DOES NOT DO. It only reproduces the DETECTION half of
@@ -369,10 +371,9 @@ def render_one_slot(
                 "using alpha=0.17 (the real algorithm's own documented "
                 "zero_denominator_alpha 'no usable prepass regression signal' "
                 "fallback) -- NOT a byte-exact reproduction of Nikon's "
-                "firmware prepass-register replay. See "
-                "processing/ICE-PROVENANCE.md's 'Handling: the "
-                "single-acquisition adaptation' section in "
-                "nikon-coolscan4-software-archaeology."
+                "firmware prepass-register replay. See this repository's "
+                "app/ScanStudio/engine/src/processing/ICE-PROVENANCE.md, "
+                "'Handling: the single-acquisition adaptation' section."
             ),
         },
         "confirmation_adaptation": {

--- a/bridge/tools/render_references.py
+++ b/bridge/tools/render_references.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
 """render_references.py -- renders fresh nikonlook color reference TIFFs for
-Scan Studio's parity harness (nikon-coolscan4-software-archaeology, phase
-13-parity-harness, plan 13-02) by invoking negfit's frozen nikonlook_core.py
-API (load_bundle / estimate_gains / apply) directly against each corpus
-slot's own raw RGB capture.
+Scan Studio's parity harness (phase 13-parity-harness, plan 13-02) by
+invoking negfit's frozen nikonlook_core.py API (load_bundle / estimate_gains
+/ apply) directly against each corpus slot's own raw RGB capture.
 
-This script lives OUTSIDE the nikon-coolscan4-software-archaeology repo (GPL
-reference code stays external -- see that repo's CLAUDE.md licensing
-constraint) and is never copied into it. By default it writes
-`acceptance_slotNN_reference_color_<bundle>.tif` next to the corpus, which
-is what app/ScanStudio/engine/src/bin/parity.rs looks for as the color
-module's reference. Pass --output-dir to write elsewhere instead (e.g. when
-the corpus directory itself must stay read-only) -- see PARITY.md for the
-current run's chosen path if --output-dir was used.
+This script is vendored in this repository, at `bridge/tools/`. The GPL
+reference code it CALLS -- negfit's nikonlook_core.py -- is the thing that
+must stay external so this repository's MIT licence is not entangled; this
+script itself is MIT-licensed like the rest of this repository and has
+always been intended to ship with it. Point --negfit-path at a checkout of
+that external negfit source (no default -- see that flag's own --help).
+By default it writes `acceptance_slotNN_reference_color_<bundle>.tif` next
+to the corpus, which is what app/ScanStudio/engine/src/bin/parity.rs looks
+for as the color module's reference. Pass --output-dir to write elsewhere
+instead (e.g. when the corpus directory itself must stay read-only) -- see
+PARITY.md for the current run's chosen path if --output-dir was used.
 """
 
 from __future__ import annotations
@@ -34,6 +36,20 @@ SLOT_COUNT = 6
 # these renders for Phase 14 -- if it differs, fix this divisor and re-run.
 FULL_SCALE = 65535.0
 
+# This checkout's own vendored nikonlook-v2 resources -- the exact
+# model.json/layer_a.json/manifest.json bytes the Rust engine embeds via
+# include_str! (see app/ScanStudio/engine/src/processing/nikonlook.rs and
+# that directory's own PROVENANCE.md). Computed from this script's own path
+# rather than hardcoded, so it resolves correctly in any checkout, not just
+# the one it was written on. Used as --bundle's default: a reference
+# rendered without --bundle is then guaranteed to match the bundle version
+# app/ScanStudio/engine/src/bin/parity.rs actually scores candidates
+# against, and no maintainer-specific path needs to appear here at all
+# (this used to default to a maintainer's home directory).
+DEFAULT_BUNDLE_DIR = (
+    Path(__file__).resolve().parents[2] / "app/ScanStudio/engine/resources/nikonlook-v2"
+)
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -46,13 +62,25 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--bundle",
-        default="~/Downloads/digital-ice-2026/negfit/bundles/nikonlook-v1",
-        help="Path to the negfit bundle directory (default: nikonlook-v1)",
+        default=str(DEFAULT_BUNDLE_DIR),
+        help=(
+            "Path to the negfit bundle directory (default: this checkout's "
+            "own vendored nikonlook-v2 resources -- see DEFAULT_BUNDLE_DIR "
+            "above). Pass this explicitly to render against a different "
+            "bundle version, e.g. a nikonlook-v1 checkout for "
+            "load_bundle_v1()-based comparison tooling."
+        ),
     )
     parser.add_argument(
         "--negfit-path",
-        default="~/Downloads/digital-ice-2026/negfit",
-        help="Path to negfit's directory, added to sys.path so nikonlook_core can be imported",
+        default=None,
+        help=(
+            "Path to negfit's directory, added to sys.path so nikonlook_core "
+            "can be imported. Required -- negfit is GPL-labeled reference "
+            "code that stays external to this repository (see this file's "
+            "own module docstring), so there is no in-checkout path to "
+            "default to."
+        ),
     )
     parser.add_argument(
         "--output-dir",
@@ -70,6 +98,11 @@ def parse_args() -> argparse.Namespace:
     if not args.corpus:
         parser.error(
             "--corpus not given and SCANSTUDIO_PARITY_CORPUS is not set in the environment"
+        )
+    if not args.negfit_path:
+        parser.error(
+            "--negfit-path is required (no default -- see --help): point it at a checkout "
+            "of negfit's GPL-licensed source"
         )
     return args
 
@@ -121,7 +154,7 @@ def main() -> int:
         out_u16 = np.clip(nikon_rgb_device * FULL_SCALE + 0.5, 0, 65535).astype(np.uint16)
 
         # 7. Write using the exact filename bin/parity.rs looks for.
-        bundle_tag = Path(args.bundle).name  # e.g. "nikonlook-v1"
+        bundle_tag = Path(args.bundle).name  # e.g. "nikonlook-v2"
         out_path = output_dir / f"{base}_reference_color_{bundle_tag}.tif"
         tifffile.imwrite(str(out_path), out_u16, photometric="rgb")
         written += 1


### PR DESCRIPTION
Follow-ups from two review passes over the v2 colour switch that merged in #1.

## What was wrong

- **The colour parity harness was comparing two different models.** Candidates render with bundle v2; the reference filename was hardcoded to v1, compared at a tolerance that exists to prove the Rust port reproduces the Python reference of the *same* bundle. A first fix made the filename bundle-derived — but a missing reference still exited 0, so colour scoring became a silent no-op instead. Both halves are fixed here: the lookup is bundle-derived *and* an absent reference fails the run.
- **Rendered positives were not reproducible from their receipts.** The exposure-metadata opt-in materially changes output, but nothing recorded which path ran, which bundle, or the gains applied.
- **Bundle validation was looser than the reference implementation**, so a malformed bundle could load here and be rejected there — and, in the other direction, a bundle the reference accepts (omitted gain bounds) was rejected here.
- **A malformed exposure relied on an assertion compiled out of release builds**, then got divided into a gain.
- **The reference-render scripts defaulted to a maintainer's home directory** and cited a file this repository does not ship as their licensing rationale.

## Verification

`cargo test` and `cargo test --release` are both green (365 lib tests plus every integration binary; the two env-gated real-hardware fixtures stay ignored). The release suite was red before this branch: an allocator probe was optimized away and its failure poisoned a shared lock, cascading into a sibling test.

## Not claimed

This does not improve colour accuracy. Layer B was never retrained; the vendored manifest still reports skin ΔE00 median/p95 of 11.42/14.36 against gates of 1.0/3.0. This branch makes the switch honest and measurable, not finished.