### PR TITLE
Fix film-shift recovery and prepare alpha 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The bundle names missing evidence instead of inventing it. It does not replace o
 ## Safety and limits
 
 - Preview establishes the current registration. Preview again after a refeed or ejection.
+- If Capture reports that the film shifted, physically refeed it and acquire a fresh preview; ScanStudio discards the old frame registration so it cannot be retried accidentally.
 - Confirm that the app identifies a real scanner before treating it as hardware. The built-in simulator is for safe workflow exploration only.
 - Keep physical film transport under supervision. Stop and inspect the scanner if the physical state is uncertain.
 - Opening ScanStudio authorizes later explicit Preview, Scan, and Eject actions for that app session; it does not move film by itself.

--- a/app/ScanStudio/Sources/ScanStudio/DeviceBarView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/DeviceBarView.swift
@@ -74,7 +74,7 @@ struct DeviceBarView: View {
                 .foregroundStyle(Color.scanStudioSecondaryText)
             Text(mediaLabel)
                 .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(hasMedia ? Color.scanStudioPrimaryText : Color.scanStudioSecondaryText)
+                .foregroundStyle(mediaLabelColor)
                 .fixedSize()
                 .layoutPriority(1)
                 .help(mediaLabel)
@@ -156,8 +156,14 @@ struct DeviceBarView: View {
             isAcquiringPreviews: sessionModel.isAcquiringThumbnails,
             mediaLoaded: hasMedia,
             carrierDisplayName: sessionModel.loadedCarrier?.displayName,
-            filmPresent: sessionModel.status?.filmPresent
+            filmPresent: sessionModel.status?.filmPresent,
+            refeedRequired: sessionModel.refeedRequired
         )
+    }
+
+    private var mediaLabelColor: Color {
+        if sessionModel.refeedRequired { return .scanStudioAmber }
+        return hasMedia ? .scanStudioPrimaryText : .scanStudioSecondaryText
     }
 }
 

--- a/app/ScanStudio/Sources/ScanStudioKit/DeviceBarMediaPolicy.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/DeviceBarMediaPolicy.swift
@@ -6,9 +6,12 @@ public enum DeviceBarMediaPolicy {
         isAcquiringPreviews: Bool,
         mediaLoaded: Bool,
         carrierDisplayName: String?,
-        filmPresent: Bool?
+        filmPresent: Bool?,
+        refeedRequired: Bool
     ) -> String {
         if isAcquiringPreviews { return "Detecting film" }
+        if refeedRequired { return "Refeed required" }
+        if filmPresent == false { return "No film detected" }
         if mediaLoaded { return carrierDisplayName ?? "Previewed film" }
         if filmPresent == true { return "Film present; preview needed" }
         if let carrierDisplayName { return "\(carrierDisplayName) identified" }

--- a/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
@@ -140,7 +140,8 @@ public enum ErrorPresentationPolicy {
         context: ErrorPresentationContext = .init()
     ) -> ErrorPresentation {
         let normalizedMessage = lastErrorMessage.uppercased()
-        let copy = previewReadinessTimeoutCopy(in: lastErrorMessage)
+        let copy = filmTransportSlipCopy(in: lastErrorMessage)
+            ?? previewReadinessTimeoutCopy(in: lastErrorMessage)
             ?? knownCopy.first { containsCode($0.code, in: normalizedMessage) }
             ?? Copy(
                 code: leadingCode(in: normalizedMessage) ?? "UNKNOWN",
@@ -160,6 +161,21 @@ public enum ErrorPresentationPolicy {
                 lastErrorMessage: lastErrorMessage,
                 context: context
             )
+        )
+    }
+
+    private static func filmTransportSlipCopy(in message: String) -> Copy? {
+        guard FilmTransportFailurePolicy.requiresPhysicalRefeed(
+            message: message
+        ) else {
+            return nil
+        }
+        return Copy(
+            code: "REFEED_REQUIRED",
+            title: "Film shifted—refeed required",
+            guidance: "The scanner lost the film’s position. Remove and firmly reinsert "
+                + "the strip, then acquire a fresh preview. Do not retry Capture with "
+                + "the current preview."
         )
     }
 

--- a/app/ScanStudio/Sources/ScanStudioKit/FilmTransportFailurePolicy.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/FilmTransportFailurePolicy.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Recognizes the fail-closed scanner responses that prove the current film
+/// registration can no longer be trusted. The engine's public error enum is
+/// intentionally smaller than the bridge vocabulary, so live bridge codes
+/// can arrive as `INTERNAL` while their original code and message remain in
+/// the diagnostic text.
+enum FilmTransportFailurePolicy {
+    static func requiresPhysicalRefeed(
+        errorCode: String? = nil,
+        message: String
+    ) -> Bool {
+        let normalized = "\(errorCode ?? "") \(message)".uppercased()
+        let compactSense = normalized
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "/", with: "")
+            .replacingOccurrences(of: "-", with: "")
+
+        let isRollMismatch = normalized.contains("ROLL_MISMATCH")
+        let isFingerprintRefusal = normalized.contains("FINGERPRINT_REFUSED")
+        let isMediaLoadFailure =
+            normalized.contains("SYNCHRONIZEDPROTOCOLERROR")
+                && compactSense.contains("SENSE045300")
+        let isAnchorResidual = normalized.contains(
+            "TRANSPORT ANCHOR RESIDUAL IS INCONSISTENT WITH ONE AFFINE PREVIEW TRAVERSAL"
+        )
+        let isSlotCountMismatch = normalized.contains("SLOT-COUNT-MISMATCH")
+
+        return (isRollMismatch && (isMediaLoadFailure || isAnchorResidual))
+            || (isFingerprintRefusal && isSlotCountMismatch)
+    }
+}

--- a/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
@@ -585,10 +585,9 @@ public final class SessionModel {
     /// simply overwritten (including a `nil` clear when no coercion was
     /// needed) by the next call to either of those two methods.
     public private(set) var multisampleCoercionNote: String?
-    /// True while the transport is in the refeed-required state: the last
-    /// preview (`scanner.thumbnailsFailed`) or batch start (a synchronous
-    /// `scan.start` refusal) failed with the bridge's `REFEED_REQUIRED`,
-    /// whose own message tells the operator to eject or refeed the strip.
+    /// True while the transport is in the refeed-required state: a preview,
+    /// synchronous batch refusal, or scan-time fresh-index check proved the
+    /// current physical registration cannot be trusted.
     /// Gates `DeviceBarView`'s Eject affordance in exactly that state —
     /// found live 2026-07-26, when the refusal's message said "eject or
     /// refeed" while the app offered no eject affordance anywhere and the
@@ -1093,7 +1092,9 @@ public final class SessionModel {
             if !refreshed.mediaLoaded || refreshed.filmPresent == false {
                 clearMediaState(preservingPreviewAuthorization: true)
             }
-            lastErrorMessage = nil
+            if !refeedRequired {
+                lastErrorMessage = nil
+            }
         } catch {
             guard pendingStatusRefresh?.id == marker.id,
                   connectionEpoch == marker.connectionEpoch
@@ -3424,6 +3425,14 @@ public final class SessionModel {
 
     private func applyCompleted(_ payload: ScanCompletedPayload, source: EngineEvent) {
         guard eventIsRelevant(payload.jobId, source: source) else { return }
+        let transportFailure = payload.summary.failed
+            .compactMap { frameErrors[$0] }
+            .first {
+                FilmTransportFailurePolicy.requiresPhysicalRefeed(
+                    errorCode: $0.code,
+                    message: $0.message
+                )
+            }
         scanSummary = payload.summary
         // A re-scan is allowed to replace a persisted frame's live display
         // state with waiting/active/failed while the attempt is in flight.
@@ -3453,6 +3462,13 @@ public final class SessionModel {
         // otherwise stuck "SCANNING"); an existing terminal state is preserved,
         // never overridden. See `ScanCompletionPolicy`.
         jobState = ScanCompletionPolicy.resolveJobState(current: jobState, summary: payload.summary)
+        if let transportFailure {
+            requirePhysicalRefeed(
+                errorCode: transportFailure.code,
+                message: transportFailure.message,
+                preservingActiveJob: true
+            )
+        }
         jobId = nil
     }
 
@@ -3479,8 +3495,26 @@ public final class SessionModel {
     func noteRefeedRequired(from error: Error) {
         guard let requestError = error as? EngineRequestError else { return }
         if requestError.message.contains("REFEED_REQUIRED") {
-            refeedRequired = true
+            requirePhysicalRefeed(
+                errorCode: requestError.code,
+                message: requestError.message,
+                preservingActiveJob: false
+            )
         }
+    }
+
+    /// Records the operator-facing recovery reason and invalidates every
+    /// preview-bound coordinate before another Capture can be attempted.
+    /// Terminal scan failures preserve their job evidence; synchronous
+    /// refusals have no accepted job to retain.
+    private func requirePhysicalRefeed(
+        errorCode: String,
+        message: String,
+        preservingActiveJob: Bool
+    ) {
+        lastErrorMessage = "\(errorCode): \(message)"
+        refeedRequired = true
+        clearMediaState(preservingActiveJob: preservingActiveJob)
     }
 
     private var diagnosticUIConnected: Bool {
@@ -3600,6 +3634,12 @@ public final class SessionModel {
         code: String,
         message: String
     ) -> String {
+        if FilmTransportFailurePolicy.requiresPhysicalRefeed(
+            errorCode: code,
+            message: message
+        ) {
+            return "REFEED_REQUIRED"
+        }
         if code == "NOT_CONNECTED"
             || message.range(
                 of: #"(?<![A-Z0-9_])NOT_CONNECTED(?![A-Z0-9_])"#,

--- a/app/ScanStudio/Tests/ScanStudioKitTests/DeviceBarMediaPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/DeviceBarMediaPolicyTests.swift
@@ -10,7 +10,8 @@ struct DeviceBarMediaPolicyTests {
             isAcquiringPreviews: true,
             mediaLoaded: false,
             carrierDisplayName: "35 mm roll",
-            filmPresent: nil
+            filmPresent: nil,
+            refeedRequired: false
         ) == "Detecting film")
     }
 
@@ -18,11 +19,35 @@ struct DeviceBarMediaPolicyTests {
     func presenceClaimsAreAuthoritativeOnly() {
         #expect(DeviceBarMediaPolicy.label(
             isAcquiringPreviews: false, mediaLoaded: false,
-            carrierDisplayName: "35 mm roll", filmPresent: nil
+            carrierDisplayName: "35 mm roll", filmPresent: nil,
+            refeedRequired: false
         ) == "35 mm roll identified")
         #expect(DeviceBarMediaPolicy.label(
             isAcquiringPreviews: false, mediaLoaded: false,
-            carrierDisplayName: "35 mm roll", filmPresent: true
+            carrierDisplayName: "35 mm roll", filmPresent: true,
+            refeedRequired: false
         ) == "Film present; preview needed")
+    }
+
+    @Test("a transport slip overrides stale loaded media copy")
+    func refeedRequiredOverridesStaleLoadedState() {
+        #expect(DeviceBarMediaPolicy.label(
+            isAcquiringPreviews: false,
+            mediaLoaded: true,
+            carrierDisplayName: "35 mm strip (6 frames)",
+            filmPresent: false,
+            refeedRequired: true
+        ) == "Refeed required")
+    }
+
+    @Test("an explicit no-film sensor reading overrides stale loaded media copy")
+    func noFilmOverridesStaleLoadedState() {
+        #expect(DeviceBarMediaPolicy.label(
+            isAcquiringPreviews: false,
+            mediaLoaded: true,
+            carrierDisplayName: "35 mm strip (6 frames)",
+            filmPresent: false,
+            refeedRequired: false
+        ) == "No film detected")
     }
 }

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
@@ -5,6 +5,35 @@ import Testing
 
 @Suite("Error presentation policy")
 struct ErrorPresentationPolicyTests {
+    @Test("diagnosed scan-time transport slips require a refeed and retain the raw diagnostic")
+    func scanTimeTransportSlip() {
+        let diagnostics = [
+            "INTERNAL: bridge scan.frameFailed (ROLL_MISMATCH): SynchronizedProtocolError: command 124: sense 045300 not in accepted ['000000']",
+            "INTERNAL: bridge scan.frameFailed (FINGERPRINT_REFUSED): ProtocolError: fresh live index does not match the reviewed roll fingerprint: slot-count-mismatch",
+            "INTERNAL: bridge scan.frameFailed (ROLL_MISMATCH): IndexDecodeError: transport anchor residual is inconsistent with one affine preview traversal (MAE 3.813 rows, max 7.554 rows)",
+        ]
+
+        for rawMessage in diagnostics {
+            let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+
+            #expect(presentation.title == "Film shifted—refeed required")
+            #expect(
+                presentation.guidance
+                    == "The scanner lost the film’s position. Remove and firmly reinsert the strip, then acquire a fresh preview. Do not retry Capture with the current preview."
+            )
+            #expect(presentation.technicalDetails == rawMessage)
+        }
+    }
+
+    @Test("an unrelated roll mismatch does not claim a physical transport slip")
+    func unrelatedRollMismatchUsesFallback() {
+        let rawMessage = "INTERNAL: bridge scan.frameFailed (ROLL_MISMATCH): calibration signature changed"
+        let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+
+        #expect(presentation.title == "ScanStudio could not complete that action")
+        #expect(presentation.technicalDetails == rawMessage)
+    }
+
     @Test("a preview readiness timeout explains what stopped and preserves the full diagnostic")
     func previewReadinessTimeout() throws {
         let rawMessage = """

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ScannerStatusRefreshTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ScannerStatusRefreshTests.swift
@@ -182,6 +182,27 @@ struct ScannerStatusRefreshTests {
         #expect(model.lastErrorMessage == nil)
     }
 
+    @Test("a successful status refresh preserves an unresolved refeed explanation")
+    @MainActor
+    func refreshPreservesRefeedExplanation() async {
+        let client = ScannerStatusRefreshEngineStub()
+        let model = SessionModel(engineClient: client)
+        await model.connect(deviceId: "real-ls5000-status-test")
+        let diagnostic =
+            "bridge error REFEED_REQUIRED: fresh index no longer matches the loaded film"
+        model.noteRefeedRequired(from: EngineRequestError(
+            code: "internal",
+            message: diagnostic,
+            recoverable: false
+        ))
+
+        await model.refreshScannerStatus()
+
+        #expect(model.refeedRequired)
+        #expect(model.lastErrorMessage == "internal: \(diagnostic)")
+        #expect(model.errorPresentation?.technicalDetails.contains(diagnostic) == true)
+    }
+
     @Test("a status response from a replaced connection cannot overwrite the new session")
     @MainActor
     func staleResponseIsDiscarded() async {

--- a/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
@@ -1871,6 +1871,88 @@ struct SessionEventPolicyTests {
         #expect(model.refeedRequired)
     }
 
+    @Test("a scan-time roll slip invalidates the preview and requires a refeed before another capture")
+    @MainActor
+    func scanTimeRollSlipRequiresFreshPhysicalRegistration() async {
+        let diagnostics = [
+            "bridge scan.frameFailed (ROLL_MISMATCH): IndexDecodeError: transport anchor residual is inconsistent with one affine preview traversal (MAE 3.813 rows, max 7.554 rows)",
+            "bridge scan.frameFailed (FINGERPRINT_REFUSED): ProtocolError: fresh live index does not match the reviewed roll fingerprint: slot-count-mismatch",
+            "bridge scan.frameFailed (ROLL_MISMATCH): SynchronizedProtocolError: command 124: sense 045300 not in accepted ['000000']",
+        ]
+
+        for (caseIndex, rawDiagnostic) in diagnostics.enumerated() {
+            let client = CountingPreviewEngineStub()
+            let model = SessionModel(engineClient: client)
+            let previewToken = PreviewIntentToken()
+            let jobId = "roll-slip-job-\(caseIndex)"
+            #expect(
+                await model.requestPreview(.initial(token: previewToken))
+                    == .started
+            )
+            establishCompletedPreview(
+                frameCount: 6,
+                operationID: previewToken.id.uuidString,
+                on: model
+            )
+            model.selectAllFrames()
+            model.beginJob(id: jobId, frames: Array(1...6))
+            model.handle(event: EngineEvent(
+                name: "scan.jobState",
+                rawLine: Data(
+                    #"{"event":"scan.jobState","payload":{"jobId":"\#(jobId)","state":"scanning"}}"#.utf8
+                )
+            ))
+            model.handle(event: EngineEvent(
+                name: "scan.frameState",
+                rawLine: Data(
+                    #"{"event":"scan.frameState","payload":{"jobId":"\#(jobId)","frameIndex":1,"state":"failed","attempt":1,"error":{"code":"INTERNAL","message":"\#(rawDiagnostic)","recoverable":false}}}"#.utf8
+                )
+            ))
+            model.handle(event: EngineEvent(
+                name: "scan.jobState",
+                rawLine: Data(
+                    #"{"event":"scan.jobState","payload":{"jobId":"\#(jobId)","state":"failed"}}"#.utf8
+                )
+            ))
+            model.handle(event: EngineEvent(
+                name: "scan.completed",
+                rawLine: Data(
+                    #"{"event":"scan.completed","payload":{"jobId":"\#(jobId)","summary":{"completed":[],"failed":[1,2,3,4,5,6],"skipped":[],"stopped":false}}}"#.utf8
+                )
+            ))
+
+            // The authoritative terminal event preserves the failed job
+            // evidence, then invalidates the registration whose physical
+            // coordinates the fresh-index check disproved.
+            #expect(model.refeedRequired)
+            #expect(model.thumbnails.isEmpty)
+            #expect(model.selectedFrameIndices.isEmpty)
+            #expect(model.latestCompletedPreviewOperationId == nil)
+            #expect(model.jobState == .failed)
+            #expect(model.scanSummary?.failed == Array(1...6))
+            #expect(model.frameErrors[1]?.message == rawDiagnostic)
+            #expect(model.lastErrorMessage == "INTERNAL: \(rawDiagnostic)")
+            #expect(model.errorPresentation?.title == "Film shifted—refeed required")
+            #expect(
+                model.errorPresentation?.guidance
+                    == "The scanner lost the film’s position. Remove and firmly reinsert the strip, then acquire a fresh preview. Do not retry Capture with the current preview."
+            )
+
+            // A following status can carry previewEstablished=true while its
+            // live film sensor says no medium is gripped. It must not erase
+            // the actionable reason or restore the old registration.
+            model.handle(event: EngineEvent(
+                name: "scanner.status",
+                rawLine: Data(
+                    #"{"event":"scanner.status","payload":{"status":{"connected":true,"adapter":"SA-21","mediaLoaded":true,"carrier":"strip6","frameCount":6,"lamp":"stable","transport":"idle","activeJobId":null,"filmPresent":false,"motionArmed":true}}}"#.utf8
+                )
+            ))
+            #expect(model.refeedRequired)
+            #expect(model.errorPresentation?.title == "Film shifted—refeed required")
+            #expect(!model.hasCompletePreviewRegistration)
+        }
+    }
+
     @Test("a FEEDER_PARKED preview failure surfaces typed but does NOT arm eject")
     @MainActor
     func feederParkedPreviewFailureDoesNotArmEject() async {
@@ -1891,11 +1973,20 @@ struct SessionEventPolicyTests {
         #expect(model.lastErrorMessage?.contains("FEEDER_PARKED") == true)
     }
 
-    @Test("a synchronous scan.start REFEED_REQUIRED refusal arms the eject affordance")
+    @Test("a synchronous scan.start REFEED_REQUIRED refusal invalidates stale registration and arms eject")
     @MainActor
-    func synchronousScanStartRefusalArmsEject() async throws {
-        let client = try EngineClient(engineURL: URL(fileURLWithPath: "/bin/cat"))
+    func synchronousScanStartRefusalRequiresFreshPreview() async {
+        let client = CountingPreviewEngineStub()
         let model = SessionModel(engineClient: client)
+        let previewToken = PreviewIntentToken()
+        #expect(await model.requestPreview(.initial(token: previewToken)) == .started)
+        establishCompletedPreview(
+            frameCount: 6,
+            operationID: previewToken.id.uuidString,
+            on: model
+        )
+        model.selectAllFrames()
+        #expect(model.hasCompletePreviewRegistration)
 
         model.noteRefeedRequired(from: EngineRequestError(
             code: "internal",
@@ -1903,7 +1994,14 @@ struct SessionEventPolicyTests {
             recoverable: false
         ))
         #expect(model.refeedRequired)
-        await client.terminate()
+        #expect(model.thumbnails.isEmpty)
+        #expect(model.selectedFrameIndices.isEmpty)
+        #expect(model.latestCompletedPreviewOperationId == nil)
+        #expect(!model.hasCompletePreviewRegistration)
+        #expect(
+            model.lastErrorMessage
+                == "internal: bridge error REFEED_REQUIRED: scan_many's fresh index read failed from the parked transport"
+        )
     }
 
     @Test("an unrelated engine error never arms the eject affordance")

--- a/app/ScanStudio/packaging/Info.plist
+++ b/app/ScanStudio/packaging/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundleShortVersionString</key>
     <string>0.3.0</string>
     <key>CFBundleVersion</key>
-    <string>4</string>
+    <string>5</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>

--- a/app/ScanStudio/scripts/package_dmg.sh
+++ b/app/ScanStudio/scripts/package_dmg.sh
@@ -18,7 +18,7 @@ if [[ ! -f "$info_plist" ]]; then
 fi
 
 bundle_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info_plist")"
-release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.2}"
+release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.3}"
 release_arch="${SCANSTUDIO_RELEASE_ARCH:-$(uname -m)}"
 output="${2:-$package_root/.build/ScanStudio-$release_version-macOS-$release_arch.dmg}"
 


### PR DESCRIPTION
## What changed

- Recognize the three scan-time transport-slip signatures observed on the Nikon hardware.
- Preserve the complete technical error in the workspace banner while presenting clear physical recovery guidance.
- Invalidate the stale preview, selection, approvals, and alignment state only after the failed job reaches its authoritative terminal event.
- Show an amber `Refeed required` device-bar state instead of stale `Previewed film` copy.
- Bump the packaged build to 0.3.0 (5) and prepare the v0.3.0-alpha.3 DMG name.

## Why

A shifted strip reached the app as a failed frame with the bridge diagnostic embedded under the engine's closed `INTERNAL` error code. ScanStudio retained the per-frame failure but never promoted it to a global recovery state, so the reason disappeared when the preview was cleared and the UI could return to the preview gate without explaining that a physical refeed was required.

## User impact

When the scanner loses the strip's position, ScanStudio now says `Film shifted—refeed required`, retains the technical details for reporting, discards the unsafe frame registration, and requires a fresh preview before Capture can be attempted again.

## Validation

- 359 Rust engine tests passed.
- 373 Swift app tests passed.
- 272 bridge tests passed.
- The final release DMG was checksum-verified, mounted read-only, strict-signature checked, checked for forbidden builder tables, and exercised with the packaged bridge/launcher checks.
- DMG SHA-256: `83533889ed4ec933165e55d1cd8d34cad1d16f287c851baf54652f57abcdd1b5`.

No scanner motion was performed while implementing or packaging this change.
