### PR TITLE
Make photo shortcuts global and focus-safe

### DIFF
--- a/app/ScanStudio/Sources/ScanStudio/ContentView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ContentView.swift
@@ -124,6 +124,10 @@ struct ContentView: View {
         .sheet(item: manualReviewRequestBinding) { request in
             ManualReviewScanSheet(request: request)
         }
+        .focusedSceneValue(
+            \.scanStudioFrameIndex,
+            sessionModel.frameTransformTargetIndex
+        )
     }
 
     private var manualReviewRequestBinding: Binding<ManualReviewScanRequest?> {

--- a/app/ScanStudio/Sources/ScanStudio/FrameDetailWorkspaceView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/FrameDetailWorkspaceView.swift
@@ -413,7 +413,6 @@ struct FrameDetailWorkspaceView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .keyboardShortcut("l", modifiers: .command)
             .help("Rotate counter-clockwise—display only; saved output is unchanged")
 
             Button {
@@ -423,7 +422,6 @@ struct FrameDetailWorkspaceView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .keyboardShortcut("r", modifiers: .command)
             .help("Rotate clockwise—display only; saved output is unchanged")
 
             Button {
@@ -444,7 +442,6 @@ struct FrameDetailWorkspaceView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .keyboardShortcut("h", modifiers: [.command, .shift])
             .help("Flip left to right—display only; saved output is unchanged")
 
             Button {
@@ -454,7 +451,6 @@ struct FrameDetailWorkspaceView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .keyboardShortcut("v", modifiers: [.command, .shift])
             .help("Flip top to bottom—display only; saved output is unchanged")
 
             Button {

--- a/app/ScanStudio/Sources/ScanStudio/ScanStudioApp.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ScanStudioApp.swift
@@ -9,12 +9,26 @@ import AppKit
 import ScanStudioKit
 import SwiftUI
 
+private struct ScanStudioFrameFocusKey: FocusedValueKey {
+    typealias Value = Int
+}
+
+extension FocusedValues {
+    var scanStudioFrameIndex: Int? {
+        get { self[ScanStudioFrameFocusKey.self] }
+        set { self[ScanStudioFrameFocusKey.self] = newValue }
+    }
+}
+
 @main
 struct ScanStudioApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     var body: some Scene {
-        WindowGroup("Scan Studio") {
+        // One process owns one physical scanner session. A single window also
+        // makes the focused Photo commands unambiguous: there is no second
+        // scene that can publish a competing focused frame.
+        Window("Scan Studio", id: "main") {
             switch appDelegate.launchState {
             case .ready(_, let model):
                 ContentView()
@@ -25,6 +39,55 @@ struct ScanStudioApp: App {
         }
         .defaultSize(width: 1_500, height: 920)
         .windowResizability(.contentMinSize)
+        .commands {
+            if case .ready(_, let model) = appDelegate.launchState {
+                FrameTransformCommands(session: model)
+            }
+        }
+    }
+}
+
+/// Global commands cannot live inside a closed contact-sheet `Menu`: live
+/// validation proved SwiftUI does not register those nested shortcuts until
+/// the menu is open. A scene-level Photo menu keeps the commands active from
+/// both the contact sheet and frame-detail workspace.
+private struct FrameTransformCommands: Commands {
+    let session: SessionModel
+    @FocusedValue(\.scanStudioFrameIndex) private var activeFrameIndex
+
+    var body: some Commands {
+        CommandMenu("Photo") {
+            Button("Rotate Focused Photo Left") {
+                perform(.rotateLeft)
+            }
+            .keyboardShortcut("l", modifiers: .command)
+            .disabled(activeFrameIndex == nil)
+
+            Button("Rotate Focused Photo Right") {
+                perform(.rotateRight)
+            }
+            .keyboardShortcut("r", modifiers: .command)
+            .disabled(activeFrameIndex == nil)
+
+            Divider()
+
+            Button("Flip Focused Photo Left to Right") {
+                perform(.flipLeftToRight)
+            }
+            .keyboardShortcut("h", modifiers: [.command, .shift])
+            .disabled(activeFrameIndex == nil)
+
+            Button("Flip Focused Photo Top to Bottom") {
+                perform(.flipTopToBottom)
+            }
+            .keyboardShortcut("v", modifiers: [.command, .option])
+            .disabled(activeFrameIndex == nil)
+        }
+    }
+
+    private func perform(_ command: FrameTransformCommand) {
+        guard let activeFrameIndex else { return }
+        session.performFrameTransformCommand(command, for: activeFrameIndex)
     }
 }
 

--- a/app/ScanStudio/Sources/ScanStudio/ThumbnailGridView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ThumbnailGridView.swift
@@ -275,13 +275,11 @@ struct ThumbnailGridView: View {
     private var rotationMenu: some View {
         Menu("Rotate", systemImage: "rotate.right") {
             Button(transformActionLabel("Rotate Left")) {
-                _ = sessionModel.rotateFocusedFrame(by: -90)
+                sessionModel.performFrameTransformCommand(.rotateLeft)
             }
-            .keyboardShortcut("l", modifiers: .command)
             Button(transformActionLabel("Rotate Right")) {
-                _ = sessionModel.rotateFocusedFrame(by: 90)
+                sessionModel.performFrameTransformCommand(.rotateRight)
             }
-            .keyboardShortcut("r", modifiers: .command)
             Button(transformActionLabel("Reset Rotation")) {
                 if let frameIndex = sessionModel.frameTransformTargetIndex {
                     sessionModel.resetFrameOrientation(frameIndex)
@@ -320,17 +318,11 @@ struct ThumbnailGridView: View {
     private var mirrorMenu: some View {
         Menu("Mirror", systemImage: "arrow.left.and.right.righttriangle.left.righttriangle.right") {
             Button(transformActionLabel("Flip Left to Right")) {
-                if let frameIndex = sessionModel.frameTransformTargetIndex {
-                    sessionModel.toggleFrameMirror(frameIndex)
-                }
+                sessionModel.performFrameTransformCommand(.flipLeftToRight)
             }
-            .keyboardShortcut("h", modifiers: [.command, .shift])
             Button(transformActionLabel("Flip Top to Bottom")) {
-                if let frameIndex = sessionModel.frameTransformTargetIndex {
-                    sessionModel.toggleFrameVerticalMirror(frameIndex)
-                }
+                sessionModel.performFrameTransformCommand(.flipTopToBottom)
             }
-            .keyboardShortcut("v", modifiers: [.command, .shift])
             Button(transformActionLabel("Reset Flips")) {
                 if let frameIndex = sessionModel.frameTransformTargetIndex {
                     sessionModel.resetFrameMirrors(frameIndex)
@@ -363,7 +355,7 @@ struct ThumbnailGridView: View {
         .disabled(sessionModel.frameTransformTargetIndex == nil)
         .help(sessionModel.frameTransformTargetIndex == nil
             ? "Click a frame to focus it, then flip it."
-            : "Flips the focused frame for display in this session only. Shift-Command-H flips left to right; Shift-Command-V flips top to bottom.")
+            : "Flips the focused frame for display in this session only. Shift-Command-H flips left to right; Option-Command-V flips top to bottom.")
     }
 
     private func transformActionLabel(_ action: String) -> String {

--- a/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
@@ -3145,6 +3145,40 @@ public final class SessionModel {
         return true
     }
 
+    /// One tested dispatch point for the app-wide Photo menu and its
+    /// keyboard shortcuts. Keeping this in the model means the global
+    /// commands and the on-screen menus cannot drift into different focus
+    /// or selection behavior.
+    @discardableResult
+    public func performFrameTransformCommand(
+        _ command: FrameTransformCommand
+    ) -> Bool {
+        guard let frameIndex = frameTransformTargetIndex else { return false }
+        return performFrameTransformCommand(command, for: frameIndex)
+    }
+
+    /// Applies a transform to the frame focused in the active app window.
+    /// The explicit target prevents a command from one window mutating the
+    /// frame focused in another window that shares this session model.
+    @discardableResult
+    public func performFrameTransformCommand(
+        _ command: FrameTransformCommand,
+        for frameIndex: Int
+    ) -> Bool {
+        guard validFrameIndices.contains(frameIndex) else { return false }
+        switch command {
+        case .rotateLeft:
+            rotateFrame(frameIndex, by: -90)
+        case .rotateRight:
+            rotateFrame(frameIndex, by: 90)
+        case .flipLeftToRight:
+            toggleFrameMirror(frameIndex)
+        case .flipTopToBottom:
+            toggleFrameVerticalMirror(frameIndex)
+        }
+        return true
+    }
+
     public func resetFrameOrientation(_ frameIndex: Int) {
         frameOrientations.removeValue(forKey: frameIndex)
     }
@@ -4074,6 +4108,15 @@ public enum FrameOrientation {
     public static func swapsLayoutAxes(_ degrees: Int) -> Bool {
         !normalized(degrees).isMultiple(of: 180)
     }
+}
+
+/// App-wide commands that change only the currently focused photo. Scan
+/// selection is deliberately not part of this type.
+public enum FrameTransformCommand: Sendable {
+    case rotateLeft
+    case rotateRight
+    case flipLeftToRight
+    case flipTopToBottom
 }
 
 /// Whether the "Resume Batch" action should be offered, given the engine's

--- a/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
@@ -2929,6 +2929,42 @@ struct SessionEventPolicyTests {
         #expect(model.frameOrientation(6) == 0)
     }
 
+    @Test("global photo shortcuts target focus while all six remain selected")
+    @MainActor
+    func globalPhotoShortcutsUseFocusedFrame() async throws {
+        let project = try projectLifecycleFixture(
+            id: "global-shortcut-project",
+            completedFrames: []
+        )
+        let model = SessionModel(
+            engineClient: ProjectFlowEngineStub(project: project)
+        )
+        await model.loadCarrier(.strip6)
+        #expect(model.performFrameTransformCommand(.rotateRight) == false)
+        model.selectAllFrames()
+        model.focusFrame(3)
+
+        #expect(model.performFrameTransformCommand(.rotateRight))
+        #expect(model.performFrameTransformCommand(.flipTopToBottom))
+        #expect(model.performFrameTransformCommand(.flipLeftToRight))
+
+        #expect(model.selectedFrames == [1, 2, 3, 4, 5, 6])
+        #expect(model.frameOrientation(3) == 90)
+        #expect(model.frameVerticalMirror(3))
+        #expect(model.frameMirror(3))
+        #expect(model.frameOrientation(2) == 0)
+        #expect(model.frameVerticalMirror(2) == false)
+        #expect(model.frameMirror(2) == false)
+
+        #expect(model.performFrameTransformCommand(.rotateRight, for: 2))
+        #expect(model.frameOrientation(2) == 90)
+        #expect(model.performFrameTransformCommand(.rotateRight, for: 99) == false)
+
+        model.focusFrame(99)
+        #expect(model.performFrameTransformCommand(.rotateLeft))
+        #expect(model.frameOrientation(3) == 0)
+    }
+
     @Test("invalid focus is ignored and a real media change clears focus")
     @MainActor
     func frameFocusIsValidatedAndClearsWithMedia() async throws {

--- a/app/ScanStudio/packaging/Info.plist
+++ b/app/ScanStudio/packaging/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundleShortVersionString</key>
     <string>0.3.0</string>
     <key>CFBundleVersion</key>
-    <string>9</string>
+    <string>10</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>

--- a/app/ScanStudio/scripts/package_dmg.sh
+++ b/app/ScanStudio/scripts/package_dmg.sh
@@ -18,7 +18,7 @@ if [[ ! -f "$info_plist" ]]; then
 fi
 
 bundle_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info_plist")"
-release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.7}"
+release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.8}"
 release_arch="${SCANSTUDIO_RELEASE_ARCH:-$(uname -m)}"
 output="${2:-$package_root/.build/ScanStudio-$release_version-macOS-$release_arch.dmg}"
 


### PR DESCRIPTION
Summary
- register rotate and mirror shortcuts in the scene-level Photo menu
- keep all selected scan frames intact while commands target only the focused photo
- use Command-L/Command-R, Shift-Command-H, and Option-Command-V
- make the app single-window to match its one physical scanner session
- prepare the alpha 8 package version

Validation
- 387 Swift tests passed
- full Rust, bridge, and CoolscanPy suites passed
- packaged bridge relocation and macOS 14 floor checks passed
- final DMG hash and code signature verified
- real LS-5000 six-frame validation passed with no simulator; fine scan was not started

Rotation and mirror remain display-only in this alpha; saved scan output is unchanged.