### PR TITLE
Fix Save Roll continuation and frame edit controls

### DIFF
--- a/app/ScanStudio/Sources/ScanStudio/ContentView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ContentView.swift
@@ -276,9 +276,17 @@ private struct ManualReviewScanSheet: View {
                 orientationDegrees: sessionModel.frameOrientation(
                     requirement.frameIndex
                 ),
-                mirrored: sessionModel.frameMirror(requirement.frameIndex)
+                mirrored: sessionModel.frameMirror(requirement.frameIndex),
+                verticallyMirrored: sessionModel.frameVerticalMirror(
+                    requirement.frameIndex
+                )
             )
-            .aspectRatio(3.0 / 2.0, contentMode: .fit)
+            .aspectRatio(
+                FrameOrientation.displayAspectRatio(
+                    sessionModel.frameOrientation(requirement.frameIndex)
+                ),
+                contentMode: .fit
+            )
             .frame(width: 190)
             .background(Color.black.opacity(0.35))
             .clipShape(
@@ -604,7 +612,10 @@ private struct PreProjectPreviewWorkspaceView: View {
         }
         .background(Color.scanStudioWorkspace)
         .sheet(isPresented: $isShowingProjectLauncher) {
-            ProjectLauncherView(session: sessionModel)
+            ProjectLauncherView(
+                session: sessionModel,
+                purpose: .saveRollAndScan
+            )
         }
         .sheet(item: $processPreviewToken) { token in
             RePreviewProcessSheet(session: sessionModel, intentToken: token)
@@ -632,7 +643,7 @@ private struct PreProjectPreviewWorkspaceView: View {
 
     private var calloutCopy: some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text("\(sessionModel.thumbnailCount) previews ready")
+            Text("\(sessionModel.thumbnailCount) previews ready · \(sessionModel.selectedFrameCount) selected")
                 .font(.system(size: 15, weight: .semibold))
             Text(calloutGuidance)
                 .font(.system(size: 11))
@@ -643,20 +654,20 @@ private struct PreProjectPreviewWorkspaceView: View {
     }
 
     private var unresolvedReviewCount: Int {
-        sessionModel.thumbnails.filter { entry in
-            entry.value.needsApproval
-                && sessionModel.manualReviewDecision(for: entry.key) == nil
+        sessionModel.selectedFrames.filter { frameIndex in
+            sessionModel.thumbnails[frameIndex]?.needsApproval == true
+                && sessionModel.manualReviewDecision(for: frameIndex) != .useFrameAnyway
         }.count
     }
 
     private var calloutGuidance: String {
         if unresolvedReviewCount == 1 {
-            return "One frame needs a boundary choice. Click its Review button to use it, skip it, or preview again."
+            return "One selected frame needs a boundary check. Save now; its review opens next, before any scan starts."
         }
         if unresolvedReviewCount > 1 {
-            return "\(unresolvedReviewCount) frames need boundary choices. Click each Review button to use it, skip it, or preview again."
+            return "\(unresolvedReviewCount) selected frames need boundary checks. Save now; those reviews open next, before any scan starts."
         }
-        return "Save Roll names this roll, creates its resumable project, sets up default output locations, and enables scanning."
+        return "Save once to name this roll and start scanning the selected frames."
     }
 
     private var calloutActions: some View {
@@ -670,13 +681,26 @@ private struct PreProjectPreviewWorkspaceView: View {
             Button {
                 isShowingProjectLauncher = true
             } label: {
-                Label("Save Roll…", systemImage: "folder.badge.plus")
+                Label(saveAndScanButtonLabel, systemImage: "folder.badge.plus")
             }
             .buttonStyle(.borderedProminent)
             .tint(.scanStudioAmber)
             .foregroundStyle(.black)
             .controlSize(.regular)
+            .disabled(sessionModel.selectedFrameCount == 0)
+            .help(
+                sessionModel.selectedFrameCount == 0
+                    ? "Select at least one frame to scan."
+                    : "Save the roll and continue into review or scanning."
+            )
         }
+    }
+
+    private var saveAndScanButtonLabel: String {
+        let count = sessionModel.selectedFrameCount
+        return unresolvedReviewCount > 0
+            ? "Save & Review \(count)…"
+            : "Save & Scan \(count)…"
     }
 }
 

--- a/app/ScanStudio/Sources/ScanStudio/FrameDetailWorkspaceView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/FrameDetailWorkspaceView.swift
@@ -258,6 +258,7 @@ struct FrameDetailWorkspaceView: View {
         let isAvailable = sessionModel.thumbnails[frameIndex].map { $0.isSimulatorShaped } ?? false
         let orientationDegrees = sessionModel.frameOrientation(frameIndex)
         let mirrored = sessionModel.frameMirror(frameIndex)
+        let verticallyMirrored = sessionModel.frameVerticalMirror(frameIndex)
 
         return VStack(alignment: .leading, spacing: 6) {
             viewingModeSwitcher
@@ -286,10 +287,17 @@ struct FrameDetailWorkspaceView: View {
                         SimulatedFrameImage(frameIndex: frameIndex, isAvailable: isAvailable)
                     }
                 }
-                .scaleEffect(x: mirrored ? -1 : 1, y: 1)
+                .scaleEffect(
+                    x: mirrored ? -1 : 1,
+                    y: verticallyMirrored ? -1 : 1
+                )
                 .rotationEffect(.degrees(Double(orientationDegrees)))
                 if viewingMode == .defectMap {
-                    defectMapOverlayContent(orientationDegrees: orientationDegrees, mirrored: mirrored)
+                    defectMapOverlayContent(
+                        orientationDegrees: orientationDegrees,
+                        mirrored: mirrored,
+                        verticallyMirrored: verticallyMirrored
+                    )
                 }
             }
             .scaleEffect(zoomState.scale)
@@ -297,7 +305,10 @@ struct FrameDetailWorkspaceView: View {
             // Swap to portrait (2:3) at 90/270 so the rotated frame fits instead
             // of being clipped to the landscape box (rotationEffect does not
             // resize layout bounds).
-            .aspectRatio(orientationDegrees % 180 == 0 ? 3.0 / 2.0 : 2.0 / 3.0, contentMode: .fit)
+            .aspectRatio(
+                FrameOrientation.displayAspectRatio(orientationDegrees),
+                contentMode: .fit
+            )
             .frame(maxWidth: .infinity, minHeight: 360, maxHeight: 480)
             .background(.black)
             .clipShape(RoundedRectangle(cornerRadius: 5))
@@ -402,6 +413,7 @@ struct FrameDetailWorkspaceView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
+            .keyboardShortcut("l", modifiers: .command)
             .help("Rotate counter-clockwise—display only; saved output is unchanged")
 
             Button {
@@ -411,6 +423,7 @@ struct FrameDetailWorkspaceView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
+            .keyboardShortcut("r", modifiers: .command)
             .help("Rotate clockwise—display only; saved output is unchanged")
 
             Button {
@@ -427,23 +440,34 @@ struct FrameDetailWorkspaceView: View {
             Button {
                 sessionModel.toggleFrameMirror(frameIndex)
             } label: {
-                Label(
-                    sessionModel.frameMirror(frameIndex) ? "Mirror On" : "Mirror Off",
-                    systemImage: "arrow.left.and.right.righttriangle.left.righttriangle.right"
-                )
+                Label("Flip Left to Right", systemImage: "arrow.left.and.right")
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .help("Toggle horizontal mirror—display only; saved output is unchanged")
+            .keyboardShortcut("h", modifiers: [.command, .shift])
+            .help("Flip left to right—display only; saved output is unchanged")
 
             Button {
-                sessionModel.resetFrameMirror(frameIndex)
+                sessionModel.toggleFrameVerticalMirror(frameIndex)
             } label: {
-                Label("Reset Mirror", systemImage: "arrow.left.and.right")
+                Label("Flip Top to Bottom", systemImage: "arrow.up.and.down")
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .disabled(!sessionModel.frameMirror(frameIndex))
+            .keyboardShortcut("v", modifiers: [.command, .shift])
+            .help("Flip top to bottom—display only; saved output is unchanged")
+
+            Button {
+                sessionModel.resetFrameMirrors(frameIndex)
+            } label: {
+                Label("Reset Flips", systemImage: "arrow.uturn.backward")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(
+                !sessionModel.frameMirror(frameIndex)
+                    && !sessionModel.frameVerticalMirror(frameIndex)
+            )
 
             Spacer(minLength: 12)
 
@@ -453,7 +477,7 @@ struct FrameDetailWorkspaceView: View {
                 .fixedSize()
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Frame orientation and mirror, display only")
+        .accessibilityLabel("Frame orientation and flips, display only")
     }
 
     /// Defect Map mode's overlay content, layered inside the same
@@ -466,7 +490,11 @@ struct FrameDetailWorkspaceView: View {
     /// keys the empty states off the authoritative wire boolean, never
     /// `defects.isEmpty` alone.
     @ViewBuilder
-    private func defectMapOverlayContent(orientationDegrees: Int, mirrored: Bool) -> some View {
+    private func defectMapOverlayContent(
+        orientationDegrees: Int,
+        mirrored: Bool,
+        verticallyMirrored: Bool
+    ) -> some View {
         if let analysis = currentDefectAnalysis {
             if analysis.digitalIceEnabled == false {
                 DigitalIceOffNotice()
@@ -474,7 +502,10 @@ struct FrameDetailWorkspaceView: View {
                 CleanFrameNotice(simulated: analysis.simulated)
             } else {
                 DefectOverlayCanvas(defects: visibleDefectsForFrame, opacity: overlayOpacity)
-                    .scaleEffect(x: mirrored ? -1 : 1, y: 1)
+                    .scaleEffect(
+                        x: mirrored ? -1 : 1,
+                        y: verticallyMirrored ? -1 : 1
+                    )
                     // Track the image rotation so markers stay on their defects.
                     // Scoped to the canvas only so the centered empty-state notices
                     // above stay upright.
@@ -521,6 +552,9 @@ struct FrameDetailWorkspaceView: View {
         }
         if sessionModel.frameMirror(frameIndex) {
             label += ", mirrored horizontally"
+        }
+        if sessionModel.frameVerticalMirror(frameIndex) {
+            label += ", mirrored vertically"
         }
         if viewingMode == .defectMap, let defects = currentDefectAnalysis?.defects, !defects.isEmpty {
             let provenance = currentDefectAnalysis?.simulated ?? true ? "simulated" : "real"
@@ -710,7 +744,8 @@ struct FrameDetailWorkspaceView: View {
                                 isCurrent: otherFrameIndex == frameIndex,
                                 thumbnail: sessionModel.thumbnails[otherFrameIndex],
                                 orientationDegrees: sessionModel.frameOrientation(otherFrameIndex),
-                                mirrored: sessionModel.frameMirror(otherFrameIndex)
+                                mirrored: sessionModel.frameMirror(otherFrameIndex),
+                                verticallyMirrored: sessionModel.frameVerticalMirror(otherFrameIndex)
                             ) {
                                 sessionModel.openFrameDetail(otherFrameIndex)
                             }
@@ -1648,12 +1683,19 @@ private struct FilmstripTile: View {
     /// — see `ThumbnailTileImage.orientationDegrees`.
     let orientationDegrees: Int
     let mirrored: Bool
+    let verticallyMirrored: Bool
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             ZStack(alignment: .bottomLeading) {
-                ThumbnailTileImage(frameIndex: frameIndex, thumbnail: thumbnail, orientationDegrees: orientationDegrees, mirrored: mirrored)
+                ThumbnailTileImage(
+                    frameIndex: frameIndex,
+                    thumbnail: thumbnail,
+                    orientationDegrees: orientationDegrees,
+                    mirrored: mirrored,
+                    verticallyMirrored: verticallyMirrored
+                )
 
                 Text(String(format: "%02d", frameIndex))
                     .font(.system(size: 8, weight: .medium, design: .monospaced))
@@ -1661,7 +1703,10 @@ private struct FilmstripTile: View {
                     .padding(3)
                     .background(Color.black.opacity(0.64))
             }
-            .frame(width: 64, height: 44)
+            .frame(
+                width: swapsLayoutAxes ? 44 : 64,
+                height: swapsLayoutAxes ? 64 : 44
+            )
             .clipShape(RoundedRectangle(cornerRadius: 4))
             .overlay {
                 RoundedRectangle(cornerRadius: 4)
@@ -1682,7 +1727,14 @@ private struct FilmstripTile: View {
         if mirrored {
             label += ", mirrored horizontally"
         }
+        if verticallyMirrored {
+            label += ", mirrored vertically"
+        }
         return label
+    }
+
+    private var swapsLayoutAxes: Bool {
+        FrameOrientation.swapsLayoutAxes(orientationDegrees)
     }
 }
 

--- a/app/ScanStudio/Sources/ScanStudio/ProjectLauncherView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ProjectLauncherView.swift
@@ -6,6 +6,11 @@ private enum LauncherTab: Hashable {
     case openRecent
 }
 
+enum ProjectLauncherPurpose: Equatable {
+    case manageProjects
+    case saveRollAndScan
+}
+
 /// New Project / Open Recent flow, presented as a sheet from
 /// `SessionSidebarView`. Takes the app's single `SessionModel` instance as
 /// an explicit `@Bindable` parameter (rather than `@Environment`) so this
@@ -16,6 +21,7 @@ struct ProjectLauncherView: View {
     @Bindable var session: SessionModel
     @Environment(\.dismiss) private var dismiss
 
+    let purpose: ProjectLauncherPurpose
     var onProjectSaved: (() -> Void)? = nil
 
     @State private var name = ""
@@ -23,9 +29,15 @@ struct ProjectLauncherView: View {
     @State private var selectedTab: LauncherTab = .newProject
     @State private var createAttemptError: String?
     @State private var openRecentAttemptError: String?
+    @State private var isSubmitting = false
 
-    init(session: SessionModel, onProjectSaved: (() -> Void)? = nil) {
+    init(
+        session: SessionModel,
+        purpose: ProjectLauncherPurpose = .manageProjects,
+        onProjectSaved: (() -> Void)? = nil
+    ) {
         self.session = session
+        self.purpose = purpose
         self.onProjectSaved = onProjectSaved
         let detectedCarrier = ProjectLaunchPolicy.initialCarrier(loadedCarrier: session.loadedCarrier)
         _carrier = State(initialValue: detectedCarrier)
@@ -33,25 +45,45 @@ struct ProjectLauncherView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Picker("", selection: $selectedTab) {
-                Text("New Project").tag(LauncherTab.newProject)
-                Text("Open Recent").tag(LauncherTab.openRecent)
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .padding([.horizontal, .top])
-            .accessibilityLabel("Project launcher tab")
+            if purpose == .saveRollAndScan {
+                saveRollHeader
+                newProjectForm
+            } else {
+                Picker("", selection: $selectedTab) {
+                    Text("New Project").tag(LauncherTab.newProject)
+                    Text("Open Recent").tag(LauncherTab.openRecent)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .padding([.horizontal, .top])
+                .accessibilityLabel("Project launcher tab")
 
-            Group {
-                if selectedTab == .newProject {
-                    newProjectForm
-                } else {
-                    openRecentSection
+                Group {
+                    if selectedTab == .newProject {
+                        newProjectForm
+                    } else {
+                        openRecentSection
+                    }
                 }
             }
         }
         .frame(width: 420, height: 460)
         .padding(20)
+        .interactiveDismissDisabled(isSubmitting)
+    }
+
+    private var saveRollHeader: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("Save Roll & Scan")
+                .font(.system(size: 20, weight: .semibold))
+            Text(saveRollGuidance)
+                .font(.system(size: 12))
+                .foregroundStyle(Color.scanStudioSecondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal)
+        .padding(.top, 8)
     }
 
     private var newProjectForm: some View {
@@ -123,7 +155,7 @@ struct ProjectLauncherView: View {
                     .foregroundStyle(Color.scanStudioSecondaryText)
             }
 
-            Button("Create") {
+            Button(submitButtonTitle) {
                 Task {
                     guard let carrier,
                           let frameCount = confirmedFrameCount,
@@ -131,24 +163,49 @@ struct ProjectLauncherView: View {
                           registeredPreviewFrameCount != nil
                     else { return }
                     createAttemptError = nil
-                    await session.createProject(
-                        name: name,
-                        carrier: carrier,
-                        frameCount: frameCount,
-                        filmProcess: previewProcess
-                    )
-                    if session.lastErrorMessage == nil {
-                        onProjectSaved?()
+                    isSubmitting = true
+                    let completed: Bool
+                    switch purpose {
+                    case .manageProjects:
+                        await session.createProject(
+                            name: name,
+                            carrier: carrier,
+                            frameCount: frameCount,
+                            filmProcess: previewProcess
+                        )
+                        completed = session.lastErrorMessage == nil
+                    case .saveRollAndScan:
+                        completed = await session.saveRollAndScanSelectedFrames(
+                            name: name,
+                            carrier: carrier,
+                            frameCount: frameCount,
+                            filmProcess: previewProcess
+                        )
+                    }
+                    isSubmitting = false
+
+                    if completed {
+                        if purpose == .manageProjects {
+                            onProjectSaved?()
+                        }
+                        dismiss()
+                    } else if purpose == .saveRollAndScan,
+                              session.project != nil {
+                        // The roll is safely saved, but scan startup failed.
+                        // Return to the project and leave its error banner
+                        // intact; retrying project creation would be wrong.
                         dismiss()
                     } else {
                         // Curated title, not the raw `lastErrorMessage` --
                         // this sheet is the primary new-project flow, not a
                         // developer pane.
                         createAttemptError = session.errorPresentation?.title
+                            ?? "Couldn’t save this roll."
                     }
                 }
             }
-            .disabled(disabledReason != nil)
+            .disabled(disabledReason != nil || isSubmitting)
+            .keyboardShortcut(.defaultAction)
         }
         .padding(.top, 12)
     }
@@ -169,9 +226,45 @@ struct ProjectLauncherView: View {
         )
     }
 
+    private var selectedFrameCount: Int {
+        session.selectedFrameCount
+    }
+
+    private var selectedReviewCount: Int {
+        session.selectedFrames.filter { frameIndex in
+            session.thumbnails[frameIndex]?.needsApproval == true
+                && session.manualReviewDecision(for: frameIndex) != .useFrameAnyway
+        }.count
+    }
+
+    private var submitButtonTitle: String {
+        if isSubmitting {
+            return purpose == .saveRollAndScan ? "Saving Roll…" : "Creating…"
+        }
+        guard purpose == .saveRollAndScan else { return "Create" }
+        let noun = selectedFrameCount == 1 ? "Frame" : "Frames"
+        return selectedReviewCount > 0
+            ? "Save & Review \(selectedFrameCount) \(noun)"
+            : "Save & Scan \(selectedFrameCount) \(noun)"
+    }
+
+    private var saveRollGuidance: String {
+        let noun = selectedFrameCount == 1 ? "frame" : "frames"
+        if selectedReviewCount > 0 {
+            let reviewNoun = selectedReviewCount == 1
+                ? "boundary check"
+                : "boundary checks"
+            return "\(selectedReviewCount) of the \(selectedFrameCount) selected \(noun) need \(reviewNoun). Save the roll now; ScanStudio will show those reviews next, then scan the selection once."
+        }
+        return "The \(selectedFrameCount) selected \(noun) will start scanning as soon as this roll is saved."
+    }
+
     private var disabledReason: String? {
         if session.isJobActive || session.jobId != nil {
             return "Finish or stop the current scan before changing projects."
+        }
+        if purpose == .saveRollAndScan, selectedFrameCount == 0 {
+            return "Select at least one frame before saving and scanning."
         }
         return ProjectLaunchPolicy.createDisabledReason(
             name: name,

--- a/app/ScanStudio/Sources/ScanStudio/RollLoadingWorkspaceView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/RollLoadingWorkspaceView.swift
@@ -183,7 +183,8 @@ struct CarrierLoadingWorkspaceView: View {
                     thumbnail: sessionModel.thumbnails[frameIndex],
                     isCurrent: frameIndex == inFlightFrame,
                     orientationDegrees: sessionModel.frameOrientation(frameIndex),
-                    mirrored: sessionModel.frameMirror(frameIndex)
+                    mirrored: sessionModel.frameMirror(frameIndex),
+                    verticallyMirrored: sessionModel.frameVerticalMirror(frameIndex)
                 )
             }
         }
@@ -238,6 +239,8 @@ private struct RollLoadingFrameCell: View {
     let orientationDegrees: Int
     /// Session-local horizontal mirror, kept in sync with the contact sheet.
     let mirrored: Bool
+    /// Session-local vertical mirror, kept in sync with the contact sheet.
+    let verticallyMirrored: Bool
 
     /// Whether the engine has reported ANY preview for this frame yet —
     /// real or simulated. This carries no real-vs-simulated meaning on its
@@ -266,7 +269,13 @@ private struct RollLoadingFrameCell: View {
             // a neutral placeholder otherwise — so it's reused here instead
             // of re-deriving that same real-vs-simulated distinction a
             // second, easy-to-drift-out-of-sync time.
-            ThumbnailTileImage(frameIndex: frameIndex, thumbnail: thumbnail, orientationDegrees: orientationDegrees, mirrored: mirrored)
+            ThumbnailTileImage(
+                frameIndex: frameIndex,
+                thumbnail: thumbnail,
+                orientationDegrees: orientationDegrees,
+                mirrored: mirrored,
+                verticallyMirrored: verticallyMirrored
+            )
 
             LinearGradient(
                 colors: [.black.opacity(0.56), .clear],
@@ -302,7 +311,10 @@ private struct RollLoadingFrameCell: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .aspectRatio(3.0 / 2.0, contentMode: .fit)
+        .aspectRatio(
+            FrameOrientation.displayAspectRatio(orientationDegrees),
+            contentMode: .fit
+        )
         .background(Color.black.opacity(0.34))
         .clipShape(RoundedRectangle(cornerRadius: ScanStudioMetrics.thumbnailCornerRadius))
         .overlay {

--- a/app/ScanStudio/Sources/ScanStudio/ThumbnailGridView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ThumbnailGridView.swift
@@ -74,10 +74,12 @@ struct ThumbnailGridView: View {
                                 frameIndex: frameIndex,
                                 thumbnail: sessionModel.thumbnails[frameIndex],
                                 isSelected: sessionModel.selectedFrameIndices.contains(frameIndex),
+                                isFocused: sessionModel.focusedFrameIndex == frameIndex,
                                 frameState: sessionModel.frameStates[frameIndex],
                                 displayMode: showAsPositive ? .positivePreview : .asScanned,
                                 orientationDegrees: sessionModel.frameOrientation(frameIndex),
                                 mirrored: sessionModel.frameMirror(frameIndex),
+                                verticallyMirrored: sessionModel.frameVerticalMirror(frameIndex),
                                 reviewDecision: sessionModel.manualReviewDecision(
                                     for: frameIndex
                                 ),
@@ -90,7 +92,10 @@ struct ThumbnailGridView: View {
                                         previewOperationId: previewOperationId
                                     )
                                 },
-                                action: { shiftHeld in
+                                onFocus: {
+                                    sessionModel.focusFrame(frameIndex)
+                                },
+                                onSelection: { shiftHeld in
                                     sessionModel.selectFrame(
                                         frameIndex,
                                         extendingSelectionIfShiftHeld: shiftHeld
@@ -269,49 +274,103 @@ struct ThumbnailGridView: View {
 
     private var rotationMenu: some View {
         Menu("Rotate", systemImage: "rotate.right") {
-            Button("Rotate Left") {
-                for frame in sessionModel.selectedFrames {
-                    sessionModel.rotateFrame(frame, by: -90)
+            Button(transformActionLabel("Rotate Left")) {
+                _ = sessionModel.rotateFocusedFrame(by: -90)
+            }
+            .keyboardShortcut("l", modifiers: .command)
+            Button(transformActionLabel("Rotate Right")) {
+                _ = sessionModel.rotateFocusedFrame(by: 90)
+            }
+            .keyboardShortcut("r", modifiers: .command)
+            Button(transformActionLabel("Reset Rotation")) {
+                if let frameIndex = sessionModel.frameTransformTargetIndex {
+                    sessionModel.resetFrameOrientation(frameIndex)
                 }
             }
-            Button("Rotate Right") {
-                for frame in sessionModel.selectedFrames {
-                    sessionModel.rotateFrame(frame, by: 90)
-                }
-            }
-            Button("Reset Rotation") {
-                for frame in sessionModel.selectedFrames {
-                    sessionModel.resetFrameOrientation(frame)
+
+            if sessionModel.selectedFrameCount > 1 {
+                Divider()
+                Menu("Apply to \(sessionModel.selectedFrameCount) Selected Frames") {
+                    Button("Rotate All Left") {
+                        for frame in sessionModel.selectedFrames {
+                            sessionModel.rotateFrame(frame, by: -90)
+                        }
+                    }
+                    Button("Rotate All Right") {
+                        for frame in sessionModel.selectedFrames {
+                            sessionModel.rotateFrame(frame, by: 90)
+                        }
+                    }
+                    Button("Reset All Rotations") {
+                        for frame in sessionModel.selectedFrames {
+                            sessionModel.resetFrameOrientation(frame)
+                        }
+                    }
                 }
             }
         }
         .controlSize(.small)
         .fixedSize(horizontal: true, vertical: false)
-        .disabled(sessionModel.selectedFrameCount == 0)
-        .help(sessionModel.selectedFrameCount == 0
-            ? "Select one or more frames to rotate them."
-            : "Rotates the selected frame(s) for display in this session only — not yet sent to the engine or saved with the project.")
+        .disabled(sessionModel.frameTransformTargetIndex == nil)
+        .help(sessionModel.frameTransformTargetIndex == nil
+            ? "Click a frame to focus it, then rotate it."
+            : "Rotates the focused frame for display in this session only. Command-L rotates left; Command-R rotates right.")
     }
 
     private var mirrorMenu: some View {
         Menu("Mirror", systemImage: "arrow.left.and.right.righttriangle.left.righttriangle.right") {
-            Button("Toggle Horizontal Mirror") {
-                for frame in sessionModel.selectedFrames {
-                    sessionModel.toggleFrameMirror(frame)
+            Button(transformActionLabel("Flip Left to Right")) {
+                if let frameIndex = sessionModel.frameTransformTargetIndex {
+                    sessionModel.toggleFrameMirror(frameIndex)
                 }
             }
-            Button("Reset Mirror") {
-                for frame in sessionModel.selectedFrames {
-                    sessionModel.resetFrameMirror(frame)
+            .keyboardShortcut("h", modifiers: [.command, .shift])
+            Button(transformActionLabel("Flip Top to Bottom")) {
+                if let frameIndex = sessionModel.frameTransformTargetIndex {
+                    sessionModel.toggleFrameVerticalMirror(frameIndex)
+                }
+            }
+            .keyboardShortcut("v", modifiers: [.command, .shift])
+            Button(transformActionLabel("Reset Flips")) {
+                if let frameIndex = sessionModel.frameTransformTargetIndex {
+                    sessionModel.resetFrameMirrors(frameIndex)
+                }
+            }
+
+            if sessionModel.selectedFrameCount > 1 {
+                Divider()
+                Menu("Apply to \(sessionModel.selectedFrameCount) Selected Frames") {
+                    Button("Flip All Left to Right") {
+                        for frame in sessionModel.selectedFrames {
+                            sessionModel.toggleFrameMirror(frame)
+                        }
+                    }
+                    Button("Flip All Top to Bottom") {
+                        for frame in sessionModel.selectedFrames {
+                            sessionModel.toggleFrameVerticalMirror(frame)
+                        }
+                    }
+                    Button("Reset All Flips") {
+                        for frame in sessionModel.selectedFrames {
+                            sessionModel.resetFrameMirrors(frame)
+                        }
+                    }
                 }
             }
         }
         .controlSize(.small)
         .fixedSize(horizontal: true, vertical: false)
-        .disabled(sessionModel.selectedFrameCount == 0)
-        .help(sessionModel.selectedFrameCount == 0
-            ? "Select one or more frames to mirror them."
-            : "Flips the selected frame(s) horizontally for display in this session only — not yet sent to the engine or saved with the project.")
+        .disabled(sessionModel.frameTransformTargetIndex == nil)
+        .help(sessionModel.frameTransformTargetIndex == nil
+            ? "Click a frame to focus it, then flip it."
+            : "Flips the focused frame for display in this session only. Shift-Command-H flips left to right; Shift-Command-V flips top to bottom.")
+    }
+
+    private func transformActionLabel(_ action: String) -> String {
+        guard let frameIndex = sessionModel.frameTransformTargetIndex else {
+            return action
+        }
+        return "\(action) — Frame \(String(format: "%02d", frameIndex))"
     }
 
     private var emptyState: some View {
@@ -494,9 +553,15 @@ private struct ManualReviewFrameSheet: View {
                 thumbnail: thumbnail,
                 displayMode: displayMode,
                 orientationDegrees: session.frameOrientation(frameIndex),
-                mirrored: session.frameMirror(frameIndex)
+                mirrored: session.frameMirror(frameIndex),
+                verticallyMirrored: session.frameVerticalMirror(frameIndex)
             )
-            .aspectRatio(3.0 / 2.0, contentMode: .fit)
+            .aspectRatio(
+                FrameOrientation.displayAspectRatio(
+                    session.frameOrientation(frameIndex)
+                ),
+                contentMode: .fit
+            )
             .frame(maxWidth: .infinity)
             .frame(maxHeight: 250)
             .background(Color.black.opacity(0.35))
@@ -747,19 +812,55 @@ struct ThumbnailTileImage: View {
     /// FrameDetail filmstrip all rotate identically for free.
     var orientationDegrees: Int = 0
     var mirrored: Bool = false
+    var verticallyMirrored: Bool = false
 
     var body: some View {
-        Group {
-            if let path = thumbnail?.imagePath, let nsImage = ThumbnailImageCache.image(atPath: path, mode: displayMode) {
-                Image(nsImage: nsImage)
-                    .resizable()
-                    .scaledToFill()
-            } else {
-                SimulatedFrameImage(frameIndex: frameIndex, isAvailable: isGenuinelySimulatedThumbnail, displayMode: displayMode)
-            }
+        GeometryReader { geometry in
+            imageContent
+                // `rotationEffect` is paint-only: without swapping these
+                // proposed dimensions first, a 90° image is still laid out
+                // as landscape and then clipped/letterboxed inside the new
+                // portrait card. Give it the card's opposite dimensions so
+                // the painted quarter-turn lands exactly inside the card.
+                .frame(
+                    width: swapsLayoutAxes
+                        ? geometry.size.height
+                        : geometry.size.width,
+                    height: swapsLayoutAxes
+                        ? geometry.size.width
+                        : geometry.size.height
+                )
+                .scaleEffect(
+                    x: mirrored ? -1 : 1,
+                    y: verticallyMirrored ? -1 : 1
+                )
+                .rotationEffect(.degrees(Double(orientationDegrees)))
+                .position(
+                    x: geometry.size.width / 2,
+                    y: geometry.size.height / 2
+                )
         }
-        .scaleEffect(x: mirrored ? -1 : 1, y: 1)
-        .rotationEffect(.degrees(Double(orientationDegrees)))
+        .clipped()
+    }
+
+    @ViewBuilder
+    private var imageContent: some View {
+        if let path = thumbnail?.imagePath,
+           let nsImage = ThumbnailImageCache.image(atPath: path, mode: displayMode) {
+            Image(nsImage: nsImage)
+                .resizable()
+                .scaledToFill()
+        } else {
+            SimulatedFrameImage(
+                frameIndex: frameIndex,
+                isAvailable: isGenuinelySimulatedThumbnail,
+                displayMode: displayMode
+            )
+        }
+    }
+
+    private var swapsLayoutAxes: Bool {
+        FrameOrientation.swapsLayoutAxes(orientationDegrees)
     }
 
     /// True only when `thumbnail` itself carries affirmative simulator
@@ -950,6 +1051,7 @@ private struct ThumbnailTile: View {
     let frameIndex: Int
     let thumbnail: Thumbnail?
     let isSelected: Bool
+    let isFocused: Bool
     let frameState: FrameState?
     /// DEF-05 "Show as positive" — see `ThumbnailTileImage`/
     /// `PositivePreviewRenderer`'s own doc comments.
@@ -959,6 +1061,7 @@ private struct ThumbnailTile: View {
     /// display-only.
     var orientationDegrees: Int = 0
     var mirrored: Bool = false
+    var verticallyMirrored: Bool = false
     let reviewDecision: ManualReviewDecision?
     let onReview: () -> Void
     /// `Bool` is whether Shift was held at tap time (Finder-style
@@ -967,10 +1070,10 @@ private struct ThumbnailTile: View {
     /// `NSEvent.modifierFlags` at the moment the tap fires and reports it
     /// here, rather than this view (or `SessionModel`) needing its own
     /// gesture recognizer.
-    let action: (Bool) -> Void
+    let onFocus: () -> Void
+    let onSelection: (Bool) -> Void
 
     @Environment(SessionModel.self) private var sessionModel
-    @State private var isHovering = false
 
     private var isRealDevice: Bool { sessionModel.device?.kind == "real" }
 
@@ -1053,16 +1156,24 @@ private struct ThumbnailTile: View {
         .accessibilityAction(named: "View Details") {
             sessionModel.openFrameDetail(frameIndex)
         }
+        .overlay(alignment: .topTrailing) { selectionButton }
         .overlay(alignment: .bottomLeading) { reviewActionButton }
         .overlay(alignment: .topLeading) { viewDetailsButton }
     }
 
     private var tileButton: some View {
         Button {
-            action(NSApp.currentEvent?.modifierFlags.contains(.shift) == true)
+            onFocus()
         } label: {
             ZStack(alignment: .topLeading) {
-                ThumbnailTileImage(frameIndex: frameIndex, thumbnail: thumbnail, displayMode: displayMode, orientationDegrees: orientationDegrees, mirrored: mirrored)
+                ThumbnailTileImage(
+                    frameIndex: frameIndex,
+                    thumbnail: thumbnail,
+                    displayMode: displayMode,
+                    orientationDegrees: orientationDegrees,
+                    mirrored: mirrored,
+                    verticallyMirrored: verticallyMirrored
+                )
 
                 LinearGradient(
                     colors: [.black.opacity(0.58), .clear],
@@ -1090,21 +1201,6 @@ private struct ThumbnailTile: View {
                     ).opacity(0.22)
                 }
 
-                if isSelected {
-                    Image(systemName: "checkmark.square.fill")
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(Color.black.opacity(0.86), Color.scanStudioAmber)
-                        .font(.system(size: 16, weight: .bold))
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-                        .padding(5)
-                } else if isHovering {
-                    Image(systemName: "square")
-                        .foregroundStyle(Color.white.opacity(0.75))
-                        .font(.system(size: 16, weight: .bold))
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-                        .padding(5)
-                }
-
                 // Excluded takes visual precedence over any live FrameState
                 // treatment in the same corner — exclusion means this frame
                 // will never be scanned regardless of a prior transient
@@ -1127,7 +1223,10 @@ private struct ThumbnailTile: View {
                     .padding(5)
                 }
             }
-            .aspectRatio(3.0 / 2.0, contentMode: .fit)
+            .aspectRatio(
+                FrameOrientation.displayAspectRatio(orientationDegrees),
+                contentMode: .fit
+            )
             .background(Color.black.opacity(0.34))
             .clipShape(RoundedRectangle(cornerRadius: ScanStudioMetrics.thumbnailCornerRadius))
             .overlay {
@@ -1137,10 +1236,40 @@ private struct ThumbnailTile: View {
             .contentShape(RoundedRectangle(cornerRadius: ScanStudioMetrics.thumbnailCornerRadius))
         }
         .buttonStyle(.plain)
-        .onHover { isHovering = $0 }
-        .accessibilityLabel("Frame \(frameIndex)")
+        .accessibilityLabel("Frame \(frameIndex) image")
         .accessibilityValue(accessibilityValue)
-        .accessibilityHint(isSelected ? "Deselect this frame" : "Select this frame")
+        .accessibilityHint("Focus this frame for rotation, flipping, or detail editing")
+    }
+
+    /// Scan inclusion is independent from edit focus. Keeping this as a
+    /// sibling overlay—not a button nested inside `tileButton`—lets all six
+    /// frames stay checked while the image button focuses only one of them.
+    private var selectionButton: some View {
+        Button {
+            onSelection(
+                NSApp.currentEvent?.modifierFlags.contains(.shift) == true
+            )
+        } label: {
+            Image(systemName: isSelected ? "checkmark.square.fill" : "square")
+                .symbolRenderingMode(isSelected ? .palette : .monochrome)
+                .foregroundStyle(
+                    isSelected ? Color.black.opacity(0.86) : Color.white.opacity(0.78),
+                    Color.scanStudioAmber
+                )
+                .font(.system(size: 16, weight: .bold))
+                .frame(
+                    minWidth: ScanStudioMetrics.minimumInteractiveTarget,
+                    minHeight: ScanStudioMetrics.minimumInteractiveTarget
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(isSelected ? "Do not scan frame \(frameIndex)" : "Scan frame \(frameIndex)")
+        .accessibilityLabel(
+            isSelected
+                ? "Remove frame \(frameIndex) from this scan"
+                : "Include frame \(frameIndex) in this scan"
+        )
     }
 
     /// Transport-smear is a completed-capture QC verdict only; it is
@@ -1168,13 +1297,16 @@ private struct ThumbnailTile: View {
                 ? Color.scanStudioAmber
                 : Color.scanStudioRed.opacity(0.85)
         }
-        if isSelected || transportSmearFlagged { return Color.scanStudioAmber }
+        if isFocused { return Color.scanStudioAmber }
+        if isSelected { return Color.scanStudioAmber.opacity(0.55) }
+        if transportSmearFlagged { return Color.scanStudioAmber }
         return Color.white.opacity(0.14)
     }
 
     private var tileBorderLineWidth: CGFloat {
         if frameState == .active { return 2.5 }
-        if isSelected || transportSmearFlagged || frameState == .failed { return 2 }
+        if isFocused { return 2.5 }
+        if isSelected || transportSmearFlagged || frameState == .failed { return 1.5 }
         return 1
     }
 
@@ -1324,7 +1456,7 @@ private struct ThumbnailTile: View {
         Button {
             sessionModel.openFrameDetail(frameIndex)
         } label: {
-            Label("Align", systemImage: "viewfinder.circle.fill")
+            Label("Edit", systemImage: "slider.horizontal.3")
                 .font(.system(size: 9, weight: .bold))
                 .foregroundStyle(Color.white.opacity(0.94))
                 .padding(.horizontal, 7)
@@ -1337,13 +1469,14 @@ private struct ThumbnailTile: View {
         }
         .buttonStyle(.plain)
         .padding(.leading, 20)
-        .help("Adjust frame alignment and view details")
-        .accessibilityLabel("Adjust frame \(frameIndex)")
-        .accessibilityHint("Opens the full preview and scanner alignment controls.")
+        .help("Edit frame alignment, rotation, and flips")
+        .accessibilityLabel("Edit frame \(frameIndex)")
+        .accessibilityHint("Opens the full preview and frame editing controls.")
     }
 
     private var accessibilityValue: String {
-        var values = [isSelected ? "selected" : "not selected"]
+        var values = [isSelected ? "selected for scanning" : "not selected for scanning"]
+        if isFocused { values.append("focused for editing") }
         values.append(thumbnail == nil ? "preview not acquired" : "preview acquired")
         if let frameState { values.append(frameState.rawValue) }
         if thumbnail?.needsApproval == true {
@@ -1358,6 +1491,7 @@ private struct ThumbnailTile: View {
         }
         if let orientationText = FrameOrientation.accessibilityText(orientationDegrees) { values.append(orientationText) }
         if mirrored { values.append("mirrored horizontally") }
+        if verticallyMirrored { values.append("mirrored vertically") }
         // Only ever appended for the simulator's genuinely live per-frame
         // fraction (see `liveFramePercent`'s own doc comment) — VoiceOver
         // must not hear a percentage real hardware cannot back either.

--- a/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
@@ -620,6 +620,10 @@ public final class SessionModel {
     /// sent with `scan.start`, and resets whenever media changes, exactly like
     /// `selectedFrameIndices` and `frameOrientations`.
     public private(set) var frameMirrors: [Int: Bool] = [:]
+    /// Session-local per-frame top-to-bottom flip intent. Kept independent
+    /// from `frameMirrors` so either axis can be toggled or reset without
+    /// changing the other.
+    public private(set) var frameVerticalMirrors: [Int: Bool] = [:]
     public var scanResolutionDpi = 4_000
     public var scanBitDepth = 16
     public var scanMultisamplePasses = 2
@@ -735,6 +739,10 @@ public final class SessionModel {
     /// a stale anchor from a previous carrier/project can never leak into a
     /// new one.
     public private(set) var selectionAnchorFrameIndex: Int?
+    /// The one frame targeted by edit commands. This is deliberately
+    /// independent from scan selection: six frames can remain checked while
+    /// rotation or flipping changes only the focused frame.
+    public private(set) var focusedFrameIndex: Int?
     private var bufferedJobEvents: [String: [EngineEvent]] = [:]
 
     /// Which frame's detail workspace is open, if any — pure UI navigation
@@ -1934,6 +1942,19 @@ public final class SessionModel {
         guard beginProjectLifecycleChange() else { return }
         defer { isChangingProject = false }
         lastErrorMessage = nil
+        // Save Roll attaches the preview already on screen to its first
+        // project. Keep that preview's scan choices across this one boundary;
+        // switching from one existing project to another still clears them.
+        let preProjectSelection = project == nil
+            ? selectedFrameIndices
+            : []
+        let preProjectSelectionAnchor = project == nil
+            ? selectionAnchorFrameIndex
+            : nil
+        let preProjectFocus = project == nil ? focusedFrameIndex : nil
+        let preProjectOrientations = project == nil ? frameOrientations : [:]
+        let preProjectHorizontalMirrors = project == nil ? frameMirrors : [:]
+        let preProjectVerticalMirrors = project == nil ? frameVerticalMirrors : [:]
         // Batch Settings is intentionally editable before Save Roll. Capture
         // those choices before awaiting the engine: the fresh manifest owns
         // its project-rooted destinations, but its all-enabled recipe defaults
@@ -1957,6 +1978,24 @@ public final class SessionModel {
             resetProjectScopedScanState()
             project = result.project
             restoreProjectProgress(from: result.project.frames)
+            let projectFrameIndices = Set(result.project.frames.map(\.index))
+            selectedFrameIndices = preProjectSelection
+                .intersection(projectFrameIndices)
+            selectionAnchorFrameIndex = preProjectSelectionAnchor.flatMap {
+                projectFrameIndices.contains($0) ? $0 : nil
+            }
+            focusedFrameIndex = preProjectFocus.flatMap {
+                projectFrameIndices.contains($0) ? $0 : nil
+            }
+            frameOrientations = preProjectOrientations.filter {
+                projectFrameIndices.contains($0.key)
+            }
+            frameMirrors = preProjectHorizontalMirrors.filter {
+                projectFrameIndices.contains($0.key)
+            }
+            frameVerticalMirrors = preProjectVerticalMirrors.filter {
+                projectFrameIndices.contains($0.key)
+            }
             scanFilmProcess = result.project.filmProcess
             canonicalizeFilmProcessDisplayState()
             rollMetadataDraft = result.project.rollMetadata
@@ -2012,6 +2051,45 @@ public final class SessionModel {
         } catch {
             lastErrorMessage = Self.describe(error)
         }
+    }
+
+    /// The pre-project contact sheet's primary action: attach the completed
+    /// preview to a new roll project, then continue the exact frame selection
+    /// into the ordinary review/scan gate. A flagged boundary intentionally
+    /// returns with `pendingManualReviewScan` rather than moving film; the
+    /// user's confirmation resumes this same frame list exactly once.
+    @discardableResult
+    public func saveRollAndScanSelectedFrames(
+        name: String,
+        carrier: SimulatedFilmCarrier,
+        frameCount: Int,
+        filmProcess: FilmProcess
+    ) async -> Bool {
+        lastErrorMessage = nil
+        guard project == nil else {
+            lastErrorMessage =
+                "This roll is already saved. Use Scan to start the selected frames."
+            return false
+        }
+
+        let requestedFrames = selectedFrames
+        guard !requestedFrames.isEmpty else {
+            lastErrorMessage = "Select at least one frame before saving and scanning."
+            return false
+        }
+
+        await createProject(
+            name: name,
+            carrier: carrier,
+            frameCount: frameCount,
+            filmProcess: filmProcess
+        )
+        guard project != nil, lastErrorMessage == nil else { return false }
+
+        let started = await startScanOrRequestManualReview(
+            frames: requestedFrames
+        )
+        return started || pendingManualReviewScan?.frames == requestedFrames
     }
 
     /// Moves any contact-sheet nudges made before Save Roll into the newly
@@ -2106,9 +2184,11 @@ public final class SessionModel {
         clearFrameAlignmentSessionState()
         selectedFrameIndices.removeAll()
         selectionAnchorFrameIndex = nil
+        focusedFrameIndex = nil
         detailFrameIndex = nil
         frameOrientations.removeAll()
         frameMirrors.removeAll()
+        frameVerticalMirrors.removeAll()
         isAcquiringThumbnails = false
         activeOperationStartedAt = nil
     }
@@ -2392,7 +2472,11 @@ public final class SessionModel {
         frameDefects.removeAll()
         selectedFrameIndices.removeAll()
         selectionAnchorFrameIndex = nil
+        focusedFrameIndex = nil
         detailFrameIndex = nil
+        frameOrientations.removeAll()
+        frameMirrors.removeAll()
+        frameVerticalMirrors.removeAll()
         bufferedJobEvents.removeAll()
     }
 
@@ -2969,6 +3053,11 @@ public final class SessionModel {
         selectedFrameIndices = Set(validFrameIndices)
             .subtracting(excludedFrameIndices)
             .subtracting(reviewSkippedFrames)
+        if focusedFrameIndex == nil
+            || !validFrameIndices.contains(focusedFrameIndex ?? -1)
+        {
+            focusedFrameIndex = selectedFrameIndices.min()
+        }
     }
 
     public func clearFrameSelection() {
@@ -2990,9 +3079,35 @@ public final class SessionModel {
             .symmetricDifference(selectedFrameIndices)
     }
 
+    // MARK: - Frame edit focus
+
+    /// Focuses one frame for rotate/flip commands without changing which
+    /// frames are selected for scanning.
+    public func focusFrame(_ frameIndex: Int) {
+        guard validFrameIndices.contains(frameIndex) else { return }
+        focusedFrameIndex = frameIndex
+    }
+
+    /// The explicit focus wins. A sole selected frame remains a useful
+    /// fallback for keyboard commands in older/session-restored UI states.
+    public var frameTransformTargetIndex: Int? {
+        if let focusedFrameIndex,
+           validFrameIndices.contains(focusedFrameIndex) {
+            return focusedFrameIndex
+        }
+        guard selectedFrameIndices.count == 1,
+              let soleSelection = selectedFrameIndices.first,
+              validFrameIndices.contains(soleSelection)
+        else {
+            return nil
+        }
+        return soleSelection
+    }
+
     // MARK: - Frame detail navigation
 
     public func openFrameDetail(_ frameIndex: Int) {
+        focusFrame(frameIndex)
         detailFrameIndex = frameIndex
     }
 
@@ -3021,6 +3136,13 @@ public final class SessionModel {
     public func rotateFrame(_ frameIndex: Int, by degrees: Int) {
         let current = frameOrientations[frameIndex] ?? 0
         frameOrientations[frameIndex] = FrameOrientation.normalized(current + degrees)
+    }
+
+    @discardableResult
+    public func rotateFocusedFrame(by degrees: Int) -> Bool {
+        guard let frameIndex = frameTransformTargetIndex else { return false }
+        rotateFrame(frameIndex, by: degrees)
+        return true
     }
 
     public func resetFrameOrientation(_ frameIndex: Int) {
@@ -3055,6 +3177,27 @@ public final class SessionModel {
 
     public func frameMirror(_ frameIndex: Int) -> Bool {
         frameMirrors[frameIndex] ?? false
+    }
+
+    public func toggleFrameVerticalMirror(_ frameIndex: Int) {
+        setFrameVerticalMirror(!frameVerticalMirror(frameIndex), for: frameIndex)
+    }
+
+    public func setFrameVerticalMirror(_ mirrored: Bool, for frameIndex: Int) {
+        if mirrored {
+            frameVerticalMirrors[frameIndex] = true
+        } else {
+            frameVerticalMirrors.removeValue(forKey: frameIndex)
+        }
+    }
+
+    public func frameVerticalMirror(_ frameIndex: Int) -> Bool {
+        frameVerticalMirrors[frameIndex] ?? false
+    }
+
+    public func resetFrameMirrors(_ frameIndex: Int) {
+        frameMirrors.removeValue(forKey: frameIndex)
+        frameVerticalMirrors.removeValue(forKey: frameIndex)
     }
 
     // MARK: - Event subscription
@@ -3238,6 +3381,7 @@ public final class SessionModel {
         clearFrameAlignmentSessionState()
         selectedFrameIndices.removeAll()
         selectionAnchorFrameIndex = nil
+        focusedFrameIndex = nil
         detailFrameIndex = nil
         if !preservingActiveJob {
             jobId = nil
@@ -3256,6 +3400,7 @@ public final class SessionModel {
         }
         frameOrientations.removeAll()
         frameMirrors.removeAll()
+        frameVerticalMirrors.removeAll()
         if !preservingActiveJob {
             bufferedJobEvents.removeAll()
             if let project {
@@ -3916,6 +4061,18 @@ public enum FrameOrientation {
         let normalized = normalized(degrees)
         guard normalized != 0 else { return nil }
         return "rotated \(normalized) degrees"
+    }
+
+    /// The contact sheet's outer card must participate in a quarter-turn;
+    /// `rotationEffect` changes pixels but not SwiftUI layout bounds.
+    public static func displayAspectRatio(_ degrees: Int) -> Double {
+        swapsLayoutAxes(degrees) ? 2.0 / 3.0 : 3.0 / 2.0
+    }
+
+    /// A quarter-turn also swaps the bitmap's proposed layout dimensions
+    /// before SwiftUI paints the rotation.
+    public static func swapsLayoutAxes(_ degrees: Int) -> Bool {
+        !normalized(degrees).isMultiple(of: 180)
     }
 }
 

--- a/app/ScanStudio/Tests/ScanStudioKitTests/SaveRollScanFlowTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/SaveRollScanFlowTests.swift
@@ -1,0 +1,288 @@
+import Foundation
+import Testing
+
+@testable import ScanStudioKit
+
+private enum SaveRollScanStubError: Error {
+    case unexpectedMethod(String)
+    case unexpectedParams(String)
+    case unexpectedResultType
+}
+
+private enum SaveRollScanCall: Equatable, Sendable {
+    case createProject
+    case approve(frameIndex: Int)
+    case startScan(frames: [Int])
+}
+
+private actor SaveRollScanEngineStub: EngineClientProtocol {
+    nonisolated let events: AsyncStream<EngineEvent> = AsyncStream { _ in }
+    var engineVersion: String? = "save-roll-scan-stub"
+
+    private let device = DeviceInfo(
+        deviceId: "sim-save-roll",
+        model: "LS-5000 simulator",
+        kind: "simulated",
+        firmware: "test",
+        connection: "in-process",
+        supportedMultisamplePasses: [1, 2, 4, 8, 16]
+    )
+    private let project = ScanProject(
+        schemaVersion: 1,
+        id: "saved-six-frame-roll",
+        name: "Saved six-frame roll",
+        carrier: .strip6,
+        frameCount: 6,
+        filmProcess: .positive,
+        recipes: OutputRecipe(
+            archive: ArchiveRecipe(
+                filenameTemplate: "Archive_####",
+                destination: "/tmp/saved-six-frame-roll/Archive"
+            ),
+            positive: PositiveRecipe(
+                enabled: true,
+                fileFormat: .tiff,
+                colorProfile: .adobeRgb1998,
+                filenameTemplate: "Positive_####",
+                destination: "/tmp/saved-six-frame-roll/Positive"
+            ),
+            preview: PreviewRecipe(
+                enabled: false,
+                fileFormat: .jpeg,
+                maxLongEdgePx: 1_024,
+                filenameTemplate: "Preview_####",
+                destination: "/tmp/saved-six-frame-roll/Preview"
+            )
+        ),
+        rollMetadata: MetadataSet(),
+        createdAt: "2026-08-02T00:00:00Z",
+        frames: (1...6).map {
+            ProjectFrame(index: $0, excluded: false, receipts: [])
+        }
+    )
+    private var recordedCalls: [SaveRollScanCall] = []
+    private let createError: EngineRequestError?
+    private let scanStartError: EngineRequestError?
+
+    init(
+        createError: EngineRequestError? = nil,
+        scanStartError: EngineRequestError? = nil
+    ) {
+        self.createError = createError
+        self.scanStartError = scanStartError
+    }
+
+    func request<Params: Encodable & Sendable, Result: Decodable & Sendable>(
+        _ method: String,
+        params: Params
+    ) async throws -> Result {
+        let value: any Sendable
+        switch method {
+        case "scanner.list":
+            value = ScannerListResult(devices: [device])
+        case "scanner.connect":
+            value = ConnectResult(
+                device: device,
+                status: ScannerStatus(
+                    connected: true,
+                    adapter: nil,
+                    mediaLoaded: false,
+                    carrier: nil,
+                    frameCount: nil,
+                    lamp: "stable",
+                    transport: "idle",
+                    activeJobId: nil
+                )
+            )
+        case "sim.loadMedia":
+            value = ScannerStatus(
+                connected: true,
+                adapter: "SA-21 (simulated)",
+                mediaLoaded: true,
+                carrier: "strip6",
+                frameCount: 6,
+                lamp: "stable",
+                transport: "idle",
+                activeJobId: nil
+            )
+        case "scanner.acquireThumbnails":
+            value = AcquireThumbnailsAck(accepted: true, frames: Array(1...6))
+        case "project.create":
+            recordedCalls.append(.createProject)
+            if let createError { throw createError }
+            value = ProjectCreateResult(
+                project: project,
+                directory: "/tmp/saved-six-frame-roll"
+            )
+        case "roll.approve":
+            guard let params = params as? RollApproveParams else {
+                throw SaveRollScanStubError.unexpectedParams(method)
+            }
+            recordedCalls.append(.approve(frameIndex: params.frameIndex))
+            value = EmptyResult()
+        case "scan.start":
+            guard let params = params as? ScanStartParams else {
+                throw SaveRollScanStubError.unexpectedParams(method)
+            }
+            recordedCalls.append(.startScan(frames: params.frames))
+            if let scanStartError { throw scanStartError }
+            value = ScanStartResult(jobId: "saved-roll-job")
+        default:
+            throw SaveRollScanStubError.unexpectedMethod(method)
+        }
+        guard let result = value as? Result else {
+            throw SaveRollScanStubError.unexpectedResultType
+        }
+        return result
+    }
+
+    func calls() -> [SaveRollScanCall] { recordedCalls }
+}
+
+@Suite("Save Roll and scan flow")
+struct SaveRollScanFlowTests {
+    @MainActor
+    private func preparedModel(
+        flaggedFrames: Set<Int> = [],
+        client: SaveRollScanEngineStub = SaveRollScanEngineStub()
+    ) async -> (SessionModel, SaveRollScanEngineStub) {
+        let suiteName = "SaveRollScanFlowTests-\(UUID().uuidString)"
+        let preferences = UserDefaults(suiteName: suiteName)!
+        preferences.removePersistentDomain(forName: suiteName)
+        let model = SessionModel(
+            engineClient: client,
+            preferences: preferences
+        )
+
+        await model.connect(deviceId: "sim-save-roll")
+        await model.loadCarrier(.strip6)
+        model.scanFilmProcess = .positive
+        let token = PreviewIntentToken()
+        #expect(await model.requestPreview(.initial(token: token)) == .started)
+        for frameIndex in 1...6 {
+            let reviewEvidence = flaggedFrames.contains(frameIndex)
+                ? #","needsApproval":true,"warnings":["ambiguous-boundary"]"#
+                : ""
+            model.handle(event: EngineEvent(
+                name: "scanner.thumbnail",
+                rawLine: Data(
+                    #"{"event":"scanner.thumbnail","payload":{"operationId":"\#(token.id.uuidString)","frameIndex":\#(frameIndex),"thumbnail":{"brightness":0.5,"tint":0.0\#(reviewEvidence)}}}"#.utf8
+                )
+            ))
+        }
+        model.handle(event: EngineEvent(
+            name: "scanner.thumbnailsComplete",
+            rawLine: Data(
+                #"{"event":"scanner.thumbnailsComplete","payload":{"operationId":"\#(token.id.uuidString)","count":6}}"#.utf8
+            )
+        ))
+        model.selectAllFrames()
+        return (model, client)
+    }
+
+    @Test("saving a completed six-frame preview starts the original selection exactly once")
+    @MainActor
+    func saveRollStartsSelectedFrames() async {
+        let (model, client) = await preparedModel()
+
+        let continued = await model.saveRollAndScanSelectedFrames(
+            name: "Saved six-frame roll",
+            carrier: .strip6,
+            frameCount: 6,
+            filmProcess: .positive
+        )
+
+        #expect(model.lastErrorMessage == nil)
+        #expect(continued)
+        #expect(await client.calls() == [
+            .createProject,
+            .startScan(frames: [1, 2, 3, 4, 5, 6]),
+        ])
+        #expect(model.jobId == "saved-roll-job")
+    }
+
+    @Test("Save Roll opens review for the original six before one scan")
+    @MainActor
+    func saveRollContinuesIntoBoundaryReview() async {
+        let (model, client) = await preparedModel(flaggedFrames: [1, 6])
+
+        let continued = await model.saveRollAndScanSelectedFrames(
+            name: "Saved six-frame roll",
+            carrier: .strip6,
+            frameCount: 6,
+            filmProcess: .positive
+        )
+
+        #expect(continued)
+        #expect(await client.calls() == [.createProject])
+        #expect(model.pendingManualReviewScan?.frames == [1, 2, 3, 4, 5, 6])
+        #expect(
+            model.pendingManualReviewScan?.requirements.map(\.frameIndex)
+                == [1, 6]
+        )
+        #expect(model.jobId == nil)
+
+        await model.approvePendingManualReviewAndStart()
+
+        #expect(await client.calls() == [
+            .createProject,
+            .approve(frameIndex: 1),
+            .approve(frameIndex: 6),
+            .startScan(frames: [1, 2, 3, 4, 5, 6]),
+        ])
+        #expect(model.jobId == "saved-roll-job")
+    }
+
+    @Test("project creation failure never reaches scan.start")
+    @MainActor
+    func saveRollCreationFailureStopsBeforeScan() async {
+        let client = SaveRollScanEngineStub(
+            createError: EngineRequestError(
+                code: "IO_ERROR",
+                message: "cannot create project",
+                recoverable: true
+            )
+        )
+        let (model, _) = await preparedModel(client: client)
+
+        let continued = await model.saveRollAndScanSelectedFrames(
+            name: "Saved six-frame roll",
+            carrier: .strip6,
+            frameCount: 6,
+            filmProcess: .positive
+        )
+
+        #expect(continued == false)
+        #expect(model.project == nil)
+        #expect(model.lastErrorMessage != nil)
+        #expect(await client.calls() == [.createProject])
+    }
+
+    @Test("scan-start failure keeps the newly saved roll open for a retry")
+    @MainActor
+    func savedRollSurvivesScanStartFailure() async {
+        let client = SaveRollScanEngineStub(
+            scanStartError: EngineRequestError(
+                code: "SCAN_REFUSED",
+                message: "scan could not start",
+                recoverable: true
+            )
+        )
+        let (model, _) = await preparedModel(client: client)
+
+        let continued = await model.saveRollAndScanSelectedFrames(
+            name: "Saved six-frame roll",
+            carrier: .strip6,
+            frameCount: 6,
+            filmProcess: .positive
+        )
+
+        #expect(continued == false)
+        #expect(model.project?.id == "saved-six-frame-roll")
+        #expect(model.lastErrorMessage != nil)
+        #expect(await client.calls() == [
+            .createProject,
+            .startScan(frames: [1, 2, 3, 4, 5, 6]),
+        ])
+    }
+}

--- a/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
@@ -49,6 +49,11 @@ private actor ProjectFlowEngineStub: EngineClientProtocol {
                 transport: "idle",
                 activeJobId: nil
             )
+        case "scanner.acquireThumbnails":
+            value = AcquireThumbnailsAck(
+                accepted: true,
+                frames: Array(1...project.frameCount)
+            )
         default: throw ProjectFlowStubError.unexpectedMethod(method)
         }
         guard let result = value as? Result else {
@@ -1256,6 +1261,46 @@ struct SessionEventPolicyTests {
         )
     }
 
+    @Test("Save Roll preserves the selected frames from its completed preview")
+    @MainActor
+    func saveRollPreservesPreProjectSelection() async throws {
+        let project = try projectLifecycleFixture(
+            id: "saved-preview-project",
+            completedFrames: []
+        )
+        let model = SessionModel(
+            engineClient: ProjectFlowEngineStub(project: project)
+        )
+
+        await model.loadCarrier(.strip6)
+        model.scanFilmProcess = .positive
+        let token = PreviewIntentToken()
+        #expect(await model.requestPreview(.initial(token: token)) == .started)
+        establishCompletedPreview(
+            frameCount: 6,
+            operationID: token.id.uuidString,
+            on: model
+        )
+        model.selectAllFrames()
+        model.focusFrame(3)
+        model.rotateFrame(3, by: 90)
+        model.toggleFrameVerticalMirror(3)
+        #expect(model.selectedFrames == [1, 2, 3, 4, 5, 6])
+
+        await model.createProject(
+            name: project.name,
+            carrier: .strip6,
+            frameCount: 6,
+            filmProcess: .positive
+        )
+
+        #expect(model.project?.id == project.id)
+        #expect(model.selectedFrames == [1, 2, 3, 4, 5, 6])
+        #expect(model.focusedFrameIndex == 3)
+        #expect(model.frameOrientation(3) == 90)
+        #expect(model.frameVerticalMirror(3))
+    }
+
     @Test("project changes clear the previous selection and last-batch state while new jobs retain other persisted completions")
     @MainActor
     func projectChangesIsolateSessionStateAndJobsPreservePriorReceipts() async throws {
@@ -1283,6 +1328,9 @@ struct SessionEventPolicyTests {
         #expect(model.pendingFrames == [1, 2, 3, 5, 6])
         #expect(model.completedFrameCount == 1)
         model.toggleFrameSelection(2)
+        model.focusFrame(2)
+        model.rotateFrame(2, by: 90)
+        model.toggleFrameMirror(2)
         model.beginJob(id: "live-job", frames: [2])
 
         #expect(model.frameStates[4] == .completed)
@@ -1314,6 +1362,10 @@ struct SessionEventPolicyTests {
 
         #expect(model.project?.id == second.id)
         #expect(model.selectedFrameIndices.isEmpty)
+        #expect(model.focusedFrameIndex == nil)
+        #expect(model.frameOrientations.isEmpty)
+        #expect(model.frameMirrors.isEmpty)
+        #expect(model.frameVerticalMirrors.isEmpty)
         #expect(model.receipts.isEmpty)
         #expect(model.scanSummary == nil)
         #expect(model.frameStates.isEmpty)
@@ -2799,6 +2851,19 @@ struct SessionEventPolicyTests {
         #expect(FrameOrientation.accessibilityText(-90) == "rotated 270 degrees")
     }
 
+    @Test("FrameOrientation.displayAspectRatio rotates the outer card as well as the pixels")
+    func frameOrientationDisplayAspectRatioTracksQuarterTurns() {
+        #expect(FrameOrientation.displayAspectRatio(0) == 3.0 / 2.0)
+        #expect(FrameOrientation.displayAspectRatio(90) == 2.0 / 3.0)
+        #expect(FrameOrientation.displayAspectRatio(180) == 3.0 / 2.0)
+        #expect(FrameOrientation.displayAspectRatio(270) == 2.0 / 3.0)
+        #expect(FrameOrientation.displayAspectRatio(-90) == 2.0 / 3.0)
+        #expect(FrameOrientation.swapsLayoutAxes(0) == false)
+        #expect(FrameOrientation.swapsLayoutAxes(90))
+        #expect(FrameOrientation.swapsLayoutAxes(180) == false)
+        #expect(FrameOrientation.swapsLayoutAxes(-90))
+    }
+
     @Test("rotateFrame accumulates and normalizes into 0/90/180/270 both clockwise and counter-clockwise, and resetFrameOrientation clears it back to 0")
     @MainActor
     func rotateFrameAccumulatesNormalizesAndResets() async throws {
@@ -2839,6 +2904,52 @@ struct SessionEventPolicyTests {
         #expect(model.frameOrientation(2) == 0)
 
         await client.terminate()
+    }
+
+    @Test("editing one focused frame keeps all six scan selections intact")
+    @MainActor
+    func focusedFrameTransformDoesNotChangeScanSelection() async throws {
+        let project = try projectLifecycleFixture(
+            id: "focused-transform-project",
+            completedFrames: []
+        )
+        let model = SessionModel(
+            engineClient: ProjectFlowEngineStub(project: project)
+        )
+        await model.loadCarrier(.strip6)
+        model.selectAllFrames()
+
+        model.focusFrame(3)
+        #expect(model.rotateFocusedFrame(by: 90))
+
+        #expect(model.focusedFrameIndex == 3)
+        #expect(model.selectedFrames == [1, 2, 3, 4, 5, 6])
+        #expect(model.frameOrientation(3) == 90)
+        #expect(model.frameOrientation(1) == 0)
+        #expect(model.frameOrientation(6) == 0)
+    }
+
+    @Test("invalid focus is ignored and a real media change clears focus")
+    @MainActor
+    func frameFocusIsValidatedAndClearsWithMedia() async throws {
+        let project = try projectLifecycleFixture(
+            id: "focus-lifecycle-project",
+            completedFrames: []
+        )
+        let model = SessionModel(
+            engineClient: ProjectFlowEngineStub(project: project)
+        )
+        await model.loadCarrier(.strip6)
+
+        model.focusFrame(3)
+        model.focusFrame(99)
+        #expect(model.focusedFrameIndex == 3)
+
+        let notLoaded = Data(
+            #"{"event":"scanner.status","payload":{"status":{"connected":true,"adapter":null,"mediaLoaded":false,"carrier":null,"frameCount":null,"lamp":"stable","transport":"idle","activeJobId":null}}}"#.utf8
+        )
+        model.handle(event: EngineEvent(name: "scanner.status", rawLine: notLoaded))
+        #expect(model.focusedFrameIndex == nil)
     }
 
     // MARK: - scan.completed terminal jobState resolution
@@ -2972,6 +3083,28 @@ struct SessionEventPolicyTests {
 
         #expect(model.frameMirror(1) == false)
         #expect(model.frameMirrors.isEmpty)
+        await client.terminate()
+    }
+
+    @Test("horizontal and vertical frame flips are independent and reset together")
+    @MainActor
+    func frameFlipsAreIndependent() async throws {
+        let client = try EngineClient(engineURL: URL(fileURLWithPath: "/bin/cat"))
+        let model = SessionModel(engineClient: client)
+
+        model.toggleFrameMirror(3)
+        model.toggleFrameVerticalMirror(3)
+        #expect(model.frameMirror(3))
+        #expect(model.frameVerticalMirror(3))
+
+        model.toggleFrameMirror(3)
+        #expect(model.frameMirror(3) == false)
+        #expect(model.frameVerticalMirror(3))
+
+        model.resetFrameMirrors(3)
+        #expect(model.frameMirror(3) == false)
+        #expect(model.frameVerticalMirror(3) == false)
+
         await client.terminate()
     }
 

--- a/app/ScanStudio/packaging/Info.plist
+++ b/app/ScanStudio/packaging/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundleShortVersionString</key>
     <string>0.3.0</string>
     <key>CFBundleVersion</key>
-    <string>8</string>
+    <string>9</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>

--- a/app/ScanStudio/scripts/package_dmg.sh
+++ b/app/ScanStudio/scripts/package_dmg.sh
@@ -18,7 +18,7 @@ if [[ ! -f "$info_plist" ]]; then
 fi
 
 bundle_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info_plist")"
-release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.6}"
+release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.7}"
 release_arch="${SCANSTUDIO_RELEASE_ARCH:-$(uname -m)}"
 output="${2:-$package_root/.build/ScanStudio-$release_version-macOS-$release_arch.dmg}"
 


### PR DESCRIPTION
## Summary
- make the pre-project Save Roll action continue directly into review or one selected-frame batch scan
- keep scan selection separate from the one frame focused for editing
- add Command-L / Command-R rotation, vertical and horizontal flips, and apply-to-selection actions
- rotate the outer thumbnail layout for portrait frames so the preview fills the card
- bump the alpha release build to 9 and default DMG label to alpha 7

Rotation and flip controls remain clearly labeled display-only; saved scan output is unchanged.

## Verification
- Rust engine suite passed
- Swift: 386 tests in 40 suites passed
- Bridge: 272 passed
- CoolscanPy: 1,367 passed, 3 skipped, 1 expected failure
- self-contained app and mounted DMG relocation checks passed
- independent diff review: no actionable findings