### PR TITLE
Clarify scan progress and preserve TIFF-only setup

### DIFF
--- a/app/ScanStudio/Sources/ScanStudio/BatchInspectorView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/BatchInspectorView.swift
@@ -298,13 +298,18 @@ struct BatchInspectorView: View {
             .padding(.bottom, 6)
 
             HStack(alignment: .top, spacing: 8) {
-                Text(sessionModel.saveLocation.isEmpty ? "Choose a save location when you are ready." : sessionModel.saveLocation)
+                Text(outputLocationSummary)
                     .font(.system(size: 11))
                     .foregroundStyle(Color.scanStudioSecondaryText)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Button("Choose…", action: chooseSaveLocation)
-                    .controlSize(.small)
+                if OutputLocationPresentation.showsChangeAction(
+                    hasOpenProject: sessionModel.project != nil
+                ) {
+                    Button("Change…", action: chooseSaveLocation)
+                        .controlSize(.small)
+                        .help("Optionally change where this roll's enabled outputs are saved")
+                }
             }
             InspectorToggleRow(label: "Save each output in its own folder", isOn: saveEachOutputInOwnFolderBinding)
             Text("Keep at least one output.")
@@ -820,6 +825,13 @@ struct BatchInspectorView: View {
         Binding(get: { sessionModel.saveEachOutputInOwnFolder }, set: { sessionModel.saveEachOutputInOwnFolder = $0 })
     }
 
+    private var outputLocationSummary: String {
+        OutputLocationPresentation.summary(
+            hasOpenProject: sessionModel.project != nil,
+            customLocation: sessionModel.saveLocation
+        )
+    }
+
     private var fullCapturePackageBinding: Binding<Bool> {
         Binding(
             get: { sessionModel.masterTIFFEnabled && sessionModel.fullCapturePackageEnabled },
@@ -879,7 +891,8 @@ struct BatchInspectorView: View {
         panel.canChooseDirectories = true
         panel.canCreateDirectories = true
         panel.allowsMultipleSelection = false
-        panel.prompt = "Choose Save Location"
+        panel.prompt = "Use This Location"
+        panel.message = "Optional: choose a custom location for this roll's enabled outputs."
         if panel.runModal() == .OK, let url = panel.url {
             sessionModel.saveLocation = url.path
         }

--- a/app/ScanStudio/Sources/ScanStudio/ContentView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ContentView.swift
@@ -656,7 +656,7 @@ private struct PreProjectPreviewWorkspaceView: View {
         if unresolvedReviewCount > 1 {
             return "\(unresolvedReviewCount) frames need boundary choices. Click each Review button to use it, skip it, or preview again."
         }
-        return "Save Roll names the output folder and enables scanning."
+        return "Save Roll names this roll, creates its resumable project, sets up default output locations, and enables scanning."
     }
 
     private var calloutActions: some View {

--- a/app/ScanStudio/Sources/ScanStudio/ScanPanelView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ScanPanelView.swift
@@ -357,12 +357,15 @@ struct ScanPanelView: View {
         return "\(frame) · Pass \(sessionModel.progress?.pass ?? 1) of \(sessionModel.progress?.totalPasses ?? 2)"
     }
 
-    /// Receipt count (always real) plus " · ETA …" only when honest
-    /// (simulator only — see `etaLabel`/`telemetryHonesty`).
+    /// Completed-frame count (backed by receipts, but expressed in user
+    /// language) plus " · ETA …" only when honest (simulator only — see
+    /// `etaLabel`/`telemetryHonesty`).
     private var receiptsAndEtaLabel: String {
-        let receipts = "\(sessionModel.receiptCount) receipts"
-        guard telemetryHonesty.showsLiveEta else { return receipts }
-        return "\(receipts) · \(etaLabel)"
+        let framesScanned = ScanTelemetryHonesty.scannedFramesLabel(
+            sessionModel.receiptCount
+        )
+        guard telemetryHonesty.showsLiveEta else { return framesScanned }
+        return "\(framesScanned) · \(etaLabel)"
     }
 }
 

--- a/app/ScanStudio/Sources/ScanStudioKit/CaptureWorkflowSupport.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/CaptureWorkflowSupport.swift
@@ -206,6 +206,30 @@ public enum OutputDestination {
     }
 }
 
+/// Presents the output location as an already-valid part of a saved roll,
+/// while keeping a custom base folder an optional override. Project creation
+/// and output redirection are separate concepts; the interface must not imply
+/// that a second save-location choice is required before scanning.
+public enum OutputLocationPresentation {
+    public static func summary(
+        hasOpenProject: Bool,
+        customLocation: String
+    ) -> String {
+        guard hasOpenProject else {
+            return "Save Roll creates the project and sets up default output locations automatically."
+        }
+        let customLocation = customLocation.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !customLocation.isEmpty else {
+            return "Ready: every enabled output already has a save location. Changing it is optional."
+        }
+        return "Custom output location:\n\(customLocation)"
+    }
+
+    public static func showsChangeAction(hasOpenProject: Bool) -> Bool {
+        hasOpenProject
+    }
+}
+
 /// A single folder needs distinct master/derivative stems. Separate output
 /// folders can intentionally share the user's template without a collision.
 public enum OutputNamingTemplate {

--- a/app/ScanStudio/Sources/ScanStudioKit/ScanTelemetryHonesty.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ScanTelemetryHonesty.swift
@@ -29,6 +29,13 @@ public struct ScanTelemetryHonesty: Equatable, Sendable {
         self.isRealDevice = isRealDevice
     }
 
+    /// User-facing wording for the number of frames whose completion is
+    /// proven by receipts. Receipts remain the underlying evidence, but that
+    /// implementation detail should not be exposed in the capture monitor.
+    public static func scannedFramesLabel(_ count: Int) -> String {
+        "\(count) frame\(count == 1 ? "" : "s") scanned"
+    }
+
     /// A genuine, continuously live per-frame completion fraction exists only
     /// on the simulator. `isInFlightFrame` must already encode "this tile is
     /// the one `scan.progress` currently names" (`frameState == .active` and

--- a/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
@@ -1934,6 +1934,18 @@ public final class SessionModel {
         guard beginProjectLifecycleChange() else { return }
         defer { isChangingProject = false }
         lastErrorMessage = nil
+        // Batch Settings is intentionally editable before Save Roll. Capture
+        // those choices before awaiting the engine: the fresh manifest owns
+        // its project-rooted destinations, but its all-enabled recipe defaults
+        // must never silently replace an explicit TIFF-only (or other)
+        // selection the user already made in this session.
+        let draftOutput = outputRecipe
+        let draftOutputOrganization = (
+            separateFolders: saveEachOutputInOwnFolder,
+            masterFolder: masterFolderName,
+            positiveFolder: positiveTiffFolderName,
+            jpegFolder: positiveJPEGFolderName
+        )
         do {
             let params = ProjectCreateParams(
                 name: name,
@@ -1950,11 +1962,30 @@ public final class SessionModel {
             rollMetadataDraft = result.project.rollMetadata
             isCustomFilmStockSelected = false
             projectDirectory = result.directory
-            // Keep the engine-created, project-rooted destinations and all
-            // recipe fields authoritative. Only the per-user naming default
-            // is intentionally seeded into a new roll; opening a project
-            // continues to use its saved recipe unchanged.
+            // Keep the engine-created, project-rooted destinations
+            // authoritative, then restore the pre-Save output choices
+            // captured above. Only the per-user naming default is seeded
+            // separately; opening a project still uses its saved recipe
+            // unchanged.
             applyRecipes(result.project.recipes)
+            if draftOutput.archive.enabled
+                || draftOutput.positive.enabled
+                || draftOutput.preview.enabled {
+                masterTIFFEnabled = draftOutput.archive.enabled
+                fullCapturePackageEnabled = draftOutput.archive.enabled
+                    && draftOutput.archive.fullCapturePackage
+                positiveEnabled = draftOutput.positive.enabled
+                positiveFileFormat = draftOutput.positive.fileFormat
+                positiveColorProfile = draftOutput.positive.colorProfile
+                previewEnabled = draftOutput.preview.enabled
+                previewFileFormat = draftOutput.preview.fileFormat
+                previewMaxLongEdgePx = draftOutput.preview.maxLongEdgePx
+                autoCropEnabled = draftOutput.autoCrop
+                saveEachOutputInOwnFolder = draftOutputOrganization.separateFolders
+                masterFolderName = draftOutputOrganization.masterFolder
+                positiveTiffFolderName = draftOutputOrganization.positiveFolder
+                positiveJPEGFolderName = draftOutputOrganization.jpegFolder
+            }
             let template = preferences.string(forKey: Self.filenameTemplateDefaultKey)
                 .flatMap { $0.isEmpty ? nil : $0 }
                 ?? FilenameTemplate.defaultTemplate

--- a/app/ScanStudio/Tests/ScanStudioKitTests/CaptureWorkflowSupportTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/CaptureWorkflowSupportTests.swift
@@ -53,6 +53,26 @@ struct CaptureWorkflowSupportTests {
         #expect(OutputNamingTemplate.template("Film-Master", roleSuffix: "Master", separateFolders: false) == "Film-Master")
     }
 
+    @Test("output location is presented as ready by default and custom only when deliberately changed")
+    func outputLocationPresentation() {
+        #expect(OutputLocationPresentation.summary(
+            hasOpenProject: false,
+            customLocation: ""
+        ) == "Save Roll creates the project and sets up default output locations automatically.")
+        #expect(!OutputLocationPresentation.showsChangeAction(hasOpenProject: false))
+
+        #expect(OutputLocationPresentation.summary(
+            hasOpenProject: true,
+            customLocation: ""
+        ) == "Ready: every enabled output already has a save location. Changing it is optional.")
+        #expect(OutputLocationPresentation.showsChangeAction(hasOpenProject: true))
+
+        #expect(OutputLocationPresentation.summary(
+            hasOpenProject: true,
+            customLocation: "  /Volumes/Film Scans  "
+        ) == "Custom output location:\n/Volumes/Film Scans")
+    }
+
     @Test("output retention allows enabling any output but never disabling the last one")
     func outputRetentionPolicy() {
         #expect(OutputRetentionPolicy.allowsChange(

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ScanTelemetryHonestyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ScanTelemetryHonestyTests.swift
@@ -14,6 +14,13 @@ struct ScanTelemetryHonestyTests {
     private let real = ScanTelemetryHonesty(isRealDevice: true)
     private let simulated = ScanTelemetryHonesty(isRealDevice: false)
 
+    @Test("Completed scan count uses user-facing frame wording and correct plurality")
+    func scannedFramesLabelUsesCorrectPlurality() {
+        #expect(ScanTelemetryHonesty.scannedFramesLabel(0) == "0 frames scanned")
+        #expect(ScanTelemetryHonesty.scannedFramesLabel(1) == "1 frame scanned")
+        #expect(ScanTelemetryHonesty.scannedFramesLabel(2) == "2 frames scanned")
+    }
+
     @Test("Simulator surfaces its genuine per-frame fraction on the in-flight frame")
     func simulatorShowsLiveFramePercent() {
         #expect(simulated.liveFramePercent(reported: 42, isInFlightFrame: true) == 42)

--- a/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
@@ -1785,6 +1785,127 @@ struct SessionEventPolicyTests {
         #expect(model.scanFilmProcess == .positive)
     }
 
+    @Test("a new project adopts its destinations without replacing pre-Save output choices")
+    @MainActor
+    func newProjectPreservesDraftOutputChoices() async {
+        let project = ScanProject(
+            schemaVersion: 1,
+            id: "tiff-only-roll",
+            name: "TIFF-only roll",
+            carrier: .mounted,
+            frameCount: 1,
+            filmProcess: .positive,
+            recipes: OutputRecipe(
+                archive: ArchiveRecipe(
+                    filenameTemplate: "Archive_####",
+                    destination: "/tmp/project/archive"
+                ),
+                positive: PositiveRecipe(
+                    enabled: true,
+                    fileFormat: .jpeg,
+                    colorProfile: .sRgb,
+                    filenameTemplate: "Positive_####",
+                    destination: "/tmp/project/positive"
+                ),
+                preview: PreviewRecipe(
+                    enabled: true,
+                    fileFormat: .tiff,
+                    maxLongEdgePx: 1_024,
+                    filenameTemplate: "Preview_####",
+                    destination: "/tmp/project/preview"
+                )
+            ),
+            rollMetadata: MetadataSet(),
+            createdAt: "2026-08-02T00:00:00Z",
+            frames: [ProjectFrame(index: 1, excluded: false, receipts: [])]
+        )
+        let model = SessionModel(engineClient: ProjectFlowEngineStub(project: project))
+        model.setMasterTIFFEnabled(false)
+        model.setPreviewEnabled(false)
+        model.positiveFileFormat = .tiff
+        model.positiveColorProfile = .proPhotoRgb
+        model.setAutoCropEnabled(true)
+        model.saveEachOutputInOwnFolder = false
+        model.masterFolderName = "Originals"
+        model.positiveTiffFolderName = "TIFF"
+        model.positiveJPEGFolderName = "JPEG"
+
+        await model.createProject(
+            name: "TIFF-only roll",
+            carrier: .mounted,
+            frameCount: 1,
+            filmProcess: .positive
+        )
+
+        #expect(!model.masterTIFFEnabled)
+        #expect(!model.fullCapturePackageEnabled)
+        #expect(model.positiveEnabled)
+        #expect(model.positiveFileFormat == .tiff)
+        #expect(model.positiveColorProfile == .proPhotoRgb)
+        #expect(!model.previewEnabled)
+        #expect(model.autoCropEnabled)
+        #expect(!model.saveEachOutputInOwnFolder)
+        #expect(model.masterFolderName == "Originals")
+        #expect(model.positiveTiffFolderName == "TIFF")
+        #expect(model.positiveJPEGFolderName == "JPEG")
+        #expect(model.outputRecipe.archive.destination == "/tmp/project/archive")
+        #expect(model.outputRecipe.positive.destination == "/tmp/project/positive")
+        #expect(model.outputRecipe.preview.destination == "/tmp/project/preview")
+    }
+
+    @Test("opening a project still replaces session output choices with its saved recipe")
+    @MainActor
+    func openProjectStillAppliesPersistedOutputChoices() async {
+        let project = ScanProject(
+            schemaVersion: 1,
+            id: "saved-preview-roll",
+            name: "Saved preview roll",
+            carrier: .mounted,
+            frameCount: 1,
+            filmProcess: .positive,
+            recipes: OutputRecipe(
+                archive: ArchiveRecipe(
+                    enabled: false,
+                    filenameTemplate: "Saved-Archive_####",
+                    destination: "/tmp/saved/archive",
+                    fullCapturePackage: false
+                ),
+                positive: PositiveRecipe(
+                    enabled: false,
+                    fileFormat: .jpeg,
+                    colorProfile: .sRgb,
+                    filenameTemplate: "Saved-Positive_####",
+                    destination: "/tmp/saved/positive"
+                ),
+                preview: PreviewRecipe(
+                    enabled: true,
+                    fileFormat: .tiff,
+                    maxLongEdgePx: 2_048,
+                    filenameTemplate: "Saved-Preview_####",
+                    destination: "/tmp/saved/preview"
+                ),
+                autoCrop: true
+            ),
+            rollMetadata: MetadataSet(),
+            createdAt: "2026-08-02T00:00:00Z",
+            frames: [ProjectFrame(index: 1, excluded: false, receipts: [])]
+        )
+        let model = SessionModel(engineClient: ProjectFlowEngineStub(project: project))
+
+        await model.openProject(directory: "/tmp/saved-preview-roll")
+
+        #expect(!model.masterTIFFEnabled)
+        #expect(!model.fullCapturePackageEnabled)
+        #expect(!model.positiveEnabled)
+        #expect(model.previewEnabled)
+        #expect(model.previewFileFormat == .tiff)
+        #expect(model.previewMaxLongEdgePx == 2_048)
+        #expect(model.autoCropEnabled)
+        #expect(model.archiveDestination == "/tmp/saved/archive")
+        #expect(model.positiveDestination == "/tmp/saved/positive")
+        #expect(model.previewDestination == "/tmp/saved/preview")
+    }
+
     @Test("a saved naming default survives new-project creation while an opened recipe remains authoritative")
     @MainActor
     func namingDefaultOnlySeedsNewProjects() async throws {

--- a/app/ScanStudio/packaging/Info.plist
+++ b/app/ScanStudio/packaging/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundleShortVersionString</key>
     <string>0.3.0</string>
     <key>CFBundleVersion</key>
-    <string>5</string>
+    <string>6</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>

--- a/app/ScanStudio/scripts/package_dmg.sh
+++ b/app/ScanStudio/scripts/package_dmg.sh
@@ -18,7 +18,7 @@ if [[ ! -f "$info_plist" ]]; then
 fi
 
 bundle_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info_plist")"
-release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.3}"
+release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.4}"
 release_arch="${SCANSTUDIO_RELEASE_ARCH:-$(uname -m)}"
 output="${2:-$package_root/.build/ScanStudio-$release_version-macOS-$release_arch.dmg}"
 


### PR DESCRIPTION
## What changed

- Replace the internal N receipts capture status with user-facing N frames scanned, including correct singular/plural wording.
- Make the existing project-rooted output location explicit and relabel custom output selection as an optional Change action.
- Clarify that Save Roll creates a resumable project and sets up default output locations.
- Preserve output choices made before Save Roll, so selecting positive-TIFF-only is not silently reset to all outputs when the project is created.
- Keep persisted recipes authoritative when reopening an existing project.
- Bump the packaged app to ScanStudio 0.3.0 build 6 and prepare the v0.3.0-alpha.4 DMG name.

## Why

The capture monitor exposed an implementation term even when the user requested only TIFFs. Separately, the UI made a custom output location look mandatory even though Save Roll already creates valid project-rooted destinations. Project creation also reloaded all-enabled engine defaults, which could erase a TIFF-only choice made before Save Roll and force the user to configure output twice.

## User impact

The app now reports completed frames in plain language, presents location changes as optional, and carries pre-Save output choices directly into the scan.

## Validation

- 359 Rust engine tests passed.
- 377 Swift app tests passed.
- The self-contained build passed strict signing, packaged launcher and bridge relocation, corresponding-source, license, forbidden-table, and privacy checks.
- No scanner motion was performed while implementing or packaging this change.