### PR TITLE
Release ScanStudio 0.3.0 beta 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,3 +123,42 @@ jobs:
         run: |
           ditto -x -k "$RUNNER_TEMP/scanstudio-package/ScanStudio-app.zip" "$RUNNER_TEMP/scanstudio-package/unpacked"
           app/ScanStudio/scripts/test_packaged_bridge.sh "$RUNNER_TEMP/scanstudio-package/unpacked/ScanStudio.app"
+
+  updater-integration:
+    name: Updater integration gate
+    # Reuses the exact signed app produced by the package job so the "release"
+    # under test is the shipped artifact, not a dev build. Same-workflow job
+    # ordering means the artifact is still present when this job runs, so the
+    # package job's 1-day retention needs no bump.
+    runs-on: macos-15
+    needs: package
+    env:
+      UV_PYTHON_PREFERENCE: only-managed
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - name: Warm the locked dependency cache
+        # Keeps the runner environment interchangeable with the other uv-managed
+        # jobs (see the bridge job note) so script behaviour is reproducible.
+        working-directory: bridge
+        run: uv sync --locked
+      - uses: actions/download-artifact@v4
+        with:
+          name: ScanStudio-app
+          path: ${{ runner.temp }}/scanstudio-updater
+      - name: Unpack the packaged app for the updater gate
+        run: |
+          ditto -x -k "$RUNNER_TEMP/scanstudio-updater/ScanStudio-app.zip" "$RUNNER_TEMP/scanstudio-updater/unpacked"
+      - name: Run the seeded updater verification against the exact packaged app
+        # Both point at the same real app: the script seeds its feed from the
+        # new-app bytes and the harness proves resolve -> download -> verify ->
+        # snapshot -> swap -> rollback on its own synthetic old/new fixtures, so
+        # the flow's hash + swap still prove out against the signed artifact.
+        env:
+          SCANSTUDIO_UPDATER_CURRENT_APP: ${{ runner.temp }}/scanstudio-updater/unpacked/ScanStudio.app
+          SCANSTUDIO_UPDATER_NEW_APP: ${{ runner.temp }}/scanstudio-updater/unpacked/ScanStudio.app
+        run: |
+          scripts/verify_updater.sh 2>&1 | tee "$RUNNER_TEMP/verify_updater.log"
+          grep -q "VERIFY_UPDATER OK" "$RUNNER_TEMP/verify_updater.log"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,38 @@ jobs:
         run: uv run pytest
 
   package:
-    name: Self-contained package build
-    runs-on: macos-15
+    name: Self-contained package build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runs-on }}
     # See the bridge job: the relocatable package requires uv's standalone
     # CPython, not the runner image's framework Python.
+    #
+    # Why package runs on BOTH archs while app-and-engine / bridge / coolscanpy
+    # stay single-arch: those suites are arch-independent logic + tests, and a
+    # full double run doubles billing for no extra coverage. The package gate
+    # is the arch-relevant one -- it proves the bundled app + libusb + CPython
+    # wheels build and pass the relocation-safe bridge check natively on arm64
+    # AND x86_64 on every PR, mirroring the release matrix before a tag exists.
+    #
+    # Only the arm64 leg uploads the ScanStudio-app artifact: package-macos-14
+    # (the OS-floor gate) and updater-integration consume that one arm64 app,
+    # and two matrix legs must not race on the same artifact name. The x86_64
+    # leg still builds + verifies natively; it just has no downstream consumer
+    # yet.
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: [arm64, x86_64]
+        include:
+          - arch: arm64
+            runs-on: macos-15
+            upload-artifact: true
+          # GitHub-hosted Intel labels change over time; per the GitHub-hosted
+          # runners reference the current standard is `macos-15-intel`. Kept in
+          # lockstep with the release.yml matrix -- if it stops resolving, the
+          # conservative fallback is `macos-13`; update BOTH files together.
+          - arch: x86_64
+            runs-on: macos-15-intel
+            upload-artifact: false
     env:
       UV_PYTHON_PREFERENCE: only-managed
     steps:
@@ -85,12 +113,17 @@ jobs:
         working-directory: bridge
         run: uv sync --locked --extra scanner
       - name: Build and verify the local package
+        # make package runs package_app.sh then test_packaged_bridge.sh on the
+        # built ScanStudio.app -- the relocation-safe bridge check -- so this
+        # leg proves the packaged app works on this runner's native arch.
         working-directory: app/ScanStudio
         run: make package
       - name: Preserve the exact signed app for the macOS 14 runtime gate
+        if: ${{ matrix.upload-artifact }}
         working-directory: app/ScanStudio/.build
         run: ditto -c -k --sequesterRsrc --keepParent ScanStudio.app ScanStudio-app.zip
       - uses: actions/upload-artifact@v4
+        if: ${{ matrix.upload-artifact }}
         with:
           name: ScanStudio-app
           path: app/ScanStudio/.build/ScanStudio-app.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,39 @@ permissions:
 
 jobs:
   release:
-    name: Build and publish release
-    runs-on: macos-15
-    # See the package job in ci.yml: the relocatable package requires uv's
-    # standalone CPython, not the runner image's framework Python. This is
-    # the same verified `make dmg` path used locally, so a release is only
-    # publishable if the exact signed app passes the packaging verification.
+    name: Build and verify ${{ matrix.arch }} DMG
+    # Per-arch DMGs (see .planning/phases/02-intel-support/02-CONTEXT.md): a
+    # universal bundle is impossible because the pinned cv2/numpy wheels are
+    # not universal, so each architecture is built natively on its own runner
+    # through the SAME verified `make dmg` path (codesign --deep --strict,
+    # relocation-safe bridge check, SHA-256). If EITHER matrix cell fails,
+    # fail-fast aborts the whole workflow and nothing is published.
+    #
+    # Intel runner label: GitHub-hosted Intel labels change over time. Per the
+    # GitHub-hosted runners reference (docs.github.com, 2026-08) the current
+    # standard Intel label is `macos-15-intel`; hosted-label availability is
+    # NOT exposed through the API (gh api /repos/{owner}/{repo}/actions/runners
+    # only lists self-hosted runners), so it cannot be probed in advance. We
+    # hard-code `macos-15-intel` and let GitHub fail the job loudly if the
+    # label is ever retired or unavailable on this account -- fail-loud is
+    # acceptable for this gate (T-02-01-02). If it stops resolving, the
+    # conservative fallback is the last Intel-only label, `macos-13`; update
+    # BOTH this include and the package matrix in ci.yml together.
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: [arm64, x86_64]
+        include:
+          - arch: arm64
+            runs-on: macos-15
+          - arch: x86_64
+            runs-on: macos-15-intel
+    runs-on: ${{ matrix.runs-on }}
     env:
+      # See the package job in ci.yml: the relocatable package requires uv's
+      # standalone CPython, not the runner image's framework Python. This is
+      # the same verified `make dmg` path used locally, so a release is only
+      # publishable if the exact signed app passes the packaging verification.
       UV_PYTHON_PREFERENCE: only-managed
     steps:
       - uses: actions/checkout@v4
@@ -50,20 +76,22 @@ jobs:
           echo "Resolved release version: $STAMP"
       - name: Build and verify the local DMG
         # package_dmg.sh names the artifact ScanStudio-<version>-macOS-<arch>.dmg
-        # from SCANSTUDIO_RELEASE_VERSION (set above from the tag) and refuses
-        # to overwrite an existing artifact. It also verifies the mounted app's
+        # (arch from uname -m, i.e. this runner's native arch) and refuses to
+        # overwrite an existing artifact. It also verifies the mounted app's
         # code signature and runs test_packaged_bridge.sh on it; any failure
         # here aborts the job and nothing is released.
         working-directory: app/ScanStudio
         run: make dmg
-      - name: Emit SHA256SUMS and latest.json
+      - name: Emit SHA256SUMS and arch-keyed latest.json
         working-directory: app/ScanStudio
         run: |
-          scripts/emit_release_assets.sh ".build/ScanStudio-$RELEASE_VERSION-macOS-$(uname -m).dmg" "$RELEASE_VERSION" ".build"
+          scripts/emit_release_assets.sh ".build/ScanStudio-$RELEASE_VERSION-macOS-$(uname -m).dmg" "$RELEASE_VERSION" ".build" "$(uname -m)"
       - name: Re-verify released assets
         # codesign --verify --deep --strict on the mounted app is already part
-        # of make dmg's packaging; do not re-mount here. Assert the checksum in
-        # SHA256SUMS matches the actual DMG and latest.json is non-empty.
+        # of make dmg's packaging; do not re-mount here. Assert the per-arch
+        # checksum in SHA256SUMS matches the actual DMG, latest.json is
+        # non-empty, and THIS arch's entry is present and carries that sha
+        # (T-02-01-04: the arm64 entry never carries the x86_64 url/sha).
         working-directory: app/ScanStudio
         run: |
           DMG=".build/ScanStudio-$RELEASE_VERSION-macOS-$(uname -m).dmg"
@@ -72,31 +100,116 @@ jobs:
           test -n "$EXPECTED"
           test "$EXPECTED" = "$ACTUAL"
           test -s .build/latest.json
+          python3 - "$(uname -m)" "$ACTUAL" <<'PY'
+          import json, sys
+          arch, actual = sys.argv[1:3]
+          d = json.load(open(".build/latest.json"))
+          entry = d["architectures"][arch]
+          assert entry["sha256"] == actual
+          assert d["architectures"][arch]["url"].endswith(".dmg")
+          print(f"{arch} entry present and matches checksum {actual}")
+          PY
           echo "Checksum re-verified: $ACTUAL"
+      - name: Upload ${{ matrix.arch }} release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: ScanStudio-dmg-${{ matrix.arch }}
+          path: |
+            app/ScanStudio/.build/ScanStudio-${{ env.RELEASE_VERSION }}-macOS-${{ matrix.arch }}.dmg
+            app/ScanStudio/.build/SHA256SUMS
+            app/ScanStudio/.build/latest.json
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish combined multi-arch release
+    needs: release
+    runs-on: macos-15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: ScanStudio-dmg-arm64
+          path: ${{ runner.temp }}/arm64
+      - uses: actions/download-artifact@v4
+        with:
+          name: ScanStudio-dmg-x86_64
+          path: ${{ runner.temp }}/x86_64
+      - name: Resolve release version from the tag
+        run: |
+          STAMP="${GITHUB_REF_NAME#v}"
+          echo "RELEASE_VERSION=$STAMP" >> "$GITHUB_ENV"
+          echo "SCANSTUDIO_RELEASE_VERSION=$STAMP" >> "$GITHUB_ENV"
+          echo "Resolved release version: $STAMP"
+      - name: Merge arch-keyed pointers and combine checksums
+        # Fold the two matrix cells' arch-keyed latest.json into ONE pointer by
+        # re-running the emitter against both downloaded DMGs: the second emit
+        # sees the same version plus a distinct arch and MERGES the entry in
+        # (never clobbers). Concatenate the basename-only SHA256SUMS files so
+        # the published checksum covers both DMGs.
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/combined"
+          app/ScanStudio/scripts/emit_release_assets.sh \
+            "$RUNNER_TEMP/arm64/ScanStudio-$RELEASE_VERSION-macOS-arm64.dmg" \
+            "$RELEASE_VERSION" "$RUNNER_TEMP/combined" arm64
+          app/ScanStudio/scripts/emit_release_assets.sh \
+            "$RUNNER_TEMP/x86_64/ScanStudio-$RELEASE_VERSION-macOS-x86_64.dmg" \
+            "$RELEASE_VERSION" "$RUNNER_TEMP/combined" x86_64
+          cat "$RUNNER_TEMP/arm64/SHA256SUMS" "$RUNNER_TEMP/x86_64/SHA256SUMS" > "$RUNNER_TEMP/combined/SHA256SUMS"
+          echo "Combined pointer:"
+          cat "$RUNNER_TEMP/combined/latest.json"
+      - name: Re-verify combined assets before publish
+        # Re-assert the merged pointer carries BOTH arch entries whose
+        # checksums match the two downloaded DMGs, so an unverified artifact
+        # is never attached (T-02-01-03).
+        run: |
+          set -euo pipefail
+          python3 - "$RUNNER_TEMP/combined/latest.json" "$RELEASE_VERSION" "$RUNNER_TEMP" <<'PY'
+          import hashlib, json, os, sys
+          path, version, base = sys.argv[1:4]
+          d = json.load(open(path))
+          assert d["version"] == version
+          assert set(d["architectures"]) == {"arm64", "x86_64"}
+          for arch in ("arm64", "x86_64"):
+              entry = d["architectures"][arch]
+              dmg = os.path.join(base, arch, os.path.basename(entry["url"]))
+              assert os.path.isfile(dmg), dmg
+              h = hashlib.sha256(open(dmg, "rb").read()).hexdigest()
+              assert entry["sha256"] == h, arch
+          print("Combined checksums re-verified for both architectures")
+          PY
       - name: Create GitHub release
         # How the alpha parcel behaves today: alphas are pre-releases on
         # GitHub. Keep that --prerelease only for -alpha versions; stable
-        # tags publish as full releases.
+        # tags publish as full releases. Both DMGs + combined checksums +
+        # the arch-keyed pointer are attached in one release.
         env:
           GH_TOKEN: ${{ github.token }}
-        working-directory: app/ScanStudio
         run: |
-          DMG=".build/ScanStudio-$RELEASE_VERSION-macOS-$(uname -m).dmg"
-          SHA256="$(awk '{print $1}' .build/SHA256SUMS)"
+          ARM_SHA256="$(awk '{print $1}' "$RUNNER_TEMP/arm64/SHA256SUMS")"
+          X86_SHA256="$(awk '{print $1}' "$RUNNER_TEMP/x86_64/SHA256SUMS")"
           PRERELEASE=""
           case "$RELEASE_VERSION" in
             *-alpha*) PRERELEASE="--prerelease" ;;
           esac
+          NOTES="Automated release of ScanStudio $RELEASE_VERSION.
+          arm64 SHA-256: $ARM_SHA256
+          x86_64 SHA-256: $X86_SHA256"
           gh release create "v$RELEASE_VERSION" \
             --repo rohanpandula/ScanStudio \
             --title "ScanStudio $RELEASE_VERSION" \
-            --notes "Automated release of ScanStudio $RELEASE_VERSION.
-
-SHA-256: $SHA256" \
+            --notes "$NOTES" \
             $PRERELEASE \
-            -- "$DMG" .build/SHA256SUMS .build/latest.json
+            "$RUNNER_TEMP/arm64/ScanStudio-$RELEASE_VERSION-macOS-arm64.dmg" \
+            "$RUNNER_TEMP/x86_64/ScanStudio-$RELEASE_VERSION-macOS-x86_64.dmg" \
+            "$RUNNER_TEMP/combined/SHA256SUMS" \
+            "$RUNNER_TEMP/combined/latest.json"
       - name: Summarize published release
-        working-directory: app/ScanStudio
         run: |
-          echo "Asset: https://github.com/rohanpandula/ScanStudio/releases/download/v$RELEASE_VERSION/ScanStudio-$RELEASE_VERSION-macOS-$(uname -m).dmg"
-          echo "SHA-256 $(awk '{print $1}' .build/SHA256SUMS)"
+          echo "arm64 asset: https://github.com/rohanpandula/ScanStudio/releases/download/v$RELEASE_VERSION/ScanStudio-$RELEASE_VERSION-macOS-arm64.dmg"
+          echo "x86_64 asset: https://github.com/rohanpandula/ScanStudio/releases/download/v$RELEASE_VERSION/ScanStudio-$RELEASE_VERSION-macOS-x86_64.dmg"
+          echo "arm64 SHA-256 $(awk '{print $1}' "$RUNNER_TEMP/arm64/SHA256SUMS")"
+          echo "x86_64 SHA-256 $(awk '{print $1}' "$RUNNER_TEMP/x86_64/SHA256SUMS")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: macos-15
+    # See the package job in ci.yml: the relocatable package requires uv's
+    # standalone CPython, not the runner image's framework Python. This is
+    # the same verified `make dmg` path used locally, so a release is only
+    # publishable if the exact signed app passes the packaging verification.
+    env:
+      UV_PYTHON_PREFERENCE: only-managed
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - name: Install optional SANE binding build prerequisite
+        # The release does not copy Homebrew's libusb: package_app.sh builds
+        # the signed app-owned copy from hash-pinned source. sane-backends is
+        # needed only to compile the optional python-sane compatibility
+        # binding included in the bundle.
+        run: brew install sane-backends
+      - name: Point the compiler at Homebrew's headers and libraries
+        # GitHub Actions does not expand $(...) inside an `env:` block and the
+        # Homebrew prefix varies by runner arch (/opt/homebrew on arm64,
+        # /usr/local on x86_64), so resolve it here and export it through
+        # GITHUB_ENV for every later step in this job.
+        run: |
+          echo "CPPFLAGS=-I$(brew --prefix)/include" >> "$GITHUB_ENV"
+          echo "LDFLAGS=-L$(brew --prefix)/lib" >> "$GITHUB_ENV"
+      - name: Install locked bridge dependencies (with scanner extra)
+        working-directory: bridge
+        run: uv sync --locked --extra scanner
+      - name: Resolve release version from the tag
+        # The workflow only runs on `v*` tag pushes, so the exact-match tag
+        # is authoritative; fall back to GITHUB_REF_NAME minus the leading v.
+        run: |
+          STAMP="$({ git describe --tags --exact-match HEAD 2>/dev/null || echo "$GITHUB_REF_NAME"; } | sed 's/^v//')"
+          echo "RELEASE_VERSION=$STAMP" >> "$GITHUB_ENV"
+          echo "SCANSTUDIO_RELEASE_VERSION=$STAMP" >> "$GITHUB_ENV"
+          echo "Resolved release version: $STAMP"
+      - name: Build and verify the local DMG
+        # package_dmg.sh names the artifact ScanStudio-<version>-macOS-<arch>.dmg
+        # from SCANSTUDIO_RELEASE_VERSION (set above from the tag) and refuses
+        # to overwrite an existing artifact. It also verifies the mounted app's
+        # code signature and runs test_packaged_bridge.sh on it; any failure
+        # here aborts the job and nothing is released.
+        working-directory: app/ScanStudio
+        run: make dmg
+      - name: Emit SHA256SUMS and latest.json
+        working-directory: app/ScanStudio
+        run: |
+          scripts/emit_release_assets.sh ".build/ScanStudio-$RELEASE_VERSION-macOS-$(uname -m).dmg" "$RELEASE_VERSION" ".build"
+      - name: Re-verify released assets
+        # codesign --verify --deep --strict on the mounted app is already part
+        # of make dmg's packaging; do not re-mount here. Assert the checksum in
+        # SHA256SUMS matches the actual DMG and latest.json is non-empty.
+        working-directory: app/ScanStudio
+        run: |
+          DMG=".build/ScanStudio-$RELEASE_VERSION-macOS-$(uname -m).dmg"
+          EXPECTED="$(awk '{print $1}' .build/SHA256SUMS)"
+          ACTUAL="$(shasum -a 256 "$DMG" | awk '{print $1}')"
+          test -n "$EXPECTED"
+          test "$EXPECTED" = "$ACTUAL"
+          test -s .build/latest.json
+          echo "Checksum re-verified: $ACTUAL"
+      - name: Create GitHub release
+        # How the alpha parcel behaves today: alphas are pre-releases on
+        # GitHub. Keep that --prerelease only for -alpha versions; stable
+        # tags publish as full releases.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        working-directory: app/ScanStudio
+        run: |
+          DMG=".build/ScanStudio-$RELEASE_VERSION-macOS-$(uname -m).dmg"
+          SHA256="$(awk '{print $1}' .build/SHA256SUMS)"
+          PRERELEASE=""
+          case "$RELEASE_VERSION" in
+            *-alpha*) PRERELEASE="--prerelease" ;;
+          esac
+          gh release create "v$RELEASE_VERSION" \
+            --repo rohanpandula/ScanStudio \
+            --title "ScanStudio $RELEASE_VERSION" \
+            --notes "Automated release of ScanStudio $RELEASE_VERSION.
+
+SHA-256: $SHA256" \
+            $PRERELEASE \
+            -- "$DMG" .build/SHA256SUMS .build/latest.json
+      - name: Summarize published release
+        working-directory: app/ScanStudio
+        run: |
+          echo "Asset: https://github.com/rohanpandula/ScanStudio/releases/download/v$RELEASE_VERSION/ScanStudio-$RELEASE_VERSION-macOS-$(uname -m).dmg"
+          echo "SHA-256 $(awk '{print $1}' .build/SHA256SUMS)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,9 +182,9 @@ jobs:
           print("Combined checksums re-verified for both architectures")
           PY
       - name: Create GitHub release
-        # How the alpha parcel behaves today: alphas are pre-releases on
-        # GitHub. Keep that --prerelease only for -alpha versions; stable
-        # tags publish as full releases. Both DMGs + combined checksums +
+        # Alpha, beta, and release-candidate parcels are pre-releases on
+        # GitHub. Stable versions publish as full releases. Both DMGs +
+        # combined checksums +
         # the arch-keyed pointer are attached in one release.
         env:
           GH_TOKEN: ${{ github.token }}
@@ -193,9 +193,15 @@ jobs:
           X86_SHA256="$(awk '{print $1}' "$RUNNER_TEMP/x86_64/SHA256SUMS")"
           PRERELEASE=""
           case "$RELEASE_VERSION" in
-            *-alpha*) PRERELEASE="--prerelease" ;;
+            *-alpha*|*-beta*|*-rc*) PRERELEASE="--prerelease" ;;
           esac
-          NOTES="Automated release of ScanStudio $RELEASE_VERSION.
+          NOTES="ScanStudio $RELEASE_VERSION
+
+          Apple Silicon (arm64): Beta. Validated with the real LS-5000 workflow.
+          Intel (x86_64): Preview. Built and tested natively in CI; real-scanner validation is still pending.
+
+          Both builds are ad-hoc signed and are not notarized. macOS may require Control-click > Open on first launch. Do not disable Gatekeeper globally.
+
           arm64 SHA-256: $ARM_SHA256
           x86_64 SHA-256: $X86_SHA256"
           gh release create "v$RELEASE_VERSION" \

--- a/README.md
+++ b/README.md
@@ -18,16 +18,24 @@ no support or release-schedule promise.
 
 ## Download
 
-The current Apple Silicon DMG is published on the
+ScanStudio ships per-architecture DMGs: `ScanStudio-<version>-macOS-arm64.dmg`
+for Apple Silicon (M-series) and `ScanStudio-<version>-macOS-x86_64.dmg` for
+Intel. Choose the DMG matching your Mac; the in-app updater does this
+automatically. Both are published on the
 [GitHub Releases page](https://github.com/rohanpandula/ScanStudio/releases).
-It targets macOS 14 or newer and contains the app, the GPL hardware bridge and
-CoolscanPy source required for redistribution, and the applicable dependency
-notices. The supported LS-5000 color-roll workflow uses the signed libusb copy
-inside the app, so installing ScanStudio does not require Homebrew, SANE, or a
-Nikon driver. The optional software-eject and legacy plain-scan paths still
-need a system SANE backend. Because this alpha is not notarized, macOS may
-require the normal Control-click **Open** confirmation on first launch. Do not
-disable Gatekeeper globally.
+A release DMG contains the app, the GPL hardware bridge and CoolscanPy source
+required for redistribution, and the applicable dependency notices. The
+supported LS-5000 color-roll workflow uses the signed libusb copy inside the
+app, so installing ScanStudio does not require Homebrew, SANE, or a Nikon
+driver. The optional software-eject and legacy plain-scan paths still need a
+system SANE backend. Because this alpha is not notarized, macOS may require
+the normal Control-click **Open** confirmation on first launch. Do not disable
+Gatekeeper globally.
+
+## System requirements
+
+- macOS 14 (Sonoma) or newer.
+- An Apple Silicon (M-series) Mac or an Intel Mac.
 
 Opening the packaged app with its hardware bridge available automatically
 prepares that app session for film movement. Launching alone does not move the

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 <img src="assets/scanstudio-ls5000-offline.jpeg" alt="ScanStudio running on macOS with an LS-5000 ED offered by the bridge as a Connect target. No scanner is selected, the status is OFFLINE, the simulator is absent, and no media or preview data is shown." width="1000">
 
-ScanStudio is a native macOS alpha for scanning 35 mm film with a Nikon SUPER COOLSCAN 5000 ED, also called the LS-5000. It replaces the practical Nikon Scan workflow on the tested setup: identify the loaded holder, preview the film, choose frames, set the recipe and outputs, scan, and stop safely when needed.
+ScanStudio is a native macOS beta for scanning 35 mm film with a Nikon SUPER COOLSCAN 5000 ED, also called the LS-5000. It replaces the practical Nikon Scan workflow on the tested Apple Silicon setup: identify the loaded holder, preview the film, choose frames, set the recipe and outputs, scan, and stop safely when needed.
 
 The screenshot above is the current installed app. The LS-5000 ED has been detected through the bridge and is offered as a Connect target, but it is not connected. The app is OFFLINE, the simulator is absent, and no media, preview, or scan image is displayed.
 
-## Alpha scope
+## Beta scope
 
-Real scanning has been tested on one Mac and one LS-5000 setup. Treat that as a narrow, useful result rather than a promise for every Coolscan, adapter, Mac, operating system, or film holder. The hardware bridge can move film, so stay nearby and supervise any real job.
+Real scanning has been tested on one Apple Silicon Mac and one LS-5000 setup. The Intel build is a prerelease preview that is built and tested natively in CI, but has not yet been validated with a real scanner. Treat both as narrow results rather than a promise for every Coolscan, adapter, Mac, operating system, or film holder. The hardware bridge can move film, so stay nearby and supervise any real job.
 
-The source is still under active development. The release DMG is an alpha,
+The source is still under active development. The release DMG is a beta,
 ad-hoc-signed build rather than a notarized Developer ID distribution; there is
 no support or release-schedule promise.
 
@@ -28,7 +28,7 @@ required for redistribution, and the applicable dependency notices. The
 supported LS-5000 color-roll workflow uses the signed libusb copy inside the
 app, so installing ScanStudio does not require Homebrew, SANE, or a Nikon
 driver. The optional software-eject and legacy plain-scan paths still need a
-system SANE backend. Because this alpha is not notarized, macOS may require
+system SANE backend. Because this beta is not notarized, macOS may require
 the normal Control-click **Open** confirmation on first launch. Do not disable
 Gatekeeper globally.
 

--- a/app/ScanStudio/Sources/ScanStudio/ScanStudioApp.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ScanStudioApp.swift
@@ -6,6 +6,7 @@
 // activate call.
 
 import AppKit
+import Observation
 import ScanStudioKit
 import SwiftUI
 
@@ -43,6 +44,10 @@ struct ScanStudioApp: App {
             if case .ready(_, let model) = appDelegate.launchState {
                 FrameTransformCommands(session: model)
             }
+        }
+
+        Settings {
+            UpdateSettingsView(model: appDelegate.updateFlowModel)
         }
     }
 }
@@ -104,6 +109,11 @@ enum LaunchState {
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let launchState: LaunchState
+    /// Shared in-app update flow (01-05): one instance per app run, handed to
+    /// the Settings scene and the launch + 24 h background check.
+    let updateFlowModel: UpdateFlowModel
+    /// Cancellable handle for the rolling 24 h background check task.
+    private var backgroundUpdateTask: Task<Void, Never>?
 
     override init() {
         do {
@@ -120,7 +130,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             launchState = .failed(message: AppDelegate.describe(error))
         }
+
+        updateFlowModel = Self.makeUpdateFlowModel()
         super.init()
+
+        // AUT-05-GUARD: mirror the real job-active signal into the update flow
+        // so no install is offered or run during an active scan/preview. When
+        // the engine failed to launch there is no SessionModel, and `jobActive`
+        // stays false -- with no connected scanner there is nothing to guard.
+        if case .ready(_, let session) = launchState {
+            Self.bindJobActivity(of: session, into: updateFlowModel)
+        }
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -128,6 +148,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
         AppDelegate.applyDockIcon()
+        startUpdateCheckLoops()
     }
 
     /// Packaged apps place resources directly in `Contents/Resources`. Source
@@ -144,6 +165,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        backgroundUpdateTask?.cancel()
         guard case .ready(let client, _) = launchState else { return }
         let finished = DispatchSemaphore(value: 0)
         Task.detached {
@@ -158,6 +180,103 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return locateError.message
         }
         return String(describing: error)
+    }
+
+    // MARK: - Update wiring (01-05)
+
+    /// The versionless `latest.json` pointer. GitHub exposes assets of the
+    /// newest non-prerelease release at `releases/latest/download/<asset>`.
+    /// Alpha pre-releases are additionally probed via the API by the checker
+    /// (01-04), so this URL plus the API probe covers both channels.
+    private static let updatePointerURL = URL(
+        string: "https://github.com/rohanpandula/ScanStudio/releases/latest/download/latest.json"
+    )!
+
+    /// Constructs the single shared `UpdateFlowModel`: the 01-03 install core
+    /// pointed at `/Applications`, the 01-04 checker/downloader against the
+    /// feed, and an installed version stamped from `Info.plist` (or an
+    /// always-up-to-date sentinel for unstamped dev builds, T-01-05-02).
+    private static func makeUpdateFlowModel() -> UpdateFlowModel {
+        let supportURL = FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent(
+                "Library/Application Support/ScanStudio",
+                isDirectory: true
+            )
+        let rollbackDirectory = supportURL.appendingPathComponent("Rollback", isDirectory: true)
+        // The rollback directory is created up front: `UpdateInstaller` only
+        // rejects non-existent directories, and `/Applications` always exists
+        // on macOS, so this construction cannot throw once the directory
+        // exists.
+        try? FileManager.default.createDirectory(
+            at: rollbackDirectory,
+            withIntermediateDirectories: true
+        )
+        let installer = try! UpdateInstaller(
+            appDirectory: URL(fileURLWithPath: "/Applications", isDirectory: true),
+            rollbackDirectory: rollbackDirectory
+        )
+        return UpdateFlowModel(
+            checker: GitHubUpdateChecker(pointerURL: Self.updatePointerURL),
+            downloader: UpdateDownloader(),
+            installer: installer,
+            installedVersion: Self.installedUpdateVersion(),
+            channelDefaultsKey: "ScanStudio.updateChannel"
+        )
+    }
+
+    /// The running app's version: the packaged `ScanStudioRelease` stamp, or
+    /// an always-up-to-date sentinel for unstamped source/dev builds so a dev
+    /// build is never offered as an install target (T-01-05-02).
+    private static func installedUpdateVersion() -> UpdateVersion {
+        if let stamp = Bundle.main.infoDictionary?["ScanStudioRelease"] as? String,
+           !stamp.isEmpty,
+           let version = UpdateVersion(raw: stamp) {
+            return version
+        }
+        return UpdateVersion(raw: "999.0.0")!
+    }
+
+    /// Mirrors `SessionModel.isJobActive` into `model.jobActive` and re-arms
+    /// the observation after every change, so the AUT-05-GUARD stays live for
+    /// the whole run without polling.
+    private static func bindJobActivity(of session: SessionModel, into model: UpdateFlowModel) {
+        let isActive = withObservationTracking {
+            MainActor.assumeIsolated { session.isJobActive }
+        } onChange: {
+            Task { @MainActor [weak model] in
+                guard let model else { return }
+                model.jobActive = session.isJobActive
+                Self.bindJobActivity(of: session, into: model)
+            }
+        }
+        model.jobActive = isActive
+    }
+
+    /// Kicks the update cadence (AUT-05-CHECK): one check at launch, then one
+    /// every 24 h via a rolling `Task.sleep`. Read-only plumbing -- `checkNow()`
+    /// only mutates check state and never downloads or installs on cadence,
+    /// and it skips a beat while an install is already in flight.
+    private func startUpdateCheckLoops() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.updateFlowModel.checkNow()
+        }
+        backgroundUpdateTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    // 24 h between checks (AUT-05-CHECK). `Duration` has no
+                    // `.hours` member, so spell it in seconds.
+                    try await Task.sleep(for: .seconds(24 * 60 * 60))
+                } catch {
+                    break
+                }
+                guard let self, self.updateFlowModel.installProgress == nil else {
+                    continue
+                }
+                await self.updateFlowModel.checkNow()
+            }
+        }
     }
 }
 

--- a/app/ScanStudio/Sources/ScanStudio/UpdateFlowModel.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateFlowModel.swift
@@ -38,8 +38,8 @@ final class UpdateFlowModel {
     private let channelDefaultsKey: String
     private let defaults: UserDefaults
 
-    /// Release channel the user is on. Persisted on change; the project ships
-    /// alphas, so the default is `.alpha`.
+    /// Release channel the user is on. Persisted on change. The `.alpha` raw
+    /// value is retained for compatibility and represents all prereleases.
     var channel: UpdateChannel {
         didSet {
             defaults.set(channel.rawValue, forKey: channelDefaultsKey)

--- a/app/ScanStudio/Sources/ScanStudio/UpdateFlowModel.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateFlowModel.swift
@@ -1,0 +1,217 @@
+// In-app update flow (01-05): the host-owned model behind the Settings scene.
+// Renders honest check/install/rollback state and enforces the AUT-05-GUARD:
+// no install while a scan/preview job is active. The model itself never
+// relaunches the app, never auto-installs, and never touches the scanner --
+// it only mutates observable state and drives the 01-03/01-04 services on
+// explicit user action. Relaunch wiring is deliberately out of scope here and
+// left to explicit user confirmation ("Restart to finish"), per the plan.
+
+import Foundation
+import Observation
+import ScanStudioKit
+
+/// The visible outcomes of an update check. "No update" and "error" are
+/// deliberately distinct so the UI never presents a failure as success.
+enum UpdateCheckState: Equatable {
+    case idle
+    case checking
+    case updateAvailable(UpdateCandidate)
+    case upToDate
+    case failed(String)
+}
+
+@MainActor
+@Observable
+final class UpdateFlowModel {
+    /// Feed client (01-04): resolves the newest candidate for a channel.
+    private let checker: any UpdateChecking
+    /// Downloads + cryptographically verifies the DMG (01-04). `UpdateDownloader`
+    /// (a public final class) is not implicitly `Sendable`, so it is carried in a
+    /// tiny immutable box that forwards the one async method; the box is honest
+    /// `@unchecked Sendable` only because the downloader is stateless by
+    /// construction (it holds just a `URLSessionProtocol`).
+    private let downloader: UpdateDownloaderBox
+    /// Snapshots/swaps/restores the app bundle (01-03).
+    private let installer: UpdateInstaller
+    /// The running app's stamped version, read from `Bundle.main` at launch.
+    private let installedVersion: UpdateVersion
+    private let channelDefaultsKey: String
+    private let defaults: UserDefaults
+
+    /// Release channel the user is on. Persisted on change; the project ships
+    /// alphas, so the default is `.alpha`.
+    var channel: UpdateChannel {
+        didSet {
+            defaults.set(channel.rawValue, forKey: channelDefaultsKey)
+        }
+    }
+
+    /// Whichever of `.idle` / `.checking` / `.updateAvailable` / `.upToDate`
+    /// / `.failed` the last action produced.
+    var checkState: UpdateCheckState = .idle
+
+    /// Non-nil while an install is in flight, 0 at download start and 1 once
+    /// the swap completes.
+    var installProgress: Double?
+
+    /// Non-nil after a successful install (the bundle that was swapped in):
+    /// this is the "Restart to finish" marker. The model never relaunches on
+    /// its own.
+    var pendingInstallURL: URL?
+
+    /// Host-owned job-active guard (AUT-05-GUARD). `ScanStudioApp`'s
+    /// `AppDelegate` mirrors the real `SessionModel.isJobActive` signal into
+    /// this property. The Settings scene disables Install while `true`, and
+    /// `install()` also refuses while `true`.
+    var jobActive = false
+
+    /// Whether a previous-version snapshot exists to restore (01-03).
+    var canRollback: Bool { installer.availableRollback != nil }
+
+    init(
+        checker: any UpdateChecking,
+        downloader: UpdateDownloader,
+        installer: UpdateInstaller,
+        installedVersion: UpdateVersion,
+        channelDefaultsKey: String,
+        defaults: UserDefaults = .standard
+    ) {
+        self.checker = checker
+        self.downloader = UpdateDownloaderBox(downloader: downloader)
+        self.installer = installer
+        self.installedVersion = installedVersion
+        self.channelDefaultsKey = channelDefaultsKey
+        self.defaults = defaults
+        if let stored = defaults.string(forKey: channelDefaultsKey),
+           let parsed = UpdateChannel(rawValue: stored) {
+            channel = parsed
+        } else {
+            channel = .alpha
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Resolves the newest candidate for the current channel and reflects it
+    /// in `checkState`. Runs regardless of `jobActive`: the job guard gates
+    /// *install* only (AUT-05-GUARD). Never throws and never crashes;
+    /// transport/decode trouble becomes `.failed`.
+    func checkNow() async {
+        checkState = .checking
+        do {
+            let candidate = try await checker.latestCandidate(channel: channel)
+            if let candidate, installedVersion < candidate.version {
+                checkState = .updateAvailable(candidate)
+            } else {
+                checkState = .upToDate
+            }
+        } catch {
+            checkState = .failed(Self.describe(error))
+        }
+    }
+
+    /// Downloads, verifies, and installs the offered candidate. Gated on
+    /// `!jobActive` (AUT-05-GUARD). On success this leaves `pendingInstallURL`
+    /// set so the Settings scene shows "Restart to finish" -- it never
+    /// auto-relaunches.
+    func install() async {
+        guard !jobActive else {
+            checkState = .failed("Cannot install while a scan is active.")
+            return
+        }
+        guard case .updateAvailable(let candidate) = checkState else {
+            checkState = .failed("Choose an available update before installing.")
+            return
+        }
+        installProgress = 0
+        do {
+            let temporaryDirectory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ScanStudio Updates", isDirectory: true)
+            let dmgURL = try await downloader.download(candidate, to: temporaryDirectory)
+            let appURL = try downloader.mountAndLocateApp(dmgURL)
+            try downloader.verifyCodeSignature(at: appURL)
+            let archive = UpdateArchive(
+                version: candidate.version,
+                sourceAppPath: appURL,
+                checksumSHA256: candidate.sha256
+            )
+            try installer.install(archive)
+            installProgress = 1
+            pendingInstallURL = appURL
+        } catch {
+            installProgress = nil
+            pendingInstallURL = nil
+            checkState = .failed(Self.describe(error))
+        }
+    }
+
+    /// Restores the 01-03 snapshot, if any. Best-effort; never crashes. Clears
+    /// the "Restart to finish" marker on success.
+    func rollback() async {
+        do {
+            try installer.restorePrevious()
+            pendingInstallURL = nil
+            installProgress = nil
+            checkState = .idle
+        } catch {
+            checkState = .failed(Self.describe(error))
+        }
+    }
+
+    // MARK: - Errors
+
+    /// User-safe copy for typed update failures. Never includes URLs or
+    /// checksum internals (T-01-05-04).
+    private static func describe(_ error: Error) -> String {
+        switch error {
+        case UpdateDownloadError.badCandidate:
+            return "The update feed described an invalid release."
+        case UpdateDownloadError.downloadFailed:
+            return "The update could not be downloaded. Check your connection and try again."
+        case UpdateDownloadError.checksumMismatch:
+            return "The downloaded update did not match its checksum and was discarded."
+        case UpdateDownloadError.mountFailed:
+            return "The update disk image could not be opened."
+        case UpdateDownloadError.signatureInvalid:
+            return "The downloaded update failed its code-signature check."
+        case UpdateDownloadError.invalidArchive:
+            return "The update is not a supported disk image."
+        case UpdateDownloadError.notAnApp:
+            return "The update disk image did not contain the Scan Studio app."
+        case UpdateInstallError.badArguments:
+            return "The updater was not configured correctly."
+        case UpdateInstallError.sourceMissing:
+            return "The verified update bundle was missing."
+        case UpdateInstallError.notVerified:
+            return "The update could not be verified before install."
+        case UpdateInstallError.cannotSnapshot:
+            return "The current app could not be snapshotted for rollback."
+        case UpdateInstallError.swapFailed:
+            return "The install failed; your previous version is still in place."
+        case UpdateInstallError.rolledBack:
+            return "No previous version was available to roll back to."
+        default:
+            return String(describing: error)
+        }
+    }
+}
+
+/// Immutable, stateless way to carry the 01-04 `UpdateDownloader` across
+/// isolation boundaries without a `sending` diagnostic: the downloader is a
+/// public final class (so not implicitly `Sendable`) that holds only a
+/// `URLSessionProtocol`, and this box forwards its three methods unchanged.
+private struct UpdateDownloaderBox: @unchecked Sendable {
+    let downloader: UpdateDownloader
+
+    func download(_ candidate: UpdateCandidate, to directory: URL) async throws -> URL {
+        try await downloader.download(candidate, to: directory)
+    }
+
+    func mountAndLocateApp(_ dmgURL: URL) throws -> URL {
+        try downloader.mountAndLocateApp(dmgURL)
+    }
+
+    func verifyCodeSignature(at appURL: URL) throws {
+        try downloader.verifyCodeSignature(at: appURL)
+    }
+}

--- a/app/ScanStudio/Sources/ScanStudio/UpdateFlowModel.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateFlowModel.swift
@@ -59,6 +59,12 @@ final class UpdateFlowModel {
     /// its own.
     var pendingInstallURL: URL?
 
+    /// The resolved install destination (user-visible path) once an install
+    /// has preflighted writability — e.g. `/Applications` or a user-writable
+    /// `~/Applications` fallback (01-08 gap closure). Surfaced in the Settings
+    /// scene so the user knows where the update is going.
+    var pendingInstallDestination: String?
+
     /// Host-owned job-active guard (AUT-05-GUARD). `ScanStudioApp`'s
     /// `AppDelegate` mirrors the real `SessionModel.isJobActive` signal into
     /// this property. The Settings scene disables Install while `true`, and
@@ -135,6 +141,12 @@ final class UpdateFlowModel {
                 sourceAppPath: appURL,
                 checksumSHA256: candidate.sha256
             )
+            // Preflight the destination so an unwritable target resolves to a
+            // user-writable location (or a clear typed error) — never a
+            // misleading bare `.swapFailed`. The installer re-resolves the same
+            // destination internally, so the surfaced path matches the swap.
+            let destination = try installer.installDestination
+            pendingInstallDestination = destination.path
             try installer.install(archive)
             installProgress = 1
             pendingInstallURL = appURL
@@ -188,6 +200,8 @@ final class UpdateFlowModel {
             return "The current app could not be snapshotted for rollback."
         case UpdateInstallError.swapFailed:
             return "The install failed; your previous version is still in place."
+        case UpdateInstallError.cannotWriteTarget:
+            return "The current user cannot write to the app folder; install to ~/Applications (or add an administrator account) and try again."
         case UpdateInstallError.rolledBack:
             return "No previous version was available to roll back to."
         default:

--- a/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
@@ -35,6 +35,17 @@ struct UpdateSettingsView: View {
 
                 stateContent
 
+                if let destination = model.pendingInstallDestination {
+                    Text("Install target: \(destination)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if destination != "/Applications" {
+                        Text("This installation uses a user-folder target instead of /Applications.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 if case .updateAvailable = model.checkState, model.jobActive {
                     Text("Install is paused while a scan or preview is active.")
                         .font(.caption)

--- a/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
@@ -1,0 +1,123 @@
+// Settings scene for the in-app update flow (01-05). Thin SwiftUI: renders
+// `UpdateFlowModel` state and forwards button taps to its async actions. All
+// policy lives in the model (install gated on `jobActive`, up-to-date vs error
+// are distinct states, no auto-relaunch). The scene lives in the executable
+// target so network/app concerns stay out of the ScanStudioKit library.
+
+import AppKit
+import ScanStudioKit
+import SwiftUI
+
+struct UpdateSettingsView: View {
+    @Bindable var model: UpdateFlowModel
+
+    var body: some View {
+        Form {
+            Section {
+                header
+            }
+
+            Section("Release channel") {
+                Picker("Channel", selection: $model.channel) {
+                    Text("Alpha").tag(UpdateChannel.alpha)
+                    Text("Stable").tag(UpdateChannel.stable)
+                }
+                Text("Alpha installs the newest pre-release; Stable only installs verified releases.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Updates") {
+                Button("Check for Updates") {
+                    Task { await model.checkNow() }
+                }
+                .disabled(model.checkState == .checking)
+
+                stateContent
+
+                if case .updateAvailable = model.checkState, model.jobActive {
+                    Text("Install is paused while a scan or preview is active.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if model.pendingInstallURL != nil {
+                    Text("Restart Scan Studio to finish the update.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Button("Roll Back to Previous Version") {
+                    Task { await model.rollback() }
+                }
+                .disabled(!model.canRollback)
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 440)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(nsImage: NSApp.applicationIconImage ?? NSImage())
+                .resizable()
+                .interpolation(.high)
+                .frame(width: 44, height: 44)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Scan Studio")
+                    .font(.title3.weight(.semibold))
+                Text(installedVersionLine)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var installedVersionLine: String {
+        // Unstamped dev/source builds show "Development" and are treated as
+        // always up to date (T-01-05-02) -- never an install target.
+        if let stamp = Bundle.main.infoDictionary?["ScanStudioRelease"] as? String,
+           !stamp.isEmpty {
+            return "Installed version \(stamp)"
+        }
+        return "Development build"
+    }
+
+    @ViewBuilder
+    private var stateContent: some View {
+        switch model.checkState {
+        case .idle:
+            Text("No update check has run yet.")
+                .foregroundStyle(.secondary)
+        case .checking:
+            ProgressView("Checking for updates\u{2026}")
+        case .upToDate:
+            Label("You're up to date", systemImage: "checkmark.circle")
+        case .updateAvailable(let candidate):
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Update available: \(candidate.version.raw)")
+                if model.pendingInstallURL != nil {
+                    Label("Restart to finish", systemImage: "arrow.triangle.2.circlepath")
+                } else if let progress = model.installProgress {
+                    ProgressView(
+                        value: progress,
+                        label: { Text("Installing\u{2026}") }
+                    )
+                } else {
+                    Button("Install Update") {
+                        Task { await model.install() }
+                    }
+                    .disabled(model.jobActive)
+                    .help(model.jobActive
+                        ? "Install is disabled while a scan is active."
+                        : "Download, verify, and install this update.")
+                }
+            }
+        case .failed(let message):
+            Text(message)
+                .foregroundStyle(.red)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}

--- a/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
@@ -19,10 +19,10 @@ struct UpdateSettingsView: View {
 
             Section("Release channel") {
                 Picker("Channel", selection: $model.channel) {
-                    Text("Alpha").tag(UpdateChannel.alpha)
+                    Text("Prerelease").tag(UpdateChannel.alpha)
                     Text("Stable").tag(UpdateChannel.stable)
                 }
-                Text("Alpha installs the newest pre-release; Stable only installs verified releases.")
+                Text("Prerelease installs the newest alpha, beta, or release candidate. Stable only installs full releases.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/app/ScanStudio/Sources/ScanStudioKit/UpdateInstaller.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/UpdateInstaller.swift
@@ -22,6 +22,9 @@ public enum UpdateInstallError: Error, Equatable {
     case swapFailed
     /// `restorePrevious()` was called but no snapshot is available.
     case rolledBack
+    /// No install destination is writable: neither `appDirectory` nor any
+    /// user-writable fallback (e.g. `~/Applications`) accepts the install.
+    case cannotWriteTarget
 }
 
 /// A verified update candidate ready to install: the mounted app bundle
@@ -53,6 +56,10 @@ public final class UpdateInstaller {
     /// Where versioned snapshots are written, e.g.
     /// `~/Library/Application Support/ScanStudio/Rollback/`.
     private let rollbackDirectory: URL
+    /// Additional destinations the caller permits falling back to when
+    /// `appDirectory` is not writable (01-08 gap closure). Empty means
+    /// "default to the user-writable `~/Applications`".
+    private let authorizedDestinations: [URL]
 
     /// The most recent snapshot taken by this instance — the only source of
     /// truth for `availableRollback`. Never cleared after a later successful
@@ -61,12 +68,29 @@ public final class UpdateInstaller {
 
     private let fileManager = FileManager.default
 
-    public init(appDirectory: URL, rollbackDirectory: URL) throws {
+    /// The preferred install candidate destinations, in preference order:
+    /// `/Applications`, then the current user's `~/Applications` (a candidate
+    /// only — never created on disk here). Kept as a pure static helper so
+    /// tests and the flow model share one source of truth.
+    public static func defaultInstallDestinations() -> [URL] {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return [
+            URL(fileURLWithPath: "/Applications", isDirectory: true),
+            home.appendingPathComponent("Applications", isDirectory: true),
+        ]
+    }
+
+    public init(
+        appDirectory: URL,
+        rollbackDirectory: URL,
+        authorizedDestinations: [URL] = []
+    ) throws {
         guard appDirectory.isExistingDirectory, rollbackDirectory.isExistingDirectory else {
             throw UpdateInstallError.badArguments
         }
         self.appDirectory = appDirectory
         self.rollbackDirectory = rollbackDirectory
+        self.authorizedDestinations = authorizedDestinations
     }
 
     /// The last snapshot this instance recorded, if any.
@@ -74,30 +98,77 @@ public final class UpdateInstaller {
         lastSnapshot
     }
 
+    /// The destination installs will actually write to, given the state of the
+    /// filesystem: `appDirectory` when writable, else the first writable
+    /// authorized destination, else `.cannotWriteTarget`. Throwing so the
+    /// caller can surface a clear error instead of a misleading `.swapFailed`.
+    public var installDestination: URL {
+        get throws { try resolveInstallDestination() }
+    }
+
+    /// Resolves where an install may happen: prefers `appDirectory` when it is
+    /// writable; otherwise falls back through `authorizedDestinations`
+    /// (defaulting to `~/Applications`) to the first writable one; otherwise
+    /// throws `.cannotWriteTarget`. `~/Applications` keeps snapshot/rollback
+    /// identical — both are per-destination rollback directories.
+    public func resolveInstallDestination() throws -> URL {
+        if fileManager.isWritableFile(atPath: appDirectory.path) {
+            return appDirectory
+        }
+        let fallbacks = authorizedDestinations.isEmpty
+            ? Array(Self.defaultInstallDestinations().dropFirst())
+            : authorizedDestinations
+        for destination in fallbacks where Self.isWritableTarget(destination) {
+            return destination
+        }
+        throw UpdateInstallError.cannotWriteTarget
+    }
+
+    /// Whether `directory` can accept a write: writable when it exists;
+    /// when it does not exist yet (e.g. `~/Applications`), writable iff its
+    /// nearest existing ancestor is writable.
+    private static func isWritableTarget(_ directory: URL) -> Bool {
+        var probe = directory
+        while !FileManager.default.fileExists(atPath: probe.path) {
+            let parent = probe.deletingLastPathComponent()
+            if parent == probe { return false }
+            probe = parent
+        }
+        return FileManager.default.isWritableFile(atPath: probe.path)
+    }
+
     /// Copies the current `<appDirectory>/ScanStudio.app` into the rollback
     /// directory as `ScanStudio-<version>.app`. No-op (does not throw) when
     /// there is no app to snapshot.
     public func snapshotCurrent() throws {
-        let appURL = appDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true)
+        try snapshotCurrentCore(in: appDirectory)
+    }
+
+    /// The snapshot core — exactly the shipped snapshot mechanics, operating
+    /// on whichever install directory is actually in use (so a user-folder
+    /// install snapshots/restores correctly from that destination).
+    private func snapshotCurrentCore(in destination: URL) throws {
+        let appURL = destination.appendingPathComponent("ScanStudio.app", isDirectory: true)
         guard fileManager.fileExists(atPath: appURL.path) else {
             return
         }
         do {
             let version = try Self.versionOfBundle(at: appURL)
             try fileManager.createDirectory(at: rollbackDirectory, withIntermediateDirectories: true)
-            let destination = rollbackDirectory.appendingPathComponent("ScanStudio-\(version.raw).app", isDirectory: true)
-            if fileManager.fileExists(atPath: destination.path) {
-                try fileManager.removeItem(at: destination)
+            let snapshotURL = rollbackDirectory.appendingPathComponent("ScanStudio-\(version.raw).app", isDirectory: true)
+            if fileManager.fileExists(atPath: snapshotURL.path) {
+                try fileManager.removeItem(at: snapshotURL)
             }
-            try fileManager.copyItem(at: appURL, to: destination)
-            lastSnapshot = (version, destination)
+            try fileManager.copyItem(at: appURL, to: snapshotURL)
+            lastSnapshot = (version, snapshotURL)
         } catch {
             throw UpdateInstallError.cannotSnapshot
         }
     }
 
-    /// Installs a verified archive: snapshot current, stage the source
-    /// bundle beside the app, atomically replace, confirm in place.
+    /// Installs a verified archive: resolve the writable destination, snapshot
+    /// current, stage the source bundle beside the app, atomically replace,
+    /// confirm in place.
     public func install(_ archive: UpdateArchive) throws {
         guard fileManager.fileExists(atPath: archive.sourceAppPath.path),
               archive.sourceAppPath.isExistingDirectory else {
@@ -106,33 +177,38 @@ public final class UpdateInstaller {
         guard !archive.checksumSHA256.isEmpty else {
             throw UpdateInstallError.notVerified
         }
-        try snapshotCurrent()
+        // Preflight the destination up front: an unwritable target surfaces a
+        // clear `.cannotWriteTarget`, never a misleading `.swapFailed`.
+        let destination = try resolveInstallDestination()
+        try snapshotCurrentCore(in: destination)
         do {
-            let staging = stagingURL()
+            let staging = stagingURL(in: destination)
             if fileManager.fileExists(atPath: staging.path) {
                 try fileManager.removeItem(at: staging)
             }
             try fileManager.copyItem(at: archive.sourceAppPath, to: staging)
-            try swapIn(staged: staging)
+            try swapIn(staged: staging, into: destination)
         } catch {
             throw UpdateInstallError.swapFailed
         }
     }
 
-    /// Restores the last snapshot (if any) into `<appDirectory>/ScanStudio.app`
-    /// via the same stage-and-swap path. Returns the restored app path.
+    /// Restores the last snapshot (if any) into the resolved install
+    /// destination's `ScanStudio.app` via the same stage-and-swap path.
+    /// Returns the restored app path.
     @discardableResult
     public func restorePrevious() throws -> URL {
         guard let snapshot = lastSnapshot else {
             throw UpdateInstallError.rolledBack
         }
-        let staging = stagingURL()
+        let destination = try resolveInstallDestination()
+        let staging = stagingURL(in: destination)
         if fileManager.fileExists(atPath: staging.path) {
             try fileManager.removeItem(at: staging)
         }
         try fileManager.copyItem(at: snapshot.url, to: staging)
-        try swapIn(staged: staging)
-        return appDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true)
+        try swapIn(staged: staging, into: destination)
+        return destination.appendingPathComponent("ScanStudio.app", isDirectory: true)
     }
 
     // MARK: - Swapping
@@ -140,9 +216,9 @@ public final class UpdateInstaller {
     /// Atomic-ish replacement: move the staged bundle into the app slot,
     /// keeping the previous app as `ScanStudio.prev` until the new one is
     /// confirmed present and readable, then drop the backup.
-    private func swapIn(staged: URL) throws {
-        let current = appDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true)
-        let backup = appDirectory.appendingPathComponent("ScanStudio.prev", isDirectory: true)
+    private func swapIn(staged: URL, into destination: URL) throws {
+        let current = destination.appendingPathComponent("ScanStudio.app", isDirectory: true)
+        let backup = destination.appendingPathComponent("ScanStudio.prev", isDirectory: true)
 
         do {
             _ = try fileManager.replaceItemAt(current, withItemAt: staged, backupItemName: "ScanStudio.prev")
@@ -169,8 +245,8 @@ public final class UpdateInstaller {
         try? fileManager.moveItem(at: backup, to: current)
     }
 
-    private func stagingURL() -> URL {
-        appDirectory.appendingPathComponent(".ScanStudio.new", isDirectory: true)
+    private func stagingURL(in directory: URL) -> URL {
+        directory.appendingPathComponent(".ScanStudio.new", isDirectory: true)
     }
 
     // MARK: - Version helpers

--- a/app/ScanStudio/Sources/ScanStudioKit/UpdateInstaller.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/UpdateInstaller.swift
@@ -1,0 +1,205 @@
+// Safe app-bundle swap with snapshot/rollback. Never touches the scanner.
+// Pure Foundation filesystem work: snapshot the current app, stage a
+// source-verified archive, atomically swap it into place, and restore the
+// previous version on demand. No bridge spawn, no device open, no motion
+// latch, no project access, no subprocesses (FileManager is the copy helper,
+// so `ditto` is not needed here).
+
+import Foundation
+
+/// Typed failures for the install core (AUT-04-SNAP, AUT-04-SWAP,
+/// AUT-04-ROLLBACK). Every case is user-presentable and testable.
+public enum UpdateInstallError: Error, Equatable {
+    /// Misconfigured `UpdateInstaller` (a path was not a directory).
+    case badArguments
+    /// `UpdateArchive.sourceAppPath` does not exist or is not a directory.
+    case sourceMissing
+    /// The archive carried no checksum, so it cannot be claimed verified.
+    case notVerified
+    /// The current app could not be snapshotted; the install is aborted.
+    case cannotSnapshot
+    /// The staged swap (or its rollback) failed; the old app is intact.
+    case swapFailed
+    /// `restorePrevious()` was called but no snapshot is available.
+    case rolledBack
+}
+
+/// A verified update candidate ready to install: the mounted app bundle
+/// produced by 01-04's `UpdateDownloader`, stamped with the version it
+/// claims to be and the SHA-256 the release feed promised.
+public struct UpdateArchive: Sendable {
+    /// The version the source bundle claims (matched against the feed).
+    public let version: UpdateVersion
+    /// Directory of the new `.app` bundle (e.g. a mounted DMG's app).
+    public let sourceAppPath: URL
+    /// Non-empty release SHA-256 (actual hash verification is 01-04's job,
+    /// run before this core ever sees the archive).
+    public let checksumSHA256: String
+
+    public init(version: UpdateVersion, sourceAppPath: URL, checksumSHA256: String) {
+        self.version = version
+        self.sourceAppPath = sourceAppPath
+        self.checksumSHA256 = checksumSHA256
+    }
+}
+
+/// The install core: swaps the running app bundle with reversible
+/// snapshot/restore. The rollback snapshot lives under the user's Support
+/// library, mirroring the existing on-disk precedent.
+public final class UpdateInstaller {
+    /// Where the installed `ScanStudio.app` lives (injectable for tests;
+    /// the real caller uses `/Applications`).
+    private let appDirectory: URL
+    /// Where versioned snapshots are written, e.g.
+    /// `~/Library/Application Support/ScanStudio/Rollback/`.
+    private let rollbackDirectory: URL
+
+    /// The most recent snapshot taken by this instance — the only source of
+    /// truth for `availableRollback`. Never cleared after a later successful
+    /// call; stays true to the last good snapshot.
+    private var lastSnapshot: (version: UpdateVersion, url: URL)?
+
+    private let fileManager = FileManager.default
+
+    public init(appDirectory: URL, rollbackDirectory: URL) throws {
+        guard appDirectory.isExistingDirectory, rollbackDirectory.isExistingDirectory else {
+            throw UpdateInstallError.badArguments
+        }
+        self.appDirectory = appDirectory
+        self.rollbackDirectory = rollbackDirectory
+    }
+
+    /// The last snapshot this instance recorded, if any.
+    public var availableRollback: (version: UpdateVersion, url: URL)? {
+        lastSnapshot
+    }
+
+    /// Copies the current `<appDirectory>/ScanStudio.app` into the rollback
+    /// directory as `ScanStudio-<version>.app`. No-op (does not throw) when
+    /// there is no app to snapshot.
+    public func snapshotCurrent() throws {
+        let appURL = appDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true)
+        guard fileManager.fileExists(atPath: appURL.path) else {
+            return
+        }
+        do {
+            let version = try Self.versionOfBundle(at: appURL)
+            try fileManager.createDirectory(at: rollbackDirectory, withIntermediateDirectories: true)
+            let destination = rollbackDirectory.appendingPathComponent("ScanStudio-\(version.raw).app", isDirectory: true)
+            if fileManager.fileExists(atPath: destination.path) {
+                try fileManager.removeItem(at: destination)
+            }
+            try fileManager.copyItem(at: appURL, to: destination)
+            lastSnapshot = (version, destination)
+        } catch {
+            throw UpdateInstallError.cannotSnapshot
+        }
+    }
+
+    /// Installs a verified archive: snapshot current, stage the source
+    /// bundle beside the app, atomically replace, confirm in place.
+    public func install(_ archive: UpdateArchive) throws {
+        guard fileManager.fileExists(atPath: archive.sourceAppPath.path),
+              archive.sourceAppPath.isExistingDirectory else {
+            throw UpdateInstallError.sourceMissing
+        }
+        guard !archive.checksumSHA256.isEmpty else {
+            throw UpdateInstallError.notVerified
+        }
+        try snapshotCurrent()
+        do {
+            let staging = stagingURL()
+            if fileManager.fileExists(atPath: staging.path) {
+                try fileManager.removeItem(at: staging)
+            }
+            try fileManager.copyItem(at: archive.sourceAppPath, to: staging)
+            try swapIn(staged: staging)
+        } catch {
+            throw UpdateInstallError.swapFailed
+        }
+    }
+
+    /// Restores the last snapshot (if any) into `<appDirectory>/ScanStudio.app`
+    /// via the same stage-and-swap path. Returns the restored app path.
+    @discardableResult
+    public func restorePrevious() throws -> URL {
+        guard let snapshot = lastSnapshot else {
+            throw UpdateInstallError.rolledBack
+        }
+        let staging = stagingURL()
+        if fileManager.fileExists(atPath: staging.path) {
+            try fileManager.removeItem(at: staging)
+        }
+        try fileManager.copyItem(at: snapshot.url, to: staging)
+        try swapIn(staged: staging)
+        return appDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true)
+    }
+
+    // MARK: - Swapping
+
+    /// Atomic-ish replacement: move the staged bundle into the app slot,
+    /// keeping the previous app as `ScanStudio.prev` until the new one is
+    /// confirmed present and readable, then drop the backup.
+    private func swapIn(staged: URL) throws {
+        let current = appDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true)
+        let backup = appDirectory.appendingPathComponent("ScanStudio.prev", isDirectory: true)
+
+        do {
+            _ = try fileManager.replaceItemAt(current, withItemAt: staged, backupItemName: "ScanStudio.prev")
+        } catch {
+            restoreBackup(backup: backup, current: current)
+            throw UpdateInstallError.swapFailed
+        }
+
+        guard fileManager.fileExists(atPath: current.path),
+              fileManager.isReadableFile(atPath: current.path) else {
+            restoreBackup(backup: backup, current: current)
+            throw UpdateInstallError.swapFailed
+        }
+
+        if fileManager.fileExists(atPath: backup.path) {
+            try? fileManager.removeItem(at: backup)
+        }
+    }
+
+    /// Best-effort: put the staged backup back over whatever is at `current`.
+    private func restoreBackup(backup: URL, current: URL) {
+        guard fileManager.fileExists(atPath: backup.path) else { return }
+        try? fileManager.removeItem(at: current)
+        try? fileManager.moveItem(at: backup, to: current)
+    }
+
+    private func stagingURL() -> URL {
+        appDirectory.appendingPathComponent(".ScanStudio.new", isDirectory: true)
+    }
+
+    // MARK: - Version helpers
+
+    /// Reads the bundled release version from `Info.plist` — the stamped
+    /// `ScanStudioRelease` key, falling back to `CFBundleShortVersionString`.
+    /// Throws `.cannotSnapshot` when no usable version can be determined.
+    private static func versionOfBundle(at appURL: URL) throws -> UpdateVersion {
+        let infoPlistURL = appURL.appendingPathComponent("Contents/Info.plist")
+        guard let data = try? Data(contentsOf: infoPlistURL),
+              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+              let dictionary = plist as? [String: Any] else {
+            throw UpdateInstallError.cannotSnapshot
+        }
+        let raw: String? = {
+            if let stamped = dictionary["ScanStudioRelease"] as? String, !stamped.isEmpty {
+                return stamped
+            }
+            return dictionary["CFBundleShortVersionString"] as? String
+        }()
+        guard let raw, let version = UpdateVersion(raw: raw) else {
+            throw UpdateInstallError.cannotSnapshot
+        }
+        return version
+    }
+}
+
+private extension URL {
+    var isExistingDirectory: Bool {
+        (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+    }
+}

--- a/app/ScanStudio/Sources/ScanStudioKit/UpdateService.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/UpdateService.swift
@@ -9,6 +9,25 @@
 import CryptoKit
 import Foundation
 
+/// The `hw.machine` string, e.g. `arm64` on Apple Silicon, `x86_64` (or
+/// `x86_64h`) on Intel. Read via a direct `sysctlbyname` syscall — no
+/// subprocess, no `Process` — so the host-arch resolver stays pure and
+/// deterministic. `ProcessInfo` does not expose this value directly on
+/// current SDKs, hence this tiny extension.
+extension ProcessInfo {
+    var machineHardwareName: String {
+        var size = 0
+        guard sysctlbyname("hw.machine", nil, &size, nil, 0) == 0, size > 0 else {
+            return ""
+        }
+        var machine = [CChar](repeating: 0, count: size)
+        guard sysctlbyname("hw.machine", &machine, &size, nil, 0) == 0 else {
+            return ""
+        }
+        return String(cString: machine)
+    }
+}
+
 /// A resolved, still-unverified update candidate: exactly what the feed
 /// promised. `sha256` is the trust anchor the downloader checks before mount.
 public struct UpdateCandidate: Sendable, Equatable {
@@ -38,11 +57,147 @@ public struct UpdatePointer: Decodable, Equatable {
     }
 }
 
+/// Host CPU architecture for update feed selection. Pure, no subprocess.
+///
+/// Mirrors the per-arch DMG suffixes Phase 02 publishes (`-macOS-arm64.dmg`,
+/// `-macOS-x86_64.dmg`): the updater must fetch the artifact for the running
+/// machine's architecture and never the other one.
+public enum HostArchitecture: String, Sendable, CaseIterable {
+    case arm64 = "arm64"
+    case x86_64 = "x86_64"
+}
+
+/// Resolves the host CPU architecture for feed selection. Pure, no subprocess.
+///
+/// `current()` reads `ProcessInfo.processInfo.machineHardwareName` only —
+/// it never launches a process (no `/usr/bin/uname`), so it is deterministic
+/// and unit-testable on any host.
+public enum HostArchitectureProvider {
+    /// Maps `machineHardwareName` to a feed architecture.
+    ///
+    /// Apple Silicon reports exactly `"arm64"`; Intel reports `"x86_64"` (or
+    /// `"x86_64h"`). Prefix mapping tolerates the fine-grained spellings
+    /// (`arm64e` → `.arm64`, `x86_64h` → `.x86_64`). Any name matching
+    /// neither family is unexpected — real Macs always report one of these —
+    /// and falls back to `.arm64`, the historically primary shipped arch;
+    /// a pointer missing the arm64 entry then surfaces the typed
+    /// unsupported-architecture error rather than silently trusting x86_64.
+    public static func current() -> HostArchitecture {
+        let name = ProcessInfo.processInfo.machineHardwareName
+        if name.hasPrefix(HostArchitecture.arm64.rawValue) {
+            return .arm64
+        }
+        if name.hasPrefix(HostArchitecture.x86_64.rawValue) {
+            return .x86_64
+        }
+        // TODO(02-02): revisit if a third shipping Mac arch ever appears.
+        return .arm64
+    }
+
+    /// Convenience for the UI: the current host architecture.
+    public static var currentHostArchitecture: HostArchitecture { current() }
+}
+
 /// The release channel a user is on. `stable` only trusts the pointer;
 /// `alpha` also probes the GitHub API for freshly published pre-releases.
 public enum UpdateChannel: String, CaseIterable, Sendable {
     case stable = "stable"
     case alpha = "alpha"
+}
+
+/// The per-arch download payload inside an arch-keyed pointer: the DMG URL
+/// and its promised SHA-256 trust anchor for a single host architecture.
+public struct UpdateArchEntry: Codable, Equatable {
+    public let url: URL
+    public let sha256: String
+
+    public init(url: URL, sha256: String) {
+        self.url = url
+        self.sha256 = sha256
+    }
+}
+
+/// The Phase-02 arch-keyed `latest.json` update pointer asset.
+///
+/// Decodes BOTH the arch-keyed form
+/// `{"version":…,"architectures":{"arm64":{"url":…,"sha256":…},"x86_64":{…}}}`
+/// AND the legacy flat form `{"version","url","sha256"}`. The flat form is
+/// represented as a dictionary with a single entry under the current host
+/// architecture, so downstream selection always consumes one shape.
+/// Encoding always emits the arch-keyed form (a JSON object keyed by raw
+/// architecture string).
+public struct UpdatePointerArch: Codable, Equatable {
+    public let version: String
+    public let architectures: [HostArchitecture: UpdateArchEntry]
+
+    public init(version: String, architectures: [HostArchitecture: UpdateArchEntry]) {
+        self.version = version
+        self.architectures = architectures
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case architectures
+        case url
+        case sha256
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try container.decode(String.self, forKey: .version)
+        // Wire form is a JSON object keyed by raw arch string; map to the
+        // known enum. An unrecognized key is a malformed/untrusted pointer
+        // (trust gate) → throw rather than silently dropping an entry.
+        if let wire = try container.decodeIfPresent([String: UpdateArchEntry].self, forKey: .architectures) {
+            var architectures: [HostArchitecture: UpdateArchEntry] = [:]
+            architectures.reserveCapacity(wire.count)
+            for (key, entry) in wire {
+                guard let arch = HostArchitecture(rawValue: key) else {
+                    throw DecodingError.dataCorruptedError(
+                        forKey: .architectures,
+                        in: container,
+                        debugDescription: "Unknown architecture key in update pointer: \(key)"
+                    )
+                }
+                architectures[arch] = entry
+            }
+            self.init(version: version, architectures: architectures)
+        } else if let url = try container.decodeIfPresent(URL.self, forKey: .url),
+                  let sha256 = try container.decodeIfPresent(String.self, forKey: .sha256) {
+            // Legacy flat pointer: one representative entry under the current
+            // host arch, so the rest of the pipeline sees an arch map.
+            self.init(
+                version: version,
+                architectures: [HostArchitectureProvider.current(): UpdateArchEntry(url: url, sha256: sha256)]
+            )
+        } else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Update pointer is neither arch-keyed nor legacy flat {version,url,sha256}"
+                )
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        var wire: [String: UpdateArchEntry] = [:]
+        wire.reserveCapacity(architectures.count)
+        for (arch, entry) in architectures {
+            wire[arch.rawValue] = entry
+        }
+        try container.encode(wire, forKey: .architectures)
+    }
+}
+
+/// Typed feed errors the checker surfaces. The trust gate: a malformed or
+/// incomplete pointer is reported to the caller, never silently skipped.
+public enum UpdateArchError: Error, Equatable {
+    /// The feed published no entry for the requested host architecture, so a
+    /// correct install is impossible — never fall back to another arch.
+    case unsupportedArchitecture(HostArchitecture)
 }
 
 /// The minimal `URLSession` surface the update service needs. The repo had
@@ -88,45 +243,68 @@ public final class GitHubUpdateChecker: UpdateChecking {
     }
 
     public func latestCandidate(channel: UpdateChannel) async throws -> UpdateCandidate? {
+        try await latestCandidate(channel: channel, arch: HostArchitectureProvider.current())
+    }
+
+    /// Resolves the newest candidate for `channel` for a specific host
+    /// architecture, so an Intel Mac fetches the x86_64 DMG and Apple Silicon
+    /// the arm64 DMG. An architecture with no published entry throws our typed
+    /// `UpdateArchError.unsupportedArchitecture` — never a wrong-arch install.
+    public func latestCandidate(channel: UpdateChannel, arch: HostArchitecture) async throws -> UpdateCandidate? {
         switch channel {
         case .stable:
-            return try await fetchPointerCandidate()
+            return try await fetchPointerCandidate(arch: arch)
         case .alpha:
-            guard let pointer = try await fetchPointerCandidate() else { return nil }
-            return await newestPreRelease(over: pointer) ?? pointer
+            guard let pointer = try await fetchPointerCandidate(arch: arch) else { return nil }
+            return try await newestPreRelease(over: pointer, arch: arch) ?? pointer
         }
     }
 
     // MARK: - Pointer
 
-    /// Fetches and decodes `latest.json`. Transport or decode trouble is
-    /// thrown so the caller can distinguish "couldn't reach the update
-    /// server" from "no update available". Returns `nil` only when the
-    /// pointer's version string does not parse — treated as no update.
-    private func fetchPointerCandidate() async throws -> UpdateCandidate? {
+    /// Fetches and decodes `latest.json` for `arch`. Transport or decode
+    /// trouble is thrown so the caller can distinguish "couldn't reach the
+    /// update server" from "no update available". Returns `nil` only when the
+    /// pointer's version string does not parse — treated as no update. A
+    /// missing entry for `arch` throws `UpdateArchError.unsupportedArchitecture`.
+    private func fetchPointerCandidate(arch: HostArchitecture) async throws -> UpdateCandidate? {
         let (data, _) = try await session.data(from: pointerURL)
-        let pointer = try JSONDecoder().decode(UpdatePointer.self, from: data)
+        let pointer = try JSONDecoder().decode(UpdatePointerArch.self, from: data)
+        let entry = try archEntry(for: arch, in: pointer)
         guard let version = UpdateVersion(raw: pointer.version) else { return nil }
         return UpdateCandidate(
             version: version,
-            downloadURL: pointer.url,
-            sha256: pointer.sha256,
+            downloadURL: entry.url,
+            sha256: entry.sha256,
             releaseNotesURL: nil
         )
+    }
+
+    /// Resolves the requested arch's entry, throwing a typed error when the
+    /// pointer has none. This is the trust gate against a wrong-arch install:
+    /// a missing entry is a real unsupported-host signal, never a silent
+    /// fallthrough to the other architecture.
+    private func archEntry(for arch: HostArchitecture, in pointer: UpdatePointerArch) throws -> UpdateArchEntry {
+        guard let entry = pointer.architectures[arch] else {
+            throw UpdateArchError.unsupportedArchitecture(arch)
+        }
+        return entry
     }
 
     // MARK: - Alpha API probe
 
     /// Best-effort: the newest pre-release from the GitHub API that is at
-    /// least as new as `pointer`. The API probe only answers *which* tag is
-    /// newest; the candidate's bytes + sha256 come from that release's OWN
-    /// per-release `latest.json` (authoritative artifact metadata), never
-    /// borrowed from the configured stable pointer. Any failure — API
-    /// transport/decode, a missing or corrupt per-release pointer, or a
-    /// version mismatch between the tag and its pointer — degrades silently to
+    /// least as new as `pointer`, for the requested host arch. The API probe
+    /// only answers *which* tag is newest; the candidate's bytes + sha256 come
+    /// from that release's OWN per-release `latest.json` (authoritative
+    /// artifact metadata), never borrowed from the configured stable pointer.
+    /// Transport/decode trouble, a missing or corrupt per-release pointer, or
+    /// a version mismatch between the tag and its pointer degrades silently to
     /// nil, so the caller keeps the configured pointer candidate (fail-closed:
     /// never a wrong install, never a self-inconsistent url+sha256 pairing).
-    private func newestPreRelease(over pointer: UpdateCandidate) async -> UpdateCandidate? {
+    /// A per-release pointer with no entry for `arch` is NOT a transient
+    /// network issue — it throws `UpdateArchError.unsupportedArchitecture`.
+    private func newestPreRelease(over pointer: UpdateCandidate, arch: HostArchitecture) async throws -> UpdateCandidate? {
         guard let (data, _) = try? await session.data(from: Self.apiReleasesURL),
               let releases = try? JSONDecoder().decode([GitHubRelease].self, from: data) else {
             return nil
@@ -156,22 +334,23 @@ public final class GitHubUpdateChecker: UpdateChecking {
               releaseVersion == newest.version else {
             return nil
         }
+        let entry = try archEntry(for: arch, in: releasePointer)
         return UpdateCandidate(
             version: newest.version,
-            downloadURL: releasePointer.url,
-            sha256: releasePointer.sha256,
+            downloadURL: entry.url,
+            sha256: entry.sha256,
             releaseNotesURL: newest.notesURL
         )
     }
 
-    /// Fetches and decodes the per-release `latest.json` pointer for `tag`.
-    /// Returns nil (never throws) on any transport or decode failure so the
-    /// alpha path can fall back silently to the configured pointer. Version
-    /// validation against the tag happens in the caller.
-    private func fetchReleasePointer(tag: String) async -> UpdatePointer? {
+    /// Fetches and decodes the per-release arch-aware `latest.json` pointer
+    /// for `tag`. Returns nil (never throws) on any transport or decode
+    /// failure so the alpha path can fall back silently to the configured
+    /// pointer. Version validation against the tag happens in the caller.
+    private func fetchReleasePointer(tag: String) async -> UpdatePointerArch? {
         let url = Self.releasePointerURL(tag: tag)
         guard let (data, _) = try? await session.data(from: url),
-              let pointer = try? JSONDecoder().decode(UpdatePointer.self, from: data) else {
+              let pointer = try? JSONDecoder().decode(UpdatePointerArch.self, from: data) else {
             return nil
         }
         return pointer

--- a/app/ScanStudio/Sources/ScanStudioKit/UpdateService.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/UpdateService.swift
@@ -1,0 +1,366 @@
+// Update feed and verified download service (01-04). Resolves the newest
+// release for a channel (the `latest.json` pointer, plus a GitHub API probe
+// for the alpha channel), downloads the DMG, verifies its SHA-256 before any
+// mount, then mounts and checks the code signature so a corrupted or
+// tampered download can never reach the install core (01-03). All network is
+// behind an injectable `URLSessionProtocol`, so the whole service is unit
+// tested offline with canned payloads — CI never touches the network.
+
+import CryptoKit
+import Foundation
+
+/// A resolved, still-unverified update candidate: exactly what the feed
+/// promised. `sha256` is the trust anchor the downloader checks before mount.
+public struct UpdateCandidate: Sendable, Equatable {
+    public let version: UpdateVersion
+    public let downloadURL: URL
+    public let sha256: String
+    public let releaseNotesURL: URL?
+
+    public init(version: UpdateVersion, downloadURL: URL, sha256: String, releaseNotesURL: URL?) {
+        self.version = version
+        self.downloadURL = downloadURL
+        self.sha256 = sha256
+        self.releaseNotesURL = releaseNotesURL
+    }
+}
+
+/// The `latest.json` update pointer asset: `{"version","url","sha256"}`.
+public struct UpdatePointer: Decodable, Equatable {
+    public let version: String
+    public let url: URL
+    public let sha256: String
+
+    public init(version: String, url: URL, sha256: String) {
+        self.version = version
+        self.url = url
+        self.sha256 = sha256
+    }
+}
+
+/// The release channel a user is on. `stable` only trusts the pointer;
+/// `alpha` also probes the GitHub API for freshly published pre-releases.
+public enum UpdateChannel: String, CaseIterable, Sendable {
+    case stable = "stable"
+    case alpha = "alpha"
+}
+
+/// The minimal `URLSession` surface the update service needs. The repo had
+/// no prior `URLSessionProtocol` (the engine client speaks over pipes, not
+/// HTTP), so this is defined here and shared by the checker and downloader so
+/// that tests can stub it with canned payloads and stay fully offline.
+public protocol URLSessionProtocol: Sendable {
+    func data(from url: URL) async throws -> (Data, URLResponse)
+    func download(from url: URL, delegate: (any URLSessionTaskDelegate)?) async throws -> (URL, URLResponse)
+}
+
+extension URLSession: URLSessionProtocol {}
+
+/// Feed resolver: latest.json pointer for stable, pointer + a best-effort
+/// GitHub API probe for alpha.
+public protocol UpdateChecking: Sendable {
+    func latestCandidate(channel: UpdateChannel) async throws -> UpdateCandidate?
+}
+
+public final class GitHubUpdateChecker: UpdateChecking {
+    /// GitHub releases list the alpha channel probes. `per_page=5` keeps the
+    /// unauthenticated rate-limit headroom (60 req/hr/IP) comfortable for a
+    /// once-per-launch check.
+    public static let apiReleasesURL: URL =
+        URL(string: "https://api.github.com/repos/rohanpandula/ScanStudio/releases?per_page=5")!
+
+    private let pointerURL: URL
+    private let session: any URLSessionProtocol
+
+    public init(pointerURL: URL, session: any URLSessionProtocol = URLSession.shared) {
+        self.pointerURL = pointerURL
+        self.session = session
+    }
+
+    public func latestCandidate(channel: UpdateChannel) async throws -> UpdateCandidate? {
+        switch channel {
+        case .stable:
+            return try await fetchPointerCandidate()
+        case .alpha:
+            guard let pointer = try await fetchPointerCandidate() else { return nil }
+            return await newestPreRelease(over: pointer) ?? pointer
+        }
+    }
+
+    // MARK: - Pointer
+
+    /// Fetches and decodes `latest.json`. Transport or decode trouble is
+    /// thrown so the caller can distinguish "couldn't reach the update
+    /// server" from "no update available". Returns `nil` only when the
+    /// pointer's version string does not parse — treated as no update.
+    private func fetchPointerCandidate() async throws -> UpdateCandidate? {
+        let (data, _) = try await session.data(from: pointerURL)
+        let pointer = try JSONDecoder().decode(UpdatePointer.self, from: data)
+        guard let version = UpdateVersion(raw: pointer.version) else { return nil }
+        return UpdateCandidate(
+            version: version,
+            downloadURL: pointer.url,
+            sha256: pointer.sha256,
+            releaseNotesURL: nil
+        )
+    }
+
+    // MARK: - Alpha API probe
+
+    /// Best-effort: the newest pre-release from the GitHub API that is at
+    /// least as new as `pointer`. Any API failure (transport, decode, no
+    /// match) degrades gracefully to nil → the caller keeps the pointer
+    /// candidate. The API payload decodes only `tag_name`/`prerelease`/
+    /// `html_url` (the source of truth for artifact bytes stays the pointer),
+    /// so a found candidate's download URL is derived from the deterministic
+    /// asset naming and its `sha256` falls back to the pointer's. If that
+    /// derivation does not match the real artifact, the downloader's
+    /// checksum gate rejects the download before anything is mounted or
+    /// installed — a safe failure, never a silent wrong install.
+    private func newestPreRelease(over pointer: UpdateCandidate) async -> UpdateCandidate? {
+        guard let (data, _) = try? await session.data(from: Self.apiReleasesURL),
+              let releases = try? JSONDecoder().decode([GitHubRelease].self, from: data) else {
+            return nil
+        }
+        var candidates: [UpdateCandidate] = []
+        candidates.reserveCapacity(releases.count)
+        for release in releases where release.prerelease {
+            // Normalize the tag so the candidate's raw version matches the
+            // pointer's spelling (no leading `v`); the tag itself is still
+            // used verbatim for the release download-URL path.
+            let tag = release.tag_name
+            let versionString = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
+            guard let version = UpdateVersion(raw: versionString) else { continue }
+            candidates.append(UpdateCandidate(
+                version: version,
+                downloadURL: Self.releaseDownloadURL(tag: tag, version: version),
+                sha256: pointer.sha256,
+                releaseNotesURL: URL(string: release.html_url)
+            ))
+        }
+        guard let newest = Self.newest(candidates), newest.version >= pointer.version else {
+            return nil
+        }
+        return newest
+    }
+
+    /// Deterministic DMG asset path on GitHub Releases for a tag, matching the
+    /// pipeline's `ScanStudio-<ver>-macOS-arm64.dmg` naming (leading `v` in
+    /// the tag is not part of the asset name).
+    private static func releaseDownloadURL(tag: String, version: UpdateVersion) -> URL {
+        let stem = version.raw.hasPrefix("v") ? String(version.raw.dropFirst()) : version.raw
+        return URL(
+            string: "https://github.com/rohanpandula/ScanStudio/releases/download/\(tag)/ScanStudio-\(stem)-macOS-arm64.dmg"
+        )!
+    }
+
+    /// Newest candidate under `UpdateVersion` ordering (`<`); nil when empty.
+    static func newest(_ candidates: [UpdateCandidate]) -> UpdateCandidate? {
+        guard var best = candidates.first else { return nil }
+        for candidate in candidates.dropFirst() where best.version < candidate.version {
+            best = candidate
+        }
+        return best
+    }
+
+    /// The subset of a GitHub release object the alpha probe decodes.
+    private struct GitHubRelease: Decodable {
+        let tag_name: String
+        let prerelease: Bool
+        let html_url: String
+    }
+}
+
+/// Typed download/verify failures. Every case is a distinct, user-visible
+/// outcome; "no update available" is the checker returning nil, not an error.
+public enum UpdateDownloadError: Error, Equatable {
+    /// The candidate itself is unusable (bad URL or malformed sha256).
+    case badCandidate
+    /// Transport or staging failure while fetching the DMG.
+    case downloadFailed
+    /// Downloaded bytes do not match the promised SHA-256 (tampered/corrupt).
+    case checksumMismatch
+    /// The DMG could not be attached (or its mount point could not be read).
+    case mountFailed
+    /// The mounted bundle failed `codesign --verify --deep --strict`.
+    case signatureInvalid
+    /// The feed described an archive format this downloader cannot handle.
+    case invalidArchive
+    /// The mounted volume held no usable `.app` bundle.
+    case notAnApp
+}
+
+/// Downloads and cryptographically verifies a candidate into a mounted,
+/// signature-checked app bundle that the install core can consume. The three
+/// sanctioned `Process` uses (hdiutil attach/detach, codesign verify) are
+/// isolated behind tiny private helpers so they are auditable.
+public final class UpdateDownloader {
+    private let session: any URLSessionProtocol
+
+    public init(session: any URLSessionProtocol = URLSession.shared) {
+        self.session = session
+    }
+
+    // MARK: - Download + SHA-256
+
+    /// Downloads the candidate DMG into `directory` as
+    /// `ScanStudio-<version>.dmg`, verifying the promised SHA-256 before
+    /// returning. A mismatch deletes the download and throws
+    /// `.checksumMismatch` — nothing is ever mounted on a bad checksum.
+    public func download(_ candidate: UpdateCandidate, to directory: URL) async throws -> URL {
+        guard isValidCandidate(candidate) else {
+            throw UpdateDownloadError.badCandidate
+        }
+        let destination = directory.appendingPathComponent("ScanStudio-\(candidate.version.raw).dmg")
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let (temporaryURL, _) = try await session.download(from: candidate.downloadURL, delegate: nil)
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.moveItem(at: temporaryURL, to: destination)
+        } catch {
+            throw UpdateDownloadError.downloadFailed
+        }
+        let actual = Self.sha256(ofFileAt: destination)
+        guard actual == candidate.sha256.lowercased() else {
+            try? FileManager.default.removeItem(at: destination)
+            throw UpdateDownloadError.checksumMismatch
+        }
+        return destination
+    }
+
+    // MARK: - Mount + locate app
+
+    /// Attaches the DMG read-only (`hdiutil attach -nobrowse -readonly
+    /// -plist`), locates the single `.app` bundle at the mount root
+    /// (preferring case-insensitive `ScanStudio.app`, else any single
+    /// `.app`), and returns the mounted app's URL. A volume with no usable
+    /// `.app` is detached again and reported as `.notAnApp`.
+    public func mountAndLocateApp(_ dmgURL: URL) throws -> URL {
+        let result: (status: Int32, output: String)
+        do {
+            result = try Self.launch("/usr/bin/hdiutil", arguments: [
+                "attach", "-nobrowse", "-readonly", "-plist", dmgURL.path,
+            ])
+        } catch {
+            throw UpdateDownloadError.mountFailed
+        }
+        guard result.status == 0 else { throw UpdateDownloadError.mountFailed }
+        guard let mountRoot = Self.mountPoint(from: result.output) else {
+            throw UpdateDownloadError.mountFailed
+        }
+
+        let apps = Self.appBundles(in: mountRoot)
+        let scanStudio = apps.filter { $0.deletingPathExtension().lastPathComponent.lowercased() == "scanstudio" }
+        var located: URL?
+        if scanStudio.count == 1 {
+            located = scanStudio.first
+        } else if apps.count == 1 {
+            located = apps.first
+        }
+        guard let located else {
+            try? tearDownMount(mountRoot)
+            throw UpdateDownloadError.notAnApp
+        }
+        return located
+    }
+
+    // MARK: - Code-signature verification
+
+    /// Verifies the mounted bundle with `codesign --verify --deep --strict`
+    /// (`/usr/bin/codesign` on macOS 14+). Any non-zero exit is
+    /// `.signatureInvalid` — no archive is produced from an unsigned or
+    /// unverifiable bundle.
+    public func verifyCodeSignature(at appURL: URL) throws {
+        let result: (status: Int32, output: String)
+        do {
+            result = try Self.launch("/usr/bin/codesign", arguments: [
+                "--verify", "--deep", "--strict", appURL.path,
+            ])
+        } catch {
+            throw UpdateDownloadError.signatureInvalid
+        }
+        guard result.status == 0 else { throw UpdateDownloadError.signatureInvalid }
+    }
+
+    // MARK: - Mount teardown (internal for tests)
+
+    /// Detaches a mounted volume previously produced by `mountAndLocateApp`.
+    /// Best-effort; failures are ignored. Internal (not private) so the
+    /// offline tests can clean up after themselves.
+    func tearDownMount(_ mountURL: URL) {
+        _ = try? Self.launch("/usr/bin/hdiutil", arguments: ["detach", mountURL.path])
+    }
+
+    // MARK: - Primitives
+
+    private func isValidCandidate(_ candidate: UpdateCandidate) -> Bool {
+        candidate.downloadURL.scheme != nil
+            && !candidate.downloadURL.absoluteString.isEmpty
+            && Self.isValidHexSHA256(candidate.sha256)
+    }
+
+    private static func isValidHexSHA256(_ value: String) -> Bool {
+        value.count == 64 && value.allSatisfy { $0.isHexDigit }
+    }
+
+    /// Streams the file through CryptoKit's SHA-256 so arbitrarily large
+    /// DMGs are hashed in bounded memory (macOS 14 target → CryptoKit is
+    /// always available; no shelling out to `/usr/bin/shasum`).
+    private static func sha256(ofFileAt url: URL) -> String {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return "" }
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while let chunk = try? handle.read(upToCount: 1 << 20), !chunk.isEmpty {
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Runs an external command and returns its exit status and combined
+    /// stdout/stderr. Introduced only for the sanctioned subprocess uses
+    /// (hdiutil attach/detach, codesign verify).
+    private static func launch(_ executablePath: String, arguments: [String]) throws -> (status: Int32, output: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let data = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
+        process.waitUntilExit()
+        return (process.terminationStatus, String(data: data, encoding: .utf8) ?? "")
+    }
+
+    /// Extracts the first `mount-point` from `hdiutil attach -plist` output.
+    private static func mountPoint(from plistOutput: String) -> URL? {
+        guard let data = plistOutput.data(using: .utf8),
+              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+              let dict = plist as? [String: Any],
+              let entities = dict["system-entities"] as? [[String: Any]] else {
+            return nil
+        }
+        for entity in entities {
+            if let mountPath = entity["mount-point"] as? String {
+                return URL(fileURLWithPath: mountPath, isDirectory: true)
+            }
+        }
+        return nil
+    }
+
+    /// Direct `.app` subdirectories (case-insensitive extension) at `directory`.
+    private static func appBundles(in directory: URL) -> [URL] {
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        ) else {
+            return []
+        }
+        return contents.filter { url in
+            url.pathExtension.lowercased() == "app"
+                && (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+        }
+    }
+}

--- a/app/ScanStudio/Sources/ScanStudioKit/UpdateService.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/UpdateService.swift
@@ -69,6 +69,16 @@ public final class GitHubUpdateChecker: UpdateChecking {
     public static let apiReleasesURL: URL =
         URL(string: "https://api.github.com/repos/rohanpandula/ScanStudio/releases?per_page=5")!
 
+    /// The deterministic per-release pointer asset for `tag`. The 01-01
+    /// release pipeline emits a `latest.json` (`{"version","url","sha256"}`)
+    /// into every release, so the alpha path can fetch the newest pre-release's
+    /// OWN pointer instead of borrowing the configured (stable) pointer's
+    /// checksum. Mirrors `apiReleasesURL` as an exposed constant surface for
+    /// tests; the tag is a parameter because it varies per release.
+    public static func releasePointerURL(tag: String) -> URL {
+        URL(string: "https://github.com/rohanpandula/ScanStudio/releases/download/\(tag)/latest.json")!
+    }
+
     private let pointerURL: URL
     private let session: any URLSessionProtocol
 
@@ -108,59 +118,63 @@ public final class GitHubUpdateChecker: UpdateChecking {
     // MARK: - Alpha API probe
 
     /// Best-effort: the newest pre-release from the GitHub API that is at
-    /// least as new as `pointer`. Any API failure (transport, decode, no
-    /// match) degrades gracefully to nil → the caller keeps the pointer
-    /// candidate. The API payload decodes only `tag_name`/`prerelease`/
-    /// `html_url` (the source of truth for artifact bytes stays the pointer),
-    /// so a found candidate's download URL is derived from the deterministic
-    /// asset naming and its `sha256` falls back to the pointer's. If that
-    /// derivation does not match the real artifact, the downloader's
-    /// checksum gate rejects the download before anything is mounted or
-    /// installed — a safe failure, never a silent wrong install.
+    /// least as new as `pointer`. The API probe only answers *which* tag is
+    /// newest; the candidate's bytes + sha256 come from that release's OWN
+    /// per-release `latest.json` (authoritative artifact metadata), never
+    /// borrowed from the configured stable pointer. Any failure — API
+    /// transport/decode, a missing or corrupt per-release pointer, or a
+    /// version mismatch between the tag and its pointer — degrades silently to
+    /// nil, so the caller keeps the configured pointer candidate (fail-closed:
+    /// never a wrong install, never a self-inconsistent url+sha256 pairing).
     private func newestPreRelease(over pointer: UpdateCandidate) async -> UpdateCandidate? {
         guard let (data, _) = try? await session.data(from: Self.apiReleasesURL),
               let releases = try? JSONDecoder().decode([GitHubRelease].self, from: data) else {
             return nil
         }
-        var candidates: [UpdateCandidate] = []
-        candidates.reserveCapacity(releases.count)
+        // Locate the newest prerelease tag that is at least as new as the
+        // pointer (as today). Normalize the tag so versions compare
+        // semantically (no leading `v`); the tag stays verbatim for the URL.
+        var newest: (tag: String, version: UpdateVersion, notesURL: URL?)?
         for release in releases where release.prerelease {
-            // Normalize the tag so the candidate's raw version matches the
-            // pointer's spelling (no leading `v`); the tag itself is still
-            // used verbatim for the release download-URL path.
             let tag = release.tag_name
             let versionString = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
-            guard let version = UpdateVersion(raw: versionString) else { continue }
-            candidates.append(UpdateCandidate(
-                version: version,
-                downloadURL: Self.releaseDownloadURL(tag: tag, version: version),
-                sha256: pointer.sha256,
-                releaseNotesURL: URL(string: release.html_url)
-            ))
+            guard let version = UpdateVersion(raw: versionString), version >= pointer.version else {
+                continue
+            }
+            if newest == nil || newest!.version < version {
+                newest = (tag, version, URL(string: release.html_url))
+            }
         }
-        guard let newest = Self.newest(candidates), newest.version >= pointer.version else {
+        guard let newest else { return nil }
+
+        // Authoritative bytes + checksum come from the newest release's own
+        // per-release pointer. Equality-of-intent: the pointer's version must
+        // match the tag we probed, or we silently fall back to the configured
+        // pointer rather than install mismatched bytes.
+        guard let releasePointer = await fetchReleasePointer(tag: newest.tag),
+              let releaseVersion = UpdateVersion(raw: releasePointer.version),
+              releaseVersion == newest.version else {
             return nil
         }
-        return newest
+        return UpdateCandidate(
+            version: newest.version,
+            downloadURL: releasePointer.url,
+            sha256: releasePointer.sha256,
+            releaseNotesURL: newest.notesURL
+        )
     }
 
-    /// Deterministic DMG asset path on GitHub Releases for a tag, matching the
-    /// pipeline's `ScanStudio-<ver>-macOS-arm64.dmg` naming (leading `v` in
-    /// the tag is not part of the asset name).
-    private static func releaseDownloadURL(tag: String, version: UpdateVersion) -> URL {
-        let stem = version.raw.hasPrefix("v") ? String(version.raw.dropFirst()) : version.raw
-        return URL(
-            string: "https://github.com/rohanpandula/ScanStudio/releases/download/\(tag)/ScanStudio-\(stem)-macOS-arm64.dmg"
-        )!
-    }
-
-    /// Newest candidate under `UpdateVersion` ordering (`<`); nil when empty.
-    static func newest(_ candidates: [UpdateCandidate]) -> UpdateCandidate? {
-        guard var best = candidates.first else { return nil }
-        for candidate in candidates.dropFirst() where best.version < candidate.version {
-            best = candidate
+    /// Fetches and decodes the per-release `latest.json` pointer for `tag`.
+    /// Returns nil (never throws) on any transport or decode failure so the
+    /// alpha path can fall back silently to the configured pointer. Version
+    /// validation against the tag happens in the caller.
+    private func fetchReleasePointer(tag: String) async -> UpdatePointer? {
+        let url = Self.releasePointerURL(tag: tag)
+        guard let (data, _) = try? await session.data(from: url),
+              let pointer = try? JSONDecoder().decode(UpdatePointer.self, from: data) else {
+            return nil
         }
-        return best
+        return pointer
     }
 
     /// The subset of a GitHub release object the alpha probe decodes.

--- a/app/ScanStudio/Sources/ScanStudioKit/UpdateService.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/UpdateService.swift
@@ -1,6 +1,6 @@
 // Update feed and verified download service (01-04). Resolves the newest
 // release for a channel (the `latest.json` pointer, plus a GitHub API probe
-// for the alpha channel), downloads the DMG, verifies its SHA-256 before any
+// for the prerelease channel), downloads the DMG, verifies its SHA-256 before any
 // mount, then mounts and checks the code signature so a corrupted or
 // tampered download can never reach the install core (01-03). All network is
 // behind an injectable `URLSessionProtocol`, so the whole service is unit
@@ -99,7 +99,8 @@ public enum HostArchitectureProvider {
 }
 
 /// The release channel a user is on. `stable` only trusts the pointer;
-/// `alpha` also probes the GitHub API for freshly published pre-releases.
+/// `alpha` is the persisted raw value for the prerelease channel and also
+/// probes the GitHub API for freshly published alpha, beta, or RC releases.
 public enum UpdateChannel: String, CaseIterable, Sendable {
     case stable = "stable"
     case alpha = "alpha"
@@ -212,13 +213,13 @@ public protocol URLSessionProtocol: Sendable {
 extension URLSession: URLSessionProtocol {}
 
 /// Feed resolver: latest.json pointer for stable, pointer + a best-effort
-/// GitHub API probe for alpha.
+/// GitHub API probe for prereleases.
 public protocol UpdateChecking: Sendable {
     func latestCandidate(channel: UpdateChannel) async throws -> UpdateCandidate?
 }
 
 public final class GitHubUpdateChecker: UpdateChecking {
-    /// GitHub releases list the alpha channel probes. `per_page=5` keeps the
+    /// GitHub releases list the prerelease channel probes. `per_page=5` keeps the
     /// unauthenticated rate-limit headroom (60 req/hr/IP) comfortable for a
     /// once-per-launch check.
     public static let apiReleasesURL: URL =
@@ -226,7 +227,7 @@ public final class GitHubUpdateChecker: UpdateChecking {
 
     /// The deterministic per-release pointer asset for `tag`. The 01-01
     /// release pipeline emits a `latest.json` (`{"version","url","sha256"}`)
-    /// into every release, so the alpha path can fetch the newest pre-release's
+    /// into every release, so the prerelease path can fetch the newest release's
     /// OWN pointer instead of borrowing the configured (stable) pointer's
     /// checksum. Mirrors `apiReleasesURL` as an exposed constant surface for
     /// tests; the tag is a parameter because it varies per release.
@@ -255,8 +256,20 @@ public final class GitHubUpdateChecker: UpdateChecking {
         case .stable:
             return try await fetchPointerCandidate(arch: arch)
         case .alpha:
-            guard let pointer = try await fetchPointerCandidate(arch: arch) else { return nil }
-            return try await newestPreRelease(over: pointer, arch: arch) ?? pointer
+            do {
+                let pointer = try await fetchPointerCandidate(arch: arch)
+                return try await newestPreRelease(over: pointer, arch: arch) ?? pointer
+            } catch {
+                // A prerelease-only repository has no GitHub "latest" release,
+                // so releases/latest/download/latest.json returns 404. Probe
+                // prereleases anyway and use the chosen release's own pointer.
+                // If that bootstrap probe also fails, preserve the original
+                // feed error rather than disguising it as "no update."
+                if let prerelease = try await newestPreRelease(over: nil, arch: arch) {
+                    return prerelease
+                }
+                throw error
+            }
         }
     }
 
@@ -291,10 +304,12 @@ public final class GitHubUpdateChecker: UpdateChecking {
         return entry
     }
 
-    // MARK: - Alpha API probe
+    // MARK: - Prerelease API probe
 
     /// Best-effort: the newest pre-release from the GitHub API that is at
-    /// least as new as `pointer`, for the requested host arch. The API probe
+    /// least as new as `pointer` when a stable pointer exists, for the
+    /// requested host arch. With no stable release yet, `pointer` is nil and
+    /// the newest valid prerelease bootstraps the channel. The API probe
     /// only answers *which* tag is newest; the candidate's bytes + sha256 come
     /// from that release's OWN per-release `latest.json` (authoritative
     /// artifact metadata), never borrowed from the configured stable pointer.
@@ -304,7 +319,7 @@ public final class GitHubUpdateChecker: UpdateChecking {
     /// never a wrong install, never a self-inconsistent url+sha256 pairing).
     /// A per-release pointer with no entry for `arch` is NOT a transient
     /// network issue — it throws `UpdateArchError.unsupportedArchitecture`.
-    private func newestPreRelease(over pointer: UpdateCandidate, arch: HostArchitecture) async throws -> UpdateCandidate? {
+    private func newestPreRelease(over pointer: UpdateCandidate?, arch: HostArchitecture) async throws -> UpdateCandidate? {
         guard let (data, _) = try? await session.data(from: Self.apiReleasesURL),
               let releases = try? JSONDecoder().decode([GitHubRelease].self, from: data) else {
             return nil
@@ -316,9 +331,10 @@ public final class GitHubUpdateChecker: UpdateChecking {
         for release in releases where release.prerelease {
             let tag = release.tag_name
             let versionString = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
-            guard let version = UpdateVersion(raw: versionString), version >= pointer.version else {
+            guard let version = UpdateVersion(raw: versionString) else {
                 continue
             }
+            if let pointer, version < pointer.version { continue }
             if newest == nil || newest!.version < version {
                 newest = (tag, version, URL(string: release.html_url))
             }
@@ -345,7 +361,7 @@ public final class GitHubUpdateChecker: UpdateChecking {
 
     /// Fetches and decodes the per-release arch-aware `latest.json` pointer
     /// for `tag`. Returns nil (never throws) on any transport or decode
-    /// failure so the alpha path can fall back silently to the configured
+    /// failure so the prerelease path can fall back silently to the configured
     /// pointer. Version validation against the tag happens in the caller.
     private func fetchReleasePointer(tag: String) async -> UpdatePointerArch? {
         let url = Self.releasePointerURL(tag: tag)

--- a/app/ScanStudio/Sources/ScanStudioKit/UpdateVersion.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/UpdateVersion.swift
@@ -1,0 +1,175 @@
+// Comparable version identity for ScanStudio release strings. This is the
+// single source of truth for "what version am I, and is a remote one newer",
+// used by the auto-update plans. It parses `major.minor[.patch][-prerelease]`
+// strings without any external dependency and never throws.
+
+import Foundation
+
+/// A parseable, comparable ScanStudio version such as `0.3.0-alpha.11`.
+///
+/// Ordering rule: `alpha < beta < rc < stable`; prerelease numeric suffix
+/// compares by value (`alpha.9 < alpha.11`).
+///
+/// `raw` preserves the caller's spelling (including any leading `v` and
+/// patch-less core), while equality and ordering are semantic: `0.3` equals
+/// `0.3.0`, and `v0.3.0` equals `0.3.0`.
+public struct UpdateVersion: Equatable, Comparable, Sendable, Codable {
+    /// The input string exactly as given (e.g. `"0.3.0-alpha.11"`).
+    public let raw: String
+
+    /// `true` when the version has a prerelease tail (e.g. `-alpha.11`).
+    public let isPrerelease: Bool
+
+    /// Core `major.minor.patch`, with missing minor/patch defaulting to 0.
+    private let major: Int
+    private let minor: Int
+    private let patch: Int
+
+    /// Rank of the prerelease tag: `0` alpha, `1` beta, `2` rc, `3` any
+    /// unknown/newer tag. `nil` when the version is stable (no tail).
+    private let tagRank: Int?
+
+    /// Numeric prerelease suffix, defaulting to 0 when absent.
+    private let suffix: Int
+
+    private static let knownRanks: [String: Int] = ["alpha": 0, "beta": 1, "rc": 2]
+
+    /// Parses `raw` (e.g. `"0.3.0-alpha.11"`, `"v0.3.0"`, `"1.2"`).
+    ///
+    /// Returns `nil` for empty input, a core with non-integer or negative
+    /// components, a core that is not 2 or 3 dot-separated integers, a
+    /// non-identifier prerelease tag, a duplicate `.` in the numeric tail,
+    /// or a trailing empty tail/number. Never throws.
+    public init?(raw: String) {
+        guard !raw.isEmpty else { return nil }
+
+        var core = raw
+        if core.hasPrefix("v") {
+            core.removeFirst()
+        }
+
+        let dashIndex = core.firstIndex(of: "-")
+        let coreString: String
+        let tailString: String?
+        if let dashIndex {
+            coreString = String(core[..<dashIndex])
+            tailString = String(core[core.index(after: dashIndex)...])
+        } else {
+            coreString = core
+            tailString = nil
+        }
+
+        let coreParts = coreString.split(separator: ".", omittingEmptySubsequences: false)
+        guard (2...3).contains(coreParts.count) else { return nil }
+        var coreNumbers: [Int] = []
+        coreNumbers.reserveCapacity(coreParts.count)
+        for part in coreParts {
+            guard let number = Int(part), number >= 0 else { return nil }
+            coreNumbers.append(number)
+        }
+        let major = coreNumbers[0]
+        let minor = coreNumbers.count > 1 ? coreNumbers[1] : 0
+        let patch = coreNumbers.count > 2 ? coreNumbers[2] : 0
+
+        var tagRank: Int?
+        var suffix = 0
+        if let tailString {
+            guard !tailString.isEmpty else { return nil }
+            let firstDot = tailString.firstIndex(of: ".")
+            let tag: String
+            let numberString: String?
+            if let firstDot {
+                tag = String(tailString[..<firstDot])
+                numberString = String(tailString[tailString.index(after: firstDot)...])
+            } else {
+                tag = tailString
+                numberString = nil
+            }
+            guard !tag.isEmpty else { return nil }
+            guard tag.allSatisfy({ $0.isLetter || $0.isNumber }) else { return nil }
+            if let numberString {
+                guard !numberString.isEmpty else { return nil }
+                guard let number = Int(numberString), number >= 0 else { return nil }
+                suffix = number
+            }
+            tagRank = UpdateVersion.knownRanks[tag.lowercased()] ?? 3
+        }
+
+        self.raw = raw
+        self.isPrerelease = tagRank != nil
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.tagRank = tagRank
+        self.suffix = suffix
+    }
+
+    public static func < (lhs: UpdateVersion, rhs: UpdateVersion) -> Bool {
+        lhs.compare(to: rhs) == .ascending
+    }
+
+    public static func == (lhs: UpdateVersion, rhs: UpdateVersion) -> Bool {
+        lhs.compare(to: rhs) == .same
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawValue = try container.decode(String.self, forKey: .raw)
+        guard let parsed = UpdateVersion(raw: rawValue) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .raw,
+                in: container,
+                debugDescription: "Invalid ScanStudio version string: \(rawValue)"
+            )
+        }
+        self = parsed
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(raw, forKey: .raw)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case raw
+    }
+
+    private enum Order {
+        case ascending
+        case same
+        case descending
+    }
+
+    private func compare(to other: UpdateVersion) -> Order {
+        if major != other.major {
+            return major < other.major ? .ascending : .descending
+        }
+        if minor != other.minor {
+            return minor < other.minor ? .ascending : .descending
+        }
+        if patch != other.patch {
+            return patch < other.patch ? .ascending : .descending
+        }
+        switch (tagRank, other.tagRank) {
+        case (nil, nil):
+            return .same
+        case (nil, _?):
+            return .descending
+        case (_?, nil):
+            return .ascending
+        case (let lhsRank?, let rhsRank?):
+            if lhsRank != rhsRank {
+                return lhsRank < rhsRank ? .ascending : .descending
+            }
+            if suffix != other.suffix {
+                return suffix < other.suffix ? .ascending : .descending
+            }
+            let lhsRaw = raw.lowercased()
+            let rhsRaw = other.raw.lowercased()
+            if lhsRaw == rhsRaw {
+                return .same
+            }
+            return lhsRaw < rhsRaw ? .ascending : .descending
+        }
+    }
+}

--- a/app/ScanStudio/Tests/ScanStudioKitTests/HostArchitectureTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/HostArchitectureTests.swift
@@ -1,0 +1,57 @@
+// Offline tests for host-architecture resolution (02-02). Guards the pure,
+// no-subprocess contract: `HostArchitectureProvider` derives its answer from
+// `ProcessInfo.machineHardwareName` (a direct `hw.machine` syscall), never
+// through a `Process` or a shelled-out `/usr/bin/uname` — so the host-arch
+// resolver is deterministic and unit-testable on any machine.
+
+import XCTest
+
+@testable import ScanStudioKit
+
+final class HostArchitectureTests: XCTestCase {
+    // No-subprocess guarantee: the provider's only information source is the
+    // `hw.machine` syscall behind `ProcessInfo.machineHardwareName`. There is
+    // no Process use in the provider path by construction; this is enforced
+    // at review level, not by a runtime capability probe.
+
+    func testEnumCases() {
+        XCTAssertEqual(HostArchitecture.arm64.rawValue, "arm64")
+        XCTAssertEqual(HostArchitecture.x86_64.rawValue, "x86_64")
+    }
+
+    func testCaseIterableHasExactlyTwoCases() {
+        XCTAssertEqual(HostArchitecture.allCases.count, 2)
+        XCTAssertEqual(Set(HostArchitecture.allCases), [.arm64, .x86_64])
+    }
+
+    func testCurrentMatchesProcessInfoMachineName() {
+        let name = ProcessInfo.processInfo.machineHardwareName
+        let current = HostArchitectureProvider.current()
+        if name.hasPrefix("arm64") {
+            XCTAssertEqual(current, .arm64,
+                           "machineHardwareName '\(name)' must map to .arm64")
+        } else if name.hasPrefix("x86_64") {
+            XCTAssertEqual(current, .x86_64,
+                           "machineHardwareName '\(name)' must map to .x86_64")
+        } else {
+            // Unrecognized machine name: the provider still resolves to a
+            // known architecture via its documented fallback, never crashes.
+            XCTAssertTrue(current == .arm64 || current == .x86_64,
+                          "provider must always resolve to a known arch (got '\(current.rawValue)' for '\(name)')")
+        }
+    }
+
+    func testCurrentArchPrefixMatchesMachineName() {
+        // The resolved arch's raw value must be a prefix of the reported
+        // machine name (arm64* → arm64, x86_64* → x86_64) on a real host.
+        let name = ProcessInfo.processInfo.machineHardwareName
+        let arch = HostArchitectureProvider.current()
+        XCTAssertTrue(name.hasPrefix(arch.rawValue),
+                      "machineHardwareName '\(name)' must begin with resolved arch '\(arch.rawValue)'")
+    }
+
+    func testCurrentHostArchitectureConvenienceMatchesCurrent() {
+        XCTAssertEqual(HostArchitectureProvider.currentHostArchitecture,
+                       HostArchitectureProvider.current())
+    }
+}

--- a/app/ScanStudio/Tests/ScanStudioKitTests/UpdateFlowIntegrationTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/UpdateFlowIntegrationTests.swift
@@ -7,6 +7,14 @@
 // /Applications mutation, and zero scanner interaction. The hdiutil mount leg
 // is bypassed for directory fixtures by design (the mount path is exercised
 // independently where a real DMG exists — see UpdateServiceTests).
+//
+// Phase 02 extends the suite with arch-selected cases: the seeded pointer is
+// arch-keyed (arm64 + x86_64 entries with distinct real shas) and the wired
+// flow must select + install the requested/HOST architecture's artifact, a
+// cross-arch byte mismatch is checksum-rejected (wrong arch never installs),
+// and a pointer with no entry for the requested arch surfaces the typed
+// unsupported-architecture error in flow. All offline; a real Intel bundle
+// only executes on the CI x86_64 leg (see 02-CONTEXT.md).
 
 import CryptoKit
 import XCTest
@@ -152,6 +160,190 @@ final class UpdateFlowIntegrationTests: XCTestCase {
         XCTAssertTrue(leftovers.isEmpty, "a rejected download must not leave a staged artifact")
     }
 
+    // MARK: - Arch-selected flow (Phase 02): right arch installs, wrong arch
+    //         never, unsupported arch is a typed error
+
+    func testArchSelectedFlowInstallsHostArchArtifact() async throws {
+        // Arch-keyed pointer (02-01 emitter shape) carrying BOTH architectures
+        // with distinct real shas: the whole wired flow must select and
+        // install the HOST architecture's artifact (on this arm64
+        // verification host, the .arm64 entry) and never the other one.
+        let armApp = releaseDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true)
+        try makeApp("ScanStudio.app", at: releaseDirectory, release: "0.3.0-alpha.11", marker: "arch")
+        let armArtifact = try makeReleaseArtifact(of: armApp)
+
+        let intelApp = releaseDirectory.appendingPathComponent("ScanStudio-intel.app", isDirectory: true)
+        try makeApp("ScanStudio-intel.app", at: releaseDirectory, release: "0.3.0-alpha.11", marker: "intel")
+        let intelArtifact = try makeReleaseArtifact(of: intelApp, version: "0.3.0-alpha.11", arch: "x86_64")
+        XCTAssertNotEqual(armArtifact.sha256, intelArtifact.sha256,
+                          "the two arch entries must describe distinct artifacts")
+
+        let pointerURL = releaseDirectory.appendingPathComponent("latest.json")
+        let pointerData = Data("""
+        {
+            "version": "0.3.0-alpha.11",
+            "architectures": {
+                "arm64": { "url": "\(armArtifact.url.absoluteString)", "sha256": "\(armArtifact.sha256)" },
+                "x86_64": { "url": "\(intelArtifact.url.absoluteString)", "sha256": "\(intelArtifact.sha256)" }
+            }
+        }
+        """.utf8)
+        try pointerData.write(to: pointerURL)
+
+        let session = CannedURLSession()
+        session.dataByURL[pointerURL] = pointerData
+        session.dataByURL[GitHubUpdateChecker.apiReleasesURL] = Data("[]".utf8)
+        session.dataByURL[armArtifact.url] = armArtifact.payload
+        session.dataByURL[intelArtifact.url] = intelArtifact.payload
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL, session: session)
+
+        // The host architecture on this verification machine (arm64, no
+        // Rosetta per CONTEXT); it must always be one of the feed archs.
+        let host = HostArchitectureProvider.current()
+        XCTAssertTrue(HostArchitecture.allCases.contains(host), "host arch must be a known feed arch")
+        let hostArtifact = host == .arm64 ? armArtifact : intelArtifact
+
+        // Explicit .arm64 selection resolves the arm64 entry.
+        let armResolved = try await checker.latestCandidate(channel: .alpha, arch: .arm64)
+        let armCandidate = try XCTUnwrap(armResolved)
+        XCTAssertEqual(armCandidate.version, UpdateVersion(raw: "0.3.0-alpha.11"))
+        XCTAssertEqual(armCandidate.downloadURL, armArtifact.url)
+        XCTAssertEqual(armCandidate.sha256, armArtifact.sha256)
+
+        // The default entry point (no explicit arch) delegates to the host
+        // arch and lands on the same entry the host-arch request returns.
+        let defaultResolved = try await checker.latestCandidate(channel: .alpha)
+        let hostCandidate = try XCTUnwrap(defaultResolved)
+        XCTAssertEqual(hostCandidate.downloadURL, hostArtifact.url)
+        XCTAssertEqual(hostCandidate.sha256, hostArtifact.sha256)
+
+        // Downloader verifies against the SELECTED arch's sha, then the
+        // installer swaps the corresponding bundle in. On this arm64 host the
+        // marker proves the arm64 artifact was the one installed.
+        let downloader = UpdateDownloader(session: session)
+        let downloadDir = root.appendingPathComponent("Downloads", isDirectory: true)
+        let downloaded = try await downloader.download(hostCandidate, to: downloadDir)
+        XCTAssertEqual(try Data(contentsOf: downloaded), hostArtifact.payload)
+
+        let sourceApp = host == .arm64 ? armApp : intelApp
+        let installer = try UpdateInstaller(appDirectory: installDirectory, rollbackDirectory: rollbackDirectory)
+        XCTAssertNil(installer.availableRollback)
+
+        let archive = UpdateArchive(
+            version: hostCandidate.version,
+            sourceAppPath: sourceApp,
+            checksumSHA256: hostCandidate.sha256
+        )
+        try installer.install(archive)
+
+        XCTAssertEqual(
+            try markerContents(installDirectory.appendingPathComponent("ScanStudio.app")),
+            host == .arm64 ? "arch" : "intel",
+            "install must consume the host-arch artifact"
+        )
+        XCTAssertNotNil(installer.availableRollback)
+        XCTAssertEqual(installer.availableRollback?.version.raw, "0.3.0-alpha.10")
+
+        let restored = try installer.restorePrevious()
+        XCTAssertEqual(restored.lastPathComponent, "ScanStudio.app")
+        XCTAssertEqual(try markerContents(installDirectory.appendingPathComponent("ScanStudio.app")), "old")
+    }
+
+    func testCrossArchChecksumMismatchIsRejected() async throws {
+        // A tampered mirror (or malformed feed) must never install: the x86_64
+        // entry promises the x86_64 artifact's real sha, but the mirror serves
+        // the ARM64 bytes at that URL — the checksum gate rejects the
+        // wrong-arch content before anything is mounted or swapped.
+        let armApp = releaseDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true)
+        try makeApp("ScanStudio.app", at: releaseDirectory, release: "0.3.0-alpha.11", marker: "arch")
+        let armArtifact = try makeReleaseArtifact(of: armApp)
+
+        let intelApp = releaseDirectory.appendingPathComponent("ScanStudio-intel.app", isDirectory: true)
+        try makeApp("ScanStudio-intel.app", at: releaseDirectory, release: "0.3.0-alpha.11", marker: "intel")
+        let intelArtifact = try makeReleaseArtifact(of: intelApp, version: "0.3.0-alpha.11", arch: "x86_64")
+        XCTAssertNotEqual(armArtifact.sha256, intelArtifact.sha256)
+
+        let pointerURL = releaseDirectory.appendingPathComponent("latest.json")
+        let pointerData = Data("""
+        {
+            "version": "0.3.0-alpha.11",
+            "architectures": {
+                "arm64": { "url": "\(armArtifact.url.absoluteString)", "sha256": "\(armArtifact.sha256)" },
+                "x86_64": { "url": "\(intelArtifact.url.absoluteString)", "sha256": "\(intelArtifact.sha256)" }
+            }
+        }
+        """.utf8)
+        try pointerData.write(to: pointerURL)
+
+        // Built-in cross-arch hazard: the intel URL answers with arm64 bytes.
+        let session = CannedURLSession()
+        session.dataByURL[pointerURL] = pointerData
+        session.dataByURL[GitHubUpdateChecker.apiReleasesURL] = Data("[]".utf8)
+        session.dataByURL[intelArtifact.url] = armArtifact.payload
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL, session: session)
+        let resolved = try await checker.latestCandidate(channel: .alpha, arch: .x86_64)
+        let candidate = try XCTUnwrap(resolved)
+        XCTAssertEqual(candidate.sha256, intelArtifact.sha256)
+
+        let downloader = UpdateDownloader(session: session)
+        let downloadDir = root.appendingPathComponent("Downloads", isDirectory: true)
+        do {
+            _ = try await downloader.download(candidate, to: downloadDir)
+            XCTFail("expected checksumMismatch for cross-arch content")
+        } catch let error as UpdateDownloadError {
+            XCTAssertEqual(error, .checksumMismatch)
+        }
+
+        // Nothing may have been swapped, snapshotted, or left staged.
+        XCTAssertEqual(try markerContents(installDirectory.appendingPathComponent("ScanStudio.app")), "old")
+        let installer = try UpdateInstaller(appDirectory: installDirectory, rollbackDirectory: rollbackDirectory)
+        XCTAssertNil(installer.availableRollback, "a rejected cross-arch download must not snapshot or swap")
+        let leftovers = try FileManager.default.contentsOfDirectory(atPath: downloadDir.path)
+        XCTAssertTrue(leftovers.isEmpty, "a rejected cross-arch download must not leave a staged artifact")
+    }
+
+    func testUnsupportedArchitectureTypedErrorInFlow() async throws {
+        // A pointer with only the arm64 entry, requested for x86_64: the
+        // surfaced outcome is the typed unsupported-architecture error through
+        // the full checker flow (not a decode-only case), never a crash and
+        // never a wrong-arch install.
+        let armApp = releaseDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true)
+        try makeApp("ScanStudio.app", at: releaseDirectory, release: "0.3.0-alpha.11", marker: "arch")
+        let armArtifact = try makeReleaseArtifact(of: armApp)
+
+        let pointerURL = releaseDirectory.appendingPathComponent("latest.json")
+        let pointerData = Data("""
+        {
+            "version": "0.3.0-alpha.11",
+            "architectures": {
+                "arm64": { "url": "\(armArtifact.url.absoluteString)", "sha256": "\(armArtifact.sha256)" }
+            }
+        }
+        """.utf8)
+        try pointerData.write(to: pointerURL)
+
+        let session = CannedURLSession()
+        session.dataByURL[pointerURL] = pointerData
+        session.dataByURL[GitHubUpdateChecker.apiReleasesURL] = Data("[]".utf8)
+        session.dataByURL[armArtifact.url] = armArtifact.payload
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL, session: session)
+        do {
+            _ = try await checker.latestCandidate(channel: .alpha, arch: .x86_64)
+            XCTFail("expected UpdateArchError.unsupportedArchitecture(.x86_64)")
+        } catch let error as UpdateArchError {
+            XCTAssertEqual(error, .unsupportedArchitecture(.x86_64))
+        }
+
+        // No install may have happened: the old bundle is intact and no
+        // snapshot exists.
+        XCTAssertEqual(try markerContents(installDirectory.appendingPathComponent("ScanStudio.app")), "old")
+        let installer = try UpdateInstaller(appDirectory: installDirectory, rollbackDirectory: rollbackDirectory)
+        XCTAssertNil(installer.availableRollback, "unsupported arch must never reach the installer")
+    }
+
     // MARK: - Fixture helpers
 
     private struct ReleaseArtifact {
@@ -161,10 +353,19 @@ final class UpdateFlowIntegrationTests: XCTestCase {
     }
 
     /// Bakes the app bundle into a release artifact (a zip) and returns its
-    /// exact bytes with the real SHA-256 the feed must carry.
+    /// exact bytes with the real SHA-256 the feed must carry. Backed by an
+    /// arm64-named artifact for the Phase-01 callers.
     private func makeReleaseArtifact(of app: URL) throws -> ReleaseArtifact {
+        try makeReleaseArtifact(of: app, version: "0.3.0-alpha.11", arch: "arm64")
+    }
+
+    /// Bakes the app bundle into a release artifact (a zip) named for its
+    /// `arch` (`-macOS-<arch>.zip`, mirroring the per-arch DMG suffix
+    /// convention) and returns its exact bytes with the real SHA-256 the feed
+    /// must carry.
+    private func makeReleaseArtifact(of app: URL, version: String, arch: String) throws -> ReleaseArtifact {
         let zipURL = releaseDirectory
-            .appendingPathComponent("ScanStudio-0.3.0-alpha.11-macOS-arm64.zip")
+            .appendingPathComponent("ScanStudio-\(version)-macOS-\(arch).zip")
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
         process.arguments = ["-c", "-k", "--keepParent", app.path, zipURL.path]

--- a/app/ScanStudio/Tests/ScanStudioKitTests/UpdateFlowIntegrationTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/UpdateFlowIntegrationTests.swift
@@ -1,0 +1,227 @@
+// End-to-end updater flow test (01-06): drives the whole wired pipeline in
+// one place — update pointer (file URL) -> GitHubUpdateChecker ->
+// UpdateDownloader (SHA-256 verified) -> UpdateInstaller (snapshot / swap /
+// rollback), plus the corrupt-checksum rejection path. Everything runs against
+// seeded fake app bundles in temp directories: a canned URLSessionProtocol
+// answers from injectable local fixtures, so there is zero network, zero
+// /Applications mutation, and zero scanner interaction. The hdiutil mount leg
+// is bypassed for directory fixtures by design (the mount path is exercised
+// independently where a real DMG exists — see UpdateServiceTests).
+
+import CryptoKit
+import XCTest
+
+@testable import ScanStudioKit
+
+final class UpdateFlowIntegrationTests: XCTestCase {
+    private var root: URL!
+    private var installDirectory: URL!
+    private var rollbackDirectory: URL!
+    private var releaseDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UpdateFlowIntegrationTests-\(UUID().uuidString)", isDirectory: true)
+        installDirectory = root.appendingPathComponent("Applications", isDirectory: true)
+        rollbackDirectory = root.appendingPathComponent("Rollback", isDirectory: true)
+        releaseDirectory = root.appendingPathComponent("Release", isDirectory: true)
+        try FileManager.default.createDirectory(at: installDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: rollbackDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: releaseDirectory, withIntermediateDirectories: true)
+
+        try makeApp("ScanStudio.app", at: installDirectory, release: "0.3.0-alpha.10", marker: "old")
+    }
+
+    override func tearDownWithError() throws {
+        if let root {
+            try? FileManager.default.removeItem(at: root)
+        }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Whole wired flow: pointer -> check -> download -> verify -> snapshot -> swap -> rollback
+
+    func testWholeWiredFlow() async throws {
+        // The "new release" bundle, plus a real on-disk release artifact (the
+        // bundle zipped) whose bytes double as the checksum trust anchor.
+        let newApp = releaseDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true)
+        try makeApp("ScanStudio.app", at: releaseDirectory, release: "0.3.0-alpha.11", marker: "new")
+        let artifact = try makeReleaseArtifact(of: newApp)
+
+        // Pointer asset: latest.json points at the artifact and carries its real sha256.
+        let pointerURL = releaseDirectory.appendingPathComponent("latest.json")
+        let pointerData = Data("""
+        {
+            "version": "0.3.0-alpha.11",
+            "url": "\(artifact.url.absoluteString)",
+            "sha256": "\(artifact.sha256)"
+        }
+        """.utf8)
+        try pointerData.write(to: pointerURL)
+
+        let session = CannedURLSession()
+        session.dataByURL[pointerURL] = pointerData
+        session.dataByURL[GitHubUpdateChecker.apiReleasesURL] = Data("[]".utf8)
+        session.dataByURL[artifact.url] = artifact.payload
+
+        // 1. Checker resolves the candidate from the pointer. Alpha channel
+        //    consults the API first; an empty release list degrades to the
+        //    pointer candidate, mirroring the production degradation path.
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL, session: session)
+        let resolvedCandidate = try await checker.latestCandidate(channel: .alpha)
+        let candidate = try XCTUnwrap(resolvedCandidate)
+        XCTAssertEqual(candidate.version, UpdateVersion(raw: "0.3.0-alpha.11"))
+        XCTAssertEqual(candidate.sha256, artifact.sha256)
+
+        // 2. Downloader fetches the artifact and must pass the SHA-256 gate
+        //    before anything can be mounted or installed.
+        let downloader = UpdateDownloader(session: session)
+        let downloadDir = root.appendingPathComponent("Downloads", isDirectory: true)
+        let downloaded = try await downloader.download(candidate, to: downloadDir)
+        XCTAssertEqual(downloaded.lastPathComponent, "ScanStudio-0.3.0-alpha.11.dmg")
+        XCTAssertEqual(try Data(contentsOf: downloaded), artifact.payload)
+
+        // 3. Installer: snapshot current (old) -> swap in new -> rollback old.
+        //    mountAndLocateApp is bypassed for directory fixtures by design
+        //    (see header); the archive is pointed at the release bundle that
+        //    corresponds to the artifact we just verified and downloaded.
+        let installer = try UpdateInstaller(appDirectory: installDirectory, rollbackDirectory: rollbackDirectory)
+        XCTAssertNil(installer.availableRollback, "no rollback is available before the first snapshot")
+
+        let archive = UpdateArchive(
+            version: candidate.version,
+            sourceAppPath: newApp,
+            checksumSHA256: candidate.sha256
+        )
+        try installer.install(archive)
+
+        XCTAssertEqual(try markerContents(installDirectory.appendingPathComponent("ScanStudio.app")), "new")
+        XCTAssertNotNil(installer.availableRollback, "install must first snapshot so rollback is available")
+        XCTAssertEqual(installer.availableRollback?.version.raw, "0.3.0-alpha.10")
+
+        let restored = try installer.restorePrevious()
+        XCTAssertEqual(restored.lastPathComponent, "ScanStudio.app")
+        XCTAssertEqual(try markerContents(installDirectory.appendingPathComponent("ScanStudio.app")), "old")
+    }
+
+    // MARK: - Corrupt release: a bad sha256 is rejected before anything swaps
+
+    func testChecksumRejectsCorruptRelease() async throws {
+        // Same fixture as the happy path, but the feed promises a bogus (yet
+        // well-formed) sha256 — the downloader must refuse the bytes.
+        let newApp = releaseDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true)
+        try makeApp("ScanStudio.app", at: releaseDirectory, release: "0.3.0-alpha.11", marker: "new")
+        let artifact = try makeReleaseArtifact(of: newApp)
+
+        let bogusSHA = String(repeating: "0", count: 64)
+        let pointerURL = releaseDirectory.appendingPathComponent("latest.json")
+        let pointerData = Data("""
+        {
+            "version": "0.3.0-alpha.11",
+            "url": "\(artifact.url.absoluteString)",
+            "sha256": "\(bogusSHA)"
+        }
+        """.utf8)
+        try pointerData.write(to: pointerURL)
+
+        let session = CannedURLSession()
+        session.dataByURL[pointerURL] = pointerData
+        session.dataByURL[GitHubUpdateChecker.apiReleasesURL] = Data("[]".utf8)
+        session.dataByURL[artifact.url] = artifact.payload
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL, session: session)
+        let resolvedCandidate = try await checker.latestCandidate(channel: .alpha)
+        let candidate = try XCTUnwrap(resolvedCandidate)
+        XCTAssertEqual(candidate.sha256, bogusSHA)
+
+        let downloader = UpdateDownloader(session: session)
+        let downloadDir = root.appendingPathComponent("Downloads", isDirectory: true)
+        do {
+            _ = try await downloader.download(candidate, to: downloadDir)
+            XCTFail("expected checksumMismatch for a corrupt release")
+        } catch let error as UpdateDownloadError {
+            XCTAssertEqual(error, .checksumMismatch)
+        }
+
+        // Nothing may have been swapped, snapshotted, or left staged.
+        XCTAssertEqual(try markerContents(installDirectory.appendingPathComponent("ScanStudio.app")), "old")
+        let installer = try UpdateInstaller(appDirectory: installDirectory, rollbackDirectory: rollbackDirectory)
+        XCTAssertNil(installer.availableRollback)
+        let leftovers = try FileManager.default.contentsOfDirectory(atPath: downloadDir.path)
+        XCTAssertTrue(leftovers.isEmpty, "a rejected download must not leave a staged artifact")
+    }
+
+    // MARK: - Fixture helpers
+
+    private struct ReleaseArtifact {
+        let payload: Data
+        let sha256: String
+        let url: URL
+    }
+
+    /// Bakes the app bundle into a release artifact (a zip) and returns its
+    /// exact bytes with the real SHA-256 the feed must carry.
+    private func makeReleaseArtifact(of app: URL) throws -> ReleaseArtifact {
+        let zipURL = releaseDirectory
+            .appendingPathComponent("ScanStudio-0.3.0-alpha.11-macOS-arm64.zip")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+        process.arguments = ["-c", "-k", "--keepParent", app.path, zipURL.path]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw NSError(
+                domain: "UpdateFlowIntegrationTests",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "ditto failed (status \(process.terminationStatus))"]
+            )
+        }
+        let payload = try Data(contentsOf: zipURL)
+        let sha = SHA256.hash(data: payload).map { String(format: "%02x", $0) }.joined()
+        return ReleaseArtifact(payload: payload, sha256: sha, url: zipURL)
+    }
+
+    private func makeApp(_ name: String, at parent: URL, release: String, marker: String) throws {
+        let appURL = parent.appendingPathComponent(name, isDirectory: true)
+        let contents = appURL.appendingPathComponent("Contents", isDirectory: true)
+        let macos = contents.appendingPathComponent("MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macos, withIntermediateDirectories: true)
+
+        let infoPlist: [String: Any] = [
+            "CFBundleShortVersionString": release,
+            "ScanStudioRelease": release,
+        ]
+        let plistData = try PropertyListSerialization.data(fromPropertyList: infoPlist, format: .xml, options: 0)
+        try plistData.write(to: contents.appendingPathComponent("Info.plist"))
+        try Data(marker.utf8).write(to: macos.appendingPathComponent("ScanStudio"))
+    }
+
+    private func markerContents(_ appURL: URL) throws -> String {
+        try String(contentsOf: appURL.appendingPathComponent("Contents/MacOS/ScanStudio"), encoding: .utf8)
+    }
+}
+
+/// Canned in-memory URLSession stand-in for the offline flow: `data(from:)`
+/// and `download(from:)` answer from a URL-keyed map. Mirrors the stub pattern
+/// from 01-04's UpdateServiceTests without coupling to its file-private type.
+private final class CannedURLSession: URLSessionProtocol, @unchecked Sendable {
+    var dataByURL: [URL: Data] = [:]
+
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        guard let data = dataByURL[url] else {
+            throw URLError(.fileDoesNotExist)
+        }
+        return (data, HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+    }
+
+    func download(from url: URL, delegate: (any URLSessionTaskDelegate)?) async throws -> (URL, URLResponse) {
+        guard let data = dataByURL[url] else {
+            throw URLError(.fileDoesNotExist)
+        }
+        let temporary = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CannedDownload-\(UUID().uuidString)")
+        try data.write(to: temporary)
+        return (temporary, HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+    }
+}

--- a/app/ScanStudio/Tests/ScanStudioKitTests/UpdateInstallerTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/UpdateInstallerTests.swift
@@ -11,6 +11,9 @@ final class UpdateInstallerTests: XCTestCase {
     private var applicationsDirectory: URL!
     private var rollbackDirectory: URL!
     private var sourceDirectory: URL!
+    /// Directories the tests chmod'd non-writable; reset to writable in
+    /// tearDown so the temp tree can always be removed.
+    private var nonWritableDirs: [URL] = []
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -28,6 +31,9 @@ final class UpdateInstallerTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        for directory in nonWritableDirs {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directory.path)
+        }
         if let root {
             try? FileManager.default.removeItem(at: root)
         }
@@ -111,10 +117,118 @@ final class UpdateInstallerTests: XCTestCase {
         }
     }
 
+    // MARK: - 01-08: install-destination resolution + rollback intact
+
+    func testResolveInstallDestinationPrefersWritableAppDir() throws {
+        let installer = try makeInstaller()
+
+        let resolved = try installer.resolveInstallDestination()
+        XCTAssertEqual(resolved, applicationsDirectory,
+                       "a writable appDirectory must be preferred as the install destination")
+        XCTAssertEqual(try installer.installDestination, applicationsDirectory,
+                       "the throwing computed installDestination must agree")
+    }
+
+    func testResolveInstallDestinationFallsBackToWritable() throws {
+        let unwritable = root.appendingPathComponent("Unwritable", isDirectory: true)
+        try FileManager.default.createDirectory(at: unwritable, withIntermediateDirectories: true)
+        guard makeNonWritable(unwritable) else {
+            // Filesystem refused chmod (e.g. a sandboxed container): the
+            // non-writable scenario cannot be simulated here — skip rather
+            // than fail the suite.
+            throw XCTSkip("chmod was refused; cannot simulate a non-writable directory")
+        }
+        nonWritableDirs.append(unwritable)
+
+        let fallback = root.appendingPathComponent("Fallback", isDirectory: true)
+        try FileManager.default.createDirectory(at: fallback, withIntermediateDirectories: true)
+
+        let installer = try UpdateInstaller(
+            appDirectory: unwritable,
+            rollbackDirectory: rollbackDirectory,
+            authorizedDestinations: [fallback]
+        )
+
+        XCTAssertEqual(try installer.resolveInstallDestination(), fallback,
+                       "an unwritable appDirectory must fall back to a writable authorized destination")
+    }
+
+    func testResolveInstallDestinationThrowsWhenNothingWritable() throws {
+        let unwritable = root.appendingPathComponent("Unwritable", isDirectory: true)
+        let unwritableFallback = root.appendingPathComponent("UnwritableFallback", isDirectory: true)
+        try FileManager.default.createDirectory(at: unwritable, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: unwritableFallback, withIntermediateDirectories: true)
+        guard makeNonWritable(unwritable), makeNonWritable(unwritableFallback) else {
+            throw XCTSkip("chmod was refused; cannot simulate non-writable directories")
+        }
+        nonWritableDirs.append(contentsOf: [unwritable, unwritableFallback])
+
+        let installer = try UpdateInstaller(
+            appDirectory: unwritable,
+            rollbackDirectory: rollbackDirectory,
+            authorizedDestinations: [unwritableFallback]
+        )
+
+        XCTAssertThrowsError(try installer.resolveInstallDestination()) { error in
+            XCTAssertEqual(error as? UpdateInstallError, .cannotWriteTarget)
+        }
+    }
+
+    func testInstallStillSwapsAndRollsBackAfterFallback() throws {
+        // The preferred target is non-writable; install must fall back to a
+        // user-writable destination and still snapshot/swap/roll back there
+        // (rollback integrity must survive the destination change).
+        let unwritable = root.appendingPathComponent("Unwritable", isDirectory: true)
+        try FileManager.default.createDirectory(at: unwritable, withIntermediateDirectories: true)
+        guard makeNonWritable(unwritable) else {
+            throw XCTSkip("chmod was refused; cannot simulate a non-writable directory")
+        }
+        nonWritableDirs.append(unwritable)
+
+        let fallback = root.appendingPathComponent("Fallback", isDirectory: true)
+        try FileManager.default.createDirectory(at: fallback, withIntermediateDirectories: true)
+        // An existing app in the fallback destination, so the snapshot has
+        // something to capture and rollback can prove full restoration.
+        try makeFakeApp("ScanStudio.app", at: fallback, release: "0.3.0-alpha.10", marker: "old")
+
+        let installer = try UpdateInstaller(
+            appDirectory: unwritable,
+            rollbackDirectory: rollbackDirectory,
+            authorizedDestinations: [fallback]
+        )
+        let archive = makeArchive(appName: "ScanStudio.app", in: sourceDirectory, version: "0.3.0-alpha.11")
+
+        XCTAssertEqual(try installer.resolveInstallDestination(), fallback)
+        try installer.install(archive)
+
+        XCTAssertEqual(try markerContents(at: fallback.appendingPathComponent("ScanStudio.app")), "new",
+                       "install must swap the new app into the fallback destination")
+        XCTAssertNotNil(installer.availableRollback, "install must first snapshot so rollback is available")
+        XCTAssertEqual(installer.availableRollback?.version.raw, "0.3.0-alpha.10")
+
+        let restored = try installer.restorePrevious()
+        XCTAssertEqual(restored.lastPathComponent, "ScanStudio.app")
+        XCTAssertEqual(try markerContents(at: fallback.appendingPathComponent("ScanStudio.app")), "old",
+                       "rollback must restore the previous app in the fallback destination")
+    }
+
     // MARK: - Fixture helpers
 
     private func makeInstaller() throws -> UpdateInstaller {
         try UpdateInstaller(appDirectory: applicationsDirectory, rollbackDirectory: rollbackDirectory)
+    }
+
+    /// Makes `directory` un-writable (chmod 0555) so destination-resolution
+    /// tests can prove fallback behavior. Returns whether it actually became
+    /// non-writable; if the filesystem refuses `chmod` (e.g. a container that
+    /// ignores modes), callers skip their assertion rather than fail the suite.
+    private func makeNonWritable(_ directory: URL) -> Bool {
+        do {
+            try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: directory.path)
+            return !FileManager.default.isWritableFile(atPath: directory.path)
+        } catch {
+            return false
+        }
     }
 
     private func makeArchive(appName: String, in directory: URL, version: String) -> UpdateArchive {

--- a/app/ScanStudio/Tests/ScanStudioKitTests/UpdateInstallerTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/UpdateInstallerTests.swift
@@ -1,0 +1,158 @@
+// UpdateInstaller snapshot/swap/rollback tests (AUT-04-SNAP, AUT-04-SWAP,
+// AUT-04-ROLLBACK, AUT-04-NOMOTION). Pure filesystem: a throwaway fake
+// `.app` tree in a temp dir, zero hardware, zero network, zero subprocess.
+
+import XCTest
+
+@testable import ScanStudioKit
+
+final class UpdateInstallerTests: XCTestCase {
+    private var root: URL!
+    private var applicationsDirectory: URL!
+    private var rollbackDirectory: URL!
+    private var sourceDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UpdateInstallerTests-\(UUID().uuidString)", isDirectory: true)
+        applicationsDirectory = root.appendingPathComponent("Applications", isDirectory: true)
+        rollbackDirectory = root.appendingPathComponent("Rollback", isDirectory: true)
+        sourceDirectory = root.appendingPathComponent("Source", isDirectory: true)
+        try FileManager.default.createDirectory(at: applicationsDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: rollbackDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+
+        try makeFakeApp("ScanStudio.app", at: applicationsDirectory, release: "0.3.0-alpha.10", marker: "old")
+        try makeFakeApp("ScanStudio.app", at: sourceDirectory, release: "0.3.0-alpha.11", marker: "new")
+    }
+
+    override func tearDownWithError() throws {
+        if let root {
+            try? FileManager.default.removeItem(at: root)
+        }
+        try super.tearDownWithError()
+    }
+
+    func testInstallSwapsApp() throws {
+        let installer = try makeInstaller()
+        let archive = makeArchive(appName: "ScanStudio.app", in: sourceDirectory, version: "0.3.0-alpha.11")
+
+        try installer.install(archive)
+
+        let marker = try markerContents(at: applicationsDirectory.appendingPathComponent("ScanStudio.app"))
+        XCTAssertEqual(marker, "new", "Install must swap the marker contents, not just create files")
+        XCTAssertNotNil(installer.availableRollback, "Install must first snapshot so rollback is available")
+        XCTAssertEqual(installer.availableRollback?.version.raw, "0.3.0-alpha.10")
+    }
+
+    func testSnapshotCreatesRollbackEntry() throws {
+        let installer = try makeInstaller()
+
+        try installer.snapshotCurrent()
+
+        let snapshotURL = rollbackDirectory.appendingPathComponent("ScanStudio-0.3.0-alpha.10.app", isDirectory: true)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: snapshotURL.path), "Snapshot must be written to the rollback directory")
+        XCTAssertEqual(try markerContents(at: snapshotURL), "old", "Snapshot must be a faithful copy of the current app")
+    }
+
+    func testRestorePreviousReturnsOldApp() throws {
+        let installer = try makeInstaller()
+        try installer.install(makeArchive(appName: "ScanStudio.app", in: sourceDirectory, version: "0.3.0-alpha.11"))
+        XCTAssertEqual(try markerContents(at: applicationsDirectory.appendingPathComponent("ScanStudio.app")), "new")
+
+        let restored = try installer.restorePrevious()
+
+        XCTAssertEqual(restored.lastPathComponent, "ScanStudio.app")
+        XCTAssertEqual(try markerContents(at: applicationsDirectory.appendingPathComponent("ScanStudio.app")), "old", "Restore must put the snapshot marker back")
+    }
+
+    func testInstallMissingSourceThrows() throws {
+        let installer = try makeInstaller()
+        let missing = sourceDirectory.appendingPathComponent("DoesNotExist.app", isDirectory: true)
+        let archive = UpdateArchive(
+            version: UpdateVersion(raw: "0.3.0-alpha.11")!,
+            sourceAppPath: missing,
+            checksumSHA256: "abc"
+        )
+
+        XCTAssertThrowsError(try installer.install(archive)) { error in
+            XCTAssertEqual(error as? UpdateInstallError, .sourceMissing)
+        }
+    }
+
+    func testInstallEmptyChecksumThrows() throws {
+        let installer = try makeInstaller()
+        let archive = UpdateArchive(
+            version: UpdateVersion(raw: "0.3.0-alpha.11")!,
+            sourceAppPath: sourceDirectory.appendingPathComponent("ScanStudio.app", isDirectory: true),
+            checksumSHA256: ""
+        )
+
+        XCTAssertThrowsError(try installer.install(archive)) { error in
+            XCTAssertEqual(error as? UpdateInstallError, .notVerified)
+        }
+    }
+
+    func testSnapshotMissingAppNoop() throws {
+        let emptyDirectory = root.appendingPathComponent("Empty", isDirectory: true)
+        try FileManager.default.createDirectory(at: emptyDirectory, withIntermediateDirectories: true)
+        let installer = try UpdateInstaller(appDirectory: emptyDirectory, rollbackDirectory: rollbackDirectory)
+
+        XCTAssertNoThrow(try installer.snapshotCurrent(), "Snapshotting a directory with no app must not throw")
+        XCTAssertNil(installer.availableRollback)
+    }
+
+    func testRollbackNothingAvailableThrows() throws {
+        let installer = try makeInstaller()
+
+        XCTAssertThrowsError(try installer.restorePrevious()) { error in
+            XCTAssertEqual(error as? UpdateInstallError, .rolledBack)
+        }
+    }
+
+    // MARK: - Fixture helpers
+
+    private func makeInstaller() throws -> UpdateInstaller {
+        try UpdateInstaller(appDirectory: applicationsDirectory, rollbackDirectory: rollbackDirectory)
+    }
+
+    private func makeArchive(appName: String, in directory: URL, version: String) -> UpdateArchive {
+        UpdateArchive(
+            version: UpdateVersion(raw: version)!,
+            sourceAppPath: directory.appendingPathComponent(appName, isDirectory: true),
+            checksumSHA256: "abc"
+        )
+    }
+
+    private func makeFakeApp(
+        _ name: String,
+        at parent: URL,
+        release: String,
+        marker: String
+    ) throws {
+        let appURL = parent.appendingPathComponent(name, isDirectory: true)
+        let contents = appURL.appendingPathComponent("Contents", isDirectory: true)
+        let macos = contents.appendingPathComponent("MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macos, withIntermediateDirectories: true)
+
+        let infoPlist: [String: Any] = [
+            "CFBundleShortVersionString": release,
+            "ScanStudioRelease": release
+        ]
+        let plistData = try PropertyListSerialization.data(fromPropertyList: infoPlist, format: .xml, options: 0)
+        try plistData.write(to: contents.appendingPathComponent("Info.plist"))
+
+        try marker.data(using: .utf8)!
+            .write(to: macos.appendingPathComponent("ScanStudio"))
+    }
+
+    private func markerContents(at appURL: URL) throws -> String {
+        let markerURL = sourceMarkerURL(at: appURL)
+        return try String(contentsOf: markerURL, encoding: .utf8)
+    }
+
+    private func sourceMarkerURL(at appURL: URL) -> URL {
+        appURL.appendingPathComponent("Contents/MacOS/ScanStudio")
+    }
+}

--- a/app/ScanStudio/Tests/ScanStudioKitTests/UpdateServiceTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/UpdateServiceTests.swift
@@ -276,6 +276,46 @@ final class UpdateServiceTests: XCTestCase {
                        "https://github.com/rohanpandula/ScanStudio/releases/tag/v0.3.0-alpha.12")
     }
 
+    func testPrereleaseBootstrapsWhenStablePointerIsMissing() async throws {
+        let stub = StubURLSession()
+        stub.failingURLs.insert(pointerURL())
+        stub.dataByURL[GitHubUpdateChecker.apiReleasesURL] = Data("""
+        [
+            {
+                "tag_name": "v0.3.0-beta.1",
+                "prerelease": true,
+                "html_url": "https://github.com/rohanpandula/ScanStudio/releases/tag/v0.3.0-beta.1"
+            }
+        ]
+        """.utf8)
+        let betaChecksum = String(repeating: "e", count: 64)
+        let betaURL = "https://github.com/rohanpandula/ScanStudio/releases/download/v0.3.0-beta.1/ScanStudio-0.3.0-beta.1-macOS-arm64.dmg"
+        stub.dataByURL[perReleaseURL(tag: "v0.3.0-beta.1")] = Data("""
+        {
+            "version": "0.3.0-beta.1",
+            "architectures": {
+                "arm64": { "url": "\(betaURL)", "sha256": "\(betaChecksum)" }
+            }
+        }
+        """.utf8)
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+        let candidate = try await checker.latestCandidate(channel: .alpha, arch: .arm64)
+
+        let resolved = try XCTUnwrap(candidate)
+        XCTAssertEqual(resolved.version.raw, "0.3.0-beta.1")
+        XCTAssertEqual(resolved.downloadURL.absoluteString, betaURL)
+        XCTAssertEqual(resolved.sha256, betaChecksum)
+        XCTAssertEqual(resolved.releaseNotesURL?.absoluteString,
+                       "https://github.com/rohanpandula/ScanStudio/releases/tag/v0.3.0-beta.1")
+        XCTAssertTrue(stub.requestedURLs.contains(pointerURL()),
+                      "the checker should first try the stable pointer")
+        XCTAssertTrue(stub.requestedURLs.contains(GitHubUpdateChecker.apiReleasesURL),
+                      "a missing stable pointer must still probe prereleases")
+        XCTAssertTrue(stub.requestedURLs.contains(perReleaseURL(tag: "v0.3.0-beta.1")),
+                      "the candidate must come from the beta release's own pointer")
+    }
+
     // MARK: - 4. Alpha degrades to the pointer on API trouble
 
     func testAlphaFallsBackOnAPIError() async throws {

--- a/app/ScanStudio/Tests/ScanStudioKitTests/UpdateServiceTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/UpdateServiceTests.swift
@@ -45,6 +45,42 @@ final class UpdateServiceTests: XCTestCase {
         """
     }
 
+    // MARK: - Phase-02 arch-aware pointer fixtures
+
+    /// The arch-keyed pointer (02-01 emitter output) for a hypothetical
+    /// `v0.3.1-alpha.13`: one distinct url+sha256 per architecture.
+    private static let archPointerVersion = "0.3.1-alpha.13"
+    private static let arm64Checksum = String(repeating: "c", count: 64)
+    private static let x8664Checksum = String(repeating: "d", count: 64)
+
+    private static let archKeyedArm64URL =
+        "https://github.com/rohanpandula/ScanStudio/releases/download/v0.3.1-alpha.13/ScanStudio-0.3.1-alpha.13-macOS-arm64.dmg"
+    private static let archKeyedX86_64URL =
+        "https://github.com/rohanpandula/ScanStudio/releases/download/v0.3.1-alpha.13/ScanStudio-0.3.1-alpha.13-macOS-x86_64.dmg"
+
+    private static var archKeyedPointerJSON: String {
+        """
+        {
+            "version": "\(archPointerVersion)",
+            "architectures": {
+                "arm64": { "url": "\(archKeyedArm64URL)", "sha256": "\(arm64Checksum)" },
+                "x86_64": { "url": "\(archKeyedX86_64URL)", "sha256": "\(x8664Checksum)" }
+            }
+        }
+        """
+    }
+
+    private static var archKeyedArm64OnlyJSON: String {
+        """
+        {
+            "version": "\(archPointerVersion)",
+            "architectures": {
+                "arm64": { "url": "\(archKeyedArm64URL)", "sha256": "\(arm64Checksum)" }
+            }
+        }
+        """
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         root = FileManager.default.temporaryDirectory
@@ -68,6 +104,120 @@ final class UpdateServiceTests: XCTestCase {
         XCTAssertEqual(pointer.version, "0.3.0-alpha.11")
         XCTAssertEqual(pointer.url.absoluteString, Self.pointerDownloadURL)
         XCTAssertEqual(pointer.sha256, String(repeating: "a", count: 64))
+    }
+
+    // MARK: - 1b. Phase-02 arch-keyed pointer decode + selection
+
+    func testArchKeyedPointerDecodesBothArchs() throws {
+        let pointer = try JSONDecoder().decode(UpdatePointerArch.self, from: Data(Self.archKeyedPointerJSON.utf8))
+
+        XCTAssertEqual(pointer.version, Self.archPointerVersion)
+        XCTAssertEqual(pointer.architectures.count, 2)
+        XCTAssertEqual(pointer.architectures[.arm64]?.url.absoluteString, Self.archKeyedArm64URL)
+        XCTAssertEqual(pointer.architectures[.x86_64]?.url.absoluteString, Self.archKeyedX86_64URL)
+        XCTAssertEqual(pointer.architectures[.arm64]?.sha256, Self.arm64Checksum)
+        XCTAssertEqual(pointer.architectures[.x86_64]?.sha256, Self.x8664Checksum)
+        XCTAssertNotEqual(pointer.architectures[.arm64]?.sha256, pointer.architectures[.x86_64]?.sha256,
+                          "the two arch entries must describe distinct artifacts")
+    }
+
+    func testPointerArchRoundTripEncodesArchKeyedForm() throws {
+        let original = UpdatePointerArch(
+            version: Self.archPointerVersion,
+            architectures: [
+                .arm64: UpdateArchEntry(url: URL(string: Self.archKeyedArm64URL)!, sha256: Self.arm64Checksum),
+                .x86_64: UpdateArchEntry(url: URL(string: Self.archKeyedX86_64URL)!, sha256: Self.x8664Checksum),
+            ]
+        )
+
+        let data = try JSONEncoder().encode(original)
+        // Encode must emit the arch-keyed JSON *object* (per-arch keys), not
+        // a key/value array.
+        let jsonObject = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let archs = try XCTUnwrap(jsonObject["architectures"] as? [String: Any])
+        XCTAssertEqual(archs.count, 2)
+        XCTAssertNotNil(archs["arm64"])
+        XCTAssertNotNil(archs["x86_64"])
+
+        let decoded = try JSONDecoder().decode(UpdatePointerArch.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testUnknownArchKeyInPointerThrowsOnDecode() throws {
+        // Trust gate: an unrecognized arch key is a malformed/untrusted
+        // pointer and must throw, never be silently dropped.
+        let json = """
+        {
+            "version": "\(Self.archPointerVersion)",
+            "architectures": {
+                "arm64": { "url": "\(Self.archKeyedArm64URL)", "sha256": "\(Self.arm64Checksum)" },
+                "powerpc": { "url": "https://example.com/ScanStudio-ppc.dmg", "sha256": "\(Self.x8664Checksum)" }
+            }
+        }
+        """
+        XCTAssertThrowsError(try JSONDecoder().decode(UpdatePointerArch.self, from: Data(json.utf8)))
+    }
+
+    func testLegacyFlatPointerStillDecodes() async throws {
+        // Regression guard: the old flat {version,url,sha256} pointer must
+        // still yield a single candidate with the promised bytes+checksum.
+        let stub = StubURLSession()
+        stub.dataByURL[pointerURL()] = Data(Self.pointerJSON.utf8)
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+        let candidate = try await checker.latestCandidate(channel: .stable)
+
+        let resolved = try XCTUnwrap(candidate, "a legacy flat pointer must still produce a candidate")
+        XCTAssertEqual(resolved.version.raw, "0.3.0-alpha.11")
+        XCTAssertEqual(resolved.downloadURL.absoluteString, Self.pointerDownloadURL)
+        XCTAssertEqual(resolved.sha256, String(repeating: "a", count: 64))
+    }
+
+    func testSelectsHostArchEntry() async throws {
+        let stub = StubURLSession()
+        stub.dataByURL[pointerURL()] = Data(Self.archKeyedPointerJSON.utf8)
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+
+        let arm = try await checker.latestCandidate(channel: .stable, arch: .arm64)
+        let armCandidate = try XCTUnwrap(arm)
+        XCTAssertEqual(armCandidate.version.raw, Self.archPointerVersion)
+        XCTAssertEqual(armCandidate.downloadURL.absoluteString, Self.archKeyedArm64URL)
+        XCTAssertEqual(armCandidate.sha256, Self.arm64Checksum)
+
+        let intel = try await checker.latestCandidate(channel: .stable, arch: .x86_64)
+        let intelCandidate = try XCTUnwrap(intel)
+        XCTAssertEqual(intelCandidate.version.raw, Self.archPointerVersion)
+        XCTAssertEqual(intelCandidate.downloadURL.absoluteString, Self.archKeyedX86_64URL)
+        XCTAssertEqual(intelCandidate.sha256, Self.x8664Checksum)
+    }
+
+    func testSelectsDefaultCurrentArchForExistingCallSites() async throws {
+        // The single-arch entry point must keep working (the 01-05 model calls
+        // it with no arch), delegating to the current host architecture.
+        let stub = StubURLSession()
+        stub.dataByURL[pointerURL()] = Data(Self.archKeyedPointerJSON.utf8)
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+
+        let fetched = try await checker.latestCandidate(channel: .stable)
+        let candidate = try XCTUnwrap(fetched)
+        let expected = HostArchitectureProvider.current() == .arm64
+            ? Self.archKeyedArm64URL
+            : Self.archKeyedX86_64URL
+        XCTAssertEqual(candidate.downloadURL.absoluteString, expected,
+                       "the default arch must match the current host architecture")
+    }
+
+    func testMissingArchThrowsUnsupported() async throws {
+        let stub = StubURLSession()
+        stub.dataByURL[pointerURL()] = Data(Self.archKeyedArm64OnlyJSON.utf8)
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+
+        do {
+            _ = try await checker.latestCandidate(channel: .stable, arch: .x86_64)
+            XCTFail("expected unsupportedArchitecture for a missing x86_64 entry")
+        } catch let error as UpdateArchError {
+            XCTAssertEqual(error, .unsupportedArchitecture(.x86_64))
+        }
     }
 
     // MARK: - 2. Stable trusts the pointer only

--- a/app/ScanStudio/Tests/ScanStudioKitTests/UpdateServiceTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/UpdateServiceTests.swift
@@ -25,6 +25,26 @@ final class UpdateServiceTests: XCTestCase {
     private static let pointerDownloadURL =
         "https://github.com/rohanpandula/ScanStudio/releases/download/v0.3.0-alpha.11/ScanStudio-0.3.0-alpha.11-macOS-arm64.dmg"
 
+    /// The configured pointer's checksum ('a'…). Deliberately distinct from the
+    /// per-release checksum below so tests can prove the alpha path never
+    /// borrows the stable pointer's sha256 for a different artifact.
+    private static let stableChecksum = String(repeating: "a", count: 64)
+
+    /// The newest pre-release's OWN per-release pointer checksum ('b'…).
+    private static let perReleaseChecksum = String(repeating: "b", count: 64)
+
+    /// The per-release `latest.json` the 01-01 pipeline emits for the
+    /// `v0.3.0-alpha.12` release: authoritative url + sha256 for THAT release.
+    private static var alpha12ReleasePointerJSON: String {
+        """
+        {
+            "version": "0.3.0-alpha.12",
+            "url": "https://github.com/rohanpandula/ScanStudio/releases/download/v0.3.0-alpha.12/ScanStudio-0.3.0-alpha.12-macOS-arm64.dmg",
+            "sha256": "\(perReleaseChecksum)"
+        }
+        """
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         root = FileManager.default.temporaryDirectory
@@ -89,6 +109,10 @@ final class UpdateServiceTests: XCTestCase {
             }
         ]
         """.utf8)
+        // Production behavior: the newer prerelease's candidate requires its
+        // own per-release pointer (authoritative bytes+checksum). Stub it so
+        // the API-probed alpha.12 is preferred, as the release pipeline emits.
+        stub.dataByURL[perReleaseURL(tag: "v0.3.0-alpha.12")] = Data(Self.alpha12ReleasePointerJSON.utf8)
 
         let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
         let candidate = try await checker.latestCandidate(channel: .alpha)
@@ -96,6 +120,8 @@ final class UpdateServiceTests: XCTestCase {
         XCTAssertEqual(candidate?.version.raw, "0.3.0-alpha.12",
                        "alpha must prefer the newer prerelease from the API")
         XCTAssertEqual(candidate?.version, UpdateVersion(raw: "0.3.0-alpha.12"))
+        XCTAssertEqual(candidate?.sha256, Self.perReleaseChecksum,
+                       "the newer prerelease's checksum must come from its own per-release pointer")
         XCTAssertEqual(candidate?.releaseNotesURL?.absoluteString,
                        "https://github.com/rohanpandula/ScanStudio/releases/tag/v0.3.0-alpha.12")
     }
@@ -113,6 +139,92 @@ final class UpdateServiceTests: XCTestCase {
         XCTAssertNotNil(candidate, "an API failure must not crash or throw")
         XCTAssertEqual(candidate?.version.raw, "0.3.0-alpha.11",
                        "alpha must fall back to the pointer candidate on API error")
+    }
+
+    // MARK: - 4b. Authoritative alpha checksum (01-08 gap closure)
+
+    func testAlphaUsesPerReleaseChecksum() async throws {
+        let stub = StubURLSession()
+        stub.dataByURL[pointerURL()] = Data(Self.pointerJSON.utf8)
+        stub.dataByURL[GitHubUpdateChecker.apiReleasesURL] = Data("""
+        [
+            {
+                "tag_name": "v0.3.0-alpha.12",
+                "prerelease": true,
+                "html_url": "https://github.com/rohanpandula/ScanStudio/releases/tag/v0.3.0-alpha.12"
+            }
+        ]
+        """.utf8)
+        // The newest pre-release's own per-release pointer — checksum 'b'…,
+        // distinct from the configured pointer's 'a'….
+        stub.dataByURL[perReleaseURL(tag: "v0.3.0-alpha.12")] = Data(Self.alpha12ReleasePointerJSON.utf8)
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+        let candidate = try await checker.latestCandidate(channel: .alpha)
+
+        let resolved = try XCTUnwrap(candidate)
+        XCTAssertEqual(resolved.version.raw, "0.3.0-alpha.12")
+        XCTAssertEqual(resolved.sha256, Self.perReleaseChecksum,
+                       "the candidate's sha256 must come from the release's own pointer, not the stable pointer")
+        XCTAssertEqual(
+            resolved.downloadURL.absoluteString,
+            "https://github.com/rohanpandula/ScanStudio/releases/download/v0.3.0-alpha.12/ScanStudio-0.3.0-alpha.12-macOS-arm64.dmg"
+        )
+        XCTAssertNotEqual(resolved.sha256, Self.stableChecksum,
+                         "the per-release checksum must differ from the configured pointer's")
+    }
+
+    func testAlphaFallsBackToPointerWhenPerReleasePointerUnavailable() async throws {
+        let stub = StubURLSession()
+        stub.dataByURL[pointerURL()] = Data(Self.pointerJSON.utf8)
+        stub.dataByURL[GitHubUpdateChecker.apiReleasesURL] = Data("""
+        [
+            { "tag_name": "v0.3.0-alpha.12", "prerelease": true, "html_url": "https://github.com/x" }
+        ]
+        """.utf8)
+        // NOTE: the per-release URL is NOT stubbed → data(from:) throws.
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+        let candidate = try await checker.latestCandidate(channel: .alpha)
+
+        let resolved = try XCTUnwrap(candidate, "a missing per-release pointer must not throw")
+        XCTAssertEqual(resolved.version.raw, "0.3.0-alpha.11",
+                       "fallback must resolve to the configured pointer candidate")
+        XCTAssertEqual(resolved.sha256, Self.stableChecksum)
+        XCTAssertEqual(resolved.downloadURL.absoluteString, Self.pointerDownloadURL)
+    }
+
+    func testAlphaIgnoresPerReleasePointerOnVersionMismatch() async throws {
+        let stub = StubURLSession()
+        stub.dataByURL[pointerURL()] = Data(Self.pointerJSON.utf8)
+        stub.dataByURL[GitHubUpdateChecker.apiReleasesURL] = Data("""
+        [
+            { "tag_name": "v0.3.0-alpha.12", "prerelease": true, "html_url": "https://github.com/x" }
+        ]
+        """.utf8)
+        // Per-release pointer decodes but its version (alpha.11) ≠ the tag
+        // (alpha.12) — equality-of-intent fails → fall back to the pointer.
+        stub.dataByURL[perReleaseURL(tag: "v0.3.0-alpha.12")] = Data(Self.pointerJSON.utf8)
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+        let candidate = try await checker.latestCandidate(channel: .alpha)
+
+        let resolved = try XCTUnwrap(candidate)
+        XCTAssertEqual(resolved.version.raw, "0.3.0-alpha.11",
+                       "a version mismatch between tag and per-release pointer must fall back to the configured pointer")
+        XCTAssertEqual(resolved.sha256, Self.stableChecksum)
+        XCTAssertEqual(resolved.downloadURL.absoluteString, Self.pointerDownloadURL)
+    }
+
+    func testAlphaStableChecksumDifferenceProvesBorrowEnded() {
+        // Guards the regression: the per-release checksum constant and the
+        // stable pointer's checksum genuinely differ, so the alpha test can
+        // actually detect a re-borrow of the stable checksum.
+        XCTAssertEqual(Self.stableChecksum, String(repeating: "a", count: 64))
+        XCTAssertEqual(Self.perReleaseChecksum, String(repeating: "b", count: 64))
+        XCTAssertNotEqual(Self.perReleaseChecksum, Self.stableChecksum)
+        XCTAssertEqual(Self.perReleaseChecksum.count, 64)
+        XCTAssertEqual(Self.stableChecksum.count, 64)
     }
 
     // MARK: - 5. Unparseable pointer version means no update
@@ -242,6 +354,12 @@ final class UpdateServiceTests: XCTestCase {
 
     private func pointerURL() -> URL {
         URL(string: "https://example.com/latest.json")!
+    }
+
+    /// The deterministic per-release pointer URL for a tag (mirrors the
+    /// checker's exposed `releasePointerURL(tag:)`).
+    private func perReleaseURL(tag: String) -> URL {
+        GitHubUpdateChecker.releasePointerURL(tag: tag)
     }
 
     private func requireHDIUtil() throws {

--- a/app/ScanStudio/Tests/ScanStudioKitTests/UpdateServiceTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/UpdateServiceTests.swift
@@ -1,0 +1,310 @@
+// Offline tests for the update service (01-04): pointer parsing, channel
+// logic (stable trusts the pointer only; alpha probes the GitHub API and
+// degrades to the pointer on any trouble), SHA-256 verification, mount +
+// locate app, and code-signature verification. Every case runs against
+// injected canned payloads — zero network, zero real GitHub. The two
+// hdiutil-dependent mount cases build a real minimal DMG via `hdiutil
+// create` and skip gracefully when hdiutil is unavailable.
+
+import CryptoKit
+import XCTest
+
+@testable import ScanStudioKit
+
+final class UpdateServiceTests: XCTestCase {
+    private var root: URL!
+
+    private static let pointerJSON = """
+    {
+        "version": "0.3.0-alpha.11",
+        "url": "https://github.com/rohanpandula/ScanStudio/releases/download/v0.3.0-alpha.11/ScanStudio-0.3.0-alpha.11-macOS-arm64.dmg",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+    """
+
+    private static let pointerDownloadURL =
+        "https://github.com/rohanpandula/ScanStudio/releases/download/v0.3.0-alpha.11/ScanStudio-0.3.0-alpha.11-macOS-arm64.dmg"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UpdateServiceTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let root {
+            try? FileManager.default.removeItem(at: root)
+        }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - 1. Pointer
+
+    func testPointerDecodes() throws {
+        let data = Data(Self.pointerJSON.utf8)
+        let pointer = try JSONDecoder().decode(UpdatePointer.self, from: data)
+
+        XCTAssertEqual(pointer.version, "0.3.0-alpha.11")
+        XCTAssertEqual(pointer.url.absoluteString, Self.pointerDownloadURL)
+        XCTAssertEqual(pointer.sha256, String(repeating: "a", count: 64))
+    }
+
+    // MARK: - 2. Stable trusts the pointer only
+
+    func testStableUsesPointerOnly() async throws {
+        let stub = StubURLSession()
+        stub.dataByURL[pointerURL()] = Data(Self.pointerJSON.utf8)
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+        let candidate = try await checker.latestCandidate(channel: .stable)
+
+        XCTAssertNotNil(candidate)
+        XCTAssertEqual(candidate?.version.raw, "0.3.0-alpha.11")
+        XCTAssertEqual(candidate?.downloadURL.absoluteString, Self.pointerDownloadURL)
+        XCTAssertEqual(candidate?.sha256, String(repeating: "a", count: 64))
+        XCTAssertTrue(stub.requestedURLs.contains(pointerURL()))
+        XCTAssertFalse(
+            stub.requestedURLs.contains(GitHubUpdateChecker.apiReleasesURL),
+            "stable must not consult the GitHub API"
+        )
+    }
+
+    // MARK: - 3. Alpha prefers a newer prerelease from the API
+
+    func testAlphaPrefersNewerPrerelease() async throws {
+        let stub = StubURLSession()
+        stub.dataByURL[pointerURL()] = Data(Self.pointerJSON.utf8)
+        stub.dataByURL[GitHubUpdateChecker.apiReleasesURL] = Data("""
+        [
+            {
+                "tag_name": "v0.3.0-alpha.12",
+                "prerelease": true,
+                "html_url": "https://github.com/rohanpandula/ScanStudio/releases/tag/v0.3.0-alpha.12"
+            },
+            {
+                "tag_name": "v0.3.0",
+                "prerelease": false,
+                "html_url": "https://github.com/rohanpandula/ScanStudio/releases/tag/v0.3.0"
+            }
+        ]
+        """.utf8)
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+        let candidate = try await checker.latestCandidate(channel: .alpha)
+
+        XCTAssertEqual(candidate?.version.raw, "0.3.0-alpha.12",
+                       "alpha must prefer the newer prerelease from the API")
+        XCTAssertEqual(candidate?.version, UpdateVersion(raw: "0.3.0-alpha.12"))
+        XCTAssertEqual(candidate?.releaseNotesURL?.absoluteString,
+                       "https://github.com/rohanpandula/ScanStudio/releases/tag/v0.3.0-alpha.12")
+    }
+
+    // MARK: - 4. Alpha degrades to the pointer on API trouble
+
+    func testAlphaFallsBackOnAPIError() async throws {
+        let stub = StubURLSession()
+        stub.dataByURL[pointerURL()] = Data(Self.pointerJSON.utf8)
+        stub.failingURLs.insert(GitHubUpdateChecker.apiReleasesURL)
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+        let candidate = try await checker.latestCandidate(channel: .alpha)
+
+        XCTAssertNotNil(candidate, "an API failure must not crash or throw")
+        XCTAssertEqual(candidate?.version.raw, "0.3.0-alpha.11",
+                       "alpha must fall back to the pointer candidate on API error")
+    }
+
+    // MARK: - 5. Unparseable pointer version means no update
+
+    func testUnparseablePointerMeansNoUpdate() async throws {
+        let stub = StubURLSession()
+        stub.dataByURL[pointerURL()] = Data("""
+        {
+            "version": "garbage",
+            "url": "https://example.com/ScanStudio.dmg",
+            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+        """.utf8)
+
+        let checker = GitHubUpdateChecker(pointerURL: pointerURL(), session: stub)
+        let candidate = try await checker.latestCandidate(channel: .stable)
+
+        XCTAssertNil(candidate, "an unparseable pointer version must be treated as no update")
+    }
+
+    // MARK: - 6. Checksum gate
+
+    func testChecksumMismatchThrows() async throws {
+        let stub = StubURLSession()
+        let payload = Data("fake dmg payload \(UUID().uuidString)".utf8)
+        let dmgURL = URL(string: "https://example.com/ScanStudio-0.3.0-alpha.11-macOS-arm64.dmg")!
+        stub.dataByURL[dmgURL] = payload
+
+        let downloader = UpdateDownloader(session: stub)
+        let outDir = root.appendingPathComponent("downloads", isDirectory: true)
+        let candidate = UpdateCandidate(
+            version: UpdateVersion(raw: "0.3.0-alpha.11")!,
+            downloadURL: dmgURL,
+            sha256: String(repeating: "0", count: 64),
+            releaseNotesURL: nil
+        )
+
+        do {
+            _ = try await downloader.download(candidate, to: outDir)
+            XCTFail("expected checksumMismatch")
+        } catch let error as UpdateDownloadError {
+            XCTAssertEqual(error, .checksumMismatch)
+        }
+    }
+
+    // MARK: - 7. Valid checksum returns the DMG
+
+    func testValidChecksumReturnsDmg() async throws {
+        let stub = StubURLSession()
+        let payload = Data("real dmg payload \(UUID().uuidString)".utf8)
+        let dmgURL = URL(string: "https://example.com/ScanStudio-0.3.0-alpha.11-macOS-arm64.dmg")!
+        stub.dataByURL[dmgURL] = payload
+        let realSHA = SHA256.hash(data: payload).map { String(format: "%02x", $0) }.joined()
+
+        let downloader = UpdateDownloader(session: stub)
+        let outDir = root.appendingPathComponent("downloads", isDirectory: true)
+        let candidate = UpdateCandidate(
+            version: UpdateVersion(raw: "0.3.0-alpha.11")!,
+            downloadURL: dmgURL,
+            sha256: realSHA,
+            releaseNotesURL: nil
+        )
+
+        let url = try await downloader.download(candidate, to: outDir)
+
+        XCTAssertEqual(url.lastPathComponent, "ScanStudio-0.3.0-alpha.11.dmg")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        XCTAssertEqual(try Data(contentsOf: url), payload)
+    }
+
+    // MARK: - 8. Mount + locate app
+
+    func testMountLocateApp() async throws {
+        try requireHDIUtil()
+
+        let appRoot = root.appendingPathComponent("Sample.app", isDirectory: true)
+        let macos = appRoot.appendingPathComponent("Contents/MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macos, withIntermediateDirectories: true)
+        try Data("marker".utf8).write(to: macos.appendingPathComponent("Sample"))
+
+        let volname = "ScanStudioMount-\(UUID().uuidString.prefix(6))"
+        let dmgURL = root.appendingPathComponent("sample.dmg")
+        try Self.createMinimalDMG(from: appRoot, volname: volname, to: dmgURL)
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let downloader = UpdateDownloader()
+        let appURL = try downloader.mountAndLocateApp(dmgURL)
+        defer { downloader.tearDownMount(appURL.deletingLastPathComponent()) }
+
+        XCTAssertEqual(appURL.lastPathComponent.lowercased(), "sample.app")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appURL.path),
+                      "locate must return an existing bundle on the mounted volume")
+    }
+
+    func testMountLocateAppNoAppThrows() async throws {
+        try requireHDIUtil()
+
+        let emptyDir = root.appendingPathComponent("empty-volume", isDirectory: true)
+        try FileManager.default.createDirectory(at: emptyDir, withIntermediateDirectories: true)
+
+        let volname = "ScanStudioEmpty-\(UUID().uuidString.prefix(6))"
+        let dmgURL = root.appendingPathComponent("empty.dmg")
+        try Self.createMinimalDMG(from: emptyDir, volname: volname, to: dmgURL)
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let downloader = UpdateDownloader()
+        XCTAssertThrowsError(try downloader.mountAndLocateApp(dmgURL)) { error in
+            XCTAssertEqual(error as? UpdateDownloadError, .notAnApp)
+        }
+    }
+
+    // MARK: - 9. Signature gate
+
+    func testSignatureInvalidForPlainDir() throws {
+        let plain = root.appendingPathComponent("Plain.app", isDirectory: true)
+        let macos = plain.appendingPathComponent("Contents/MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macos, withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: macos.appendingPathComponent("ScanStudio"))
+
+        let downloader = UpdateDownloader()
+        XCTAssertThrowsError(try downloader.verifyCodeSignature(at: plain)) { error in
+            XCTAssertEqual(error as? UpdateDownloadError, .signatureInvalid)
+        }
+    }
+
+    // MARK: - Fixture helpers
+
+    private func pointerURL() -> URL {
+        URL(string: "https://example.com/latest.json")!
+    }
+
+    private func requireHDIUtil() throws {
+        guard FileManager.default.fileExists(atPath: "/usr/bin/hdiutil") else {
+            throw XCTSkip("hdiutil not available; skipping mount tests")
+        }
+    }
+
+    /// Builds a real minimal read-only DMG from `folder` via `hdiutil create`,
+    /// so `mountAndLocateApp` runs against an actual mounted volume.
+    private static func createMinimalDMG(from folder: URL, volname: String, to output: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
+        process.arguments = [
+            "create", "-srcfolder", folder.path, "-volname", volname,
+            "-format", "UDRO", "-ov", output.path,
+        ]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        _ = try? pipe.fileHandleForReading.readToEnd()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw NSError(
+                domain: "UpdateServiceTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "hdiutil create failed (status \(process.terminationStatus))"]
+            )
+        }
+    }
+}
+
+/// Canned in-memory URLSession stand-in: `data(from:)`/`download(from:)`
+/// answer from a URL-keyed map, so no test touches the network.
+private final class StubURLSession: URLSessionProtocol, @unchecked Sendable {
+    var dataByURL: [URL: Data] = [:]
+    var failingURLs: Set<URL> = []
+    private(set) var requestedURLs: [URL] = []
+
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        requestedURLs.append(url)
+        if failingURLs.contains(url) {
+            throw URLError(.cannotConnectToHost)
+        }
+        guard let data = dataByURL[url] else {
+            throw URLError(.fileDoesNotExist)
+        }
+        return (data, response(for: url))
+    }
+
+    func download(from url: URL, delegate: (any URLSessionTaskDelegate)?) async throws -> (URL, URLResponse) {
+        requestedURLs.append(url)
+        guard let data = dataByURL[url] else {
+            throw URLError(.fileDoesNotExist)
+        }
+        let temporary = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StubDownload-\(UUID().uuidString)")
+        try data.write(to: temporary)
+        return (temporary, response(for: url))
+    }
+
+    private func response(for url: URL) -> URLResponse {
+        HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+    }
+}

--- a/app/ScanStudio/Tests/ScanStudioKitTests/UpdateVersionTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/UpdateVersionTests.swift
@@ -1,0 +1,59 @@
+// Ordering + parsing tests for UpdateVersion (AUT-02-CMP, AUT-02-TEST).
+// Keep pure: no network, no filesystem.
+
+import XCTest
+
+@testable import ScanStudioKit
+
+final class UpdateVersionTests: XCTestCase {
+    private func parse(_ raw: String) -> UpdateVersion {
+        guard let version = UpdateVersion(raw: raw) else {
+            XCTFail("Expected to parse \(raw)")
+            return UpdateVersion(raw: "0.0")!
+        }
+        return version
+    }
+
+    func testOrderingTable() {
+        XCTAssertLessThan(parse("0.3.0-alpha.9"), parse("0.3.0-alpha.11"))
+        XCTAssertLessThan(parse("0.3.0-alpha.11"), parse("0.3.0"))
+        XCTAssertLessThan(parse("0.3.0-alpha.1"), parse("0.3.0-beta.1"))
+        XCTAssertLessThan(parse("0.3.0-beta.1"), parse("0.3.0-rc.1"))
+        XCTAssertLessThan(parse("0.3.0-rc.1"), parse("0.3.0"))
+        XCTAssertEqual(parse("0.3.0"), parse("0.3.0"))
+
+        let padded = UpdateVersion(raw: "0.3.0.0")
+        XCTAssertNil(padded, "Core is 2 or 3 dot-separated integers; 4 components are rejected")
+        XCTAssertEqual(parse("0.3"), parse("0.3.0"), "Patch-less core defaults patch to 0")
+
+        XCTAssertGreaterThan(parse("1.0.0"), parse("0.9.9"))
+    }
+
+    func testCrossMajorOrdering() {
+        XCTAssertGreaterThan(parse("2.0.0-alpha.1"), parse("1.9.9"))
+    }
+
+    func testParseFailures() {
+        for raw in ["", "abc", "1.2.x", "1.2.3-alpha.", "1..2", "1.2.3--bad"] {
+            XCTAssertNil(UpdateVersion(raw: raw), "Expected \(String(reflecting: raw)) to be rejected")
+        }
+    }
+
+    func testIsPrerelease() {
+        XCTAssertTrue(parse("0.3.0-alpha.11").isPrerelease)
+        XCTAssertTrue(parse("0.3.0-rc.1").isPrerelease)
+        XCTAssertFalse(parse("0.3.0").isPrerelease)
+    }
+
+    func testCodableRoundTrip() {
+        let original = parse("0.3.0-alpha.11")
+        let data = try! JSONEncoder().encode(original)
+        let decoded = try! JSONDecoder().decode(UpdateVersion.self, from: data)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.raw, original.raw)
+    }
+
+    func testVPrefixStability() {
+        XCTAssertEqual(parse("v0.3.0"), parse("0.3.0"))
+    }
+}

--- a/app/ScanStudio/packaging/Info.plist
+++ b/app/ScanStudio/packaging/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundleShortVersionString</key>
     <string>0.3.0</string>
     <key>CFBundleVersion</key>
-    <string>13</string>
+    <string>14</string>
     <key>ScanStudioRelease</key>
     <string></string>
     <key>LSMinimumSystemVersion</key>

--- a/app/ScanStudio/packaging/Info.plist
+++ b/app/ScanStudio/packaging/Info.plist
@@ -18,6 +18,8 @@
     <string>0.3.0</string>
     <key>CFBundleVersion</key>
     <string>13</string>
+    <key>ScanStudioRelease</key>
+    <string></string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>

--- a/app/ScanStudio/scripts/emit_release_assets.sh
+++ b/app/ScanStudio/scripts/emit_release_assets.sh
@@ -1,0 +1,76 @@
+#!/bin/zsh
+# Emit the release metadata assets for a ScanStudio DMG.
+#
+# Interface:
+#   emit_release_assets.sh [-f] <dmg> <version> <outdir>
+#
+#   dmg      Absolute path to the built ScanStudio-<version>-macOS-<arch>.dmg
+#   version  Full release version string, e.g. 0.3.0-alpha.11
+#   outdir   Directory to write assets into (created if missing)
+#
+# Writes:
+#   SHA256SUMS   one line: "<sha256>  <dmg basename>" (basename only, so the
+#                file is portable across machines -- no runner path leaks)
+#   latest.json  {"version", "url", "sha256"} -- the in-app updater pointer
+#
+# Exit codes follow package_dmg.sh: 64 bad arguments, 66 missing file,
+# 73 refuse-to-overwrite. Never touches the DMG itself.
+set -euo pipefail
+
+usage() {
+    print -u2 "Usage: emit_release_assets.sh [-f] <dmg> <version> <outdir>"
+}
+
+overwrite=0
+while (( $# > 0 )) && [[ "$1" == "-f" ]]; do
+    overwrite=1
+    shift
+done
+
+if (( $# != 3 )); then
+    usage
+    exit 64
+fi
+
+dmg="$1"
+version="$2"
+outdir="$3"
+
+if [[ ! -f "$dmg" ]]; then
+    print -u2 "ScanStudio release asset prerequisite missing: $dmg"
+    exit 66
+fi
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+    print -u2 "Bad release version: $version"
+    exit 64
+fi
+
+mkdir -p "$outdir"
+outdir="${outdir:A}"
+
+latest_json="$outdir/latest.json"
+if [[ -e "$latest_json" && "$overwrite" == 0 ]]; then
+    print -u2 "Refusing to overwrite an existing release asset: $latest_json"
+    exit 73
+fi
+
+sha256="$(shasum -a 256 "$dmg" | awk '{print $1}')"
+if [[ -z "$sha256" ]]; then
+    print -u2 "Failed to compute SHA-256 for $dmg"
+    exit 1
+fi
+
+dmg_basename="${dmg:t}"
+tag="v$version"
+url="https://github.com/rohanpandula/ScanStudio/releases/download/$tag/$dmg_basename"
+
+printf '%s  %s\n' "$sha256" "$dmg_basename" > "$outdir/SHA256SUMS"
+python3 -c '
+import json, sys
+version, url, sha256, out = sys.argv[1:5]
+with open(out, "w") as f:
+    json.dump({"version": version, "url": url, "sha256": sha256}, f, indent=2)
+' "$version" "$url" "$sha256" "$latest_json"
+
+print "SHA-256 $sha256"

--- a/app/ScanStudio/scripts/emit_release_assets.sh
+++ b/app/ScanStudio/scripts/emit_release_assets.sh
@@ -2,23 +2,30 @@
 # Emit the release metadata assets for a ScanStudio DMG.
 #
 # Interface:
-#   emit_release_assets.sh [-f] <dmg> <version> <outdir>
+#   emit_release_assets.sh [-f] <dmg> <version> <outdir> [arch]
 #
 #   dmg      Absolute path to the built ScanStudio-<version>-macOS-<arch>.dmg
 #   version  Full release version string, e.g. 0.3.0-alpha.11
 #   outdir   Directory to write assets into (created if missing)
+#   arch     Machine architecture, exactly arm64 or x86_64. Defaults to
+#            `uname -m` for backward compatibility with the single-arch calls.
 #
 # Writes:
 #   SHA256SUMS   one line: "<sha256>  <dmg basename>" (basename only, so the
 #                file is portable across machines -- no runner path leaks)
-#   latest.json  {"version", "url", "sha256"} -- the in-app updater pointer
+#   latest.json  arch-keyed pointer (per-arch DMG contract, 02-CONTEXT.md):
+#                {"version", "architectures": {"<arch>": {"url","sha256"}}}
+#                Re-invoking with the SAME version and the OTHER architecture
+#                MERGES the entry in rather than clobbering the existing one
+#                (each release-matrix cell emits one arch; the publish step
+#                finalizes the combined pointer this way).
 #
 # Exit codes follow package_dmg.sh: 64 bad arguments, 66 missing file,
 # 73 refuse-to-overwrite. Never touches the DMG itself.
 set -euo pipefail
 
 usage() {
-    print -u2 "Usage: emit_release_assets.sh [-f] <dmg> <version> <outdir>"
+    print -u2 "Usage: emit_release_assets.sh [-f] <dmg> <version> <outdir> [arch]"
 }
 
 overwrite=0
@@ -27,7 +34,7 @@ while (( $# > 0 )) && [[ "$1" == "-f" ]]; do
     shift
 done
 
-if (( $# != 3 )); then
+if (( $# != 3 && $# != 4 )); then
     usage
     exit 64
 fi
@@ -35,6 +42,12 @@ fi
 dmg="$1"
 version="$2"
 outdir="$3"
+arch="${4:-$(uname -m)}"
+
+if [[ "$arch" != "arm64" && "$arch" != "x86_64" ]]; then
+    print -u2 "Bad architecture: $arch (expected arm64 or x86_64)"
+    exit 64
+fi
 
 if [[ ! -f "$dmg" ]]; then
     print -u2 "ScanStudio release asset prerequisite missing: $dmg"
@@ -51,8 +64,27 @@ outdir="${outdir:A}"
 
 latest_json="$outdir/latest.json"
 if [[ -e "$latest_json" && "$overwrite" == 0 ]]; then
-    print -u2 "Refusing to overwrite an existing release asset: $latest_json"
-    exit 73
+    # Refuse to clobber an existing release asset. The one legal exception is
+    # merging a DISTINCT arch entry into the same-version arch-keyed pointer
+    # (matrix cells each emit one arch; the publish step's second emit merges).
+    if ! python3 - "$latest_json" "$version" "$arch" <<'PY'
+import json, sys
+path, version, arch = sys.argv[1:4]
+try:
+    with open(path) as f:
+        data = json.load(f)
+except (json.JSONDecodeError, OSError):
+    sys.exit(1)
+if data.get("version") != version:
+    sys.exit(2)
+arches = data.get("architectures")
+if not isinstance(arches, dict) or arch in arches:
+    sys.exit(3)
+PY
+    then
+        print -u2 "Refusing to overwrite an existing release asset: $latest_json"
+        exit 73
+    fi
 fi
 
 sha256="$(shasum -a 256 "$dmg" | awk '{print $1}')"
@@ -66,11 +98,17 @@ tag="v$version"
 url="https://github.com/rohanpandula/ScanStudio/releases/download/$tag/$dmg_basename"
 
 printf '%s  %s\n' "$sha256" "$dmg_basename" > "$outdir/SHA256SUMS"
-python3 -c '
-import json, sys
-version, url, sha256, out = sys.argv[1:5]
+python3 - "$version" "$arch" "$url" "$sha256" "$latest_json" <<'PY'
+import json, os, sys
+version, arch, url, sha256, out = sys.argv[1:6]
+data = {}
+if os.path.exists(out):
+    with open(out) as f:
+        data = json.load(f)
+data["version"] = version
+data.setdefault("architectures", {})[arch] = {"url": url, "sha256": sha256}
 with open(out, "w") as f:
-    json.dump({"version": version, "url": url, "sha256": sha256}, f, indent=2)
-' "$version" "$url" "$sha256" "$latest_json"
+    json.dump(data, f, indent=2)
+PY
 
 print "SHA-256 $sha256"

--- a/app/ScanStudio/scripts/package_app.sh
+++ b/app/ScanStudio/scripts/package_app.sh
@@ -166,6 +166,15 @@ install -m 755 "$package_root/packaging/ScanStudioLauncher" "$staged_app/Content
 install -m 755 "$package_root/packaging/ScanStudioBridge" "$staged_app/Contents/MacOS/scanstudio-bridge"
 install -m 644 "$package_root/packaging/Info.plist" "$staged_app/Contents/Info.plist"
 
+# Stamp the exact release version from the build environment, so the running
+# app can report "I am 0.3.0-alpha.N". Best-effort: dev builds without
+# SCANSTUDIO_RELEASE_VERSION keep the empty default.
+if [[ -n "${SCANSTUDIO_RELEASE_VERSION:-}" ]]; then
+    /usr/libexec/PlistBuddy -c "Set :ScanStudioRelease '$SCANSTUDIO_RELEASE_VERSION'" \
+        "$staged_app/Contents/Info.plist" \
+        || { print -u2 "Failed to stamp ScanStudioRelease=$SCANSTUDIO_RELEASE_VERSION"; exit 1; }
+fi
+
 bundled_libusb="$staged_app/Contents/Frameworks/coolscanpy/_native/libusb-1.0.dylib"
 install -m 755 "$bundled_libusb_build/libusb-1.0.dylib" "$bundled_libusb"
 app_minimum="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$staged_app/Contents/Info.plist")"

--- a/app/ScanStudio/scripts/package_dmg.sh
+++ b/app/ScanStudio/scripts/package_dmg.sh
@@ -18,7 +18,7 @@ if [[ ! -f "$info_plist" ]]; then
 fi
 
 bundle_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info_plist")"
-release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-alpha.11}"
+release_version="${SCANSTUDIO_RELEASE_VERSION:-$bundle_version-beta.1}"
 release_arch="${SCANSTUDIO_RELEASE_ARCH:-$(uname -m)}"
 output="${2:-$package_root/.build/ScanStudio-$release_version-macOS-$release_arch.dmg}"
 

--- a/docs/AUTO-UPDATE.md
+++ b/docs/AUTO-UPDATE.md
@@ -18,17 +18,19 @@ works with the existing ad-hoc signing, so it ships now and Path B waits.
 
 ## Path A (active) — how it works
 
-As of this writing the shipped pieces are the release pipeline (01-01),
-version identity (01-02), and the install core (01-03). The service (01-04)
-and Settings UI (01-05) are next in the plan queue but not yet shipped; the
-bullets mark them as such rather than claim they exist.
+As of this writing the shipped pieces are the release pipeline (01-01), version
+identity (01-02), the install core (01-03), and the verified update service
+(01-04, extended in Phase 02 with host-architecture-aware resolution); the
+Settings UI (01-05) is next in the plan queue but not yet shipped; the bullets
+mark status rather than claim what exists.
 
 - **Release pipeline (plan 01-01, shipped):** tag-triggered
   `.github/workflows/release.yml` (`on: push: tags: ['v*']`) runs `make dmg`
   the same way CI already does, then
   `app/ScanStudio/scripts/emit_release_assets.sh` writes `SHA256SUMS` +
-  `latest.json` (the `{"version","url","sha256"}` pointer), re-verifies the
-  checksum, and `gh release create`s the DMG + `SHA256SUMS` + `latest.json`.
+  `latest.json` (the arch-keyed `{"version","architectures":{<arch>:{url,sha256}}}`
+  pointer), re-verifies the checksum, and `gh release create`s the DMGs +
+  `SHA256SUMS` + `latest.json`.
 - **Version identity (plan 01-02, shipped):** the packaged app stamps its
   exact release into `Info.plist` (`ScanStudioRelease`, from
   `SCANSTUDIO_RELEASE_VERSION`), and
@@ -39,11 +41,21 @@ bullets mark them as such rather than claim they exist.
   `app/ScanStudio/Sources/ScanStudioKit/UpdateInstaller.swift` does the pure
   app-bundle snapshot → stage (`ditto`) → swap → rollback, always without
   spawning the bridge or touching the scanner.
-- **Service (plan 01-04, NOT yet shipped):** once landed,
-  `app/ScanStudio/Sources/ScanStudioKit/UpdateService.swift` will bring
+- **Service (plan 01-04, shipped):**
+  `app/ScanStudio/Sources/ScanStudioKit/UpdateService.swift` provides
   `GitHubUpdateChecker` + `UpdateDownloader`, which resolve the pointer/channel,
   verify the downloaded DMG's SHA-256 before mounting, and code-signature
   verify (`codesign --verify --deep --strict`) the mounted app before install.
+- **Architecture-aware resolution (Phase 02, shipped):** the updater resolves
+  the newest release for the HOST architecture from the arch-keyed
+  `latest.json` (a single `architectures` mapping with a distinct
+  `url`+`sha256` per `arm64`/`x86_64`) and downloads + verifies only that
+  architecture's DMG. Intel (x86_64) support shipped in Phase 02: each release
+  publishes a `-macOS-arm64.dmg` for Apple Silicon and a `-macOS-x86_64.dmg`
+  for Intel. A missing entry for a host architecture surfaces the typed
+  unsupported-architecture error — never a wrong-arch install. Local
+  verification proves selection + hash integrity offline; the real Intel
+  bundle executes on the CI x86_64 runner.
 - **UI (plan 01-05, NOT yet shipped):** once landed, `UpdateSettingsView.swift`
   + `UpdateFlowModel.swift` will surface current version, "Check for Updates",
   channel toggle, install/rollback, a 24 h background cadence, and the guard

--- a/docs/AUTO-UPDATE.md
+++ b/docs/AUTO-UPDATE.md
@@ -1,0 +1,124 @@
+# ScanStudio Auto-Update: Two-Path Strategy
+
+> **DO NOT attempt the Sparkle steps until a Developer ID exists.**
+
+| Path | Status |
+|------|--------|
+| **Path A — custom updater** (shipped mechanism in this repo) | **ACTIVE** |
+| **Path B — Sparkle** | **GATED** on Developer ID; **NOT active** |
+
+## Why two paths
+
+ScanStudio is ad-hoc signed today (`codesign -dv` → `Signature=adhoc`, no
+TeamIdentifier). Sparkle's real value is silent, auto-verified updates via
+Gatekeeper — and that only works once the app is Developer ID signed and
+**notarized**, both of which are blocked on a Developer ID certificate. Path A
+is a custom updater that delivers verified-update + rollback value at $0 and
+works with the existing ad-hoc signing, so it ships now and Path B waits.
+
+## Path A (active) — how it works
+
+As of this writing the shipped pieces are the release pipeline (01-01),
+version identity (01-02), and the install core (01-03). The service (01-04)
+and Settings UI (01-05) are next in the plan queue but not yet shipped; the
+bullets mark them as such rather than claim they exist.
+
+- **Release pipeline (plan 01-01, shipped):** tag-triggered
+  `.github/workflows/release.yml` (`on: push: tags: ['v*']`) runs `make dmg`
+  the same way CI already does, then
+  `app/ScanStudio/scripts/emit_release_assets.sh` writes `SHA256SUMS` +
+  `latest.json` (the `{"version","url","sha256"}` pointer), re-verifies the
+  checksum, and `gh release create`s the DMG + `SHA256SUMS` + `latest.json`.
+- **Version identity (plan 01-02, shipped):** the packaged app stamps its
+  exact release into `Info.plist` (`ScanStudioRelease`, from
+  `SCANSTUDIO_RELEASE_VERSION`), and
+  `app/ScanStudio/Sources/ScanStudioKit/UpdateVersion.swift` provides the
+  comparable `UpdateVersion` parser (orders `alpha < beta < rc < stable` and
+  `alpha.9 < alpha.11`).
+- **Install core (plan 01-03, shipped):**
+  `app/ScanStudio/Sources/ScanStudioKit/UpdateInstaller.swift` does the pure
+  app-bundle snapshot → stage (`ditto`) → swap → rollback, always without
+  spawning the bridge or touching the scanner.
+- **Service (plan 01-04, NOT yet shipped):** once landed,
+  `app/ScanStudio/Sources/ScanStudioKit/UpdateService.swift` will bring
+  `GitHubUpdateChecker` + `UpdateDownloader`, which resolve the pointer/channel,
+  verify the downloaded DMG's SHA-256 before mounting, and code-signature
+  verify (`codesign --verify --deep --strict`) the mounted app before install.
+- **UI (plan 01-05, NOT yet shipped):** once landed, `UpdateSettingsView.swift`
+  + `UpdateFlowModel.swift` will surface current version, "Check for Updates",
+  channel toggle, install/rollback, a 24 h background cadence, and the guard
+  that refuses an install while a scan/preview job is active.
+
+## Path B (gated) — unlock checklist
+
+Nothing in this section happens until the gate opens. Each item has a one-line
+**why** and a **where** (how/where it is satisfied). If the Developer ID is
+borrowed from a friend, the checklist applies identically after the cert is
+imported into your keychain.
+
+1. **Developer ID Application certificate in the keychain** — the identity
+   Gatekeeper trusts; nothing signed works without it.
+   **Why:** without it `codesign` cannot attest authorship, so macOS keeps
+   flagging the bundle. **Where:** Apple's certs portal → download → double-click
+   to install into `login` keychain; record the **Team ID** (visible via
+   `codesign -dv` on a signed product, e.g. `TEAMID`).
+2. **Notarization capability** — a channel to submit builds to Apple's
+   notary and staple the ticket.
+   **Why:** notarization is what turns "first-launch warning" into Gatekeeper
+   approval. **Where:** App Store Connect API key (preferred for CI) or Apple ID
+   + app-specific password, usable via `xcrun notarytool submit ... --wait`.
+3. **EdDSA signing keypair for the Sparkle feed** — Sparkle's feed-signature
+   mechanism.
+   **Why:** Sparkle requires every appcast item to carry an EdDSA signature so
+   updates cannot be tampered with in transit. **Where:** generate with
+   Sparkle's `generate_keys`/`sign_update` tooling; store the **private** key
+   only as a GitHub Actions **secret** — never in the repo.
+4. **A hosted appcast feed (XML)** — the thing Sparkle polls for new versions.
+   **Why:** Sparkle has no feed without an appcast, and the feed signature needs
+   a stable URL. **Where:** GitHub Pages on this repo is the zero-cost candidate
+   (set up on `gh-pages`); the existing `SHA256SUMS` + `latest.json` values are
+   the feed's base data (see reuse map below).
+5. **Decide and document repo-secret names before wiring CI** — settle the
+   secret surface only after the cert + notary + key all exist.
+   **Why:** CI wiring is the last step and should reference already-decided
+   names (`DEVELOPER_ID_CERT`, `DEVELOPER_ID_TEAM`, `NOTARY_API_KEY`,
+   `NOTARY_KEY_ID`, `NOTARY_KEY_ISSUER_ID`, `SPARKLE_EDDSA_KEY`, …) so the
+   appcast step is a one-shot edit to `release.yml`. **Where:** repository
+   Settings → Secrets and variables → Actions; record the chosen names in the
+   future Sparkle plan.
+
+## Reuse map
+
+What Path B reuses from Path A, and what Path B adds.
+
+| Existing artifact (01-xx) | How Sparkle reuses it |
+|---------------------------|-----------------------|
+| `release.yml` + `SHA256SUMS` + `latest.json` (01-01) | Base data for the appcast feed entry; keeps the release pipeline single-source-of-truth for version + sha256 |
+| `UpdateVersion` (01-02, `UpdateVersion.swift`) | Orders the appcast items / compares installed-version-vs-feed so the UI shows a truthful "up to date" |
+| `UpdateInstaller` (01-03, `UpdateInstaller.swift`) | The atomic snapshot→swap→rollback engine Sparkle's installer triggers; no scanner motion boundary is preserved |
+| `UpdateDownloader` (01-04, planned) | Already validates hash + code signature; can gate what Sparkle is offered as a candidate |
+| `UpdateSettingsView` / `UpdateFlowModel` (01-05, planned) | Unchanged — they keep presenting version/install/rollback, just fed by Sparkle instead of Path A |
+
+**What Sparkle ADDS (none exist today):** the `SUFeedURL` key in the packaged
+`Info.plist`, EdDSA feed signatures, Developer ID signing, notarization +
+staple, and an appcast publish step in CI.
+
+**What would change when the gate opens:** `app/ScanStudio/packaging/Info.plist`
+(SUFeedURL), `app/ScanStudio/scripts/package_app.sh` (sign `-` → Developer ID
+identity), `release.yml` (emit + upload appcast, notarize).
+
+**Explicitly untouched by Path B:** the update safety boundary (no bridge spawn,
+no scanner motion), the snapshot/swap/rollback core (`UpdateInstaller`), version
+ordering (`UpdateVersion`), and the GitHub Releases distribution surface.
+
+## Explicit non-goals while gated
+
+- No Sparkle SPM dependency is added.
+- No `SUFeedURL` is added to the packaged `Info.plist`.
+- No EdDSA keys are generated.
+- No Developer ID signing is configured.
+- No appcast step is added to `release.yml`.
+
+When a future task needs Path B, start here: this document is the handoff and
+the checklist above is the unlock gate. Do not skip the "decide + document
+repo-secret names" step.

--- a/docs/AUTO-UPDATE.md
+++ b/docs/AUTO-UPDATE.md
@@ -18,11 +18,9 @@ works with the existing ad-hoc signing, so it ships now and Path B waits.
 
 ## Path A (active) — how it works
 
-As of this writing the shipped pieces are the release pipeline (01-01), version
-identity (01-02), the install core (01-03), and the verified update service
-(01-04, extended in Phase 02 with host-architecture-aware resolution); the
-Settings UI (01-05) is next in the plan queue but not yet shipped; the bullets
-mark status rather than claim what exists.
+The shipped pieces are the release pipeline (01-01), version identity (01-02),
+install core (01-03), verified update service (01-04), Settings UI (01-05),
+integration gate (01-06), and host-architecture-aware resolution (Phase 02).
 
 - **Release pipeline (plan 01-01, shipped):** tag-triggered
   `.github/workflows/release.yml` (`on: push: tags: ['v*']`) runs `make dmg`
@@ -56,8 +54,8 @@ mark status rather than claim what exists.
   unsupported-architecture error — never a wrong-arch install. Local
   verification proves selection + hash integrity offline; the real Intel
   bundle executes on the CI x86_64 runner.
-- **UI (plan 01-05, NOT yet shipped):** once landed, `UpdateSettingsView.swift`
-  + `UpdateFlowModel.swift` will surface current version, "Check for Updates",
+- **UI (plan 01-05, shipped):** `UpdateSettingsView.swift` +
+  `UpdateFlowModel.swift` surface current version, "Check for Updates",
   channel toggle, install/rollback, a 24 h background cadence, and the guard
   that refuses an install while a scan/preview job is active.
 

--- a/scripts/verify_updater.sh
+++ b/scripts/verify_updater.sh
@@ -5,6 +5,17 @@
 #   emit release assets -> resolve pointer -> check -> download -> SHA-256
 #   verify -> snapshot -> swap -> rollback.
 #
+# Phase 02 (02-03): the seeded pointer is arch-keyed — the 01-01 emitter is
+# invoked for the HOST architecture and then a second fake x86_64 entry with a
+# distinct sha is injected, so the pointer carries BOTH architectures exactly
+# as the matrix publish job produces. The script asserts the host entry is
+# present and correct, and the Swift harness (whose arch-selected e2e cases
+# run here) proves the updater selects + installs the HOST architecture's
+# artifact while cross-arch / unsupported-arch cases are rejected. Real Intel
+# (x86_64) bundle execution only happens on the CI x86_64 leg, never here
+# (no Rosetta on this arm64 host — see 02-CONTEXT.md); local proof is
+# host-arch selection + SHA-256 hash integrity, fully offline.
+#
 # THIS SCRIPT TOUCHES ONLY TEMP DIRECTORIES. It never writes to /Applications,
 # never mutates this repo, never touches the scanner, and makes no network
 # calls. The flow itself is driven in-process by the offline Swift harness
@@ -73,31 +84,67 @@ for app in "$current_app" "$new_app"; do
 done
 pass "resolve: current=$current_app new=$new_app"
 
-# ---- Step 2: seed the "release" via the 01-01 emitter -----------------------
+# ---- Step 2: seed the "release" via the 01-01 emitter (arch-keyed) ---------
 # The emitter's CDN story is irrelevant offline; it only hashes its file
-# argument. The new bundle zipped stands in for the DMG.
-new_zip="$WORK/ScanStudio-$VERSION-macOS-arm64.zip"
-ditto -c -k --keepParent "$new_app" "$new_zip" || fail "ditto $new_app -> $new_zip"
+# argument. The new bundle zipped stands in for the DMG. The pointer is
+# arch-keyed: first emit for the HOST arch, then inject a fake second arch
+# entry (distinct sha) so the pointer carries both archs like the CI matrix
+# publish job.
+host_arch="$(uname -m)"
+case "$host_arch" in
+    arm64)  other_arch="x86_64" ;;
+    x86_64) other_arch="arm64"  ;;
+    *) fail "unsupported host architecture: $host_arch" ;;
+esac
+
+host_zip="$WORK/ScanStudio-$VERSION-macOS-$host_arch.zip"
+other_zip="$WORK/ScanStudio-$VERSION-macOS-$other_arch.zip"
+ditto -c -k --keepParent "$new_app" "$host_zip" || fail "ditto $new_app -> $host_zip"
+other_app="$WORK/other/ScanStudio.app"
+make_fake_app "$other_app" "$VERSION" "intel"
+ditto -c -k --keepParent "$other_app" "$other_zip" || fail "ditto $other_app -> $other_zip"
 
 staging="$WORK/staging"
-if ! "$EMITTER" "$new_zip" "$VERSION" "$staging" >"$WORK/emit.log" 2>&1; then
+if ! "$EMITTER" "$host_zip" "$VERSION" "$staging" "$host_arch" >"$WORK/emit.log" 2>&1; then
     cat "$WORK/emit.log" >&2
-    fail "emit_release_assets.sh (01-01 emitter)"
+    fail "emit_release_assets.sh (01-01 emitter, host arch)"
 fi
 [[ -f "$staging/latest.json" ]]  || fail "emitter produced no latest.json"
 [[ -f "$staging/SHA256SUMS" ]]   || fail "emitter produced no SHA256SUMS"
 grep -q "\"version\": \"$VERSION\"" "$staging/latest.json" || fail "latest.json version mismatch"
-expected="$(shasum -a 256 "$new_zip" | awk '{print $1}')"
+host_expected="$(shasum -a 256 "$host_zip" | awk '{print $1}')"
 recorded="$(awk '{print $1}' "$staging/SHA256SUMS")"
-[[ "$expected" == "$recorded" ]] || fail "SHA256SUMS does not match the seeded artifact"
-pass "seed: emit_release_assets.sh -> latest.json + SHA256SUMS ($VERSION, sha256 $recorded)"
+[[ "$host_expected" == "$recorded" ]] || fail "SHA256SUMS does not match the seeded host artifact"
+pass "seed: emit_release_assets.sh -> latest.json + SHA256SUMS ($VERSION, host=$host_arch, sha256 $recorded)"
+
+# ---- Step 2b: inject the second arch entry (distinct sha) ------------------
+# Re-invoking the emitter with the SAME version + the OTHER arch merges the
+# entry in (merge-don't-clobber), mirroring the matrix publish job's combined
+# pointer. The two arch entries must describe distinct artifacts.
+if ! "$EMITTER" "$other_zip" "$VERSION" "$staging" "$other_arch" >"$WORK/emit2.log" 2>&1; then
+    cat "$WORK/emit2.log" >&2
+    fail "emit_release_assets.sh (01-01 emitter, other arch)"
+fi
+other_expected="$(shasum -a 256 "$other_zip" | awk '{print $1}')"
+[[ "$host_expected" != "$other_expected" ]] || fail "the two arch entries must have distinct shas"
+grep -q "\"$host_arch\":"  "$staging/latest.json" || fail "latest.json missing host-arch ($host_arch) entry"
+grep -q "\"$other_arch\":" "$staging/latest.json" || fail "latest.json missing other-arch ($other_arch) entry"
+grep -q "ScanStudio-$VERSION-macOS-$host_arch.zip"  "$staging/latest.json" || fail "latest.json host url mismatch"
+grep -q "ScanStudio-$VERSION-macOS-$other_arch.zip" "$staging/latest.json" || fail "latest.json other url mismatch"
+grep -q "$host_expected" "$staging/latest.json"  || fail "latest.json host sha mismatch"
+grep -q "$other_expected" "$staging/latest.json" || fail "latest.json other sha mismatch"
+pass "seed: arch-keyed latest.json carries BOTH $host_arch + $other_arch (host selection asserted)"
 
 # ---- Step 3: drive the wired flow in-process (Swift harness) ----------------
 # UpdateFlowIntegrationTests runs pointer -> GitHubUpdateChecker ->
 # UpdateDownloader (SHA-256 verified) -> UpdateInstaller (snapshot / swap /
 # rollback, corrupt-checksum rejection) fully offline against synthetic
-# fixtures. Fail-loud: a non-green run aborts here, so a bad wiring cannot
-# reach VERIFY_UPDATER OK.
+# fixtures. Phase 02: the suite's arch-selected cases prove the updater
+# selects + installs the HOST architecture's entry from the arch-keyed
+# pointer, rejects cross-arch byte mismatches at the checksum gate, and
+# surfaces the typed unsupported-architecture error for a missing arch — the
+# Phase-01 swap/rollback integrity is unchanged. Fail-loud: a non-green run
+# aborts here, so a bad wiring cannot reach VERIFY_UPDATER OK.
 printf '[verify_updater] running: swift test --filter UpdateFlowIntegrationTests\n'
 if ! (cd "$SWIFT_DIR" && swift test --filter UpdateFlowIntegrationTests >"$WORK/swift-test.log" 2>&1); then
     tail -60 "$WORK/swift-test.log" >&2
@@ -109,4 +156,4 @@ summary="$(grep -E 'Executed [0-9]+ tests?, with [0-9]+ failure' "$WORK/swift-te
 pass "harness: UpdateFlowIntegrationTests (pointer -> check -> download -> verify -> snapshot -> swap -> rollback) green"
 
 # ---- Step 4: acceptance evidence ---------------------------------------------
-printf 'VERIFY_UPDATER OK\n'
+printf 'VERIFY_UPDATER OK (host=%s, arch-selected flow offline)\n' "$host_arch"

--- a/scripts/verify_updater.sh
+++ b/scripts/verify_updater.sh
@@ -30,7 +30,7 @@
 #                                   "new release" whose bytes seed the feed
 #                                   (default: synthetic)
 #   SCANSTUDIO_UPDATER_VERSION      release version string for the seeded feed
-#                                   (default: 0.3.0-alpha.11)
+#                                   (default: 0.3.0-beta.1)
 #
 # Exit code is nonzero on any failure; a green run ends with
 #   VERIFY_UPDATER OK
@@ -40,7 +40,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 EMITTER="$ROOT/app/ScanStudio/scripts/emit_release_assets.sh"
 SWIFT_DIR="$ROOT/app/ScanStudio"
 
-VERSION="${SCANSTUDIO_UPDATER_VERSION:-0.3.0-alpha.11}"
+VERSION="${SCANSTUDIO_UPDATER_VERSION:-0.3.0-beta.1}"
 
 WORK="$(mktemp -d)"
 cleanup() {
@@ -76,7 +76,7 @@ else
     current_app="$WORK/current/ScanStudio.app"
     new_app="$WORK/new/ScanStudio.app"
     make_fake_app "$current_app" "0.3.0-alpha.10" "old"
-    make_fake_app "$new_app" "0.3.0-alpha.11" "new"
+    make_fake_app "$new_app" "0.3.0-beta.1" "new"
 fi
 
 for app in "$current_app" "$new_app"; do

--- a/scripts/verify_updater.sh
+++ b/scripts/verify_updater.sh
@@ -1,0 +1,112 @@
+#!/bin/zsh
+# verify_updater.sh — seeded, end-to-end updater verification gate (01-06).
+#
+# Proves the whole delivered auto-update pipeline on fake, on-disk fixtures:
+#   emit release assets -> resolve pointer -> check -> download -> SHA-256
+#   verify -> snapshot -> swap -> rollback.
+#
+# THIS SCRIPT TOUCHES ONLY TEMP DIRECTORIES. It never writes to /Applications,
+# never mutates this repo, never touches the scanner, and makes no network
+# calls. The flow itself is driven in-process by the offline Swift harness
+# `UpdateFlowIntegrationTests` (a normal `swift test` target), which wires
+# GitHubUpdateChecker -> UpdateDownloader -> UpdateInstaller against seeded
+# fake bundles.
+#
+# Environment overrides:
+#   SCANSTUDIO_UPDATER_CURRENT_APP  path to a ScanStudio.app to treat as the
+#                                   "current install" (default: synthetic)
+#   SCANSTUDIO_UPDATER_NEW_APP      path to a ScanStudio.app to treat as the
+#                                   "new release" whose bytes seed the feed
+#                                   (default: synthetic)
+#   SCANSTUDIO_UPDATER_VERSION      release version string for the seeded feed
+#                                   (default: 0.3.0-alpha.11)
+#
+# Exit code is nonzero on any failure; a green run ends with
+#   VERIFY_UPDATER OK
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EMITTER="$ROOT/app/ScanStudio/scripts/emit_release_assets.sh"
+SWIFT_DIR="$ROOT/app/ScanStudio"
+
+VERSION="${SCANSTUDIO_UPDATER_VERSION:-0.3.0-alpha.11}"
+
+WORK="$(mktemp -d)"
+cleanup() {
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+pass() { printf 'PASS %s\n' "$*"; }
+fail() { printf 'FAIL %s\n' "$*" >&2; exit 1; }
+
+# Builds a minimal ScanStudio.app bundle stamped with a release version and a
+# distinguishing marker file (bash/zsh-portable; python3 is present on macOS).
+make_fake_app() {
+    local app="$1" release="$2" marker="$3"
+    mkdir -p "$app/Contents/MacOS"
+    python3 - "$release" "$app/Contents/Info.plist" <<'PY'
+import plistlib, sys
+release, outfile = sys.argv[1], sys.argv[2]
+with open(outfile, "wb") as f:
+    plistlib.dump({"CFBundleShortVersionString": release, "ScanStudioRelease": release}, f)
+PY
+    printf '%s' "$marker" > "$app/Contents/MacOS/ScanStudio"
+}
+
+# ---- Step 1: resolve the "current install" and "new release" bundles --------
+if [[ -n "${SCANSTUDIO_UPDATER_CURRENT_APP:-}" || -n "${SCANSTUDIO_UPDATER_NEW_APP:-}" ]]; then
+    if [[ -z "${SCANSTUDIO_UPDATER_CURRENT_APP:-}" || -z "${SCANSTUDIO_UPDATER_NEW_APP:-}" ]]; then
+        fail "SCANSTUDIO_UPDATER_CURRENT_APP and SCANSTUDIO_UPDATER_NEW_APP must be set together"
+    fi
+    current_app="$SCANSTUDIO_UPDATER_CURRENT_APP"
+    new_app="$SCANSTUDIO_UPDATER_NEW_APP"
+else
+    current_app="$WORK/current/ScanStudio.app"
+    new_app="$WORK/new/ScanStudio.app"
+    make_fake_app "$current_app" "0.3.0-alpha.10" "old"
+    make_fake_app "$new_app" "0.3.0-alpha.11" "new"
+fi
+
+for app in "$current_app" "$new_app"; do
+    [[ -d "$app" ]] || fail "app bundle missing: $app"
+done
+pass "resolve: current=$current_app new=$new_app"
+
+# ---- Step 2: seed the "release" via the 01-01 emitter -----------------------
+# The emitter's CDN story is irrelevant offline; it only hashes its file
+# argument. The new bundle zipped stands in for the DMG.
+new_zip="$WORK/ScanStudio-$VERSION-macOS-arm64.zip"
+ditto -c -k --keepParent "$new_app" "$new_zip" || fail "ditto $new_app -> $new_zip"
+
+staging="$WORK/staging"
+if ! "$EMITTER" "$new_zip" "$VERSION" "$staging" >"$WORK/emit.log" 2>&1; then
+    cat "$WORK/emit.log" >&2
+    fail "emit_release_assets.sh (01-01 emitter)"
+fi
+[[ -f "$staging/latest.json" ]]  || fail "emitter produced no latest.json"
+[[ -f "$staging/SHA256SUMS" ]]   || fail "emitter produced no SHA256SUMS"
+grep -q "\"version\": \"$VERSION\"" "$staging/latest.json" || fail "latest.json version mismatch"
+expected="$(shasum -a 256 "$new_zip" | awk '{print $1}')"
+recorded="$(awk '{print $1}' "$staging/SHA256SUMS")"
+[[ "$expected" == "$recorded" ]] || fail "SHA256SUMS does not match the seeded artifact"
+pass "seed: emit_release_assets.sh -> latest.json + SHA256SUMS ($VERSION, sha256 $recorded)"
+
+# ---- Step 3: drive the wired flow in-process (Swift harness) ----------------
+# UpdateFlowIntegrationTests runs pointer -> GitHubUpdateChecker ->
+# UpdateDownloader (SHA-256 verified) -> UpdateInstaller (snapshot / swap /
+# rollback, corrupt-checksum rejection) fully offline against synthetic
+# fixtures. Fail-loud: a non-green run aborts here, so a bad wiring cannot
+# reach VERIFY_UPDATER OK.
+printf '[verify_updater] running: swift test --filter UpdateFlowIntegrationTests\n'
+if ! (cd "$SWIFT_DIR" && swift test --filter UpdateFlowIntegrationTests >"$WORK/swift-test.log" 2>&1); then
+    tail -60 "$WORK/swift-test.log" >&2
+    fail "UpdateFlowIntegrationTests harness"
+fi
+grep -q "Executed " "$WORK/swift-test.log" || fail "harness produced no test summary"
+summary="$(grep -E 'Executed [0-9]+ tests?, with [0-9]+ failure' "$WORK/swift-test.log" | tail -1 || true)"
+[[ -n "$summary" ]] && printf '%s\n' "$summary"
+pass "harness: UpdateFlowIntegrationTests (pointer -> check -> download -> verify -> snapshot -> swap -> rollback) green"
+
+# ---- Step 4: acceptance evidence ---------------------------------------------
+printf 'VERIFY_UPDATER OK\n'


### PR DESCRIPTION
Ships the completed in-app updater and native Intel build pipeline, then prepares the first macOS beta release.

Release status:
- Apple Silicon: Beta, existing LS-5000 workflow validated
- Intel: Preview, native CI validation only
- Both builds are ad-hoc signed and not notarized

Also fixes prerelease update discovery when the repository has no stable GitHub release yet.

Verified locally:
- make test (365 Rust + 49 XCTest + 401 Swift Testing tests)
- ./scripts/verify_updater.sh
- actionlint .github/workflows/release.yml
- arm64 DMG build, mounted signature check, relocated bundled-runtime smoke, hdiutil verify