### PR TITLE
fix(roll): instrument A/B/near-twin gap-count raises + close pitch dead zone

### DIFF
--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -36,7 +36,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "83903d5abc099011cfc0d72166f6991c2cde8aec25da1422aea6ef4cc7c6bd9b",
+    "roll_index.py": "850c28197dc0f9aec505996efa19553a68a72aab25df60adc0db5f6e1202eb81",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -36,7 +36,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "850c28197dc0f9aec505996efa19553a68a72aab25df60adc0db5f6e1202eb81",
+    "roll_index.py": "46147850ff5e7e42b83a7ca04eb0d262eb9028858e444beb4818c4f217426d7a",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -7,6 +7,7 @@ pcap discovery, rendering, and scanner lifecycle remain outside this module.
 
 from __future__ import annotations
 
+import json
 import math
 import struct
 import sys
@@ -31,9 +32,45 @@ LEADING_ANCHOR_REVIEW_REASON = "leading-anchor-divergence"
 TRANSPORT_ORIGIN_CLAMP_REASON = "transport-origin-extrapolated-clamp"
 MINIMUM_CONFIDENT_CLEAR_FILM_FRACTION = 0.95
 
+# Stable short codes for the three physical-gap-count IndexDecodeError sites
+# in detect_roll_frames (Lane C, C2-style instrumentation). Field reports
+# quote the exception's own text, and two of these three raises are
+# near-identical prose for different predicates -- these ids are the
+# unambiguous, greppable discriminator the bridge's parenthetical catch-all
+# cannot provide on its own.
+GAP_COUNT_FLOOR_ERROR_ID = "gap-count-floor"
+GAP_LATTICE_ANCHOR_ERROR_ID = "gap-lattice-anchor-floor"
+GAP_DIRECT_SUPPORT_ERROR_ID = "gap-direct-support-floor"
+
 
 class IndexDecodeError(ValueError):
-    """Input is not a self-consistent LS-5000 roll-index capture."""
+    """Input is not a self-consistent LS-5000 roll-index capture.
+
+    ``error_id`` and ``diagnostics`` are optional, keyword-only, and additive
+    (Lane C, C2 style): a stable short code plus a numbers-only, JSON-safe
+    payload of exactly what the failing predicate evaluated, appended to the
+    message the same way ``preview_session._roll_session_diagnostics``
+    embeds ``RollSessionError``'s numbers -- never image or array data. Every
+    raise site that omits them keeps today's plain single-string behavior.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_id: str | None = None,
+        diagnostics: dict | None = None,
+    ) -> None:
+        full_message = message
+        if error_id is not None:
+            full_message = f"{full_message} [{error_id}]"
+        if diagnostics is not None:
+            full_message = f"{full_message} " + json.dumps(
+                diagnostics, sort_keys=True
+            )
+        super().__init__(full_message)
+        self.error_id = error_id
+        self.diagnostics = diagnostics
 
 
 class LeadingFrameClippedError(IndexDecodeError):
@@ -795,6 +832,85 @@ def _nearest_evidence_run(
     return nearest, nearest_distance
 
 
+def _gap_run_diagnostics(
+    rgb16: np.ndarray,
+    aperture: tuple[int, int],
+    evidence_runs: list[tuple[int, int]],
+    narrow_runs: list[tuple[int, int]],
+    transmission: np.ndarray,
+    nonuniformity: np.ndarray,
+    direct: np.ndarray,
+) -> dict:
+    """Numbers-only physical-gap diagnostics shared by every distinct-gap-
+    count ``IndexDecodeError`` (Lane C, C2 style): raster/aperture geometry,
+    every detected evidence-run width, which widths the ``[3, 12]``-row
+    narrow window discarded and why, and how strong the accepted gap rows'
+    transmission/uniformity readings actually were. Scalars and lists of
+    numbers only -- no image or array data -- safe to embed verbatim in a
+    field report.
+    """
+
+    widths = [int(end - start) for start, end in evidence_runs]
+    gap_transmission = transmission[direct]
+    gap_nonuniformity = nonuniformity[direct]
+    return {
+        "raster_rows": int(len(rgb16)),
+        "aperture_columns": [int(aperture[0]), int(aperture[1])],
+        "aperture_width": int(aperture[1] - aperture[0]),
+        "evidence_run_count": len(evidence_runs),
+        "evidence_run_widths": widths,
+        "narrow_run_count": len(narrow_runs),
+        "narrow_run_count_required": 3,
+        "discarded_narrow_widths": sorted(width for width in widths if width < 3),
+        "discarded_wide_widths": sorted(width for width in widths if width > 12),
+        "gap_row_transmission_median": (
+            float(np.median(gap_transmission)) if gap_transmission.size else None
+        ),
+        "gap_row_transmission_min": (
+            float(gap_transmission.min()) if gap_transmission.size else None
+        ),
+        "gap_row_nonuniformity_median": (
+            float(np.median(gap_nonuniformity)) if gap_nonuniformity.size else None
+        ),
+        "gap_row_nonuniformity_max": (
+            float(gap_nonuniformity.max()) if gap_nonuniformity.size else None
+        ),
+    }
+
+
+def _gap_lattice_diagnostics(
+    *,
+    anchor_centers: list[float],
+    assignments: dict[int, tuple[float, float]],
+    residuals: list[float],
+    autocorrelation_peak: float,
+    autocorrelation_lag: int,
+    coarse_pitch: float,
+    coarse_phase: float,
+) -> dict:
+    """Numbers-only lattice-anchor diagnostics (Lane C, C2 style) for the
+    physical-gap-lattice-anchoring failure: how many narrow-run centers were
+    found vs. survived assignment to the fitted comb, their displacement
+    (residual) distribution, and the coarse pitch/phase the comb was fit
+    against. Scalars and lists of numbers only.
+    """
+
+    return {
+        "anchor_center_count": len(anchor_centers),
+        "anchor_assignment_count": len(assignments),
+        "anchor_assignment_count_required": 3,
+        "anchor_residual_rows": [round(float(value), 3) for value in residuals],
+        "anchor_residual_max_rows": 8.0,
+        "anchor_residuals_rejected_count": sum(
+            1 for value in residuals if value > 8.0
+        ),
+        "autocorrelation_peak": float(autocorrelation_peak),
+        "autocorrelation_lag": int(autocorrelation_lag),
+        "coarse_pitch_rows": float(coarse_pitch),
+        "coarse_phase_rows": float(coarse_phase),
+    }
+
+
 def detect_roll_frames(
     rgb16: np.ndarray,
     known: np.ndarray,
@@ -833,7 +949,19 @@ def detect_roll_frames(
         (start, end) for start, end in evidence_runs if 3 <= end - start <= 12
     ]
     if len(narrow_runs) < 3:
-        raise IndexDecodeError("roll detector found too few distinct physical gaps")
+        raise IndexDecodeError(
+            "roll detector found too few distinct physical gaps",
+            error_id=GAP_COUNT_FLOOR_ERROR_ID,
+            diagnostics=_gap_run_diagnostics(
+                rgb16,
+                aperture,
+                evidence_runs,
+                narrow_runs,
+                transmission,
+                nonuniformity,
+                direct,
+            ),
+        )
     anchor_signal = np.zeros_like(evidence)
     anchor_centers = []
     for start, end in narrow_runs:
@@ -876,9 +1004,11 @@ def detect_roll_frames(
     # more than eight rows from the comb are scene artifacts; a second robust
     # fit removes assignments whose residual still exceeds three rows.
     assignments: dict[int, tuple[float, float]] = {}
+    anchor_residuals: list[float] = []
     for center in anchor_centers:
         lattice_index = int(np.rint((center - coarse_phase) / coarse_pitch))
         residual = abs(center - (coarse_phase + lattice_index * coarse_pitch))
+        anchor_residuals.append(residual)
         if residual > 8.0:
             continue
         previous = assignments.get(lattice_index)
@@ -886,7 +1016,28 @@ def detect_roll_frames(
             assignments[lattice_index] = (residual, center)
     if len(assignments) < 3:
         raise IndexDecodeError(
-            "roll detector could not anchor the physical-gap lattice"
+            "roll detector could not anchor the physical-gap lattice",
+            error_id=GAP_LATTICE_ANCHOR_ERROR_ID,
+            diagnostics={
+                **_gap_run_diagnostics(
+                    rgb16,
+                    aperture,
+                    evidence_runs,
+                    narrow_runs,
+                    transmission,
+                    nonuniformity,
+                    direct,
+                ),
+                **_gap_lattice_diagnostics(
+                    anchor_centers=anchor_centers,
+                    assignments=assignments,
+                    residuals=anchor_residuals,
+                    autocorrelation_peak=autocorrelation_peak,
+                    autocorrelation_lag=peak_lag,
+                    coarse_pitch=coarse_pitch,
+                    coarse_phase=coarse_phase,
+                ),
+            },
         )
     anchor_indices = np.asarray(sorted(assignments), dtype=np.float64)
     anchored_centers = np.asarray(
@@ -1137,9 +1288,32 @@ def detect_roll_frames(
         raise IndexDecodeError("roll detector found fewer than two frame intervals")
     alignment_boundary_count = alignment_end - cell_start + 1
     alignment_boundaries = boundaries[:alignment_boundary_count]
-    if sum(item.support == "direct" for item in alignment_boundaries) < 3:
+    direct_support_count = sum(
+        item.support == "direct" for item in alignment_boundaries
+    )
+    if direct_support_count < 3:
         raise IndexDecodeError(
-            "roll detector found insufficient distinct physical gaps"
+            "roll detector found insufficient distinct physical gaps",
+            error_id=GAP_DIRECT_SUPPORT_ERROR_ID,
+            diagnostics={
+                **_gap_run_diagnostics(
+                    rgb16,
+                    aperture,
+                    evidence_runs,
+                    narrow_runs,
+                    transmission,
+                    nonuniformity,
+                    direct,
+                ),
+                "alignment_boundary_count": alignment_boundary_count,
+                "alignment_boundary_supports": [
+                    item.support for item in alignment_boundaries
+                ],
+                "direct_support_count": direct_support_count,
+                "direct_support_count_required": 3,
+                "refined_pitch_rows": float(pitch),
+                "phase_rows": float(phase),
+            },
         )
 
     intervals: list[FrameInterval] = []

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -969,8 +969,16 @@ def detect_roll_frames(
         anchor_centers.append((start + end - 1) / 2.0)
 
     centered = anchor_signal - float(anchor_signal.mean())
-    lag_min = max(3, int(math.floor(nominal_frame_rows * 0.90)))
-    lag_max = min(len(evidence) - 3, int(math.ceil(nominal_frame_rows * 1.10)))
+    # Matches the band the final refined-pitch check below already declares
+    # acceptable (0.85x/1.15x nominal). The search used to stop at
+    # 0.90x/1.10x, so pitches the band check would happily accept were
+    # structurally unreachable here -- a real dead zone, always reported as
+    # "no physical gap periodicity" (misleading: the periodicity exists, the
+    # search simply never looked there). Replayed bit-identical (frame
+    # origins, pitch, confidence) on all 44 real archived LS-5000 whole-roll
+    # previews in the corpus; see FEEDING-ROBUSTNESS-20260805.md P2.
+    lag_min = max(3, int(math.floor(nominal_frame_rows * 0.85)))
+    lag_max = min(len(evidence) - 3, int(math.ceil(nominal_frame_rows * 1.15)))
     correlations: list[tuple[float, int]] = []
     for lag in range(lag_min, lag_max + 1):
         value = float(np.dot(centered[:-lag], centered[lag:]) / (len(centered) - lag))

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -655,6 +655,26 @@ def test_gap_beyond_alignment_window_raises_direct_support_floor_with_diagnostic
     assert json.dumps(diagnostics, sort_keys=True) in str(error)
 
 
+def test_autocorrelation_lag_search_matches_declared_pitch_band() -> None:
+    """P2 (FEEDING-ROBUSTNESS-20260805.md).  The lag search now spans the
+    same ``[0.85, 1.15] * nominal`` band the refined-pitch check already
+    declares acceptable (:879), closing the dead zone where a real
+    periodicity existed but the old ``[0.90, 1.10]`` search never looked.
+    Pitches just inside the widened band now resolve; pitches just outside
+    it still correctly refuse.
+    """
+    for pitch in (125, 165):  # inside [0.85, 1.15] * 145, outside the old band
+        rgb, _boundaries = _synthetic_roll(30, pitch=pitch, leader=30, tail=30)
+        detection = _detect(rgb)
+        assert detection.confidence == "high"
+        assert detection.pitch_rows == pytest.approx(pitch, abs=0.01)
+
+    for pitch in (123, 167):  # just outside even the widened [0.85, 1.15] band
+        rgb, _boundaries = _synthetic_roll(30, pitch=pitch, leader=30, tail=30)
+        with pytest.raises(roll.IndexDecodeError):
+            _detect(rgb)
+
+
 def _boundary(
     index: int,
     row: int,

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -1,5 +1,6 @@
 """Regression contracts for whole-roll index decoding and dynamic frame origins."""
 
+import json
 import math
 import os
 import struct
@@ -483,6 +484,175 @@ def test_expected_count_must_be_an_integer_in_supported_range(expected: int) -> 
     rgb, _boundaries = _synthetic_roll(8, leader=91, tail=47)
     with pytest.raises(roll.IndexDecodeError, match="integer in 2..40"):
         _detect(rgb, expected_frame_count=expected)
+
+
+# --- P1: numeric diagnostics + stable ids on the physical-gap-count raises ---
+# (FEEDING-ROBUSTNESS-20260805.md P1). :810, :861 and :1085 (near-identical
+# prose to :810 but a different predicate, per the report's own reporting
+# hazard, Sec 1.0) were previously bare strings; each now carries a unique
+# ``error_id`` plus a numbers-only, JSON-safe ``diagnostics`` payload of
+# exactly what its predicate evaluated, mirroring how
+# ``preview_session._roll_session_diagnostics`` already instruments
+# ``RollSessionError`` (Lane C, C2).
+
+
+def _synthetic_roll_with_gap_rows(
+    boundary_rows: list[int],
+    *,
+    height: int,
+    band_halfwidth: int = 3,
+) -> np.ndarray:
+    """Like ``_synthetic_roll`` but with explicit clear-film gap rows and a
+    configurable band half-width, so a test can force run widths outside the
+    ``[3, 12]``-row narrow window or place a gap off the fitted lattice.
+    """
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[:, :, channel] = base + texture * (3 - channel) // 2
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    clear_noise = ((x * 19 + y * 13) % 301 - 150)[:, :, None]
+    for boundary in boundary_rows:
+        lo = max(0, boundary - band_halfwidth)
+        hi = min(height, boundary + band_halfwidth)
+        aperture[lo:hi] = clear_base + clear_noise[lo:hi]
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16)
+
+
+def test_wide_gaps_raise_gap_count_floor_with_numeric_diagnostics() -> None:
+    """P1, site :810.  Six gaps widened to 20 rows (>12, discarded as "wide")
+    leaves zero narrow runs -- confirms the id and every field the predicate
+    actually evaluated.
+    """
+    boundary_rows = [200 + index * 143 for index in range(6)]
+    rgb = _synthetic_roll_with_gap_rows(
+        boundary_rows, height=6 * 145 + 200, band_halfwidth=10
+    )
+
+    with pytest.raises(roll.IndexDecodeError) as excinfo:
+        _detect(rgb)
+
+    error = excinfo.value
+    assert error.error_id == roll.GAP_COUNT_FLOOR_ERROR_ID
+    assert f"[{roll.GAP_COUNT_FLOOR_ERROR_ID}]" in str(error)
+    diagnostics = error.diagnostics
+    assert diagnostics["narrow_run_count"] == 0
+    assert diagnostics["narrow_run_count_required"] == 3
+    assert diagnostics["evidence_run_count"] == 6
+    assert diagnostics["discarded_wide_widths"] == [20] * 6
+    assert diagnostics["discarded_narrow_widths"] == []
+    assert diagnostics["raster_rows"] == rgb.shape[0]
+    assert diagnostics["aperture_width"] == 90
+    assert json.dumps(diagnostics, sort_keys=True) in str(error)
+
+
+def test_off_lattice_gap_raises_lattice_anchor_floor_with_numeric_diagnostics() -> None:
+    """P1, site :861-864.  Three narrow gaps clear the count floor, but the
+    third is 30 rows off the pitch the other two establish, so it cannot be
+    assigned to the fitted comb -- confirms the id and the lattice-specific
+    fields (autocorrelation, coarse pitch/phase, anchor residuals).
+    """
+    boundary_rows = [200, 345, 520]  # third displaced +30 rows from pitch 145
+    rgb = _synthetic_roll_with_gap_rows(boundary_rows, height=6 * 145, band_halfwidth=3)
+
+    with pytest.raises(roll.IndexDecodeError) as excinfo:
+        _detect(rgb)
+
+    error = excinfo.value
+    assert error.error_id == roll.GAP_LATTICE_ANCHOR_ERROR_ID
+    assert f"[{roll.GAP_LATTICE_ANCHOR_ERROR_ID}]" in str(error)
+    diagnostics = error.diagnostics
+    assert diagnostics["narrow_run_count"] == 3
+    assert diagnostics["anchor_center_count"] == 3
+    assert diagnostics["anchor_assignment_count"] == 2
+    assert diagnostics["anchor_assignment_count_required"] == 3
+    assert len(diagnostics["anchor_residual_rows"]) == 3
+    assert max(diagnostics["anchor_residual_rows"]) > 8.0
+    assert diagnostics["anchor_residuals_rejected_count"] == 1
+    assert diagnostics["autocorrelation_peak"] > 0
+    assert diagnostics["coarse_pitch_rows"] > 0
+    assert json.dumps(diagnostics, sort_keys=True) in str(error)
+
+
+def _synthetic_roll_with_isolated_trailing_gap(
+    *,
+    pitch: int = 145,
+    leading_gap: int = 300,
+    band_halfwidth: int = 3,
+    background_fraction: float = 0.80,
+    tail: int = 250,
+) -> np.ndarray:
+    """Two real content-bordered gaps (the alignment window's real evidence)
+    plus a third narrow gap two pitches further out, sitting in a flat,
+    content-free background. All three clear the count floor (:810) and the
+    lattice-anchor floor (:861), but the third lies outside the
+    content-driven alignment window: the window sees only 2 "direct"
+    boundaries out of the 3 required, tripping the near-twin at :1085
+    without tripping either earlier, differently-worded gate. The
+    background must be perfectly flat (zero row-to-row variation) -- any
+    noise crosses the derived content-range threshold and pulls the window
+    past the isolated third gap.
+    """
+    trailing_gap = leading_gap + 2 * pitch
+    isolated_gap = trailing_gap + pitch
+    height = isolated_gap + tail
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    clear_noise = ((x * 19 + y * 13) % 301 - 150)[:, :, None]
+
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    aperture[:, :, :] = (clear_base * background_fraction).astype(np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[leading_gap:trailing_gap, :, channel] = (
+            base + texture[leading_gap:trailing_gap] * (3 - channel) // 2
+        )
+    for boundary in (leading_gap, trailing_gap, isolated_gap):
+        lo = max(0, boundary - band_halfwidth)
+        hi = min(height, boundary + band_halfwidth)
+        aperture[lo:hi] = clear_base + clear_noise[lo:hi]
+
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16)
+
+
+def test_gap_beyond_alignment_window_raises_direct_support_floor_with_diagnostics() -> (
+    None
+):
+    """P1, near-twin site :1085.  A predicate distinct from :810 despite
+    near-identical prose (the report's reporting hazard, Sec 1.0): this one
+    fires on the content-truncated alignment window, evaluated ~270 lines
+    after the count floor, with its own id and payload.
+    """
+    rgb = _synthetic_roll_with_isolated_trailing_gap()
+
+    with pytest.raises(roll.IndexDecodeError) as excinfo:
+        _detect(rgb)
+
+    error = excinfo.value
+    assert error.error_id == roll.GAP_DIRECT_SUPPORT_ERROR_ID
+    assert error.error_id != roll.GAP_COUNT_FLOOR_ERROR_ID
+    assert f"[{roll.GAP_DIRECT_SUPPORT_ERROR_ID}]" in str(error)
+    diagnostics = error.diagnostics
+    assert diagnostics["narrow_run_count"] == 3  # the count floor (:810) passed
+    assert diagnostics["direct_support_count"] == 2
+    assert diagnostics["direct_support_count_required"] == 3
+    assert diagnostics["alignment_boundary_count"] == len(
+        diagnostics["alignment_boundary_supports"]
+    )
+    assert diagnostics["alignment_boundary_supports"].count("direct") == 2
+    assert diagnostics["refined_pitch_rows"] == pytest.approx(145.0, abs=0.5)
+    assert json.dumps(diagnostics, sort_keys=True) in str(error)
 
 
 def _boundary(

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -36,7 +36,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "83903d5abc099011cfc0d72166f6991c2cde8aec25da1422aea6ef4cc7c6bd9b",
+    "roll_index.py": "850c28197dc0f9aec505996efa19553a68a72aab25df60adc0db5f6e1202eb81",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -36,7 +36,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "850c28197dc0f9aec505996efa19553a68a72aab25df60adc0db5f6e1202eb81",
+    "roll_index.py": "46147850ff5e7e42b83a7ca04eb0d262eb9028858e444beb4818c4f217426d7a",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -7,6 +7,7 @@ pcap discovery, rendering, and scanner lifecycle remain outside this module.
 
 from __future__ import annotations
 
+import json
 import math
 import struct
 import sys
@@ -31,9 +32,45 @@ LEADING_ANCHOR_REVIEW_REASON = "leading-anchor-divergence"
 TRANSPORT_ORIGIN_CLAMP_REASON = "transport-origin-extrapolated-clamp"
 MINIMUM_CONFIDENT_CLEAR_FILM_FRACTION = 0.95
 
+# Stable short codes for the three physical-gap-count IndexDecodeError sites
+# in detect_roll_frames (Lane C, C2-style instrumentation). Field reports
+# quote the exception's own text, and two of these three raises are
+# near-identical prose for different predicates -- these ids are the
+# unambiguous, greppable discriminator the bridge's parenthetical catch-all
+# cannot provide on its own.
+GAP_COUNT_FLOOR_ERROR_ID = "gap-count-floor"
+GAP_LATTICE_ANCHOR_ERROR_ID = "gap-lattice-anchor-floor"
+GAP_DIRECT_SUPPORT_ERROR_ID = "gap-direct-support-floor"
+
 
 class IndexDecodeError(ValueError):
-    """Input is not a self-consistent LS-5000 roll-index capture."""
+    """Input is not a self-consistent LS-5000 roll-index capture.
+
+    ``error_id`` and ``diagnostics`` are optional, keyword-only, and additive
+    (Lane C, C2 style): a stable short code plus a numbers-only, JSON-safe
+    payload of exactly what the failing predicate evaluated, appended to the
+    message the same way ``preview_session._roll_session_diagnostics``
+    embeds ``RollSessionError``'s numbers -- never image or array data. Every
+    raise site that omits them keeps today's plain single-string behavior.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_id: str | None = None,
+        diagnostics: dict | None = None,
+    ) -> None:
+        full_message = message
+        if error_id is not None:
+            full_message = f"{full_message} [{error_id}]"
+        if diagnostics is not None:
+            full_message = f"{full_message} " + json.dumps(
+                diagnostics, sort_keys=True
+            )
+        super().__init__(full_message)
+        self.error_id = error_id
+        self.diagnostics = diagnostics
 
 
 class LeadingFrameClippedError(IndexDecodeError):
@@ -795,6 +832,85 @@ def _nearest_evidence_run(
     return nearest, nearest_distance
 
 
+def _gap_run_diagnostics(
+    rgb16: np.ndarray,
+    aperture: tuple[int, int],
+    evidence_runs: list[tuple[int, int]],
+    narrow_runs: list[tuple[int, int]],
+    transmission: np.ndarray,
+    nonuniformity: np.ndarray,
+    direct: np.ndarray,
+) -> dict:
+    """Numbers-only physical-gap diagnostics shared by every distinct-gap-
+    count ``IndexDecodeError`` (Lane C, C2 style): raster/aperture geometry,
+    every detected evidence-run width, which widths the ``[3, 12]``-row
+    narrow window discarded and why, and how strong the accepted gap rows'
+    transmission/uniformity readings actually were. Scalars and lists of
+    numbers only -- no image or array data -- safe to embed verbatim in a
+    field report.
+    """
+
+    widths = [int(end - start) for start, end in evidence_runs]
+    gap_transmission = transmission[direct]
+    gap_nonuniformity = nonuniformity[direct]
+    return {
+        "raster_rows": int(len(rgb16)),
+        "aperture_columns": [int(aperture[0]), int(aperture[1])],
+        "aperture_width": int(aperture[1] - aperture[0]),
+        "evidence_run_count": len(evidence_runs),
+        "evidence_run_widths": widths,
+        "narrow_run_count": len(narrow_runs),
+        "narrow_run_count_required": 3,
+        "discarded_narrow_widths": sorted(width for width in widths if width < 3),
+        "discarded_wide_widths": sorted(width for width in widths if width > 12),
+        "gap_row_transmission_median": (
+            float(np.median(gap_transmission)) if gap_transmission.size else None
+        ),
+        "gap_row_transmission_min": (
+            float(gap_transmission.min()) if gap_transmission.size else None
+        ),
+        "gap_row_nonuniformity_median": (
+            float(np.median(gap_nonuniformity)) if gap_nonuniformity.size else None
+        ),
+        "gap_row_nonuniformity_max": (
+            float(gap_nonuniformity.max()) if gap_nonuniformity.size else None
+        ),
+    }
+
+
+def _gap_lattice_diagnostics(
+    *,
+    anchor_centers: list[float],
+    assignments: dict[int, tuple[float, float]],
+    residuals: list[float],
+    autocorrelation_peak: float,
+    autocorrelation_lag: int,
+    coarse_pitch: float,
+    coarse_phase: float,
+) -> dict:
+    """Numbers-only lattice-anchor diagnostics (Lane C, C2 style) for the
+    physical-gap-lattice-anchoring failure: how many narrow-run centers were
+    found vs. survived assignment to the fitted comb, their displacement
+    (residual) distribution, and the coarse pitch/phase the comb was fit
+    against. Scalars and lists of numbers only.
+    """
+
+    return {
+        "anchor_center_count": len(anchor_centers),
+        "anchor_assignment_count": len(assignments),
+        "anchor_assignment_count_required": 3,
+        "anchor_residual_rows": [round(float(value), 3) for value in residuals],
+        "anchor_residual_max_rows": 8.0,
+        "anchor_residuals_rejected_count": sum(
+            1 for value in residuals if value > 8.0
+        ),
+        "autocorrelation_peak": float(autocorrelation_peak),
+        "autocorrelation_lag": int(autocorrelation_lag),
+        "coarse_pitch_rows": float(coarse_pitch),
+        "coarse_phase_rows": float(coarse_phase),
+    }
+
+
 def detect_roll_frames(
     rgb16: np.ndarray,
     known: np.ndarray,
@@ -833,7 +949,19 @@ def detect_roll_frames(
         (start, end) for start, end in evidence_runs if 3 <= end - start <= 12
     ]
     if len(narrow_runs) < 3:
-        raise IndexDecodeError("roll detector found too few distinct physical gaps")
+        raise IndexDecodeError(
+            "roll detector found too few distinct physical gaps",
+            error_id=GAP_COUNT_FLOOR_ERROR_ID,
+            diagnostics=_gap_run_diagnostics(
+                rgb16,
+                aperture,
+                evidence_runs,
+                narrow_runs,
+                transmission,
+                nonuniformity,
+                direct,
+            ),
+        )
     anchor_signal = np.zeros_like(evidence)
     anchor_centers = []
     for start, end in narrow_runs:
@@ -876,9 +1004,11 @@ def detect_roll_frames(
     # more than eight rows from the comb are scene artifacts; a second robust
     # fit removes assignments whose residual still exceeds three rows.
     assignments: dict[int, tuple[float, float]] = {}
+    anchor_residuals: list[float] = []
     for center in anchor_centers:
         lattice_index = int(np.rint((center - coarse_phase) / coarse_pitch))
         residual = abs(center - (coarse_phase + lattice_index * coarse_pitch))
+        anchor_residuals.append(residual)
         if residual > 8.0:
             continue
         previous = assignments.get(lattice_index)
@@ -886,7 +1016,28 @@ def detect_roll_frames(
             assignments[lattice_index] = (residual, center)
     if len(assignments) < 3:
         raise IndexDecodeError(
-            "roll detector could not anchor the physical-gap lattice"
+            "roll detector could not anchor the physical-gap lattice",
+            error_id=GAP_LATTICE_ANCHOR_ERROR_ID,
+            diagnostics={
+                **_gap_run_diagnostics(
+                    rgb16,
+                    aperture,
+                    evidence_runs,
+                    narrow_runs,
+                    transmission,
+                    nonuniformity,
+                    direct,
+                ),
+                **_gap_lattice_diagnostics(
+                    anchor_centers=anchor_centers,
+                    assignments=assignments,
+                    residuals=anchor_residuals,
+                    autocorrelation_peak=autocorrelation_peak,
+                    autocorrelation_lag=peak_lag,
+                    coarse_pitch=coarse_pitch,
+                    coarse_phase=coarse_phase,
+                ),
+            },
         )
     anchor_indices = np.asarray(sorted(assignments), dtype=np.float64)
     anchored_centers = np.asarray(
@@ -1137,9 +1288,32 @@ def detect_roll_frames(
         raise IndexDecodeError("roll detector found fewer than two frame intervals")
     alignment_boundary_count = alignment_end - cell_start + 1
     alignment_boundaries = boundaries[:alignment_boundary_count]
-    if sum(item.support == "direct" for item in alignment_boundaries) < 3:
+    direct_support_count = sum(
+        item.support == "direct" for item in alignment_boundaries
+    )
+    if direct_support_count < 3:
         raise IndexDecodeError(
-            "roll detector found insufficient distinct physical gaps"
+            "roll detector found insufficient distinct physical gaps",
+            error_id=GAP_DIRECT_SUPPORT_ERROR_ID,
+            diagnostics={
+                **_gap_run_diagnostics(
+                    rgb16,
+                    aperture,
+                    evidence_runs,
+                    narrow_runs,
+                    transmission,
+                    nonuniformity,
+                    direct,
+                ),
+                "alignment_boundary_count": alignment_boundary_count,
+                "alignment_boundary_supports": [
+                    item.support for item in alignment_boundaries
+                ],
+                "direct_support_count": direct_support_count,
+                "direct_support_count_required": 3,
+                "refined_pitch_rows": float(pitch),
+                "phase_rows": float(phase),
+            },
         )
 
     intervals: list[FrameInterval] = []

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -969,8 +969,16 @@ def detect_roll_frames(
         anchor_centers.append((start + end - 1) / 2.0)
 
     centered = anchor_signal - float(anchor_signal.mean())
-    lag_min = max(3, int(math.floor(nominal_frame_rows * 0.90)))
-    lag_max = min(len(evidence) - 3, int(math.ceil(nominal_frame_rows * 1.10)))
+    # Matches the band the final refined-pitch check below already declares
+    # acceptable (0.85x/1.15x nominal). The search used to stop at
+    # 0.90x/1.10x, so pitches the band check would happily accept were
+    # structurally unreachable here -- a real dead zone, always reported as
+    # "no physical gap periodicity" (misleading: the periodicity exists, the
+    # search simply never looked there). Replayed bit-identical (frame
+    # origins, pitch, confidence) on all 44 real archived LS-5000 whole-roll
+    # previews in the corpus; see FEEDING-ROBUSTNESS-20260805.md P2.
+    lag_min = max(3, int(math.floor(nominal_frame_rows * 0.85)))
+    lag_max = min(len(evidence) - 3, int(math.ceil(nominal_frame_rows * 1.15)))
     correlations: list[tuple[float, int]] = []
     for lag in range(lag_min, lag_max + 1):
         value = float(np.dot(centered[:-lag], centered[lag:]) / (len(centered) - lag))

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -655,6 +655,26 @@ def test_gap_beyond_alignment_window_raises_direct_support_floor_with_diagnostic
     assert json.dumps(diagnostics, sort_keys=True) in str(error)
 
 
+def test_autocorrelation_lag_search_matches_declared_pitch_band() -> None:
+    """P2 (FEEDING-ROBUSTNESS-20260805.md).  The lag search now spans the
+    same ``[0.85, 1.15] * nominal`` band the refined-pitch check already
+    declares acceptable (:879), closing the dead zone where a real
+    periodicity existed but the old ``[0.90, 1.10]`` search never looked.
+    Pitches just inside the widened band now resolve; pitches just outside
+    it still correctly refuse.
+    """
+    for pitch in (125, 165):  # inside [0.85, 1.15] * 145, outside the old band
+        rgb, _boundaries = _synthetic_roll(30, pitch=pitch, leader=30, tail=30)
+        detection = _detect(rgb)
+        assert detection.confidence == "high"
+        assert detection.pitch_rows == pytest.approx(pitch, abs=0.01)
+
+    for pitch in (123, 167):  # just outside even the widened [0.85, 1.15] band
+        rgb, _boundaries = _synthetic_roll(30, pitch=pitch, leader=30, tail=30)
+        with pytest.raises(roll.IndexDecodeError):
+            _detect(rgb)
+
+
 def _boundary(
     index: int,
     row: int,

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -1,5 +1,6 @@
 """Regression contracts for whole-roll index decoding and dynamic frame origins."""
 
+import json
 import math
 import os
 import struct
@@ -483,6 +484,175 @@ def test_expected_count_must_be_an_integer_in_supported_range(expected: int) -> 
     rgb, _boundaries = _synthetic_roll(8, leader=91, tail=47)
     with pytest.raises(roll.IndexDecodeError, match="integer in 2..40"):
         _detect(rgb, expected_frame_count=expected)
+
+
+# --- P1: numeric diagnostics + stable ids on the physical-gap-count raises ---
+# (FEEDING-ROBUSTNESS-20260805.md P1). :810, :861 and :1085 (near-identical
+# prose to :810 but a different predicate, per the report's own reporting
+# hazard, Sec 1.0) were previously bare strings; each now carries a unique
+# ``error_id`` plus a numbers-only, JSON-safe ``diagnostics`` payload of
+# exactly what its predicate evaluated, mirroring how
+# ``preview_session._roll_session_diagnostics`` already instruments
+# ``RollSessionError`` (Lane C, C2).
+
+
+def _synthetic_roll_with_gap_rows(
+    boundary_rows: list[int],
+    *,
+    height: int,
+    band_halfwidth: int = 3,
+) -> np.ndarray:
+    """Like ``_synthetic_roll`` but with explicit clear-film gap rows and a
+    configurable band half-width, so a test can force run widths outside the
+    ``[3, 12]``-row narrow window or place a gap off the fitted lattice.
+    """
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[:, :, channel] = base + texture * (3 - channel) // 2
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    clear_noise = ((x * 19 + y * 13) % 301 - 150)[:, :, None]
+    for boundary in boundary_rows:
+        lo = max(0, boundary - band_halfwidth)
+        hi = min(height, boundary + band_halfwidth)
+        aperture[lo:hi] = clear_base + clear_noise[lo:hi]
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16)
+
+
+def test_wide_gaps_raise_gap_count_floor_with_numeric_diagnostics() -> None:
+    """P1, site :810.  Six gaps widened to 20 rows (>12, discarded as "wide")
+    leaves zero narrow runs -- confirms the id and every field the predicate
+    actually evaluated.
+    """
+    boundary_rows = [200 + index * 143 for index in range(6)]
+    rgb = _synthetic_roll_with_gap_rows(
+        boundary_rows, height=6 * 145 + 200, band_halfwidth=10
+    )
+
+    with pytest.raises(roll.IndexDecodeError) as excinfo:
+        _detect(rgb)
+
+    error = excinfo.value
+    assert error.error_id == roll.GAP_COUNT_FLOOR_ERROR_ID
+    assert f"[{roll.GAP_COUNT_FLOOR_ERROR_ID}]" in str(error)
+    diagnostics = error.diagnostics
+    assert diagnostics["narrow_run_count"] == 0
+    assert diagnostics["narrow_run_count_required"] == 3
+    assert diagnostics["evidence_run_count"] == 6
+    assert diagnostics["discarded_wide_widths"] == [20] * 6
+    assert diagnostics["discarded_narrow_widths"] == []
+    assert diagnostics["raster_rows"] == rgb.shape[0]
+    assert diagnostics["aperture_width"] == 90
+    assert json.dumps(diagnostics, sort_keys=True) in str(error)
+
+
+def test_off_lattice_gap_raises_lattice_anchor_floor_with_numeric_diagnostics() -> None:
+    """P1, site :861-864.  Three narrow gaps clear the count floor, but the
+    third is 30 rows off the pitch the other two establish, so it cannot be
+    assigned to the fitted comb -- confirms the id and the lattice-specific
+    fields (autocorrelation, coarse pitch/phase, anchor residuals).
+    """
+    boundary_rows = [200, 345, 520]  # third displaced +30 rows from pitch 145
+    rgb = _synthetic_roll_with_gap_rows(boundary_rows, height=6 * 145, band_halfwidth=3)
+
+    with pytest.raises(roll.IndexDecodeError) as excinfo:
+        _detect(rgb)
+
+    error = excinfo.value
+    assert error.error_id == roll.GAP_LATTICE_ANCHOR_ERROR_ID
+    assert f"[{roll.GAP_LATTICE_ANCHOR_ERROR_ID}]" in str(error)
+    diagnostics = error.diagnostics
+    assert diagnostics["narrow_run_count"] == 3
+    assert diagnostics["anchor_center_count"] == 3
+    assert diagnostics["anchor_assignment_count"] == 2
+    assert diagnostics["anchor_assignment_count_required"] == 3
+    assert len(diagnostics["anchor_residual_rows"]) == 3
+    assert max(diagnostics["anchor_residual_rows"]) > 8.0
+    assert diagnostics["anchor_residuals_rejected_count"] == 1
+    assert diagnostics["autocorrelation_peak"] > 0
+    assert diagnostics["coarse_pitch_rows"] > 0
+    assert json.dumps(diagnostics, sort_keys=True) in str(error)
+
+
+def _synthetic_roll_with_isolated_trailing_gap(
+    *,
+    pitch: int = 145,
+    leading_gap: int = 300,
+    band_halfwidth: int = 3,
+    background_fraction: float = 0.80,
+    tail: int = 250,
+) -> np.ndarray:
+    """Two real content-bordered gaps (the alignment window's real evidence)
+    plus a third narrow gap two pitches further out, sitting in a flat,
+    content-free background. All three clear the count floor (:810) and the
+    lattice-anchor floor (:861), but the third lies outside the
+    content-driven alignment window: the window sees only 2 "direct"
+    boundaries out of the 3 required, tripping the near-twin at :1085
+    without tripping either earlier, differently-worded gate. The
+    background must be perfectly flat (zero row-to-row variation) -- any
+    noise crosses the derived content-range threshold and pulls the window
+    past the isolated third gap.
+    """
+    trailing_gap = leading_gap + 2 * pitch
+    isolated_gap = trailing_gap + pitch
+    height = isolated_gap + tail
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    clear_noise = ((x * 19 + y * 13) % 301 - 150)[:, :, None]
+
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    aperture[:, :, :] = (clear_base * background_fraction).astype(np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[leading_gap:trailing_gap, :, channel] = (
+            base + texture[leading_gap:trailing_gap] * (3 - channel) // 2
+        )
+    for boundary in (leading_gap, trailing_gap, isolated_gap):
+        lo = max(0, boundary - band_halfwidth)
+        hi = min(height, boundary + band_halfwidth)
+        aperture[lo:hi] = clear_base + clear_noise[lo:hi]
+
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16)
+
+
+def test_gap_beyond_alignment_window_raises_direct_support_floor_with_diagnostics() -> (
+    None
+):
+    """P1, near-twin site :1085.  A predicate distinct from :810 despite
+    near-identical prose (the report's reporting hazard, Sec 1.0): this one
+    fires on the content-truncated alignment window, evaluated ~270 lines
+    after the count floor, with its own id and payload.
+    """
+    rgb = _synthetic_roll_with_isolated_trailing_gap()
+
+    with pytest.raises(roll.IndexDecodeError) as excinfo:
+        _detect(rgb)
+
+    error = excinfo.value
+    assert error.error_id == roll.GAP_DIRECT_SUPPORT_ERROR_ID
+    assert error.error_id != roll.GAP_COUNT_FLOOR_ERROR_ID
+    assert f"[{roll.GAP_DIRECT_SUPPORT_ERROR_ID}]" in str(error)
+    diagnostics = error.diagnostics
+    assert diagnostics["narrow_run_count"] == 3  # the count floor (:810) passed
+    assert diagnostics["direct_support_count"] == 2
+    assert diagnostics["direct_support_count_required"] == 3
+    assert diagnostics["alignment_boundary_count"] == len(
+        diagnostics["alignment_boundary_supports"]
+    )
+    assert diagnostics["alignment_boundary_supports"].count("direct") == 2
+    assert diagnostics["refined_pitch_rows"] == pytest.approx(145.0, abs=0.5)
+    assert json.dumps(diagnostics, sort_keys=True) in str(error)
 
 
 def _boundary(


### PR DESCRIPTION
## What

Two low-risk roll-detector changes from `FEEDING-ROBUSTNESS-20260805.md` (P1 + P2), ported from the canonical `public-release/coolscanpy@port/cross-platform` fix into this repo's vendored `coolscanpy/` and its `ports/tauri/vendor/coolscanpy` mirror.

**P1 — instrument the three physical-gap-count `IndexDecodeError` raises.**
`roll_index.py:810` ("too few distinct physical gaps"), `:861-864` ("could not anchor the physical-gap lattice"), and `:1085` ("insufficient distinct physical gaps" — near-identical prose to `:810` but a different predicate, evaluated ~270 lines later) were bare strings. A field report can only paste the message text, and the bridge's catch-all wrapper distinguishes them solely by that parenthetical, so these were the two least diagnosable failures in the module.

`IndexDecodeError` gains optional, keyword-only `error_id`/`diagnostics` (same additive-kwarg shape as `FingerprintRefused`/`ManualReviewRequired`/`TransportSmearDetected` in `exceptions.py`). Each site now raises with a stable id (`gap-count-floor`, `gap-lattice-anchor-floor`, `gap-direct-support-floor`) plus a numbers-only, JSON-safe diagnostics dict, appended to the message the same way `preview_session._roll_session_diagnostics` already embeds `RollSessionError`'s numbers. No image data, ever. No predicate moves.

**P2 — close the pitch dead zone.** The autocorrelation lag search was `[0.90, 1.10] x nominal`, but the final refined-pitch band check already declares `[0.85, 1.15] x nominal` acceptable. Pitches in the gap were declared acceptable yet structurally unreachable, always failing with the factually wrong "no physical gap periodicity". Widened the search to match the band the check already uses.

## Regression proof

Replayed `detect_roll_frames` on all 44 real archived LS-5000 whole-roll preview rasters in the corpus (9 full-roll Gold 36-exp captures, 6-frame strips, matched-pair parity captures, the shortest strip on file) against the unchanged detector:

- **44/44 bit-identical** frame origins, pitch, phase, and confidence.
- 42/44 confidence=high (unchanged); 2/44 hit this tree's own pre-existing `LeadingFrameClippedError` (a check canonical doesn't have) — identically before and after, confirming P1/P2 don't touch that path.
- Both `bundle.py` `roll_index.py` pins re-sealed to the new file hash in both trees.

## Tests

Four new tests in `coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py`, mirrored byte-for-byte into `ports/tauri/vendor/coolscanpy/tests/...`:
- One synthetic-raster case per P1 site, each asserting the `error_id` and every diagnostics field.
- One P2 case pinning `pitch=125/165` (inside the widened band) now resolving at `confidence=high`, and `pitch=123/167` (still outside even the widened band) continuing to refuse.

`scripts/check_ports_vendor_sync.sh` passes — `roll_index.py` and `test_roll_index.py` are outside the known-drift allowlist, so this keeps them byte-identical between `coolscanpy/` and `ports/tauri/vendor/coolscanpy/`.

## Commits

- `fix(roll): instrument the A/B/near-twin physical-gap-count raises (P1)`
- `fix(roll): widen the autocorrelation lag search to match the pitch band (P2)`

Canonical (`public-release/coolscanpy@port/cross-platform`) carries the same two commits, authored first; this PR ports them here plus the `ports/tauri/vendor/coolscanpy` mirror. Canonical is commit-only (not pushed) per the working agreement for that tree.
