### PR TITLE
Fix leading-frame detection and prepare alpha 6

### DIFF
--- a/app/ScanStudio/packaging/Info.plist
+++ b/app/ScanStudio/packaging/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundleShortVersionString</key>
     <string>0.3.0</string>
     <key>CFBundleVersion</key>
-    <string>7</string>
+    <string>8</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>

--- a/app/ScanStudio/scripts/package_dmg.sh
+++ b/app/ScanStudio/scripts/package_dmg.sh
@@ -18,7 +18,7 @@ if [[ ! -f "$info_plist" ]]; then
 fi
 
 bundle_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info_plist")"
-release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.5}"
+release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.6}"
 release_arch="${SCANSTUDIO_RELEASE_ARCH:-$(uname -m)}"
 output="${2:-$package_root/.build/ScanStudio-$release_version-macOS-$release_arch.dmg}"
 

--- a/coolscanpy/CHANGELOG.md
+++ b/coolscanpy/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Whole-roll preview now keeps a content-supported leading frame when an
+otherwise valid feed places its fitted start exactly one 97-dpi preview row
+before the captured raster. The thumbnail is clamped to row zero, its
+same-capture transport origin is inferred from the validated interior mapping,
+and the frame remains blocked on explicit manual review; clips of two or more
+rows are still excluded fail-closed. This prevents a six-exposure strip from
+being silently presented as five after a one-row feed variation.
+
 Transparent macOS app bundles can now pin PyUSB to an app-owned libusb
 without pretending the interpreter is PyInstaller-frozen. The resolver accepts
 only the fixed `*.app/Contents/Resources/BridgeRuntime/python/bin` interpreter

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -36,7 +36,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "436b504ecfa6bd01219e34c36e0e0fa29f11c9cd740dafcebc93685a9149545d",
+    "roll_index.py": "b9cdec8fe47f470eed45185622c6d16ad1583520792c84aa2a89709555331e1b",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -946,8 +946,9 @@ def detect_roll_frames(
     # local evidence window needs neighbours on both sides.  The extended
     # lattice used here has already been fitted, so applying that margin again
     # silently drops a complete first cell whose rounded boundary is row 0 or
-    # row 1.  Admit those fully in-raster starts.  A genuinely clipped leading
-    # cell still has a negative start and remains excluded fail-closed.
+    # row 1. Admit those fully in-raster starts. A content-supported cell that
+    # starts exactly one row before the raster remains visible for manual
+    # review below; larger leading clips remain excluded fail-closed.
     lattice_starts = [
         index
         for index, row in enumerate(all_positions[:-1])
@@ -956,6 +957,20 @@ def detect_roll_frames(
     if not lattice_starts:
         raise IndexDecodeError("roll detector found no in-raster lattice origin")
     cell_start = lattice_starts[0]
+    preceding_cell = cell_start - 1
+    if (
+        preceding_cell >= 0
+        and int(all_positions[preceding_cell]) == -1
+        and float(cell_coverage[preceding_cell]) >= 0.99
+        and bool(cell_supported[preceding_cell])
+    ):
+        # A normal feed can place the fitted leading boundary one preview row
+        # before the saved raster while retaining more than 99% of a real
+        # first frame. Keep that frame visible for explicit manual review;
+        # ``make_boundary`` clamps its thumbnail to row zero and the transport
+        # mapper independently infers a same-capture origin. Larger clips stay
+        # excluded because they no longer meet this exact one-row contract.
+        cell_start = preceding_cell
     in_raster_starts = np.flatnonzero(
         (all_positions[:-1] >= all_positions[cell_start])
         & (all_positions[:-1] < len(evidence))

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -246,22 +246,50 @@ def test_scanner_addressable_interval_count_keeps_interior_manual_cells() -> Non
     assert roll.scanner_addressable_interval_count(detection.intervals) == 6
 
 
-def test_clipped_leading_cell_remains_excluded_fail_closed() -> None:
+def test_one_row_clipped_leading_cell_is_exposed_for_manual_review() -> None:
     complete_rgb, _boundaries = _synthetic_roll(6, leader=0, tail=24)
     clipped_rgb = complete_rgb[1:]
 
     detection = _detect(clipped_rgb)
 
-    # Cropping even one row moves the fitted leading boundary outside the
-    # captured raster.  The near-complete leading cell must not be promoted
-    # ahead of the first wholly scanner-addressable lattice start.
+    # A one-row feed variation retains 99% of the first frame and the whole
+    # physical lattice. Expose that frame without silently treating its
+    # inferred leading boundary as automatic.
+    leading = detection.intervals[0]
+    assert leading.start_row == 0
+    assert leading.coverage_fraction == pytest.approx(142 / 143)
+    assert leading.count_supported
+    assert leading.manual_review
+    assert "start-outside-index-raster" in leading.review_reasons
+    assert "partial-index-coverage" in leading.review_reasons
+    scanner_frame_count = roll.scanner_addressable_interval_count(detection.intervals)
+    assert scanner_frame_count == 6
+
+    records = roll.parse_live_transport_records_bytes(
+        _live_extent(len(clipped_rgb)), maximum_rows=len(clipped_rgb)
+    )
+    mapping = roll.derive_transport_mapping(
+        detection.boundaries, scanner_frame_count, records
+    )
+    assert len(mapping.origins) == 6
+    assert mapping.origins[0].manual_review
+    assert not mapping.origins[0].automatic
+    assert "outside-index-raster" in mapping.origins[0].review_reasons
+    assert "transport-origin-inferred" in mapping.origins[0].review_reasons
+    assert all(
+        first.native_origin < second.native_origin
+        for first, second in zip(mapping.origins, mapping.origins[1:])
+    )
+
+
+def test_two_row_clipped_leading_cell_remains_excluded_fail_closed() -> None:
+    complete_rgb, _boundaries = _synthetic_roll(6, leader=0, tail=24)
+    clipped_rgb = complete_rgb[2:]
+
+    detection = _detect(clipped_rgb)
+
     assert detection.frame_starts[0] > 100
-    complete = [
-        interval
-        for interval in detection.intervals
-        if interval.coverage_fraction == 1.0 and interval.count_supported
-    ]
-    assert len(complete) == 5
+    assert roll.scanner_addressable_interval_count(detection.intervals) == 5
 
 
 def test_channel_gain_changes_do_not_move_detected_boundaries() -> None:

--- a/coolscanpy/tests/roll/test_ls5000_roll_session.py
+++ b/coolscanpy/tests/roll/test_ls5000_roll_session.py
@@ -86,13 +86,14 @@ def _encode_index(rgb16: np.ndarray) -> bytes:
 def _synthetic_index(
     *,
     height: int = 6_104,
+    frame_count: int = 40,
     content_frames: int = 40,
+    leader: int = 128,
 ) -> np.ndarray:
-    """Make 40 textured cells separated by physical clear-film gaps."""
+    """Make textured cells separated by physical clear-film gaps."""
 
     pitch = 143
-    leader = 128
-    boundaries = [leader + index * pitch for index in range(41)]
+    boundaries = [leader + index * pitch for index in range(frame_count + 1)]
     y = np.arange(height, dtype=np.int64)[:, None]
     x = np.arange(90, dtype=np.int64)[None, :]
     texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
@@ -104,10 +105,10 @@ def _synthetic_index(
     aperture[: boundaries[0]] = clear_base + clear_noise[: boundaries[0]]
     aperture[boundaries[-1] :] = clear_base + clear_noise[boundaries[-1] :]
     for boundary in boundaries:
-        aperture[boundary - 3 : boundary + 3] = (
-            clear_base + clear_noise[boundary - 3 : boundary + 3]
-        )
-    if content_frames < 40:
+        start = max(0, boundary - 3)
+        end = min(height, boundary + 3)
+        aperture[start:end] = clear_base + clear_noise[start:end]
+    if content_frames < frame_count:
         clear_start = boundaries[content_frames]
         aperture[clear_start:] = clear_base + clear_noise[clear_start:]
     rgb = np.empty((height, 96, 3), dtype=np.int64)
@@ -136,6 +137,7 @@ def _preview_fixture(
     *,
     content_frames: int = 40,
     slot_capacity_hint: int = 40,
+    active_rgb: np.ndarray | None = None,
     density_capture_attempt_id: str | None = None,
     density_scan_identity: str | None = None,
 ) -> PreviewFixture:
@@ -156,12 +158,28 @@ def _preview_fixture(
     preview_path = attempt / "capture-preview.bin"
     table_path = attempt / "capture-008e.bin"
     mapping_path = attempt / "capture-frame-map.json"
-    rgb = _synthetic_index(
-        height=decoded_height,
-        content_frames=content_frames,
-    )
-    preview = _encode_index(rgb)
-    table = _transport_table(len(rgb))
+    if active_rgb is None:
+        rgb = _synthetic_index(
+            height=decoded_height,
+            content_frames=content_frames,
+        )
+        usable_rows = len(rgb)
+        preview = _encode_index(rgb)
+    else:
+        if active_rgb.ndim != 3 or active_rgb.shape[1:] != (96, 3):
+            raise ValueError("active preview RGB must have shape (rows, 96, 3)")
+        if not 0 < len(active_rgb) < decoded_height:
+            raise ValueError("active preview RGB must fit inside the allocation")
+        usable_rows = len(active_rgb)
+        rgb = np.zeros((decoded_height, 96, 3), dtype=np.uint16)
+        rgb[:usable_rows] = active_rgb
+        rows = np.frombuffer(_encode_index(rgb), dtype=">u2").copy().reshape(
+            decoded_height,
+            roll_index.INDEX_ROW_WORDS,
+        )
+        rows[usable_rows:] = rows[usable_rows]
+        preview = rows.astype(">u2", copy=False).tobytes()
+    table = _transport_table(usable_rows)
     preview_path.write_bytes(preview)
     table_path.write_bytes(table)
     density_session_id = "single-reservation-roll-preview"
@@ -479,6 +497,63 @@ def test_preview_session_accepts_the_observed_six_record_short_strip(
     assert len(session.slots) == 6
     assert fixture.result.density_evidence is not None
     assert fixture.result.density_evidence.source_binding.height == 1_162
+
+
+def test_preview_session_keeps_one_row_clipped_first_frame_for_review(
+    tmp_path: Path,
+) -> None:
+    complete = _synthetic_index(
+        height=882,
+        frame_count=6,
+        content_frames=6,
+        leader=0,
+    )
+    fixture = _preview_fixture(
+        tmp_path,
+        slot_capacity_hint=6,
+        active_rgb=complete[1:],
+    )
+
+    session = build_roll_preview_session(
+        fixture.result,
+        material=ScanMaterial.COLOR_NEGATIVE,
+    )
+
+    assert session.preview.usable_rows == 881
+    assert [slot.slot_id for slot in session.slots] == [1, 2, 3, 4, 5, 6]
+    assert [
+        (slot.start_boundary_row, slot.end_boundary_row) for slot in session.slots
+    ] == [
+        (0, 142),
+        (142, 285),
+        (285, 428),
+        (428, 571),
+        (571, 714),
+        (714, 857),
+    ]
+    leading = session.slots[0]
+    assert leading.manual_review
+    assert {
+        "start-outside-index-raster",
+        "partial-index-coverage",
+        "outside-index-raster",
+        "transport-origin-inferred",
+    }.issubset(leading.warnings)
+    assert leading.base_origin.method == "affine-guided-local-lookup"
+    assert leading.base_origin.manual_review
+    assert not leading.base_origin.automatic
+    np.testing.assert_array_equal(leading.thumbnail, fixture.rgb[:142])
+    assert all(
+        first.base_origin.native_origin < second.base_origin.native_origin
+        for first, second in zip(session.slots, session.slots[1:])
+    )
+
+    approval = session.approve_manual_origin(1, 0)
+    assert session.validate_manual_approval(
+        approval,
+        slot_id=1,
+        boundary_offset_rows=0,
+    )
 
 
 def test_preview_refuses_density_source_geometry_from_another_startup_count(


### PR DESCRIPTION
## What changed

- bundle the one-row leading-frame recovery from CoolscanPy
- keep the recovered first frame behind ScanStudio's existing Review flow
- preserve fail-closed exclusion for clips of two or more preview rows
- add detector, mapping, and complete preview-session regressions
- update the sealed bundled-source hash
- prepare ScanStudio 0.3.0 alpha 6 (bundle build 8 and corrected DMG name)

## Root cause and user impact

A real six-exposure strip was shown as five after its leading boundary landed one preview row outside the saved raster. The raw scanner data contained all six images. Alpha 6 exposes all six while requiring the operator to review the inferred edge before scanning.

## Validation

- the saved real preview replays through the same public session builder used by the app as six slots
- recovered slot 1 is manual-review only; all six native origins are strictly increasing
- two-row clipping remains excluded
- full ScanStudio app/engine, bridge, and bundled CoolscanPy suites pass
- alpha 5 rollback DMG is pinned and verified before release replacement
