### PR TITLE
Release alpha 10: refuse clipped leading frames

### DIFF
--- a/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
@@ -140,7 +140,8 @@ public enum ErrorPresentationPolicy {
         context: ErrorPresentationContext = .init()
     ) -> ErrorPresentation {
         let normalizedMessage = lastErrorMessage.uppercased()
-        let copy = filmFeedInterruptedCopy(in: lastErrorMessage)
+        let copy = leadingFrameClippedCopy(in: lastErrorMessage)
+            ?? filmFeedInterruptedCopy(in: lastErrorMessage)
             ?? filmTransportSlipCopy(in: lastErrorMessage)
             ?? previewReadinessTimeoutCopy(in: lastErrorMessage)
             ?? knownCopy.first { containsCode($0.code, in: normalizedMessage) }
@@ -162,6 +163,27 @@ public enum ErrorPresentationPolicy {
                 lastErrorMessage: lastErrorMessage,
                 context: context
             )
+        )
+    }
+
+    private static func leadingFrameClippedCopy(in message: String) -> Copy? {
+        guard
+            message.range(
+                of: "the first frame begins",
+                options: .caseInsensitive
+            ) != nil,
+            message.range(
+                of: "before the captured preview area",
+                options: .caseInsensitive
+            ) != nil
+        else {
+            return nil
+        }
+        return Copy(
+            code: "REFEED_REQUIRED",
+            title: "The first frame is not fully inside the scanner",
+            guidance: "Reinsert the film a little farther into the adapter, then preview it again. "
+                + "ScanStudio did not offer the cropped frame for scanning."
         )
     }
 

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
@@ -5,6 +5,22 @@ import Testing
 
 @Suite("Error presentation policy")
 struct ErrorPresentationPolicyTests {
+    @Test("a clipped first frame asks for a deeper refeed without offering a crop")
+    func leadingFrameClipped() {
+        let rawMessage = "REFEED_REQUIRED: the first frame begins 17 preview rows before "
+            + "the captured preview area (88.1% remains); refeed the film slightly deeper "
+            + "and acquire a fresh preview. ScanStudio did not expose the cropped frame for scanning"
+
+        let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+
+        #expect(presentation.title == "The first frame is not fully inside the scanner")
+        #expect(
+            presentation.guidance
+                == "Reinsert the film a little farther into the adapter, then preview it again. ScanStudio did not offer the cropped frame for scanning."
+        )
+        #expect(presentation.technicalDetails == rawMessage)
+    }
+
     @Test("medium-not-present during batch positioning is a clear feed interruption")
     func filmFeedInterrupted() {
         let rawMessage = "FILM_FEED_INTERRUPTED: bridge scan.frameFailed "

--- a/app/ScanStudio/packaging/Info.plist
+++ b/app/ScanStudio/packaging/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundleShortVersionString</key>
     <string>0.3.0</string>
     <key>CFBundleVersion</key>
-    <string>11</string>
+    <string>12</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>

--- a/app/ScanStudio/scripts/package_dmg.sh
+++ b/app/ScanStudio/scripts/package_dmg.sh
@@ -18,7 +18,7 @@ if [[ ! -f "$info_plist" ]]; then
 fi
 
 bundle_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info_plist")"
-release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.9}"
+release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.10}"
 release_arch="${SCANSTUDIO_RELEASE_ARCH:-$(uname -m)}"
 output="${2:-$package_root/.build/ScanStudio-$release_version-macOS-$release_arch.dmg}"
 

--- a/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -34,7 +34,10 @@ import tifffile
 # coolscanpy leak, not a wire contract of coolscanpy's own -- it becomes
 # harmless, dead code the day coolscanpy's own facade translates these into
 # its public taxonomy instead.
-from coolscanpy.protocol.ls5000_single_pass.roll_index import IndexDecodeError
+from coolscanpy.protocol.ls5000_single_pass.roll_index import (
+    IndexDecodeError,
+    LeadingFrameClippedError,
+)
 from coolscanpy.roll.preview_session import (
     RollSessionError,
     RollSessionIntegrityError,
@@ -554,6 +557,11 @@ class CoolscanPyTransport:
             raise BridgeError(ErrorCode.REFEED_REQUIRED, str(exc)) from exc
         except coolscanpy.DeviceBusy as exc:
             raise BridgeError(ErrorCode.DEVICE_BUSY, str(exc)) from exc
+        except LeadingFrameClippedError as exc:
+            # This is a proven physical-registration condition, unlike the
+            # broader IndexDecodeError bucket below. Preserve its precise
+            # deeper-refeed guidance in both the UI and diagnostics.
+            raise BridgeError(ErrorCode.REFEED_REQUIRED, str(exc)) from exc
         except IndexDecodeError as exc:
             # Hedged wording (2026-07-25 adversarial-review finding): the
             # IndexDecodeError class also covers malformed envelopes and

--- a/bridge/tests/test_transport_coolscanpy.py
+++ b/bridge/tests/test_transport_coolscanpy.py
@@ -852,6 +852,34 @@ def test_preview_maps_leaked_index_decode_error(monkeypatch: pytest.MonkeyPatch)
     assert "MAE 4.447" in message
 
 
+def test_preview_preserves_leading_frame_clipped_refeed_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from coolscanpy.protocol.ls5000_single_pass.roll_index import (
+        LeadingFrameClippedError,
+    )
+
+    class _LeadingFrameClippedRoll(_FakeRoll):
+        def preview(self, slots: list[int] | None = None) -> list["coolscanpy.Thumbnail"]:
+            raise LeadingFrameClippedError(
+                fitted_start_row=-17,
+                coverage_fraction=126 / 143,
+                content_fraction=41 / 42,
+                clear_film_fraction=1 / 42,
+            )
+
+    transport, _device = _opened_transport(monkeypatch, _LeadingFrameClippedRoll())
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    assert excinfo.value.code == ErrorCode.REFEED_REQUIRED
+    message = str(excinfo.value)
+    assert "first frame begins 17 preview rows" in message
+    assert "refeed the film slightly deeper" in message
+    assert "uniform traversal" not in message
+
+
 def test_preview_maps_leaked_roll_session_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """`coolscanpy.roll.preview_session.RollSessionError` is another
     coolscanpy-internal type outside the public taxonomy that `Roll.preview()`

--- a/coolscanpy/CHANGELOG.md
+++ b/coolscanpy/CHANGELOG.md
@@ -6,9 +6,15 @@ Whole-roll preview now keeps a content-supported leading frame when an
 otherwise valid feed places its fitted start exactly one 97-dpi preview row
 before the captured raster. The thumbnail is clamped to row zero, its
 same-capture transport origin is inferred from the validated interior mapping,
-and the frame remains blocked on explicit manual review; clips of two or more
-rows are still excluded fail-closed. This prevents a six-exposure strip from
-being silently presented as five after a one-row feed variation.
+and the frame remains blocked on explicit manual review. When enough of a
+leading frame remains to prove it exists but two or more rows fall outside the
+captured raster, preview now refuses with a typed deeper-refeed instruction
+instead of silently presenting a six-exposure strip as five. It also refuses
+to clamp that missing origin into the transport table, which would scan a
+cropped first frame and overlap the second. Clips with less than half a frame
+visible remain excluded as non-addressable edge material, while cells that
+meet the strict clear-film contract remain ordinary leader rather than being
+misreported as a clipped exposure.
 
 Transparent macOS app bundles can now pin PyUSB to an app-owned libusb
 without pretending the interpreter is PyInstaller-frozen. The resolver accepts

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/__init__.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/__init__.py
@@ -73,6 +73,7 @@ from .plan import (
 from .roll_index import (
     IndexDecodeError,
     IndexGeometry,
+    LeadingFrameClippedError,
     RollDetection,
     TransportMapping,
     decode_full_index_bytes,
@@ -106,6 +107,7 @@ __all__ = [
     "FineStreamSession",
     "IndexDecodeError",
     "IndexGeometry",
+    "LeadingFrameClippedError",
     "MeterObservation",
     "MeterProposal",
     "MeterResult",

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -36,7 +36,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "b9cdec8fe47f470eed45185622c6d16ad1583520792c84aa2a89709555331e1b",
+    "roll_index.py": "817f39fc177253f031f6cf7f40b42c9b5b021096a3cc04d0a8915ce86338beec",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -29,10 +29,36 @@ MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS = 2.0
 MAXIMUM_LEADING_ANCHOR_ERROR_ROWS = 5.0
 LEADING_ANCHOR_REVIEW_REASON = "leading-anchor-divergence"
 TRANSPORT_ORIGIN_CLAMP_REASON = "transport-origin-extrapolated-clamp"
+MINIMUM_CONFIDENT_CLEAR_FILM_FRACTION = 0.95
 
 
 class IndexDecodeError(ValueError):
     """Input is not a self-consistent LS-5000 roll-index capture."""
+
+
+class LeadingFrameClippedError(IndexDecodeError):
+    """A photographed leading cell is visible but cannot be scanned whole."""
+
+    def __init__(
+        self,
+        *,
+        fitted_start_row: int,
+        coverage_fraction: float,
+        content_fraction: float,
+        clear_film_fraction: float,
+    ) -> None:
+        self.fitted_start_row = fitted_start_row
+        self.clipped_preview_rows = max(0, -fitted_start_row)
+        self.coverage_fraction = coverage_fraction
+        self.content_fraction = content_fraction
+        self.clear_film_fraction = clear_film_fraction
+        super().__init__(
+            "the first frame begins "
+            f"{self.clipped_preview_rows} preview rows before the captured preview "
+            f"area ({coverage_fraction:.1%} remains); refeed the film slightly deeper "
+            "and acquire a fresh preview. ScanStudio did not expose the cropped frame "
+            "for scanning"
+        )
 
 
 class IncompleteIndexError(IndexDecodeError):
@@ -958,6 +984,37 @@ def detect_roll_frames(
         raise IndexDecodeError("roll detector found no in-raster lattice origin")
     cell_start = lattice_starts[0]
     preceding_cell = cell_start - 1
+    if preceding_cell >= 0:
+        preceding_start = int(all_positions[preceding_cell])
+        preceding_coverage = float(cell_coverage[preceding_cell])
+        preceding_content = float(cell_content[preceding_cell])
+        observed_start = max(0, preceding_start)
+        observed_end = min(len(direct), int(all_positions[preceding_cell + 1]))
+        preceding_clear_film = (
+            float(direct[observed_start:observed_end].mean())
+            if observed_end > observed_start
+            else 1.0
+        )
+        if (
+            preceding_start < -1
+            and bool(cell_supported[preceding_cell])
+            and preceding_clear_film < MINIMUM_CONFIDENT_CLEAR_FILM_FRACTION
+        ):
+            # ``direct`` is the detector's strict clear-film contract: high
+            # transmission, low nonuniformity, and safe samples. A normal
+            # leader fixture satisfies it on 100% of this cell. If at least 5%
+            # does not look like clear film, the normal content threshold is
+            # enough to prove a photographed slot exists even when that slot
+            # is bright or partly blank. Its fitted origin is outside the
+            # scanner-addressable range. Silently starting at the next cell
+            # renumbers a six-frame strip as five; clamping to row zero would
+            # crop frame 1 and overlap frame 2. Refuse both outcomes.
+            raise LeadingFrameClippedError(
+                fitted_start_row=preceding_start,
+                coverage_fraction=preceding_coverage,
+                content_fraction=preceding_content,
+                clear_film_fraction=preceding_clear_film,
+            )
     if (
         preceding_cell >= 0
         and int(all_positions[preceding_cell]) == -1

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -282,14 +282,63 @@ def test_one_row_clipped_leading_cell_is_exposed_for_manual_review() -> None:
     )
 
 
-def test_two_row_clipped_leading_cell_remains_excluded_fail_closed() -> None:
+def test_content_supported_leading_cell_with_real_feed_clip_requires_refeed() -> None:
+    complete_rgb, _boundaries = _synthetic_roll(6, leader=0, tail=24)
+    clipped_rgb = complete_rgb[17:]
+
+    with pytest.raises(roll.LeadingFrameClippedError) as excinfo:
+        _detect(clipped_rgb)
+
+    error = excinfo.value
+    assert error.fitted_start_row == -17
+    assert error.clipped_preview_rows == 17
+    assert error.coverage_fraction == pytest.approx(126 / 143)
+    assert error.content_fraction == pytest.approx(0.9761904761904762)
+    assert error.clear_film_fraction < 0.05
+    assert "17 preview rows" in str(error)
+    assert "refeed" in str(error).lower()
+
+
+def test_two_row_clipped_leading_cell_requires_refeed() -> None:
     complete_rgb, _boundaries = _synthetic_roll(6, leader=0, tail=24)
     clipped_rgb = complete_rgb[2:]
 
+    with pytest.raises(roll.LeadingFrameClippedError, match="2 preview rows"):
+        _detect(clipped_rgb)
+
+
+def test_partly_blank_clipped_leading_frame_still_requires_refeed() -> None:
+    complete_rgb, _boundaries = _synthetic_roll(6, leader=0, tail=24)
+    # Make roughly half of frame 1 indistinguishable from clear film. The
+    # remaining photographed rows still prove that the off-raster cell is a
+    # real exposure, even though its content score is well below 75%.
+    complete_rgb[:75] = complete_rgb[-1]
+    clipped_rgb = complete_rgb[17:]
+
+    with pytest.raises(roll.LeadingFrameClippedError) as excinfo:
+        _detect(clipped_rgb)
+
+    assert 0.25 <= excinfo.value.content_fraction < 0.75
+    assert excinfo.value.clear_film_fraction < 0.95
+
+
+def test_less_than_half_visible_leading_cell_is_not_mistaken_for_a_frame() -> None:
+    complete_rgb, _boundaries = _synthetic_roll(6, leader=0, tail=24)
+    clipped_rgb = complete_rgb[72:]
+
     detection = _detect(clipped_rgb)
 
-    assert detection.frame_starts[0] > 100
+    assert detection.frame_starts[0] > 50
     assert roll.scanner_addressable_interval_count(detection.intervals) == 5
+
+
+def test_clear_leader_is_not_mistaken_for_a_clipped_photographed_frame() -> None:
+    rgb, _boundaries = _synthetic_roll(6, leader=128, tail=176)
+
+    detection = _detect(rgb)
+
+    assert detection.frame_starts[0] == pytest.approx(128, abs=1)
+    assert detection.intervals[0].coverage_fraction == 1.0
 
 
 def test_channel_gain_changes_do_not_move_detected_boundaries() -> None:

--- a/coolscanpy/tests/roll/test_ls5000_roll_session.py
+++ b/coolscanpy/tests/roll/test_ls5000_roll_session.py
@@ -556,6 +556,32 @@ def test_preview_session_keeps_one_row_clipped_first_frame_for_review(
     )
 
 
+def test_preview_session_refuses_a_first_frame_clipped_beyond_scannable_range(
+    tmp_path: Path,
+) -> None:
+    complete = _synthetic_index(
+        height=882,
+        frame_count=6,
+        content_frames=6,
+        leader=0,
+    )
+    fixture = _preview_fixture(
+        tmp_path,
+        slot_capacity_hint=6,
+        active_rgb=complete[17:],
+    )
+
+    with pytest.raises(roll_index.LeadingFrameClippedError) as excinfo:
+        build_roll_preview_session(
+            fixture.result,
+            material=ScanMaterial.COLOR_NEGATIVE,
+        )
+
+    assert excinfo.value.fitted_start_row == -17
+    assert excinfo.value.coverage_fraction == pytest.approx(126 / 143)
+    assert "fresh preview" in str(excinfo.value)
+
+
 def test_preview_refuses_density_source_geometry_from_another_startup_count(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What changed

- Detect a photographed leading frame whose origin falls outside the captured preview.
- Refuse the preview with specific deeper-refeed guidance instead of silently renumbering six frames as five.
- Never clamp the missing origin into the transport table, which would crop frame 1 and overlap frame 2.
- Preserve the existing safe one-row manual-review case and distinguish ordinary clear leader.
- Bump the packaged app to build 12 / alpha 10.

## Validation

- Real clipped capture replay: typed REFEED_REQUIRED at -17 rows, 88.0% coverage.
- Known-good real capture replay: six frames and six transport origins preserved.
- CoolScanPy: 1,372 passed, 3 skipped, 1 expected failure.
- Bridge: 281 passed.
- Rust engine: 363 tests plus integrations passed.
- ScanStudio: 401 tests in 40 suites passed.
- Ruff checks, bundle hash pin, plist, and diff checks passed.

## Safety

- No scanner motion was issued during implementation or offline validation.
- Saved rotation and horizontal/vertical mirror behavior from alpha 9 remains unchanged.