### PR TITLE
Offer to update at launch, plus two field-found updater fixes

### DIFF
--- a/app/ScanStudio/Sources/ScanStudio/ScanStudioApp.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ScanStudioApp.swift
@@ -135,6 +135,22 @@ private struct FrameTransformCommands: Commands {
     }
 }
 
+/// The real `AppRelaunching`: spawns a detached new process for the app at
+/// `appURL` via `/usr/bin/open -n`, so the fresh instance is independent of
+/// the quitting one. `UpdateFlowModel.relaunchToFinishUpdate()` only calls
+/// `NSApp.terminate` after this returns without throwing. Kept in the
+/// executable target -- spawning a process and quitting the running app are
+/// host/AppKit concerns -- with only the guard/routing logic (`RelaunchCoordinator`)
+/// living in ScanStudioKit, where it is unit tested with a fake instead.
+private struct ProcessAppRelauncher: AppRelaunching {
+    func relaunch(appURL: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-n", appURL.path]
+        try process.run()
+    }
+}
+
 /// What `ScanStudioApp` could build at launch: either a working
 /// `EngineClient`/`SessionModel` pair, or — if `EngineLocator.locate()`
 /// threw — a message describing exactly why, surfaced in the window rather
@@ -261,7 +277,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             installer: installer,
             installedVersion: Self.installedUpdateVersion(),
             channelDefaultsKey: "ScanStudio.updateChannel",
-            launchCheckEnabledDefaultsKey: "ScanStudio.checkForUpdatesAtLaunch"
+            launchCheckEnabledDefaultsKey: "ScanStudio.checkForUpdatesAtLaunch",
+            relauncher: ProcessAppRelauncher()
         )
     }
 

--- a/app/ScanStudio/Sources/ScanStudio/ScanStudioApp.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ScanStudioApp.swift
@@ -30,13 +30,16 @@ struct ScanStudioApp: App {
         // makes the focused Photo commands unambiguous: there is no second
         // scene that can publish a competing focused frame.
         Window("Scan Studio", id: "main") {
-            switch appDelegate.launchState {
-            case .ready(_, let model):
-                ContentView()
-                    .environment(model)
-            case .failed(let message):
-                EngineUnavailableView(message: message)
+            Group {
+                switch appDelegate.launchState {
+                case .ready(_, let model):
+                    ContentView()
+                        .environment(model)
+                case .failed(let message):
+                    EngineUnavailableView(message: message)
+                }
             }
+            .launchUpdateOfferAlert(appDelegate.updateFlowModel)
         }
         .defaultSize(width: 1_500, height: 920)
         .windowResizability(.contentMinSize)
@@ -48,6 +51,42 @@ struct ScanStudioApp: App {
 
         Settings {
             UpdateSettingsView(model: appDelegate.updateFlowModel)
+        }
+    }
+}
+
+private extension View {
+    /// The launch-time "Update Now" / "Not Now" offer (feat/launch-update-offer,
+    /// item 1): a native alert. The app's one existing notice idiom
+    /// (`WorkspaceErrorBanner` in ContentView.swift) is purpose-built for
+    /// `SessionModel` scan/preview errors -- it needs a `SessionModel` in the
+    /// environment, which does not exist while `launchState == .failed`, and
+    /// its red "something went wrong" styling and issue-report action do not
+    /// fit an informational "there's a new version" notice. A plain alert
+    /// covers both launch states from one place at the Window scene level and
+    /// matches the two-action (primary / cancel) confirmation shape already
+    /// used elsewhere (e.g. `AcquirePreviewConfirmationSheet`).
+    func launchUpdateOfferAlert(_ model: UpdateFlowModel) -> some View {
+        alert(
+            "Update Available",
+            isPresented: Binding(
+                get: { model.launchUpdateOffer != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        model.dismissLaunchUpdateOffer()
+                    }
+                }
+            ),
+            presenting: model.launchUpdateOffer
+        ) { _ in
+            Button("Update Now") {
+                Task { await model.installFromLaunchUpdateOffer() }
+            }
+            Button("Not Now", role: .cancel) {
+                model.dismissLaunchUpdateOffer()
+            }
+        } message: { candidate in
+            Text("Scan Studio \(candidate.version.raw) is available.")
         }
     }
 }
@@ -221,7 +260,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             downloader: UpdateDownloader(),
             installer: installer,
             installedVersion: Self.installedUpdateVersion(),
-            channelDefaultsKey: "ScanStudio.updateChannel"
+            channelDefaultsKey: "ScanStudio.updateChannel",
+            launchCheckEnabledDefaultsKey: "ScanStudio.checkForUpdatesAtLaunch"
         )
     }
 
@@ -254,13 +294,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Kicks the update cadence (AUT-05-CHECK): one check at launch, then one
-    /// every 24 h via a rolling `Task.sleep`. Read-only plumbing -- `checkNow()`
-    /// only mutates check state and never downloads or installs on cadence,
-    /// and it skips a beat while an install is already in flight.
+    /// every 24 h via a rolling `Task.sleep`. Read-only plumbing -- neither
+    /// leg downloads or installs, and the 24 h leg skips a beat while an
+    /// install is already in flight.
+    ///
+    /// The launch leg (feat/launch-update-offer) is gated on the "Check for
+    /// updates at launch" setting and, when it finds something newer, also
+    /// drives the visible launch-time offer -- see
+    /// `UpdateFlowModel.checkForUpdateAtLaunch()`. The 24 h leg below is
+    /// untouched: it always runs, regardless of that setting.
     private func startUpdateCheckLoops() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.updateFlowModel.checkNow()
+            await self.updateFlowModel.checkForUpdateAtLaunch()
         }
         backgroundUpdateTask = Task { [weak self] in
             while !Task.isCancelled {

--- a/app/ScanStudio/Sources/ScanStudio/UpdateFlowModel.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateFlowModel.swift
@@ -1,13 +1,23 @@
 // In-app update flow (01-05): the host-owned model behind the Settings scene,
 // PLUS the launch-time "Update Now" / "Not Now" offer (feat/launch-update-offer).
-// Renders honest check/install/rollback state and enforces the AUT-05-GUARD:
-// no install while a scan/preview job is active. The model itself never
-// relaunches the app, never auto-installs, and never touches the scanner --
-// it only mutates observable state and drives the ScanStudioKit services
-// (checker, downloader, installer, and now the launch-offer model) on
-// explicit user action. Relaunch wiring is deliberately out of scope here and
-// left to explicit user confirmation ("Restart to finish"), per the plan.
+// Renders honest check/install/rollback state and enforces the job-active
+// guard: no install, and no relaunch, while a scan/preview job is active. The
+// model itself never auto-installs and never touches the scanner -- it only
+// mutates observable state and drives the ScanStudioKit services (checker,
+// downloader, installer, launch-offer model, relaunch coordinator) on
+// explicit user action.
+//
+// Relaunching used to be left entirely to the user quitting and reopening the
+// app by hand: "Restart to finish" was instructional copy attached to inert
+// text/labels, not a wired control (field-found 2026-08-05 running the first
+// real beta.1 -> beta.2 update: clicking it twice did nothing, and the swap
+// only actually took effect once the user quit via the menu). It is now a
+// real "Relaunch Now" action routed through an injected `AppRelaunching`, so
+// the actual process spawn is a real side effect only in production while the
+// guard/routing logic is unit tested in ScanStudioKit with a fake (see
+// RelaunchCoordinatorTests).
 
+import AppKit
 import Foundation
 import Observation
 import ScanStudioKit
@@ -43,6 +53,9 @@ final class UpdateFlowModel {
     /// Gates + runs the once-per-launch check and owns the offer's
     /// shown/dismissed state (ScanStudioKit; unit tested there directly).
     private let launchOfferModel: LaunchUpdateOfferModel
+    /// Guard + routing for "Relaunch Now" (ScanStudioKit; unit tested there
+    /// directly with a fake `AppRelaunching`).
+    private let relaunchCoordinator: RelaunchCoordinator
 
     /// Release channel the user is on. Persisted on change. The `.alpha` raw
     /// value is retained for compatibility and represents all prereleases.
@@ -102,6 +115,7 @@ final class UpdateFlowModel {
         installedVersion: UpdateVersion,
         channelDefaultsKey: String,
         launchCheckEnabledDefaultsKey: String,
+        relauncher: any AppRelaunching,
         defaults: UserDefaults = .standard
     ) {
         self.checker = checker
@@ -111,6 +125,7 @@ final class UpdateFlowModel {
         self.channelDefaultsKey = channelDefaultsKey
         self.launchCheckEnabledDefaultsKey = launchCheckEnabledDefaultsKey
         self.launchOfferModel = LaunchUpdateOfferModel(checker: checker, installedVersion: installedVersion)
+        self.relaunchCoordinator = RelaunchCoordinator(relauncher: relauncher)
         self.defaults = defaults
         if let stored = defaults.string(forKey: channelDefaultsKey),
            let parsed = UpdateChannel(rawValue: stored) {
@@ -176,10 +191,34 @@ final class UpdateFlowModel {
         await install()
     }
 
+    // MARK: - Relaunch
+
+    /// "Relaunch Now": spawns a fresh process at the install destination and
+    /// quits the current one via the normal `NSApp.terminate` path (so
+    /// `AppDelegate.applicationWillTerminate` still cleans up the engine
+    /// client exactly as a manual Quit would). Refuses while `jobActive`
+    /// (mirrors AUT-05-GUARD) and surfaces a failure through the same
+    /// `checkState = .failed(...)` idiom `install()` uses, rather than
+    /// silently doing nothing -- which is what the old inert "Restart to
+    /// finish" text/label did.
+    func relaunchToFinishUpdate() {
+        guard let destinationPath = pendingInstallDestination else { return }
+        let appURL = URL(fileURLWithPath: destinationPath, isDirectory: true)
+            .appendingPathComponent("ScanStudio.app", isDirectory: true)
+        do {
+            try relaunchCoordinator.relaunch(appURL: appURL, jobActive: jobActive)
+        } catch {
+            checkState = .failed(Self.describe(error))
+            return
+        }
+        NSApp.terminate(nil)
+    }
+
     /// Downloads, verifies, and installs the offered candidate. Gated on
     /// `!jobActive` (AUT-05-GUARD). On success this leaves `pendingInstallURL`
-    /// set so the Settings scene shows "Restart to finish" -- it never
-    /// auto-relaunches.
+    /// set so the Settings scene offers "Relaunch Now" -- installing never
+    /// auto-relaunches by itself; relaunching is always the separate,
+    /// explicit action above.
     func install() async {
         guard !jobActive else {
             checkState = .failed("Cannot install while a scan is active.")
@@ -218,7 +257,7 @@ final class UpdateFlowModel {
     }
 
     /// Restores the 01-03 snapshot, if any. Best-effort; never crashes. Clears
-    /// the "Restart to finish" marker on success.
+    /// the pending-install ("Relaunch Now") marker on success.
     func rollback() async {
         do {
             try installer.restorePrevious()
@@ -264,6 +303,10 @@ final class UpdateFlowModel {
             return "The current user cannot write to the app folder; install to ~/Applications (or add an administrator account) and try again."
         case UpdateInstallError.rolledBack:
             return "No previous version was available to roll back to."
+        case RelaunchError.jobActive:
+            return "Cannot relaunch while a scan is active."
+        case RelaunchError.launchFailed:
+            return "Scan Studio could not relaunch itself. Quit and reopen it manually to finish the update."
         default:
             return String(describing: error)
         }

--- a/app/ScanStudio/Sources/ScanStudio/UpdateFlowModel.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateFlowModel.swift
@@ -1,8 +1,10 @@
-// In-app update flow (01-05): the host-owned model behind the Settings scene.
+// In-app update flow (01-05): the host-owned model behind the Settings scene,
+// PLUS the launch-time "Update Now" / "Not Now" offer (feat/launch-update-offer).
 // Renders honest check/install/rollback state and enforces the AUT-05-GUARD:
 // no install while a scan/preview job is active. The model itself never
 // relaunches the app, never auto-installs, and never touches the scanner --
-// it only mutates observable state and drives the 01-03/01-04 services on
+// it only mutates observable state and drives the ScanStudioKit services
+// (checker, downloader, installer, and now the launch-offer model) on
 // explicit user action. Relaunch wiring is deliberately out of scope here and
 // left to explicit user confirmation ("Restart to finish"), per the plan.
 
@@ -36,7 +38,11 @@ final class UpdateFlowModel {
     /// The running app's stamped version, read from `Bundle.main` at launch.
     private let installedVersion: UpdateVersion
     private let channelDefaultsKey: String
+    private let launchCheckEnabledDefaultsKey: String
     private let defaults: UserDefaults
+    /// Gates + runs the once-per-launch check and owns the offer's
+    /// shown/dismissed state (ScanStudioKit; unit tested there directly).
+    private let launchOfferModel: LaunchUpdateOfferModel
 
     /// Release channel the user is on. Persisted on change. The `.alpha` raw
     /// value is retained for compatibility and represents all prereleases.
@@ -45,6 +51,21 @@ final class UpdateFlowModel {
             defaults.set(channel.rawValue, forKey: channelDefaultsKey)
         }
     }
+
+    /// Persisted "Check for updates at launch" setting (default ON). When
+    /// `false`, `checkForUpdateAtLaunch()` makes no network call at all; the
+    /// manual "Check for Updates" button and the 24 h background cadence are
+    /// unaffected either way -- this only gates the once-per-launch check.
+    var launchCheckEnabled: Bool {
+        didSet {
+            defaults.set(launchCheckEnabled, forKey: launchCheckEnabledDefaultsKey)
+        }
+    }
+
+    /// Non-nil while the launch-time offer alert should be visible. Set by
+    /// `checkForUpdateAtLaunch()`; cleared by `dismissLaunchUpdateOffer()`
+    /// ("Not Now") or `installFromLaunchUpdateOffer()` ("Update Now").
+    var launchUpdateOffer: UpdateCandidate?
 
     /// Whichever of `.idle` / `.checking` / `.updateAvailable` / `.upToDate`
     /// / `.failed` the last action produced.
@@ -80,6 +101,7 @@ final class UpdateFlowModel {
         installer: UpdateInstaller,
         installedVersion: UpdateVersion,
         channelDefaultsKey: String,
+        launchCheckEnabledDefaultsKey: String,
         defaults: UserDefaults = .standard
     ) {
         self.checker = checker
@@ -87,12 +109,19 @@ final class UpdateFlowModel {
         self.installer = installer
         self.installedVersion = installedVersion
         self.channelDefaultsKey = channelDefaultsKey
+        self.launchCheckEnabledDefaultsKey = launchCheckEnabledDefaultsKey
+        self.launchOfferModel = LaunchUpdateOfferModel(checker: checker, installedVersion: installedVersion)
         self.defaults = defaults
         if let stored = defaults.string(forKey: channelDefaultsKey),
            let parsed = UpdateChannel(rawValue: stored) {
             channel = parsed
         } else {
             channel = .alpha
+        }
+        if defaults.object(forKey: launchCheckEnabledDefaultsKey) != nil {
+            launchCheckEnabled = defaults.bool(forKey: launchCheckEnabledDefaultsKey)
+        } else {
+            launchCheckEnabled = true
         }
     }
 
@@ -114,6 +143,37 @@ final class UpdateFlowModel {
         } catch {
             checkState = .failed(Self.describe(error))
         }
+    }
+
+    // MARK: - Launch-time offer
+
+    /// The once-per-launch check (AUT-05-CHECK's "one check at launch"
+    /// half), gated on `launchCheckEnabled` and delegated to
+    /// `LaunchUpdateOfferModel` so the gate is unit tested in ScanStudioKit.
+    /// When it finds something strictly newer than `installedVersion`,
+    /// mirrors the candidate into `launchUpdateOffer` so the root scene can
+    /// show the "Update Now" / "Not Now" alert. Intended to run at most once
+    /// per app launch (the `AppDelegate` call site does exactly that);
+    /// `LaunchUpdateOfferModel` itself also refuses a second run.
+    func checkForUpdateAtLaunch() async {
+        await launchOfferModel.checkAtLaunch(launchCheckEnabled: launchCheckEnabled, channel: channel)
+        launchUpdateOffer = launchOfferModel.offer.candidate
+    }
+
+    /// "Not Now": dismiss the launch-time offer for the rest of this app run.
+    func dismissLaunchUpdateOffer() {
+        launchOfferModel.dismiss()
+        launchUpdateOffer = nil
+    }
+
+    /// "Update Now": routes the offered candidate into the EXISTING install
+    /// flow (`install()`, unchanged below -- same AUT-05-GUARD, same error
+    /// mapping) instead of duplicating any of its logic.
+    func installFromLaunchUpdateOffer() async {
+        guard let candidate = launchOfferModel.consumeForInstall() else { return }
+        launchUpdateOffer = nil
+        checkState = .updateAvailable(candidate)
+        await install()
     }
 
     /// Downloads, verifies, and installs the offered candidate. Gated on

--- a/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
@@ -111,7 +111,15 @@ struct UpdateSettingsView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Update available: \(candidate.version.raw)")
                 if model.pendingInstallURL != nil {
-                    Label("Restart to finish", systemImage: "arrow.triangle.2.circlepath")
+                    Button {
+                        model.relaunchToFinishUpdate()
+                    } label: {
+                        Label("Relaunch Now", systemImage: "arrow.triangle.2.circlepath")
+                    }
+                    .disabled(model.jobActive)
+                    .help(model.jobActive
+                        ? "Relaunch is disabled while a scan is active."
+                        : "Quit and reopen Scan Studio to finish the update.")
                 } else if let progress = model.installProgress {
                     ProgressView(
                         value: progress,

--- a/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
@@ -28,6 +28,8 @@ struct UpdateSettingsView: View {
             }
 
             Section("Updates") {
+                Toggle("Check for updates at launch", isOn: $model.launchCheckEnabled)
+
                 Button("Check for Updates") {
                     Task { await model.checkNow() }
                 }

--- a/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
@@ -108,14 +108,30 @@ struct UpdateSettingsView: View {
         case .upToDate:
             Label("You're up to date", systemImage: "checkmark.circle")
         case .updateAvailable(let candidate):
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Update available: \(candidate.version.raw)")
+            // Made visually unmissable (field feedback 2026-08-05: a first
+            // live update read as "nothing happened" when this was just a
+            // plain Text row with a plain-style button). Same amber-card
+            // idiom WorkspaceErrorBanner uses for red errors, and the same
+            // prominent-tinted-button idiom already used for primary actions
+            // elsewhere (Save & Scan, Acquire Previews, device connect).
+            VStack(alignment: .leading, spacing: 10) {
+                Label("Update available: \(candidate.version.raw)", systemImage: "arrow.down.circle.fill")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.scanStudioAmber)
+
                 if model.pendingInstallURL != nil {
+                    // The prominent next action once install() has already
+                    // swapped the bundle on disk (feat/launch-update-offer,
+                    // field fix: this used to be an inert Label).
                     Button {
                         model.relaunchToFinishUpdate()
                     } label: {
                         Label("Relaunch Now", systemImage: "arrow.triangle.2.circlepath")
+                            .frame(maxWidth: .infinity)
                     }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.scanStudioAmber)
+                    .foregroundStyle(.black)
                     .disabled(model.jobActive)
                     .help(model.jobActive
                         ? "Relaunch is disabled while a scan is active."
@@ -129,12 +145,20 @@ struct UpdateSettingsView: View {
                     Button("Install Update") {
                         Task { await model.install() }
                     }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.scanStudioAmber)
+                    .foregroundStyle(.black)
                     .disabled(model.jobActive)
                     .help(model.jobActive
                         ? "Install is disabled while a scan is active."
                         : "Download, verify, and install this update.")
                 }
             }
+            .padding(12)
+            .background(
+                Color.scanStudioAmber.opacity(0.14),
+                in: RoundedRectangle(cornerRadius: ScanStudioMetrics.cardCornerRadius)
+            )
         case .failed(let message):
             Text(message)
                 .foregroundStyle(.red)

--- a/app/ScanStudio/Sources/ScanStudioKit/LaunchUpdateOffer.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/LaunchUpdateOffer.swift
@@ -1,0 +1,86 @@
+// Launch-time update offer: decides whether to run the once-per-launch
+// update check and whether to surface a visible "Update Now" / "Not Now"
+// offer. Split out from the host `UpdateFlowModel` (Sources/ScanStudio) so
+// the rule that matters most -- the launch-check setting being off means
+// literally no network call, not just a suppressed UI -- is directly unit
+// testable here with an injected `UpdateChecking` fake, the same seam
+// `GitHubUpdateChecker`/`UpdateFlowModel` already use. This type never
+// installs anything itself: "Update Now" hands the candidate back to the
+// caller, which routes it into the existing `UpdateFlowModel.install()`
+// flow (the job-active guard stays there, unchanged).
+
+import Foundation
+
+/// The outcome of a launch-time offer check.
+public enum LaunchUpdateOffer: Equatable, Sendable {
+    case none
+    case available(UpdateCandidate)
+
+    /// The candidate to install, if one is currently offered.
+    public var candidate: UpdateCandidate? {
+        if case .available(let candidate) = self { return candidate }
+        return nil
+    }
+}
+
+/// Runs the launch-time offer check at most once per instance (the host
+/// creates one instance per app run) and remembers whether the resulting
+/// offer has already been shown/dismissed, so nothing re-nags the user
+/// within the same launch.
+@MainActor
+public final class LaunchUpdateOfferModel {
+    private let checker: any UpdateChecking
+    private let installedVersion: UpdateVersion
+
+    /// The current offer. `.none` before the check has run, when the
+    /// launch-check setting was off, when nothing strictly newer was found,
+    /// on any checker failure, after "Not Now", and after the candidate is
+    /// consumed for install.
+    public private(set) var offer: LaunchUpdateOffer = .none
+
+    /// Latches true the first time `checkAtLaunch` runs its gate (whether or
+    /// not it was enabled). Once true, every later call is a no-op -- this
+    /// is both "at most one network call per launch" and "Not Now never
+    /// re-offers within the same session (instance) lifetime" in one guard.
+    private var hasCheckedThisLaunch = false
+
+    public init(checker: any UpdateChecking, installedVersion: UpdateVersion) {
+        self.checker = checker
+        self.installedVersion = installedVersion
+    }
+
+    /// Performs the once-per-launch check for `channel` when
+    /// `launchCheckEnabled` is true. When `false`, or when this instance has
+    /// already run its launch check once, this makes NO call into `checker`
+    /// at all -- the gate sits before the network call, not after it. Never
+    /// throws; a transport/decode failure or a candidate that is not
+    /// strictly newer than `installedVersion` both resolve to `.none`,
+    /// exactly like "no update" everywhere else in the update flow.
+    public func checkAtLaunch(launchCheckEnabled: Bool, channel: UpdateChannel) async {
+        guard launchCheckEnabled, !hasCheckedThisLaunch else { return }
+        hasCheckedThisLaunch = true
+        guard
+            let candidate = try? await checker.latestCandidate(channel: channel),
+            installedVersion < candidate.version
+        else {
+            offer = .none
+            return
+        }
+        offer = .available(candidate)
+    }
+
+    /// "Not Now": clears the current offer. `hasCheckedThisLaunch` is
+    /// already latched by the check that produced it, so no later call to
+    /// `checkAtLaunch` in this instance's lifetime can bring it back.
+    public func dismiss() {
+        offer = .none
+    }
+
+    /// "Update Now": returns the offered candidate for the caller to install
+    /// and clears the offer so it cannot be shown or consumed twice. `nil`
+    /// when nothing is currently offered.
+    public func consumeForInstall() -> UpdateCandidate? {
+        defer { offer = .none }
+        return offer.candidate
+    }
+}

--- a/app/ScanStudio/Sources/ScanStudioKit/RelaunchCoordinator.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/RelaunchCoordinator.swift
@@ -1,0 +1,47 @@
+// Relaunches the installed app after a completed update. `AppRelaunching` is
+// the process-spawning seam (mirrors `URLSessionProtocol`'s role for network
+// calls): the real implementation lives in the executable target
+// (Sources/ScanStudio) since spawning a process and quitting the running app
+// are host/AppKit concerns, not ScanStudioKit's. `RelaunchCoordinator`
+// carries only the routing decision -- refuse while a scan/preview job is
+// active (the same guard `UpdateFlowModel.install()` already applies),
+// otherwise call the injected relauncher exactly once -- so that guard is
+// directly unit testable with a fake here, without ever spawning a real
+// process or quitting anything during a test run.
+
+import Foundation
+
+/// Spawns a fresh process for the app at `appURL`. The caller is
+/// responsible for terminating the current process afterward; this
+/// protocol's only job is starting the new one.
+public protocol AppRelaunching: Sendable {
+    func relaunch(appURL: URL) throws
+}
+
+/// Typed relaunch failures.
+public enum RelaunchError: Error, Equatable {
+    /// Refused because a scan/preview job is active.
+    case jobActive
+    /// The injected `AppRelaunching` failed to spawn the new process.
+    case launchFailed
+}
+
+@MainActor
+public final class RelaunchCoordinator {
+    private let relauncher: any AppRelaunching
+
+    public init(relauncher: any AppRelaunching) {
+        self.relauncher = relauncher
+    }
+
+    /// Attempts to relaunch `appURL`. Refuses -- without calling the
+    /// relauncher at all -- while `jobActive`, mirroring the install guard.
+    public func relaunch(appURL: URL, jobActive: Bool) throws {
+        guard !jobActive else { throw RelaunchError.jobActive }
+        do {
+            try relauncher.relaunch(appURL: appURL)
+        } catch {
+            throw RelaunchError.launchFailed
+        }
+    }
+}

--- a/app/ScanStudio/Tests/ScanStudioKitTests/LaunchUpdateOfferTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/LaunchUpdateOfferTests.swift
@@ -1,0 +1,141 @@
+// Offline tests for the launch-time update offer (feat/launch-update-offer):
+// the toggle gate must sit BEFORE the network call (not after, as a
+// suppressed UI would), an equal-version candidate must never be offered,
+// and "Not Now" must not re-offer within the same instance's lifetime.
+// Mirrors UpdateVersionTests/UpdateServiceTests' offline, injected-fake
+// style: a private fake `UpdateChecking` stands in for `GitHubUpdateChecker`
+// so no case ever touches the network.
+
+import XCTest
+
+@testable import ScanStudioKit
+
+@MainActor
+final class LaunchUpdateOfferTests: XCTestCase {
+    private func candidate(_ version: String) -> UpdateCandidate {
+        UpdateCandidate(
+            version: UpdateVersion(raw: version)!,
+            downloadURL: URL(string: "https://example.com/ScanStudio.dmg")!,
+            sha256: String(repeating: "a", count: 64),
+            releaseNotesURL: nil
+        )
+    }
+
+    // MARK: - Shown when enabled + newer
+
+    func testOfferShownWhenLaunchCheckEnabledAndCandidateIsNewer() async {
+        let checker = FakeUpdateChecker()
+        checker.candidateToReturn = candidate("0.4.0")
+        let model = LaunchUpdateOfferModel(checker: checker, installedVersion: UpdateVersion(raw: "0.3.0")!)
+
+        await model.checkAtLaunch(launchCheckEnabled: true, channel: .stable)
+
+        XCTAssertEqual(model.offer, .available(candidate("0.4.0")))
+        XCTAssertEqual(checker.callCount, 1)
+    }
+
+    // MARK: - Suppressed when the toggle is off: NO network call at all
+
+    func testOfferSuppressedWhenLaunchCheckDisabledMakesNoNetworkCall() async {
+        let checker = FakeUpdateChecker()
+        checker.candidateToReturn = candidate("0.4.0")
+        let model = LaunchUpdateOfferModel(checker: checker, installedVersion: UpdateVersion(raw: "0.3.0")!)
+
+        await model.checkAtLaunch(launchCheckEnabled: false, channel: .stable)
+
+        XCTAssertEqual(model.offer, .none)
+        XCTAssertEqual(checker.callCount, 0, "the toggle being off must never reach the checker")
+    }
+
+    // MARK: - Suppressed when the candidate equals the installed version
+
+    func testOfferSuppressedWhenCandidateEqualsInstalled() async {
+        let checker = FakeUpdateChecker()
+        checker.candidateToReturn = candidate("0.3.0")
+        let model = LaunchUpdateOfferModel(checker: checker, installedVersion: UpdateVersion(raw: "0.3.0")!)
+
+        await model.checkAtLaunch(launchCheckEnabled: true, channel: .stable)
+
+        XCTAssertEqual(model.offer, .none)
+    }
+
+    // MARK: - "Not Now" never re-offers within the same session (instance) lifetime
+
+    func testNotNowDoesNotReofferWithinTheSameSessionLifetime() async {
+        let checker = FakeUpdateChecker()
+        checker.candidateToReturn = candidate("0.4.0")
+        let model = LaunchUpdateOfferModel(checker: checker, installedVersion: UpdateVersion(raw: "0.3.0")!)
+
+        await model.checkAtLaunch(launchCheckEnabled: true, channel: .stable)
+        XCTAssertEqual(model.offer, .available(candidate("0.4.0")))
+
+        model.dismiss()
+        XCTAssertEqual(model.offer, .none)
+
+        // A later call on the SAME instance (e.g. if the launch call site
+        // were ever invoked twice in one run) must neither resurrect the
+        // offer nor hit the network again.
+        await model.checkAtLaunch(launchCheckEnabled: true, channel: .stable)
+
+        XCTAssertEqual(model.offer, .none)
+        XCTAssertEqual(checker.callCount, 1, "a dismissed offer must not trigger a second check")
+    }
+
+    // MARK: - At most one network call per instance, even without a dismissal
+
+    func testCheckAtLaunchRunsAtMostOncePerInstance() async {
+        let checker = FakeUpdateChecker()
+        checker.candidateToReturn = candidate("0.4.0")
+        let model = LaunchUpdateOfferModel(checker: checker, installedVersion: UpdateVersion(raw: "0.3.0")!)
+
+        await model.checkAtLaunch(launchCheckEnabled: true, channel: .stable)
+        await model.checkAtLaunch(launchCheckEnabled: true, channel: .stable)
+
+        XCTAssertEqual(checker.callCount, 1)
+    }
+
+    // MARK: - consumeForInstall hands the candidate over exactly once
+
+    func testConsumeForInstallReturnsAndClearsTheOffer() async {
+        let checker = FakeUpdateChecker()
+        checker.candidateToReturn = candidate("0.4.0")
+        let model = LaunchUpdateOfferModel(checker: checker, installedVersion: UpdateVersion(raw: "0.3.0")!)
+        await model.checkAtLaunch(launchCheckEnabled: true, channel: .stable)
+
+        let consumed = model.consumeForInstall()
+
+        XCTAssertEqual(consumed, candidate("0.4.0"))
+        XCTAssertEqual(model.offer, .none)
+        XCTAssertNil(model.consumeForInstall(), "a second consume must find nothing left to take")
+    }
+
+    // MARK: - A checker failure degrades to "no offer", never a crash
+
+    func testOfferStaysNoneOnCheckerFailure() async {
+        let checker = FakeUpdateChecker()
+        checker.errorToThrow = URLError(.notConnectedToInternet)
+        let model = LaunchUpdateOfferModel(checker: checker, installedVersion: UpdateVersion(raw: "0.3.0")!)
+
+        await model.checkAtLaunch(launchCheckEnabled: true, channel: .stable)
+
+        XCTAssertEqual(model.offer, .none)
+        XCTAssertEqual(checker.callCount, 1)
+    }
+}
+
+/// Fake `UpdateChecking` conformer: answers a canned candidate/error and
+/// counts calls, so tests can assert the toggle gate stops the call from
+/// ever reaching the checker (rather than only suppressing its result).
+private final class FakeUpdateChecker: UpdateChecking, @unchecked Sendable {
+    var candidateToReturn: UpdateCandidate?
+    var errorToThrow: Error?
+    private(set) var callCount = 0
+
+    func latestCandidate(channel: UpdateChannel) async throws -> UpdateCandidate? {
+        callCount += 1
+        if let errorToThrow {
+            throw errorToThrow
+        }
+        return candidateToReturn
+    }
+}

--- a/app/ScanStudio/Tests/ScanStudioKitTests/RelaunchCoordinatorTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/RelaunchCoordinatorTests.swift
@@ -1,0 +1,60 @@
+// Offline tests for RelaunchCoordinator (field fix: "Restart to finish" was
+// inert text with no wired action -- see UpdateFlowModel.relaunchToFinishUpdate()
+// and ProcessAppRelauncher). The real process spawn is never exercised here:
+// a fake `AppRelaunching` stands in so the test asserts the call/guard
+// instead of actually spawning and quitting a process.
+
+import XCTest
+
+@testable import ScanStudioKit
+
+@MainActor
+final class RelaunchCoordinatorTests: XCTestCase {
+    private let appURL = URL(fileURLWithPath: "/Applications/ScanStudio.app", isDirectory: true)
+
+    func testRelaunchCallsTheInjectedRelauncherWithTheGivenURL() throws {
+        let relauncher = FakeAppRelauncher()
+        let coordinator = RelaunchCoordinator(relauncher: relauncher)
+
+        try coordinator.relaunch(appURL: appURL, jobActive: false)
+
+        XCTAssertEqual(relauncher.requestedURLs, [appURL])
+    }
+
+    func testRelaunchRefusesWhileJobActiveAndNeverCallsTheRelauncher() {
+        let relauncher = FakeAppRelauncher()
+        let coordinator = RelaunchCoordinator(relauncher: relauncher)
+
+        XCTAssertThrowsError(try coordinator.relaunch(appURL: appURL, jobActive: true)) { error in
+            XCTAssertEqual(error as? RelaunchError, .jobActive)
+        }
+        XCTAssertTrue(relauncher.requestedURLs.isEmpty, "a job-active refusal must never reach the relauncher")
+    }
+
+    func testRelaunchSurfacesATypedErrorWhenTheRelauncherFails() {
+        let relauncher = FakeAppRelauncher()
+        relauncher.errorToThrow = NSError(domain: "test", code: 1)
+        let coordinator = RelaunchCoordinator(relauncher: relauncher)
+
+        XCTAssertThrowsError(try coordinator.relaunch(appURL: appURL, jobActive: false)) { error in
+            XCTAssertEqual(error as? RelaunchError, .launchFailed)
+        }
+        XCTAssertEqual(relauncher.requestedURLs, [appURL], "the relauncher was still called once before failing")
+    }
+}
+
+/// Fake `AppRelaunching`: records every call instead of spawning a real
+/// process, so tests never launch or quit a second ScanStudio instance.
+/// `requestedURLs` records the call itself, independent of whether it then
+/// succeeds or throws, so a failure test can still assert the attempt.
+private final class FakeAppRelauncher: AppRelaunching, @unchecked Sendable {
+    private(set) var requestedURLs: [URL] = []
+    var errorToThrow: Error?
+
+    func relaunch(appURL: URL) throws {
+        requestedURLs.append(appURL)
+        if let errorToThrow {
+            throw errorToThrow
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a launch-time update offer, per the owner's spec: "it should check
for update when you launch and also offer to disable that and offer
user to update when they launch if there is one." Plus two field-found
fixes from running the first live end-to-end updater test (beta.1 ->
beta.2) on real hardware during this work.

## 1. Launch-time update offer (`feat(updater)`)

- New persisted **"Check for updates at launch"** toggle in
  UpdateSettingsView (default ON), using the same UserDefaults-backed
  `didSet` pattern the existing channel picker already uses. Off means
  no launch-time network call at all; the manual "Check for Updates"
  button and the 24h background cadence are untouched either way.
- When enabled and a check at launch finds a version strictly newer
  than the installed one, a native alert now surfaces it with the
  version string and two actions: **Update Now** (routes into the
  existing `install()` flow unchanged, so the job-active guard still
  applies) and **Not Now** (dismisses for the rest of the run, no
  re-offer).
- The gate and offer/dismiss state live in a new ScanStudioKit type,
  `LaunchUpdateOfferModel`, so "toggle off means literally no network
  call" and "Not Now never re-offers this run" are directly unit
  tested with an injected `UpdateChecking` fake, rather than living
  untestable in the host-only `UpdateFlowModel`.

## 2. Field fix: "Restart to finish" did nothing (`fix(updater)`)

Confirmed live: the "Restart to finish" text/label in
UpdateSettingsView had no action wired to it at all -- clicking it
twice left the app running unchanged. The staged swap itself was
correct (`UpdateInstaller.install()` already replaces the app bundle
on disk immediately; quitting via the menu picked up the new version
on relaunch). There was just no way to relaunch from inside the app.

Now a real **"Relaunch Now"** action: spawns a fresh process at the
install destination via an injected `AppRelaunching` (real
implementation: `/usr/bin/open -n`, executable-target only), then
terminates the current process through the normal `NSApp.terminate`
path so engine cleanup still runs. Refuses while a scan/preview job is
active, mirroring the existing install guard. The guard/routing logic
(`RelaunchCoordinator`) is unit tested in ScanStudioKit with a fake
relauncher -- no test spawns a real process or quits anything.

## 3. Field fix: an available update was easy to miss (`fix(updater)`)

Also confirmed live: clicking "Check for Updates" and getting a match
rendered as a plain text row with a plain-style button, and read as
"nothing happened." The `.updateAvailable` state now uses the app's
existing emphasis idioms -- the same amber-card treatment
`WorkspaceErrorBanner` uses for errors (recolored positive), and the
same prominent-tinted-button styling already used for primary actions
elsewhere (Save & Scan, Acquire Previews, device connect) -- applied
to both "Install Update" and "Relaunch Now", so there's no unstyled
hand-off between install completing and the next action. Pure SwiftUI
styling; no new test, consistent with how views are covered elsewhere
in this repo (only the policies/models behind them are unit tested).

## Out of scope (unchanged)

- Wire protocols, engine, bridge -- nothing outside `app/ScanStudio/`.
- The existing 24h background check cadence and manual "Check for
  Updates" button behavior.

## Tests

`swift test` (ScanStudioKit package): **463 tests green** (59 XCTest +
404 swift-testing), 0 failures. New coverage:

- `Tests/ScanStudioKitTests/LaunchUpdateOfferTests.swift` (7 cases):
  offer shown when enabled + newer; suppressed when disabled with zero
  calls into the injected checker fake; suppressed when the candidate
  equals the installed version; "Not Now" not re-offering within the
  same instance's lifetime; at-most-once-per-instance; consume-for-
  install; checker failure degrading to no offer.
- `Tests/ScanStudioKitTests/RelaunchCoordinatorTests.swift` (3 cases):
  relaunch calls the injected fake with the right URL; refuses while
  job-active without ever calling the fake; surfaces a typed error
  when the fake throws.

## Where the offer surfaces

A native macOS alert, attached at the `Window` scene level (covers
both the ready and engine-unavailable launch states) -- the app's one
existing notice idiom, `WorkspaceErrorBanner`, is purpose-built for
`SessionModel` scan/preview errors and doesn't generalize to an
app-level, session-independent notice.
