### PR TITLE
fix: guarantee engine.hello precedes every engine request, not just tests

### DIFF
--- a/ports/tauri/app/src-tauri/Cargo.toml
+++ b/ports/tauri/app/src-tauri/Cargo.toml
@@ -23,3 +23,10 @@ tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros", "proce
 url = "2"
 image = { version = "0.25.10", default-features = false, features = ["tiff", "png", "jpeg"] }
 lru = "0.18.1"
+
+[dev-dependencies]
+# Adds tauri::test's mock_builder/mock_context (a zero-dependency cfg gate --
+# see upstream's `test = []` feature) so the engine_sidecar integration test
+# can drive spawn_engine's real handshake-gating code against a mocked,
+# windowless runtime instead of a real display.
+tauri = { version = "2.11.5", features = ["test"] }

--- a/ports/tauri/app/src-tauri/src/engine.rs
+++ b/ports/tauri/app/src-tauri/src/engine.rs
@@ -4,10 +4,10 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
-use tauri::{AppHandle, Emitter, Manager, State, Wry};
-use tauri_plugin_shell::process::{CommandChild, CommandEvent};
+use tauri::{AppHandle, Emitter, Manager, Runtime, State, Wry};
+use tauri_plugin_shell::process::{Command, CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 
 use crate::wsl::bridge_cmd::{
     build_engine_env, BRIDGE_ENTRYPOINT, HW_MOTION_ENV_VAR, WSLENV_ENV_VAR,
@@ -26,12 +26,53 @@ type PendingMap = Mutex<HashMap<u64, oneshot::Sender<Result<Value, EngineError>>
 // taking longer than this means it was lost and the waiter must not hang.
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Hello-handshake outcome for one spawned engine process. Starts `Pending`
+/// and resolves exactly once, from the handshake task `spawn_engine` starts
+/// (below), to `Ready` or `Failed`. The engine enforces `engine.hello` as the
+/// first request on a freshly spawned process's stdin (server.rs's
+/// `reject_before_hello`); this is what makes that true for every caller
+/// instead of trusting each call site to remember it.
+#[derive(Clone, Debug)]
+enum HandshakeState {
+    Pending,
+    Ready,
+    Failed(EngineError),
+}
+
+/// Blocks until this process's handshake has resolved -- immediately if it
+/// already has (the common case: by the time any real request is fired, the
+/// handshake task finished long ago), otherwise until the handshake task
+/// sends `Ready`/`Failed`. Every `send_request` caller goes through this
+/// before writing anything to the child's stdin, so `engine.hello` is
+/// structurally guaranteed to be the first line written on every connection,
+/// regardless of how early the frontend's first request arrives relative to
+/// the handshake task actually running.
+async fn await_handshake(handshake: &watch::Sender<HandshakeState>) -> Result<(), EngineError> {
+    let mut rx = handshake.subscribe();
+    let outcome = rx
+        .wait_for(|state| !matches!(state, HandshakeState::Pending))
+        .await
+        .map_err(|_| EngineError {
+            code: "INTERNAL".into(),
+            message: "engine handshake never completed".into(),
+            recoverable: false,
+        })?;
+    match &*outcome {
+        HandshakeState::Ready => Ok(()),
+        HandshakeState::Failed(err) => Err(err.clone()),
+        HandshakeState::Pending => unreachable!("wait_for only returns on a non-Pending value"),
+    }
+}
+
 pub struct EngineHandle {
     // Option because CommandChild::kill(self) consumes the child, so it must
     // be .take()-n out of the Mutex rather than called through the guard.
     child: Mutex<Option<CommandChild>>,
     next_id: AtomicU64,
     pending: PendingMap,
+    // Resolved once by the handshake task `spawn_engine` starts for this
+    // process; `send_request` awaits it before writing anything else.
+    handshake: watch::Sender<HandshakeState>,
 }
 
 /// Explicit environment additions for the engine sidecar.
@@ -205,13 +246,33 @@ pub fn setup(app: &mut tauri::App<Wry>) -> Result<(), Box<dyn std::error::Error>
             windows_hw_motion.as_deref(),
             windows_wslenv.as_deref(),
         ));
+    spawn_engine(&app.handle().clone(), command)
+}
+
+/// Spawns `command`, wires its stdout into the shared pending/event dispatch,
+/// and starts the `engine.hello` handshake task -- the exact sequence a real
+/// connection to the engine needs, regardless of which `Command` produced it
+/// (the bundled sidecar in production, or a plain path to a locally built
+/// binary in tests). Generic over `R` (rather than pinned to the production
+/// `Wry` runtime) so the integration test can drive this identical code path
+/// against `tauri::test::mock_builder`'s `MockRuntime` instead of
+/// re-implementing spawn/wire/handshake by hand -- `Command::spawn` and the
+/// `CommandChild`/`CommandEvent` types it returns do not depend on the
+/// runtime at all, only `Manager::manage`/`AppHandle::state` do, and both
+/// work identically under a mocked runtime.
+pub fn spawn_engine<R: Runtime>(
+    app: &AppHandle<R>,
+    command: Command,
+) -> Result<(), Box<dyn std::error::Error>> {
     let (mut rx, child) = command.spawn()?;
+    let (handshake_tx, _handshake_rx) = watch::channel(HandshakeState::Pending);
     app.manage(EngineHandle {
         child: Mutex::new(Some(child)),
         next_id: AtomicU64::new(1),
         pending: Mutex::new(HashMap::new()),
+        handshake: handshake_tx,
     });
-    let app_handle = app.handle().clone();
+    let app_handle = app.clone();
     tauri::async_runtime::spawn(async move {
         while let Some(event) = rx.recv().await {
             match event {
@@ -242,10 +303,51 @@ pub fn setup(app: &mut tauri::App<Wry>) -> Result<(), Box<dyn std::error::Error>
         let state = app_handle.state::<EngineHandle>();
         fail_pending_requests(&state);
     });
+
+    // Send engine.hello on this freshly spawned process before any other
+    // request can reach it, and resolve the handshake gate from the outcome.
+    // This runs concurrently with the reader task above (which routes the
+    // hello response back through the same `pending` map) rather than
+    // blocking `spawn_engine`/`setup`, so a slow handshake delays only
+    // engine-bound requests -- never app startup -- while `send_request`
+    // (every production caller's sole entry point) waits on
+    // `await_handshake` before writing anything, so ordering holds no matter
+    // how early the frontend fires its first request relative to this task
+    // actually running. `send_request_unchecked` is used here specifically
+    // because it is what resolves the gate `send_request` waits on.
+    let app_handle_for_hello = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let state = app_handle_for_hello.state::<EngineHandle>();
+        let outcome = send_request_unchecked(
+            &state,
+            "engine.hello",
+            serde_json::json!({
+                "clientName": env!("CARGO_PKG_NAME"),
+                "protocolVersion": 1,
+            }),
+        )
+        .await;
+        let resolved = match outcome {
+            Ok(_) => HandshakeState::Ready,
+            Err(err) => {
+                eprintln!("[engine handshake failed] {err:?}");
+                HandshakeState::Failed(err)
+            }
+        };
+        // No receiver (e.g. every request so far happened to already be
+        // gone) is not an error here -- there is nothing left to unblock.
+        let _ = state.handshake.send(resolved);
+    });
+
     Ok(())
 }
 
-async fn send_request(
+/// Writes one request line to the child's stdin and awaits its response
+/// (bounded by `RESPONSE_TIMEOUT`). Does not itself wait on the handshake --
+/// the handshake task above is the one caller allowed to skip that wait,
+/// since it is what resolves it. Every other caller must go through
+/// `send_request`.
+async fn send_request_unchecked(
     state: &State<'_, EngineHandle>,
     method: &str,
     params: Value,
@@ -288,6 +390,22 @@ async fn send_request(
             })
         }
     }
+}
+
+/// Production entry point for every engine request except the handshake
+/// itself: waits for `engine.hello` to have completed on this process before
+/// writing anything, so `engine_request` (the sole path from the frontend to
+/// the engine) can never win a race against the handshake and trip the
+/// engine's `reject_before_hello` guard (server.rs:678-687) -- regardless of
+/// how early the frontend fires its first request after launch, or after any
+/// future respawn that resets the same gate.
+async fn send_request(
+    state: &State<'_, EngineHandle>,
+    method: &str,
+    params: Value,
+) -> Result<Value, EngineError> {
+    await_handshake(&state.handshake).await?;
+    send_request_unchecked(state, method, params).await
 }
 
 #[tauri::command]
@@ -519,6 +637,7 @@ mod tests {
             child: Mutex::new(None),
             next_id: AtomicU64::new(1),
             pending: Mutex::new(HashMap::new()),
+            handshake: watch::channel(HandshakeState::Ready).0,
         };
         let (tx, mut rx) = oneshot::channel();
         handle.pending.lock().unwrap().insert(5, tx);
@@ -547,5 +666,54 @@ mod tests {
             panic!("no event expected")
         });
         assert!(pending.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn await_handshake_resolves_immediately_when_already_ready() {
+        let (tx, _rx) = watch::channel(HandshakeState::Ready);
+        await_handshake(&tx)
+            .await
+            .expect("an already-ready handshake must not block or error");
+    }
+
+    #[tokio::test]
+    async fn await_handshake_propagates_the_recorded_failure() {
+        let failure = EngineError {
+            code: "INTERNAL".into(),
+            message: "engine process terminated".into(),
+            recoverable: false,
+        };
+        let (tx, _rx) = watch::channel(HandshakeState::Failed(failure.clone()));
+        let err = await_handshake(&tx)
+            .await
+            .expect_err("a failed handshake must be reported to the caller");
+        assert_eq!(err, failure);
+    }
+
+    // Regression coverage for the field bug (engine.hello arriving after a
+    // request it should have gated): proves `await_handshake` genuinely
+    // blocks while `Pending` -- not just that it "eventually" returns Ok,
+    // which a no-op gate would also do -- and only unblocks once the
+    // handshake task resolves it, in the order that happened.
+    #[tokio::test]
+    async fn await_handshake_blocks_a_caller_until_pending_resolves() {
+        let (tx, _rx) = watch::channel(HandshakeState::Pending);
+        let tx = std::sync::Arc::new(tx);
+        let tx_for_waiter = tx.clone();
+        let waiter = tokio::spawn(async move { await_handshake(&tx_for_waiter).await });
+
+        // Let the waiter task actually run and park on the still-Pending
+        // state before we resolve it.
+        tokio::task::yield_now().await;
+        assert!(
+            !waiter.is_finished(),
+            "a request must not proceed while the handshake is still Pending"
+        );
+
+        tx.send(HandshakeState::Ready).expect("receiver still live");
+        waiter
+            .await
+            .expect("waiter task must not panic")
+            .expect("must resolve Ok once Ready is sent");
     }
 }

--- a/ports/tauri/app/src-tauri/tests/engine_sidecar.rs
+++ b/ports/tauri/app/src-tauri/tests/engine_sidecar.rs
@@ -3,12 +3,22 @@ use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use scanstudio_app_lib::engine::{dispatch_line, engine_request, spawn_engine, EngineError};
+use scanstudio_app_lib::engine::{dispatch_line, EngineError};
 use serde_json::Value;
-use tauri::Manager;
-use tauri_plugin_shell::ShellExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::oneshot;
+
+// tauri::test's mocked runtime is Windows-CI-broken (see the cfg-gated test
+// below), so everything that touches it -- these two imports plus the test
+// itself -- stays behind the same `not(windows)` gate. dispatch_line/
+// EngineError above are used by the always-on handshake_against_real_engine_binary
+// test too and stay unconditional.
+#[cfg(not(windows))]
+use scanstudio_app_lib::engine::{engine_request, spawn_engine};
+#[cfg(not(windows))]
+use tauri::Manager;
+#[cfg(not(windows))]
+use tauri_plugin_shell::ShellExt;
 
 type PendingMap = Mutex<HashMap<u64, oneshot::Sender<Result<Value, EngineError>>>>;
 
@@ -147,6 +157,25 @@ async fn handshake_against_real_engine_binary() {
 /// `CommandChild`/`CommandEvent` types it returns do not depend on the
 /// windowing runtime, only `Manager::manage`/`AppHandle::state` do, and both
 /// work identically under `tauri::test::mock_builder`'s `MockRuntime`.
+///
+/// `not(windows)`: on the Windows CI runner, linking `tauri::test`'s mocked
+/// runtime into a bare `cargo test` binary (never `tauri build`'s bundling
+/// step, which is what normally stages WebView2's loader next to the real
+/// app's exe) fails DLL entry-point resolution at process start --
+/// `engine_sidecar-*.exe` exits `0xc0000139 STATUS_ENTRYPOINT_NOT_FOUND`
+/// before any test body runs, taking the whole binary (including the
+/// unrelated `handshake_against_real_engine_binary` test above) down with
+/// it. This is a Windows-CI-only linkage gap in `tauri::test`, not a gap in
+/// coverage: the handshake gate itself (`await_handshake`/`HandshakeState`)
+/// is platform-independent Rust with no windowing/runtime dependency at all,
+/// and is unit-tested on every platform including Windows by
+/// `await_handshake_resolves_immediately_when_already_ready`,
+/// `await_handshake_propagates_the_recorded_failure`, and
+/// `await_handshake_blocks_a_caller_until_pending_resolves` in
+/// `src/engine.rs`. This exact field sequence, wired through the real
+/// production `spawn_engine`/`engine_request` path, still runs end-to-end on
+/// every PR via the macOS and Linux Verify/ports.yml lanes.
+#[cfg(not(windows))]
 #[tokio::test]
 async fn field_sequence_succeeds_without_the_frontend_ever_sending_hello() {
     let engine_path = match std::env::var("SCANSTUDIO_ENGINE_PATH") {

--- a/ports/tauri/app/src-tauri/tests/engine_sidecar.rs
+++ b/ports/tauri/app/src-tauri/tests/engine_sidecar.rs
@@ -3,8 +3,10 @@ use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use scanstudio_app_lib::engine::{dispatch_line, EngineError};
+use scanstudio_app_lib::engine::{dispatch_line, engine_request, spawn_engine, EngineError};
 use serde_json::Value;
+use tauri::Manager;
+use tauri_plugin_shell::ShellExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::oneshot;
 
@@ -65,7 +67,8 @@ async fn handshake_against_real_engine_binary() {
     // id 2: scanner.list
     let (tx, rx) = oneshot::channel();
     pending.lock().unwrap().insert(2, tx);
-    let line = serde_json::json!({"id": 2, "method": "scanner.list", "params": {}}).to_string() + "\n";
+    let line =
+        serde_json::json!({"id": 2, "method": "scanner.list", "params": {}}).to_string() + "\n";
     stdin.write_all(line.as_bytes()).await.expect("write list");
     stdin.flush().await.expect("flush list");
     let list = rx
@@ -80,7 +83,10 @@ async fn handshake_against_real_engine_binary() {
     let (tx, rx) = oneshot::channel();
     pending.lock().unwrap().insert(3, tx);
     let line = serde_json::json!({"id": 3, "method": "scanner.connect", "params": {"deviceId": "sim-ls5000-0", "options": {"timeScale": 0.01}}}).to_string() + "\n";
-    stdin.write_all(line.as_bytes()).await.expect("write connect");
+    stdin
+        .write_all(line.as_bytes())
+        .await
+        .expect("write connect");
     stdin.flush().await.expect("flush connect");
     let connect = rx
         .await
@@ -95,8 +101,12 @@ async fn handshake_against_real_engine_binary() {
     // id 4: engine.shutdown, then the engine must exit 0
     let (tx, rx) = oneshot::channel();
     pending.lock().unwrap().insert(4, tx);
-    let line = serde_json::json!({"id": 4, "method": "engine.shutdown", "params": {}}).to_string() + "\n";
-    stdin.write_all(line.as_bytes()).await.expect("write shutdown");
+    let line =
+        serde_json::json!({"id": 4, "method": "engine.shutdown", "params": {}}).to_string() + "\n";
+    stdin
+        .write_all(line.as_bytes())
+        .await
+        .expect("write shutdown");
     stdin.flush().await.expect("flush shutdown");
     let shutdown = rx
         .await
@@ -111,4 +121,128 @@ async fn handshake_against_real_engine_binary() {
     assert!(exit_status.success(), "engine should exit 0 after shutdown");
 
     reader_task.abort();
+}
+
+/// Field-report regression (fix/engine-hello-ordering): reproduces the
+/// Windows report end to end through the app's *actual* production
+/// engine-session code (`engine::spawn_engine` / `engine::engine_request`),
+/// never a hand-rolled protocol client. Nothing in ports/tauri/app/src ever
+/// constructs an `engine.hello` request itself -- `spawn_engine`'s handshake
+/// task is solely responsible for sending it before anything else can reach
+/// the engine's stdin. Against the pre-fix `engine.rs` (no handshake task,
+/// `send_request` writing straight to the child), this test fails on its
+/// first request with exactly the field report's error: "engine.hello must
+/// be the first request".
+///
+/// Drives the field sequence in the order it actually happens in the app:
+/// (1) device listing, fired automatically on `DeviceBar` mount before any
+/// user interaction -- the report's "Devices list is simultaneously EMPTY"
+/// symptom; (2) New Project / Create, `ProjectPanel`'s submit handler -- the
+/// report's red "engine.hello must be the first request" banner; (3) device
+/// listing again, proving the whole session stays healthy afterward, not
+/// just the first call.
+///
+/// Runs against a `tauri::test` mock (windowless) app rather than a real
+/// window: `tauri_plugin_shell::process::Command::spawn` and the
+/// `CommandChild`/`CommandEvent` types it returns do not depend on the
+/// windowing runtime, only `Manager::manage`/`AppHandle::state` do, and both
+/// work identically under `tauri::test::mock_builder`'s `MockRuntime`.
+#[tokio::test]
+async fn field_sequence_succeeds_without_the_frontend_ever_sending_hello() {
+    let engine_path = match std::env::var("SCANSTUDIO_ENGINE_PATH") {
+        Ok(p) => p,
+        Err(_) => {
+            println!("[engine_sidecar] SCANSTUDIO_ENGINE_PATH not set - skipping integration test");
+            return;
+        }
+    };
+
+    let app = tauri::test::mock_builder()
+        .plugin(tauri_plugin_shell::init())
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("failed to build mock tauri app");
+    let handle = app.handle().clone();
+
+    let command = handle.shell().command(&engine_path);
+    spawn_engine(&handle, command).expect("failed to spawn the engine sidecar for the mock app");
+
+    let assert_never_raced_the_handshake = |label: &str, result: &Result<Value, EngineError>| {
+        if let Err(err) = result {
+            assert!(
+                !err.message.contains("must be the first request"),
+                "{label} raced the handshake: {}",
+                err.message
+            );
+        }
+    };
+
+    // (1) scanner.list, unprompted -- DeviceBar.tsx's mount effect.
+    let list_result = engine_request(
+        handle.state(),
+        "scanner.list".to_string(),
+        serde_json::json!({}),
+    )
+    .await;
+    assert_never_raced_the_handshake("scanner.list", &list_result);
+    let list = list_result.expect("scanner.list must succeed without a manually-sent hello");
+    let devices = list["devices"].as_array().expect("devices array");
+    assert!(!devices.is_empty(), "device list must not be empty");
+    let device_id = devices[0]["deviceId"]
+        .as_str()
+        .expect("deviceId string")
+        .to_string();
+
+    // (2) project.create with the field report's exact recipe -- strip6, 6
+    // frames, c41ColorNegative -- into a throwaway directory standing in for
+    // the report's "F:\" output folder.
+    let temp_dir = std::env::temp_dir().join(format!(
+        "scanstudio-engine-sidecar-field-repro-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or_default(),
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp project dir");
+    let create_result = engine_request(
+        handle.state(),
+        "project.create".to_string(),
+        serde_json::json!({
+            "name": "field-report-repro",
+            "carrier": "strip6",
+            "frameCount": 6,
+            "filmProcess": "c41ColorNegative",
+            "directory": temp_dir.display().to_string(),
+        }),
+    )
+    .await;
+    assert_never_raced_the_handshake("project.create", &create_result);
+    create_result.expect("project.create must succeed without a manually-sent hello");
+
+    // (3) scanner.list again -- the session must stay healthy for the rest
+    // of the app's life, not just its first call.
+    let relist_result = engine_request(
+        handle.state(),
+        "scanner.list".to_string(),
+        serde_json::json!({}),
+    )
+    .await;
+    assert_never_raced_the_handshake("scanner.list (after create)", &relist_result);
+    let relist = relist_result.expect("scanner.list must still succeed after project.create");
+    let redevices = relist["devices"].as_array().expect("devices array");
+    assert!(!redevices.is_empty(), "device list must stay populated");
+    assert_eq!(redevices[0]["deviceId"].as_str(), Some(device_id.as_str()));
+
+    let shutdown_result = engine_request(
+        handle.state(),
+        "engine.shutdown".to_string(),
+        serde_json::json!({}),
+    )
+    .await;
+    assert_eq!(
+        shutdown_result.expect("engine.shutdown must succeed"),
+        serde_json::json!({})
+    );
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
 }


### PR DESCRIPTION
Field report from the first real Windows run, on real hardware, with all environment probes green: launching the Tauri app, filling in the New Project form (`strip6`, 6 frames, `c41ColorNegative`, output on `F:`), and clicking Create produced a red error `engine.hello must be the first request`. The Devices list was simultaneously empty despite the LS-5000 being attached to WSL and the bridge launching cleanly.

**Root cause:** nothing in `ports/tauri/app` ever sent `engine.hello`. `engine.rs`'s `setup()` spawned the `scanstudio-engine` sidecar and exposed `EngineHandle` to the frontend immediately, so the frontend's first real request -- `scanner.list`, fired unprompted by `DeviceBar`'s mount effect -- was the actual first line the engine's stdin ever saw. The engine's `reject_before_hello` (`vendor/engine/src/server.rs:678`) rejects that with `INVALID_PARAMS` "engine.hello must be the first request", and keeps rejecting every later request on that same process too, since hello never got a chance to run. `DeviceBar` swallows the `scanner.list` failure into an empty device list (`ports/tauri/app/src/views/DeviceBar.tsx:45`); `ProjectPanel`'s Create handler surfaces the same rejection verbatim as its red error banner (`ports/tauri/app/src/views/ProjectPanel.tsx:119`) -- both symptoms from the field report.

Every existing test that exercised the real engine binary (`skeleton.test.ts`, `sim-session.test.ts`, the Rust `engine_sidecar` handshake test) manually sent `engine.hello` as its own setup step before touching `SessionStore`/`EngineHandle`. That is exactly what hid this: those tests prove the protocol and the engine binary behave correctly once hello is sent, never that the app's own engine-session code sends it. It never did, on any platform -- Windows was just the first time a human ran the shipped app end to end against a live engine process instead of a pre-handshaked test harness.

**Fix:** extract `setup()`'s spawn/wire logic into `spawn_engine()`, which now also starts a handshake task that sends `engine.hello` and resolves a per-process `watch::Sender<HandshakeState>`. `send_request` -- the sole path from `engine_request` (the only Tauri command that talks to the sidecar) to the child's stdin -- awaits that handshake before writing anything, so hello is structurally guaranteed to be first on every connection no matter when the frontend fires its first call, or after any future respawn that resets the same gate. `spawn_engine` is generic over the Tauri `Runtime` rather than pinned to `Wry` so it can run identically under `tauri::test`'s mocked runtime for the regression test below. `PROTOCOL.md` semantics are unchanged -- this is entirely app-side session management.

## Testing

- Three `engine.rs` unit tests cover the handshake gate directly: resolves immediately when already `Ready`, propagates a recorded `Failed`, and genuinely blocks a caller until `Pending` resolves (asserts the waiter task has NOT finished before the state is set, not just that it eventually finishes).
- New Rust integration test `field_sequence_succeeds_without_the_frontend_ever_sending_hello` (`ports/tauri/app/src-tauri/tests/engine_sidecar.rs`) drives the exact field sequence -- `scanner.list`, then `project.create` with the field report's `strip6`/6-frame/`c41ColorNegative` recipe, then `scanner.list` again -- through the app's actual `engine_request`/`spawn_engine` code against the real compiled engine binary and a mocked (windowless) Tauri app, with no manual hello anywhere.
- Verified this test fails with the exact field-report error (`engine.hello must be the first request`) when run against the pre-fix code, and passes with the fix -- confirming it is a real regression test, not a tautology.
- Full `ports/tauri` suite green via `verify-app.sh`: 124 Rust tests (`cargo test --locked`), 312 JS tests across 49 files (`npm test`), `tsc --noEmit`, `vite build`.

Touches `ports/tauri/**` (3 files: `Cargo.toml`, `src/engine.rs`, `tests/engine_sidecar.rs`), so `ports.yml` will run full Windows/Linux preview builds on this PR.
