### PR TITLE
Error reporting v2: build header, 40-event window, generic payloads, diagnostic bundle, setup-check integration

### DIFF
--- a/app/ScanStudio/Sources/ScanStudio/ContentView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ContentView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ScanStudioKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct ContentView: View {
     @Environment(SessionModel.self) private var sessionModel
@@ -361,8 +362,10 @@ private struct WorkspaceErrorBanner: View {
     let onDismiss: () -> Void
 
     @Environment(\.openURL) private var openURL
+    @Environment(SessionModel.self) private var sessionModel
     @State private var isShowingTechnicalDetails = false
     @State private var didCopyTechnicalDetails = false
+    @State private var didSaveDiagnosticBundle = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -453,6 +456,23 @@ private struct WorkspaceErrorBanner: View {
                             .buttonStyle(.borderless)
                             .font(.system(size: 11, weight: .medium))
                             .accessibilityLabel("Copy technical details")
+
+                            Button {
+                                saveDiagnosticBundle()
+                            } label: {
+                                Label(
+                                    didSaveDiagnosticBundle ? "Saved" : "Save Diagnostic Bundle…",
+                                    systemImage: didSaveDiagnosticBundle ? "checkmark" : "shippingbox"
+                                )
+                                .frame(minHeight: 32)
+                            }
+                            .buttonStyle(.borderless)
+                            .font(.system(size: 11, weight: .medium))
+                            .help(
+                                "Save a zip with this session's diagnostics, the report, "
+                                    + "and the roll preview when one is available"
+                            )
+                            .accessibilityLabel("Save diagnostic bundle")
                         }
 
                         ScrollView(.vertical) {
@@ -491,6 +511,37 @@ private struct WorkspaceErrorBanner: View {
             try? await Task.sleep(for: .seconds(1.5))
             didCopyTechnicalDetails = false
         }
+    }
+
+    /// Presents a native save panel, then writes `SessionModel
+    /// .makeDiagnosticBundleData()`'s zip bytes verbatim -- this view never
+    /// builds the archive itself, so the saved bundle always matches
+    /// whatever ScanStudioKit assembled (T-ERR-04).
+    private func saveDiagnosticBundle() {
+        let panel = NSSavePanel()
+        panel.title = "Save Diagnostic Bundle"
+        panel.nameFieldStringValue = "ScanStudio-Diagnostics-\(Self.diagnosticBundleTimestamp()).zip"
+        panel.allowedContentTypes = [.zip]
+        panel.canCreateDirectories = true
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        let data = sessionModel.makeDiagnosticBundleData()
+        // Best-effort local save: a write failure leaves the banner's
+        // existing error state untouched rather than fabricating a new one.
+        try? data.write(to: url, options: .atomic)
+        didSaveDiagnosticBundle = true
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.5))
+            didSaveDiagnosticBundle = false
+        }
+    }
+
+    private static func diagnosticBundleTimestamp() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withFullDate, .withTime, .withTimeZone]
+        return formatter.string(from: Date())
+            .replacingOccurrences(of: ":", with: "")
     }
 }
 

--- a/app/ScanStudio/Sources/ScanStudioKit/DiagnosticBundle.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/DiagnosticBundle.swift
@@ -1,0 +1,217 @@
+import Foundation
+
+/// A minimal, dependency-free ZIP writer using the uncompressed ("stored")
+/// method only. "Save Diagnostic Bundle..." (T-ERR-04) favors a small,
+/// easily-audited implementation over a compression dependency: the JSONL
+/// log and report text are already small, and a preview raster is already a
+/// compressed image format (PNG/TIFF), so stored-only costs little.
+public enum StoredZipWriter {
+    public struct Entry: Equatable {
+        public let name: String
+        public let data: Data
+
+        public init(name: String, data: Data) {
+            self.name = name
+            self.data = data
+        }
+    }
+
+    /// A fixed, valid DOS date/time (1980-01-01, the DOS epoch) so archive
+    /// bytes are deterministic and never depend on wall-clock time -- the
+    /// bundle's own report.txt already timestamps the export.
+    private static let dosTime: UInt16 = 0
+    private static let dosDate: UInt16 = 0x21
+    // General-purpose bit 11: filenames/comments are UTF-8, per the ZIP
+    // appendix D "language encoding flag" -- entry names below are never
+    // guaranteed ASCII (e.g. a preview file's original extension).
+    private static let utf8NameFlag: UInt16 = 0x0800
+
+    public static func write(_ entries: [Entry]) -> Data {
+        var output = Data()
+        var centralDirectory = Data()
+        var recordCount: UInt16 = 0
+
+        for entry in entries {
+            let nameBytes = Array(entry.name.utf8)
+            let crc = crc32(entry.data)
+            let size = UInt32(entry.data.count)
+            let localHeaderOffset = UInt32(output.count)
+
+            var localHeader = Data()
+            appendUInt32LE(0x0403_4b50, to: &localHeader)
+            appendUInt16LE(20, to: &localHeader)
+            appendUInt16LE(utf8NameFlag, to: &localHeader)
+            appendUInt16LE(0, to: &localHeader)
+            appendUInt16LE(dosTime, to: &localHeader)
+            appendUInt16LE(dosDate, to: &localHeader)
+            appendUInt32LE(crc, to: &localHeader)
+            appendUInt32LE(size, to: &localHeader)
+            appendUInt32LE(size, to: &localHeader)
+            appendUInt16LE(UInt16(nameBytes.count), to: &localHeader)
+            appendUInt16LE(0, to: &localHeader)
+            localHeader.append(contentsOf: nameBytes)
+
+            output.append(localHeader)
+            output.append(entry.data)
+
+            var centralEntry = Data()
+            appendUInt32LE(0x0201_4b50, to: &centralEntry)
+            appendUInt16LE(20, to: &centralEntry)
+            appendUInt16LE(20, to: &centralEntry)
+            appendUInt16LE(utf8NameFlag, to: &centralEntry)
+            appendUInt16LE(0, to: &centralEntry)
+            appendUInt16LE(dosTime, to: &centralEntry)
+            appendUInt16LE(dosDate, to: &centralEntry)
+            appendUInt32LE(crc, to: &centralEntry)
+            appendUInt32LE(size, to: &centralEntry)
+            appendUInt32LE(size, to: &centralEntry)
+            appendUInt16LE(UInt16(nameBytes.count), to: &centralEntry)
+            appendUInt16LE(0, to: &centralEntry)
+            appendUInt16LE(0, to: &centralEntry)
+            appendUInt16LE(0, to: &centralEntry)
+            appendUInt16LE(0, to: &centralEntry)
+            appendUInt32LE(0, to: &centralEntry)
+            appendUInt32LE(localHeaderOffset, to: &centralEntry)
+            centralEntry.append(contentsOf: nameBytes)
+
+            centralDirectory.append(centralEntry)
+            recordCount += 1
+        }
+
+        let centralDirectoryOffset = UInt32(output.count)
+        output.append(centralDirectory)
+
+        var eocd = Data()
+        appendUInt32LE(0x0605_4b50, to: &eocd)
+        appendUInt16LE(0, to: &eocd)
+        appendUInt16LE(0, to: &eocd)
+        appendUInt16LE(recordCount, to: &eocd)
+        appendUInt16LE(recordCount, to: &eocd)
+        appendUInt32LE(UInt32(centralDirectory.count), to: &eocd)
+        appendUInt32LE(centralDirectoryOffset, to: &eocd)
+        appendUInt16LE(0, to: &eocd)
+        output.append(eocd)
+
+        return output
+    }
+
+    private static func appendUInt16LE(_ value: UInt16, to data: inout Data) {
+        data.append(UInt8(value & 0xff))
+        data.append(UInt8((value >> 8) & 0xff))
+    }
+
+    private static func appendUInt32LE(_ value: UInt32, to data: inout Data) {
+        data.append(UInt8(value & 0xff))
+        data.append(UInt8((value >> 8) & 0xff))
+        data.append(UInt8((value >> 16) & 0xff))
+        data.append(UInt8((value >> 24) & 0xff))
+    }
+
+    private static let crcTable: [UInt32] = {
+        (0...255).map { index -> UInt32 in
+            var value = UInt32(index)
+            for _ in 0..<8 {
+                value = (value & 1 != 0) ? (0xEDB8_8320 ^ (value >> 1)) : (value >> 1)
+            }
+            return value
+        }
+    }()
+
+    private static func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            let index = Int((crc ^ UInt32(byte)) & 0xff)
+            crc = crcTable[index] ^ (crc >> 8)
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+}
+
+/// Assembles "Save Diagnostic Bundle..."'s contents (T-ERR-04) from
+/// already-in-memory data -- no filesystem access here, so the exact
+/// contents (including the honest manifest note when the raster is missing)
+/// are unit-testable with plain values, no real files or fake filesystem
+/// needed for this half of the pipeline.
+public enum DiagnosticBundleBuilder {
+    public struct PreviewRaster: Equatable {
+        public let filename: String
+        public let data: Data
+
+        public init(filename: String, data: Data) {
+            self.filename = filename
+            self.data = data
+        }
+    }
+
+    /// - Parameters:
+    ///   - diagnosticsJSONL: the current session's diagnostics log, one JSON
+    ///     object per line (`SessionDiagnosticTimeline`'s durable format).
+    ///   - reportText: the generated error report (`ErrorPresentation
+    ///     .technicalDetails`) at the moment the bundle was requested.
+    ///   - previewRaster: the roll preview raster file, when the session had
+    ///     one and the frontend could locate it from already-decoded
+    ///     `Thumbnail.imagePath` state -- never a new engine round trip.
+    ///   - unavailableRasterReason: when `previewRaster` is `nil`, the
+    ///     specific, honest reason recorded in `manifest.txt` instead of
+    ///     silently omitting the raster with no explanation.
+    public static func makeEntries(
+        diagnosticsJSONL: Data,
+        reportText: String,
+        previewRaster: PreviewRaster?,
+        unavailableRasterReason: String?
+    ) -> [StoredZipWriter.Entry] {
+        var manifestLines = [
+            "ScanStudio diagnostic bundle",
+            "",
+            "diagnostics.jsonl: this session's diagnostic events, one JSON object per line",
+            "report.txt: the generated error report at the time of export",
+        ]
+        var entries = [
+            StoredZipWriter.Entry(name: "diagnostics.jsonl", data: diagnosticsJSONL),
+            StoredZipWriter.Entry(name: "report.txt", data: Data(reportText.utf8)),
+        ]
+        if let previewRaster {
+            manifestLines.append("\(previewRaster.filename): the roll preview raster")
+            entries.append(StoredZipWriter.Entry(name: previewRaster.filename, data: previewRaster.data))
+        } else {
+            let reason = unavailableRasterReason ?? "no roll preview in this session"
+            manifestLines.append("raster: not available in this build (\(reason))")
+        }
+        entries.append(
+            StoredZipWriter.Entry(
+                name: "manifest.txt",
+                data: Data(manifestLines.joined(separator: "\n").utf8)
+            )
+        )
+        return entries
+    }
+}
+
+/// Resolves the diagnostic bundle's preview raster from state the frontend
+/// already holds -- `Thumbnail.imagePath`, exactly what the contact sheet
+/// already reads to render preview tiles -- never a new bridge/engine wire
+/// method. `readFile` is injectable so this is testable against a fake
+/// filesystem (a plain `[String: Data]` lookup) with zero real disk I/O.
+public enum DiagnosticBundleRasterPolicy {
+    public static func resolve(
+        thumbnails: [Int: Thumbnail],
+        readFile: (String) -> Data?
+    ) -> (raster: DiagnosticBundleBuilder.PreviewRaster?, unavailableReason: String?) {
+        guard !thumbnails.isEmpty else {
+            return (nil, "no roll preview in this session")
+        }
+        guard
+            let lowestIndex = thumbnails.keys.sorted().first,
+            let imagePath = thumbnails[lowestIndex]?.imagePath,
+            !imagePath.isEmpty
+        else {
+            return (nil, "the roll preview has no locally-known image path")
+        }
+        guard let data = readFile(imagePath) else {
+            return (nil, "the roll preview image file is missing or unreadable")
+        }
+        let extensionName = URL(fileURLWithPath: imagePath).pathExtension
+        let filename = extensionName.isEmpty ? "preview" : "preview.\(extensionName)"
+        return (DiagnosticBundleBuilder.PreviewRaster(filename: filename, data: data), nil)
+    }
+}

--- a/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
@@ -8,6 +8,15 @@ import Foundation
 public struct ErrorPresentationContext: Equatable, Sendable {
     public let scanStudioVersion: String?
     public let operatingSystemVersion: String?
+    /// CPU architecture of the host running ScanStudio (e.g. `"arm64"`).
+    public let cpuArchitecture: String?
+    /// The connected scanner's reported firmware revision, when a device is
+    /// connected and the identity handshake has recorded one.
+    public let scannerFirmware: String?
+    /// `ScannerStatus.adapter`, when known.
+    public let scannerAdapter: String?
+    /// `ScannerStatus.carrier` (the loaded film holder), when known.
+    public let scannerHolder: String?
     public let selectedPaths: [String]
     public let filmMetadataValues: [String]
     public let deviceIdentifiers: [String]
@@ -15,11 +24,20 @@ public struct ErrorPresentationContext: Equatable, Sendable {
     public let engineVersion: String?
     public let connectionSummary: String?
     public let recentDiagnosticEvents: [String]
+    /// Home-relative (`~/...`) diagnostic log location, safe to publish in a
+    /// public issue draft -- never reveals the local account name.
     public let diagnosticLogRelativePath: String?
+    /// The true absolute diagnostic log path, for the local-only technical
+    /// details view. Never included in the public issue draft.
+    public let diagnosticLogPath: String?
 
     public init(
         scanStudioVersion: String? = nil,
         operatingSystemVersion: String? = nil,
+        cpuArchitecture: String? = nil,
+        scannerFirmware: String? = nil,
+        scannerAdapter: String? = nil,
+        scannerHolder: String? = nil,
         selectedPaths: [String] = [],
         filmMetadataValues: [String] = [],
         deviceIdentifiers: [String] = [],
@@ -27,10 +45,15 @@ public struct ErrorPresentationContext: Equatable, Sendable {
         engineVersion: String? = nil,
         connectionSummary: String? = nil,
         recentDiagnosticEvents: [String] = [],
-        diagnosticLogRelativePath: String? = nil
+        diagnosticLogRelativePath: String? = nil,
+        diagnosticLogPath: String? = nil
     ) {
         self.scanStudioVersion = scanStudioVersion
         self.operatingSystemVersion = operatingSystemVersion
+        self.cpuArchitecture = cpuArchitecture
+        self.scannerFirmware = scannerFirmware
+        self.scannerAdapter = scannerAdapter
+        self.scannerHolder = scannerHolder
         self.selectedPaths = selectedPaths
         self.filmMetadataValues = filmMetadataValues
         self.deviceIdentifiers = deviceIdentifiers
@@ -39,6 +62,7 @@ public struct ErrorPresentationContext: Equatable, Sendable {
         self.connectionSummary = connectionSummary
         self.recentDiagnosticEvents = recentDiagnosticEvents
         self.diagnosticLogRelativePath = diagnosticLogRelativePath
+        self.diagnosticLogPath = diagnosticLogPath
     }
 }
 
@@ -66,6 +90,15 @@ public struct ErrorPresentation: Equatable, Sendable {
 /// diagnostic detail.
 public enum ErrorPresentationPolicy {
     public static let maximumIssueBodyCharacters = 4_000
+    /// Both report outputs show at most this many of the most recent
+    /// diagnostic events. Matches `SessionDiagnosticTimeline`'s own retention
+    /// cap (T-ERR-02), so raising one without the other cannot silently
+    /// under-fill the report.
+    public static let maximumRecentDiagnosticEvents = 40
+    /// Rendered in place of any build-identifying header field ScanStudio
+    /// could not determine, so a field is always present and never silently
+    /// dropped from the report.
+    private static let unknownFieldValue = "unknown"
 
     private struct Copy {
         let code: String
@@ -288,17 +321,14 @@ public enum ErrorPresentationPolicy {
     ) -> URL {
         let safeMessage = redactIssueText(lastErrorMessage, context: context)
         var bodyLines = ["ScanStudio error report"]
-        if let version = context.scanStudioVersion, !version.isEmpty {
-            bodyLines.append("ScanStudio version: \(version)")
+        appendBuildHeader(to: &bodyLines, context: context)
+        // Home-relative, never the true absolute path -- this line ships in a
+        // public GitHub issue draft and must not disclose the local account
+        // name (see `diagnosticLogPath` for the local-only absolute form).
+        if let relativeLogPath = context.diagnosticLogRelativePath, !relativeLogPath.isEmpty {
+            bodyLines.append("Local log: \(relativeLogPath)")
         }
-        if let operatingSystem = context.operatingSystemVersion, !operatingSystem.isEmpty {
-            bodyLines.append("Operating system: \(operatingSystem)")
-        }
-        appendDiagnosticContext(
-            to: &bodyLines,
-            context: context,
-            includeLocalLogPath: false
-        )
+        appendDiagnosticContext(to: &bodyLines, context: context)
         bodyLines.append("Error code: \(copy.code)")
         bodyLines.append("")
         bodyLines.append("Message:")
@@ -307,7 +337,7 @@ public enum ErrorPresentationPolicy {
             bodyLines.append("")
             bodyLines.append("Recent diagnostic events:")
             bodyLines.append(
-                contentsOf: context.recentDiagnosticEvents.suffix(12).map {
+                contentsOf: context.recentDiagnosticEvents.suffix(maximumRecentDiagnosticEvents).map {
                     "- \(redactIssueText($0, context: context))"
                 }
             )
@@ -332,30 +362,65 @@ public enum ErrorPresentationPolicy {
         context: ErrorPresentationContext
     ) -> String {
         let hasDiagnostics =
-            context.diagnosticSessionId != nil
+            context.scanStudioVersion != nil
+            || context.operatingSystemVersion != nil
+            || context.cpuArchitecture != nil
+            || context.scannerFirmware != nil
+            || context.scannerAdapter != nil
+            || context.scannerHolder != nil
+            || context.diagnosticSessionId != nil
             || context.engineVersion != nil
             || context.connectionSummary != nil
             || !context.recentDiagnosticEvents.isEmpty
             || context.diagnosticLogRelativePath != nil
+            || context.diagnosticLogPath != nil
         guard hasDiagnostics else { return lastErrorMessage }
 
         var lines = [lastErrorMessage, "", "Diagnostic context"]
-        appendDiagnosticContext(
-            to: &lines,
-            context: context,
-            includeLocalLogPath: true
-        )
+        appendBuildHeader(to: &lines, context: context)
+        // The true absolute path -- safe here because this view is local-only
+        // and never leaves the machine (contrast the public issue draft's
+        // home-relative `diagnosticLogRelativePath` line).
+        if let logPath = context.diagnosticLogPath, !logPath.isEmpty {
+            lines.append("Local log: \(logPath)")
+        }
+        appendDiagnosticContext(to: &lines, context: context)
         if !context.recentDiagnosticEvents.isEmpty {
             lines.append("Recent events:")
-            lines.append(contentsOf: context.recentDiagnosticEvents.suffix(20).map { "- \($0)" })
+            lines.append(
+                contentsOf: context.recentDiagnosticEvents.suffix(maximumRecentDiagnosticEvents).map { "- \($0)" }
+            )
         }
         return lines.joined(separator: "\n")
     }
 
+    /// Appends the build-identifying header (T-ERR-01): release stamp,
+    /// OS name+version, CPU architecture, and -- when a scanner session has
+    /// established them -- firmware revision and adapter/holder. Every field
+    /// always renders, falling back to `unknownFieldValue` rather than being
+    /// silently omitted, so a reader never has to wonder whether a value was
+    /// dropped versus genuinely undetermined.
+    private static func appendBuildHeader(
+        to lines: inout [String],
+        context: ErrorPresentationContext
+    ) {
+        lines.append("ScanStudio version: \(rendered(context.scanStudioVersion))")
+        lines.append("Operating system: \(rendered(context.operatingSystemVersion))")
+        lines.append("CPU architecture: \(rendered(context.cpuArchitecture))")
+        lines.append("Scanner firmware: \(rendered(context.scannerFirmware))")
+        lines.append("Adapter: \(rendered(context.scannerAdapter))")
+        lines.append("Holder: \(rendered(context.scannerHolder))")
+    }
+
+    private static func rendered(_ value: String?) -> String {
+        guard let value else { return unknownFieldValue }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? unknownFieldValue : trimmed
+    }
+
     private static func appendDiagnosticContext(
         to lines: inout [String],
-        context: ErrorPresentationContext,
-        includeLocalLogPath: Bool
+        context: ErrorPresentationContext
     ) {
         if let sessionID = context.diagnosticSessionId, !sessionID.isEmpty {
             lines.append("Diagnostic session: \(sessionID)")
@@ -365,11 +430,6 @@ public enum ErrorPresentationPolicy {
         }
         if let connectionSummary = context.connectionSummary, !connectionSummary.isEmpty {
             lines.append("Connection state: \(connectionSummary)")
-        }
-        if includeLocalLogPath,
-           let logPath = context.diagnosticLogRelativePath,
-           !logPath.isEmpty {
-            lines.append("Local log: \(logPath)")
         }
     }
 

--- a/app/ScanStudio/Sources/ScanStudioKit/SessionDiagnosticTimeline.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/SessionDiagnosticTimeline.swift
@@ -1,5 +1,111 @@
 import Foundation
 
+/// A generic, JSON-shaped diagnostic field value. Event authors may record a
+/// string, a number, a boolean, or a nested array/object without the report
+/// renderer ever needing per-event or per-key knowledge of the shape --
+/// future instrumentation (e.g. detector confidence scores) starts rendering
+/// into reports the moment it starts recording a field, with zero coupling
+/// to `SessionDiagnosticEntry.summaryLine` or the error-report builder.
+public enum DiagnosticFieldValue: Equatable, Sendable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case array([DiagnosticFieldValue])
+    case object([String: DiagnosticFieldValue])
+
+    /// Compact, single-line rendering used by `SessionDiagnosticEntry
+    /// .summaryLine` and, transitively, every generated error report. Never
+    /// multi-line and never pretty-printed JSON -- nested values still
+    /// collapse into one `key=value` diagnostic line.
+    public var compactDescription: String {
+        switch self {
+        case .string(let value):
+            return value
+        case .number(let value):
+            return DiagnosticFieldValue.formatNumber(value)
+        case .bool(let value):
+            return value ? "true" : "false"
+        case .array(let values):
+            return "[" + values.map(\.compactDescription).joined(separator: ",") + "]"
+        case .object(let fields):
+            let rendered = fields
+                .sorted { $0.key < $1.key }
+                .map { "\($0.key)=\($0.value.compactDescription)" }
+                .joined(separator: ",")
+            return "{\(rendered)}"
+        }
+    }
+
+    private static func formatNumber(_ value: Double) -> String {
+        if value.isFinite, value == value.rounded(), value.magnitude < 1e15 {
+            return String(Int64(value))
+        }
+        return String(value)
+    }
+}
+
+extension DiagnosticFieldValue: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) { self = .string(value) }
+}
+
+extension DiagnosticFieldValue: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) { self = .number(Double(value)) }
+}
+
+extension DiagnosticFieldValue: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) { self = .number(value) }
+}
+
+extension DiagnosticFieldValue: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) { self = .bool(value) }
+}
+
+extension DiagnosticFieldValue: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: DiagnosticFieldValue...) { self = .array(elements) }
+}
+
+extension DiagnosticFieldValue: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (String, DiagnosticFieldValue)...) {
+        self = .object(Dictionary(uniqueKeysWithValues: elements))
+    }
+}
+
+/// Round-trips through the timeline's durable JSONL log as plain JSON --
+/// a string field stays a JSON string, a number stays a JSON number, and so
+/// on -- so the on-disk log and the in-memory value never diverge in shape.
+extension DiagnosticFieldValue: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([DiagnosticFieldValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: DiagnosticFieldValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported DiagnosticFieldValue payload"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .bool(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        }
+    }
+}
+
 /// One privacy-safe, structured decision or state transition from the current
 /// ScanStudio session. Callers supply only operational fields; paths, film
 /// metadata, image names, receipts, and device identifiers do not belong here.
@@ -7,13 +113,13 @@ public struct SessionDiagnosticEntry: Codable, Equatable, Sendable {
     public let timestamp: String
     public let sessionId: String
     public let event: String
-    public let fields: [String: String]
+    public let fields: [String: DiagnosticFieldValue]
 
     public init(
         timestamp: String,
         sessionId: String,
         event: String,
-        fields: [String: String]
+        fields: [String: DiagnosticFieldValue]
     ) {
         self.timestamp = timestamp
         self.sessionId = sessionId
@@ -24,7 +130,7 @@ public struct SessionDiagnosticEntry: Codable, Equatable, Sendable {
     public var summaryLine: String {
         let details = fields
             .sorted { $0.key < $1.key }
-            .map { "\($0.key)=\($0.value)" }
+            .map { "\($0.key)=\($0.value.compactDescription)" }
             .joined(separator: " ")
         return details.isEmpty
             ? "\(timestamp) \(event)"
@@ -90,7 +196,7 @@ public struct SessionDiagnosticTimeline: Sendable {
     public mutating func record(
         timestamp: String? = nil,
         event: String,
-        fields: [String: String] = [:]
+        fields: [String: DiagnosticFieldValue] = [:]
     ) {
         let entry = SessionDiagnosticEntry(
             timestamp: timestamp ?? SessionDiagnosticTimeline.currentTimestamp(),

--- a/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
@@ -538,14 +538,15 @@ public final class SessionModel {
             outputRecipe.preview.destination,
         ].compactMap { $0 }.filter { !$0.isEmpty } + frameOutputPaths
 
-        let appVersion = Bundle.main.object(
-            forInfoDictionaryKey: "CFBundleShortVersionString"
-        ) as? String
         return ErrorPresentationPolicy.make(
             lastErrorMessage: lastErrorMessage,
             context: ErrorPresentationContext(
-                scanStudioVersion: appVersion,
-                operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+                scanStudioVersion: Self.releaseStamp,
+                operatingSystemVersion: "macOS " + ProcessInfo.processInfo.operatingSystemVersionString,
+                cpuArchitecture: HostArchitectureProvider.currentHostArchitecture.rawValue,
+                scannerFirmware: device?.firmware,
+                scannerAdapter: status?.adapter,
+                scannerHolder: status?.carrier,
                 selectedPaths: selectedPaths,
                 filmMetadataValues: metadataValues,
                 deviceIdentifiers: (
@@ -556,10 +557,26 @@ public final class SessionModel {
                 engineVersion: engineVersion,
                 connectionSummary: diagnosticConnectionSummary,
                 recentDiagnosticEvents: diagnosticTimeline.summaryLines,
-                diagnosticLogRelativePath: diagnosticLogRelativePath
+                diagnosticLogRelativePath: diagnosticLogRelativePath,
+                diagnosticLogPath: diagnosticLogPath
             )
         )
     }
+
+    /// The packaged `ScanStudioRelease` stamp, falling back to
+    /// `CFBundleShortVersionString` for an unstamped dev/source build --
+    /// mirrors `ScanStudioApp.installedUpdateVersion()`'s own precedence so
+    /// the error report names the exact same build the updater would offer
+    /// to replace. `nil` (never a hardcoded placeholder) when neither key is
+    /// set, so `ErrorPresentationPolicy` renders the header's honest
+    /// "unknown" instead of a fabricated version string.
+    private static var releaseStamp: String? {
+        if let stamp = Bundle.main.infoDictionary?["ScanStudioRelease"] as? String, !stamp.isEmpty {
+            return stamp
+        }
+        return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+
     public private(set) var project: ScanProject?
     public private(set) var projectDirectory: String?
     public private(set) var recentProjects: [ProjectSummary] = []
@@ -3966,11 +3983,61 @@ public final class SessionModel {
         return "~/.scanstudio/diagnostics/\(logURL.lastPathComponent)"
     }
 
+    /// The true absolute path to the durable diagnostics log, for the
+    /// local-only technical details view (T-ERR-02). Never surfaced in the
+    /// public issue draft -- see `diagnosticLogRelativePath` for that form.
+    private var diagnosticLogPath: String? {
+        diagnosticTimeline.logURL?.path
+    }
+
+    /// Builds "Save Diagnostic Bundle..."'s zip bytes (T-ERR-04): the
+    /// session's diagnostics.jsonl, the current generated report text, and
+    /// -- when the session had a roll preview whose image path is still
+    /// readable -- that preview raster. The raster comes only from
+    /// already-decoded `Thumbnail.imagePath` state; this never opens a new
+    /// engine/bridge round trip to locate it.
+    public func makeDiagnosticBundleData() -> Data {
+        let reportText = errorPresentation?.technicalDetails
+            ?? lastErrorMessage
+            ?? "No error was active when this bundle was saved."
+        let (raster, unavailableReason) = DiagnosticBundleRasterPolicy.resolve(
+            thumbnails: thumbnails,
+            readFile: { FileManager.default.contents(atPath: $0) }
+        )
+        let entries = DiagnosticBundleBuilder.makeEntries(
+            diagnosticsJSONL: diagnosticsJSONLData(),
+            reportText: reportText,
+            previewRaster: raster,
+            unavailableRasterReason: unavailableReason
+        )
+        return StoredZipWriter.write(entries)
+    }
+
+    /// Re-derives diagnostics.jsonl's exact bytes from the in-memory
+    /// timeline -- identical in shape to what `SessionDiagnosticTimeline`
+    /// persists to disk -- so the bundle never depends on a prior disk write
+    /// having succeeded (a memory-only timeline in tests still bundles).
+    private func diagnosticsJSONLData() -> Data {
+        var data = Data()
+        let encoder = JSONEncoder()
+        for entry in diagnosticTimeline.entries {
+            guard let encoded = try? encoder.encode(entry) else { continue }
+            data.append(encoded)
+            data.append(0x0A)
+        }
+        return data
+    }
+
     private func recordDiagnostic(
         event: String,
         fields: [String: String] = [:]
     ) {
-        diagnosticTimeline.record(event: event, fields: fields)
+        // Every current call site hands this plain String fields, but the
+        // timeline itself stores the generic `DiagnosticFieldValue` shape
+        // (SessionDiagnosticTimeline.swift) so future instrumentation can
+        // record numbers/bools/nested objects straight into
+        // `diagnosticTimeline.record` without a report-side change.
+        diagnosticTimeline.record(event: event, fields: fields.mapValues { .string($0) })
     }
 
     /// A scanner operation can prove that the bridge has no live device

--- a/app/ScanStudio/Tests/ScanStudioKitTests/DiagnosticBundleTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/DiagnosticBundleTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Testing
+
+@testable import ScanStudioKit
+
+/// Minimal reader for the exact "stored" (uncompressed) ZIP shape
+/// `StoredZipWriter` produces -- enough to round-trip-verify contents
+/// without depending on a system unzip tool or a third-party archive
+/// library in the test target.
+private func readStoredZipEntries(_ data: Data) throws -> [(name: String, data: Data)] {
+    var entries: [(name: String, data: Data)] = []
+    var offset = data.startIndex
+    func readUInt16LE(_ at: Data.Index) -> UInt16 {
+        UInt16(data[at]) | (UInt16(data[at + 1]) << 8)
+    }
+    func readUInt32LE(_ at: Data.Index) -> UInt32 {
+        UInt32(data[at]) | (UInt32(data[at + 1]) << 8)
+            | (UInt32(data[at + 2]) << 16) | (UInt32(data[at + 3]) << 24)
+    }
+
+    while offset < data.endIndex {
+        let signature = readUInt32LE(offset)
+        guard signature == 0x0403_4b50 else { break }
+        let compressedSize = Int(readUInt32LE(offset + 18))
+        let nameLength = Int(readUInt16LE(offset + 26))
+        let extraLength = Int(readUInt16LE(offset + 28))
+        let nameStart = offset + 30
+        let nameEnd = nameStart + nameLength
+        let name = String(decoding: data[nameStart..<nameEnd], as: UTF8.self)
+        let dataStart = nameEnd + extraLength
+        let dataEnd = dataStart + compressedSize
+        entries.append((name: name, data: data[dataStart..<dataEnd]))
+        offset = dataEnd
+    }
+    return entries
+}
+
+@Suite("Stored zip writer")
+struct StoredZipWriterTests {
+    @Test("round-trips filenames and bytes exactly, including an empty entry")
+    func roundTrips() throws {
+        let entries: [StoredZipWriter.Entry] = [
+            .init(name: "diagnostics.jsonl", data: Data(#"{"event":"session.started"}"#.utf8)),
+            .init(name: "report.txt", data: Data("ScanStudio error report\n".utf8)),
+            .init(name: "empty.txt", data: Data()),
+        ]
+
+        let zip = StoredZipWriter.write(entries)
+
+        #expect(zip.prefix(4) == Data([0x50, 0x4b, 0x03, 0x04]))
+        // The 22-byte End Of Central Directory record is the tail of the
+        // file whenever the (unused) archive comment is empty, as here --
+        // its signature is the record's first 4 bytes, not the file's last 4.
+        #expect(zip.suffix(22).prefix(4) == Data([0x50, 0x4b, 0x05, 0x06]))
+        let readBack = try readStoredZipEntries(zip)
+        #expect(readBack.map(\.name) == entries.map(\.name))
+        #expect(readBack.map(\.data) == entries.map(\.data))
+    }
+
+    @Test("an empty entry list still produces a well-formed (empty) archive")
+    func emptyArchive() throws {
+        let zip = StoredZipWriter.write([])
+        #expect(zip.count == 22, "an empty archive is exactly one EOCD record")
+        #expect(zip.prefix(4) == Data([0x50, 0x4b, 0x05, 0x06]))
+        #expect(try readStoredZipEntries(zip).isEmpty)
+    }
+}
+
+@Suite("Diagnostic bundle builder")
+struct DiagnosticBundleBuilderTests {
+    @Test("includes the diagnostics log, report text, and raster when one is available")
+    func entriesWithRaster() throws {
+        let entries = DiagnosticBundleBuilder.makeEntries(
+            diagnosticsJSONL: Data(#"{"event":"session.started"}"#.utf8),
+            reportText: "ScanStudio error report\nError code: NOT_CONNECTED",
+            previewRaster: .init(filename: "preview.png", data: Data([0x89, 0x50, 0x4e, 0x47])),
+            unavailableRasterReason: nil
+        )
+
+        let names = Set(entries.map(\.name))
+        #expect(names == ["diagnostics.jsonl", "report.txt", "preview.png", "manifest.txt"])
+
+        let manifest = try #require(entries.first { $0.name == "manifest.txt" })
+        let manifestText = String(decoding: manifest.data, as: UTF8.self)
+        #expect(manifestText.contains("preview.png: the roll preview raster"))
+        #expect(!manifestText.contains("not available"))
+
+        let raster = try #require(entries.first { $0.name == "preview.png" })
+        #expect(raster.data == Data([0x89, 0x50, 0x4e, 0x47]))
+    }
+
+    @Test("records the specific unavailability reason instead of silently dropping the raster")
+    func entriesWithoutRaster() throws {
+        let entries = DiagnosticBundleBuilder.makeEntries(
+            diagnosticsJSONL: Data(),
+            reportText: "ScanStudio error report",
+            previewRaster: nil,
+            unavailableRasterReason: "the roll preview image file is missing or unreadable"
+        )
+
+        #expect(entries.map(\.name).sorted() == ["diagnostics.jsonl", "manifest.txt", "report.txt"])
+        let manifest = try #require(entries.first { $0.name == "manifest.txt" })
+        let manifestText = String(decoding: manifest.data, as: UTF8.self)
+        #expect(
+            manifestText.contains(
+                "raster: not available in this build (the roll preview image file is missing or unreadable)"
+            )
+        )
+    }
+}
+
+@Suite("Diagnostic bundle raster policy")
+struct DiagnosticBundleRasterPolicyTests {
+    @Test("an empty session honestly reports it never had a roll preview")
+    func noThumbnails() {
+        let (raster, reason) = DiagnosticBundleRasterPolicy.resolve(
+            thumbnails: [:],
+            readFile: { _ in Data() }
+        )
+        #expect(raster == nil)
+        #expect(reason == "no roll preview in this session")
+    }
+
+    @Test("a thumbnail with no image path is reported, not silently skipped")
+    func thumbnailWithoutImagePath() {
+        let thumbnails: [Int: Thumbnail] = [
+            1: Thumbnail(brightness: 0.5, tint: 0, imagePath: nil),
+        ]
+        let (raster, reason) = DiagnosticBundleRasterPolicy.resolve(
+            thumbnails: thumbnails,
+            readFile: { _ in Data() }
+        )
+        #expect(raster == nil)
+        #expect(reason == "the roll preview has no locally-known image path")
+    }
+
+    @Test("a fake filesystem miss reports the file as missing, not silently skipped")
+    func imageFileUnreadable() {
+        let thumbnails: [Int: Thumbnail] = [
+            1: Thumbnail(brightness: nil, tint: nil, imagePath: "/fake/frame1.tif"),
+        ]
+        let (raster, reason) = DiagnosticBundleRasterPolicy.resolve(
+            thumbnails: thumbnails,
+            readFile: { _ in nil }
+        )
+        #expect(raster == nil)
+        #expect(reason == "the roll preview image file is missing or unreadable")
+    }
+
+    @Test("resolves the lowest-indexed frame's image against a fake filesystem, naming it by extension")
+    func resolvesLowestIndexedFrame() throws {
+        let fakeFilesystem: [String: Data] = [
+            "/fake/frame3.tif": Data("wrong frame".utf8),
+            "/fake/frame1.tif": Data("roll preview bytes".utf8),
+        ]
+        let thumbnails: [Int: Thumbnail] = [
+            3: Thumbnail(brightness: nil, tint: nil, imagePath: "/fake/frame3.tif"),
+            1: Thumbnail(brightness: nil, tint: nil, imagePath: "/fake/frame1.tif"),
+        ]
+
+        let (raster, reason) = DiagnosticBundleRasterPolicy.resolve(
+            thumbnails: thumbnails,
+            readFile: { fakeFilesystem[$0] }
+        )
+
+        #expect(reason == nil)
+        let resolved = try #require(raster)
+        #expect(resolved.filename == "preview.tif")
+        #expect(resolved.data == Data("roll preview bytes".utf8))
+    }
+}

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
@@ -268,7 +268,8 @@ struct ErrorPresentationPolicyTests {
                     "2026-07-28T00:08:18Z device.connect.succeeded connected=true kind=real",
                     "2026-07-28T00:09:01Z preview.failed code=NOT_CONNECTED uiConnectedBefore=true",
                 ],
-                diagnosticLogRelativePath: "~/.scanstudio/diagnostics/session-1234.jsonl"
+                diagnosticLogRelativePath: "~/.scanstudio/diagnostics/session-1234.jsonl",
+                diagnosticLogPath: "/Users/tester/.scanstudio/diagnostics/session-1234.jsonl"
             )
         )
         let components = try #require(
@@ -285,9 +286,93 @@ struct ErrorPresentationPolicyTests {
         #expect(body.contains("preview.failed code=NOT_CONNECTED uiConnectedBefore=true"))
         #expect(body.contains("No images, receipts, or raw logs are attached automatically."))
 
+        // The public issue draft gets the home-relative form only -- it must
+        // never disclose the local account name baked into the absolute path.
+        #expect(body.contains("Local log: ~/.scanstudio/diagnostics/session-1234.jsonl"))
+        #expect(!body.contains("/Users/tester"))
+
         #expect(presentation.technicalDetails.contains("Diagnostic session: session-1234"))
-        #expect(presentation.technicalDetails.contains("Local log: ~/.scanstudio/diagnostics/session-1234.jsonl"))
+        #expect(
+            presentation.technicalDetails
+                .contains("Local log: /Users/tester/.scanstudio/diagnostics/session-1234.jsonl")
+        )
         #expect(presentation.technicalDetails.contains("preview.failed code=NOT_CONNECTED"))
+    }
+
+    @Test("the build-identifying header always renders every field, falling back to unknown")
+    func buildHeaderRendersUnknownForMissingFields() throws {
+        let presentation = ErrorPresentationPolicy.make(
+            lastErrorMessage: "NOT_CONNECTED: no device is open",
+            context: ErrorPresentationContext(scanStudioVersion: "0.3.0-alpha.11")
+        )
+        let components = try #require(
+            URLComponents(url: presentation.issueURL, resolvingAgainstBaseURL: false)
+        )
+        let body = try #require(components.queryItems?.first { $0.name == "body" }?.value)
+
+        #expect(body.contains("ScanStudio version: 0.3.0-alpha.11"))
+        #expect(body.contains("Operating system: unknown"))
+        #expect(body.contains("CPU architecture: unknown"))
+        #expect(body.contains("Scanner firmware: unknown"))
+        #expect(body.contains("Adapter: unknown"))
+        #expect(body.contains("Holder: unknown"))
+        // Never silently dropped: technicalDetails renders the exact same
+        // always-present header once any part of the context is populated.
+        #expect(presentation.technicalDetails.contains("Scanner firmware: unknown"))
+    }
+
+    @Test("known scanner identity and holder state populate the build header")
+    func buildHeaderPopulatesKnownScannerIdentity() throws {
+        let presentation = ErrorPresentationPolicy.make(
+            lastErrorMessage: "INTERNAL: unexpected scanner identity",
+            context: ErrorPresentationContext(
+                scanStudioVersion: "0.3.0-alpha.11",
+                operatingSystemVersion: "macOS Version 15.4.1 (Build 24E263)",
+                cpuArchitecture: "arm64",
+                scannerFirmware: "1.02",
+                scannerAdapter: "SA-21",
+                scannerHolder: "roll36"
+            )
+        )
+        let components = try #require(
+            URLComponents(url: presentation.issueURL, resolvingAgainstBaseURL: false)
+        )
+        let body = try #require(components.queryItems?.first { $0.name == "body" }?.value)
+
+        #expect(body.contains("Operating system: macOS Version 15.4.1 (Build 24E263)"))
+        #expect(body.contains("CPU architecture: arm64"))
+        #expect(body.contains("Scanner firmware: 1.02"))
+        #expect(body.contains("Adapter: SA-21"))
+        #expect(body.contains("Holder: roll36"))
+    }
+
+    @Test("both report outputs include up to the last 40 diagnostic events, not ~10")
+    func reportsIncludeUpToFortyDiagnosticEvents() throws {
+        // Distinct per-index timestamps (no wraparound) keep every event
+        // string unique, so a substring check can never cross-match a
+        // different index.
+        let events = (1...50).map { "2026-08-05T00:00:00Z-\($0) event-\($0)" }
+        let droppedLine = "- 2026-08-05T00:00:00Z-10 event-10"
+        let survivingOldestLine = "- 2026-08-05T00:00:00Z-11 event-11"
+        let survivingNewestLine = "- 2026-08-05T00:00:00Z-50 event-50"
+        let presentation = ErrorPresentationPolicy.make(
+            lastErrorMessage: "INTERNAL: something failed",
+            context: ErrorPresentationContext(recentDiagnosticEvents: events)
+        )
+        let components = try #require(
+            URLComponents(url: presentation.issueURL, resolvingAgainstBaseURL: false)
+        )
+        let body = try #require(components.queryItems?.first { $0.name == "body" }?.value)
+
+        #expect(ErrorPresentationPolicy.maximumRecentDiagnosticEvents == 40)
+        // The most recent 40 (event-11 through event-50) survive; earlier
+        // ones fall off the bounded window in both outputs.
+        #expect(body.contains(survivingNewestLine))
+        #expect(body.contains(survivingOldestLine))
+        #expect(!body.contains(droppedLine))
+        #expect(presentation.technicalDetails.contains(survivingNewestLine))
+        #expect(presentation.technicalDetails.contains(survivingOldestLine))
+        #expect(!presentation.technicalDetails.contains(droppedLine))
     }
 
     @Test("issue text redacts paths and explicitly supplied private work details")

--- a/app/ScanStudio/Tests/ScanStudioKitTests/SessionDiagnosticTimelineTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/SessionDiagnosticTimelineTests.swift
@@ -128,4 +128,62 @@ struct SessionDiagnosticTimelineTests {
             "old-3.jsonl",
         ])
     }
+
+    @Test("The default retention matches the error report's 40-event window")
+    func defaultRetentionMatchesReportWindow() {
+        let timeline = SessionDiagnosticTimeline(sessionID: "defaults")
+        #expect(timeline.maximumEntries == ErrorPresentationPolicy.maximumRecentDiagnosticEvents)
+    }
+
+    @Test("Numbers, bools, arrays, and objects render as compact key=value lines with zero per-field coupling")
+    func genericFieldRendering() throws {
+        var timeline = SessionDiagnosticTimeline(sessionID: "generic-fields")
+
+        timeline.record(
+            timestamp: "2026-08-05T12:31:10Z",
+            event: "detector.scored",
+            fields: [
+                "confidence": 0.937,
+                "boxCount": 3,
+                "simulated": false,
+                "box": ["x": 10, "y": 20, "w": 30, "h": 40],
+                "scores": [0.1, 0.5, 0.9],
+            ]
+        )
+
+        let line = try #require(timeline.summaryLines.first)
+        // Field order is sorted by key, exactly like the existing string-only
+        // path -- adding a numeric/bool/nested field never needs a code
+        // change here or in the report builder.
+        #expect(line == "2026-08-05T12:31:10Z detector.scored "
+            + "box={h=40,w=30,x=10,y=20} boxCount=3 confidence=0.937 "
+            + "scores=[0.1,0.5,0.9] simulated=false")
+    }
+
+    @Test("Numeric and boolean fields persist as real JSON types, not stringified text")
+    func structuredFieldsPersistAsRealJSONTypes() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("scanstudio-diagnostics-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        var timeline = SessionDiagnosticTimeline(
+            sessionID: "typed-fields",
+            directory: directory
+        )
+        timeline.record(
+            event: "detector.scored",
+            fields: ["confidence": 0.5, "boxCount": 3, "simulated": true]
+        )
+
+        let logURL = try #require(timeline.logURL)
+        let line = try String(contentsOf: logURL, encoding: .utf8)
+            .split(separator: "\n")[0]
+        let object = try #require(
+            JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+        )
+        let fields = try #require(object["fields"] as? [String: Any])
+        #expect(fields["confidence"] as? Double == 0.5)
+        #expect(fields["boxCount"] as? Int == 3)
+        #expect(fields["simulated"] as? Bool == true)
+    }
 }

--- a/ports/tauri/app/package-lock.json
+++ b/ports/tauri/app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tauri-apps/api": "2.11.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",
+        "@tauri-apps/plugin-os": "^2.3.2",
         "react": "19.2.8",
         "react-dom": "19.2.8"
       },
@@ -884,6 +885,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-os": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-os/-/plugin-os-2.3.2.tgz",
+      "integrity": "sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/ports/tauri/app/package.json
+++ b/ports/tauri/app/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@tauri-apps/api": "2.11.1",
     "@tauri-apps/plugin-dialog": "^2.7.2",
+    "@tauri-apps/plugin-os": "^2.3.2",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },

--- a/ports/tauri/app/src-tauri/Cargo.lock
+++ b/ports/tauri/app/src-tauri/Cargo.lock
@@ -322,6 +322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1034,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1742,6 +1758,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +1906,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "num-conv"
@@ -2140,6 +2174,22 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "os_pipe"
@@ -2583,6 +2633,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,6 +2672,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-os",
  "tauri-plugin-shell",
  "tokio",
  "url",
@@ -3099,6 +3163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,6 +3410,24 @@ dependencies = [
  "thiserror 2.0.19",
  "toml 1.1.4+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-os"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997"
+dependencies = [
+ "gethostname",
+ "log",
+ "os_info",
+ "serde",
+ "serde_json",
+ "serialize-to-javascript",
+ "sys-locale",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/ports/tauri/app/src-tauri/Cargo.toml
+++ b/ports/tauri/app/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros", "proce
 url = "2"
 image = { version = "0.25.10", default-features = false, features = ["tiff", "png", "jpeg"] }
 lru = "0.18.1"
+tauri-plugin-os = "2"
 
 [dev-dependencies]
 # Adds tauri::test's mock_builder/mock_context (a zero-dependency cfg gate --

--- a/ports/tauri/app/src-tauri/capabilities/default.json
+++ b/ports/tauri/app/src-tauri/capabilities/default.json
@@ -1,5 +1,5 @@
 {
   "identifier": "default",
   "windows": ["main"],
-  "permissions": ["core:default", "dialog:default"]
+  "permissions": ["core:default", "dialog:default", "os:default"]
 }

--- a/ports/tauri/app/src-tauri/src/diagnostics.rs
+++ b/ports/tauri/app/src-tauri/src/diagnostics.rs
@@ -1,0 +1,130 @@
+//! Local-only "Save Diagnostic Bundle..." support (error report v2, T-ERR-04).
+//!
+//! This module never talks to the engine or the bridge and never decides
+//! bundle contents -- the frontend assembles the zip bytes entirely
+//! (`session/zip.ts` + `session/diagnosticBundle.ts`) from state it already
+//! holds. This module's only jobs are (1) writing those bytes to a
+//! user-chosen path from the save dialog, and (2) reading the roll-preview
+//! raster's bytes so the frontend can fold them into the bundle -- the
+//! frontend cannot read the filesystem itself.
+
+use tauri::Manager;
+
+/// Writes `bytes` verbatim to `path`, overwriting any existing file. Returns
+/// a plain, display-safe error string on failure (no panics).
+#[tauri::command]
+pub fn write_diagnostic_bundle(path: String, bytes: Vec<u8>) -> Result<(), String> {
+    std::fs::write(&path, bytes).map_err(|error| format!("failed to write {path}: {error}"))
+}
+
+/// Reads the roll-preview raster's raw bytes for the diagnostic bundle.
+/// `path` is always a `Thumbnail.imagePath` the frontend already holds from
+/// the engine's own preview response -- never a new engine/bridge round
+/// trip, only a local read of a file the app already knows about (the same
+/// path the `scanstudio-preview://` scheme already reads to render the
+/// contact sheet).
+///
+/// Scoped exactly like that scheme handler (`crate::preview`): only a path
+/// that canonicalizes to somewhere under the user's home directory is
+/// readable. Known gap (follow-up): on Windows, a real-hardware preview
+/// lives under the pinned WSL share rather than the Windows home directory
+/// (see `crate::preview::handle_with_windows_wsl_share`), so this command
+/// currently reports it as unavailable there rather than reusing that
+/// second scope -- the bundle still saves, with the raster honestly marked
+/// not available.
+#[tauri::command]
+pub fn read_preview_raster(app: tauri::AppHandle, path: String) -> Result<Vec<u8>, String> {
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|_| "could not resolve home directory".to_string())?;
+    read_within_scope(&path, &home)
+}
+
+fn read_within_scope(path: &str, allowed_root: &std::path::Path) -> Result<Vec<u8>, String> {
+    let canonical_root = std::fs::canonicalize(allowed_root)
+        .map_err(|_| "could not resolve home directory".to_string())?;
+    let canonical = std::fs::canonicalize(path)
+        .map_err(|_| "preview raster path not found or inaccessible".to_string())?;
+    if !canonical.starts_with(&canonical_root) {
+        return Err("preview raster path is outside the allowed scope".to_string());
+    }
+    std::fs::read(&canonical).map_err(|error| format!("failed to read preview raster: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_the_exact_bytes_given() {
+        let dir = std::env::temp_dir().join(format!("scanstudio-diagnostics-bundle-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let path = dir.join("bundle.zip");
+
+        let result = write_diagnostic_bundle(path.to_string_lossy().into_owned(), vec![1, 2, 3, 4]);
+
+        assert!(result.is_ok());
+        assert_eq!(std::fs::read(&path).unwrap(), vec![1, 2, 3, 4]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_within_scope_returns_bytes_for_a_path_under_the_allowed_root() {
+        let dir = std::env::temp_dir().join(format!("scanstudio-diagnostics-raster-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let file = dir.join("preview.png");
+        std::fs::write(&file, [1, 2, 3, 4]).expect("write fixture");
+
+        let result = read_within_scope(&file.to_string_lossy(), &dir);
+
+        assert_eq!(result.unwrap(), vec![1, 2, 3, 4]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_within_scope_refuses_a_path_outside_the_allowed_root() {
+        let allowed_root = std::env::temp_dir().join(format!("scanstudio-diagnostics-raster-scope-{}", std::process::id()));
+        std::fs::create_dir_all(&allowed_root).expect("create allowed root");
+        let outside_dir = std::env::temp_dir().join(format!("scanstudio-diagnostics-raster-outside-{}", std::process::id()));
+        std::fs::create_dir_all(&outside_dir).expect("create outside dir");
+        let outside_file = outside_dir.join("secret.png");
+        std::fs::write(&outside_file, [9]).expect("write outside fixture");
+
+        let result = read_within_scope(&outside_file.to_string_lossy(), &allowed_root);
+
+        assert_eq!(result, Err("preview raster path is outside the allowed scope".to_string()));
+        let _ = std::fs::remove_dir_all(&allowed_root);
+        let _ = std::fs::remove_dir_all(&outside_dir);
+    }
+
+    #[test]
+    fn read_within_scope_reports_a_missing_file_honestly() {
+        let dir = std::env::temp_dir().join(format!("scanstudio-diagnostics-raster-missing-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let missing = dir.join("never-created.png");
+
+        let result = read_within_scope(&missing.to_string_lossy(), &dir);
+
+        assert_eq!(result, Err("preview raster path not found or inaccessible".to_string()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reports_a_display_safe_error_instead_of_panicking() {
+        // A path through a file (not a directory) as a parent component
+        // cannot be created on any platform -- a deterministic, portable
+        // way to force a write failure without touching a real restricted
+        // path.
+        let dir = std::env::temp_dir().join(format!("scanstudio-diagnostics-bundle-test-err-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let blocking_file = dir.join("not-a-directory");
+        std::fs::write(&blocking_file, b"x").expect("write blocking file");
+        let impossible_path = blocking_file.join("bundle.zip");
+
+        let result = write_diagnostic_bundle(impossible_path.to_string_lossy().into_owned(), vec![1]);
+
+        assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/ports/tauri/app/src-tauri/src/lib.rs
+++ b/ports/tauri/app/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod diagnostics;
 pub mod engine;
 pub mod preview;
 mod wsl;
@@ -107,13 +108,16 @@ pub fn run() {
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_os::init())
         .register_uri_scheme_protocol("scanstudio-preview", preview::handle_request)
         .invoke_handler(tauri::generate_handler![
             engine::engine_request,
             engine::engine_state,
             wsl_run_checks,
             wsl_max_read_report,
-            wsl_write_mode_report
+            wsl_write_mode_report,
+            diagnostics::write_diagnostic_bundle,
+            diagnostics::read_preview_raster
         ])
         .setup(|app| engine::setup(app))
         .build(tauri::generate_context!())

--- a/ports/tauri/app/src/session/__tests__/diagnosticBundle.test.ts
+++ b/ports/tauri/app/src/session/__tests__/diagnosticBundle.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDiagnosticBundleEntries,
+  resolveDiagnosticBundleRaster,
+} from "../diagnosticBundle";
+
+const decode = (data: Uint8Array): string => new TextDecoder().decode(data);
+
+describe("buildDiagnosticBundleEntries", () => {
+  it("includes the diagnostics log, report text, and raster when one is available", () => {
+    const entries = buildDiagnosticBundleEntries({
+      diagnosticsJsonl: '{"event":"session.started"}',
+      reportText: "ScanStudio error report\nError code: NOT_CONNECTED",
+      previewRaster: { filename: "preview.png", data: new Uint8Array([0x89, 0x50, 0x4e, 0x47]) },
+    });
+
+    expect(entries.map((entry) => entry.name).sort()).toEqual([
+      "diagnostics.jsonl",
+      "manifest.txt",
+      "preview.png",
+      "report.txt",
+    ]);
+
+    const manifest = entries.find((entry) => entry.name === "manifest.txt")!;
+    expect(decode(manifest.data)).toContain("preview.png: the roll preview raster");
+    expect(decode(manifest.data)).not.toContain("not available");
+
+    const raster = entries.find((entry) => entry.name === "preview.png")!;
+    expect(Array.from(raster.data)).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  it("records the specific unavailability reason instead of silently dropping the raster", () => {
+    const entries = buildDiagnosticBundleEntries({
+      diagnosticsJsonl: "",
+      reportText: "ScanStudio error report",
+      previewRaster: null,
+      unavailableRasterReason: "the roll preview image file is missing or unreadable",
+    });
+
+    expect(entries.map((entry) => entry.name).sort()).toEqual(["diagnostics.jsonl", "manifest.txt", "report.txt"]);
+    const manifest = entries.find((entry) => entry.name === "manifest.txt")!;
+    expect(decode(manifest.data)).toContain(
+      "raster: not available in this build (the roll preview image file is missing or unreadable)",
+    );
+  });
+
+  it("falls back to a generic reason when none is supplied", () => {
+    const entries = buildDiagnosticBundleEntries({
+      diagnosticsJsonl: "",
+      reportText: "report",
+      previewRaster: null,
+    });
+    const manifest = entries.find((entry) => entry.name === "manifest.txt")!;
+    expect(decode(manifest.data)).toContain("raster: not available in this build (no roll preview in this session)");
+  });
+});
+
+describe("resolveDiagnosticBundleRaster", () => {
+  it("honestly reports an empty session never had a roll preview", async () => {
+    const result = await resolveDiagnosticBundleRaster({}, () => new Uint8Array());
+    expect(result).toEqual({ raster: null, unavailableReason: "no roll preview in this session" });
+  });
+
+  it("reports a thumbnail with no image path rather than silently skipping it", async () => {
+    const result = await resolveDiagnosticBundleRaster({ 1: { imagePath: undefined } }, () => new Uint8Array());
+    expect(result).toEqual({
+      raster: null,
+      unavailableReason: "the roll preview has no locally-known image path",
+    });
+  });
+
+  it("reports a fake-filesystem miss as missing rather than silently skipping it", async () => {
+    const result = await resolveDiagnosticBundleRaster({ 1: { imagePath: "/fake/frame1.tif" } }, () => null);
+    expect(result).toEqual({
+      raster: null,
+      unavailableReason: "the roll preview image file is missing or unreadable",
+    });
+  });
+
+  it("resolves the lowest-indexed frame's image against a fake filesystem, naming it by extension", async () => {
+    const fakeFilesystem: Record<string, Uint8Array> = {
+      "/fake/frame3.tif": new TextEncoder().encode("wrong frame"),
+      "/fake/frame1.tif": new TextEncoder().encode("roll preview bytes"),
+    };
+    const thumbnails = {
+      3: { imagePath: "/fake/frame3.tif" },
+      1: { imagePath: "/fake/frame1.tif" },
+    };
+
+    const result = await resolveDiagnosticBundleRaster(thumbnails, (path) => fakeFilesystem[path] ?? null);
+
+    expect(result.unavailableReason).toBeNull();
+    expect(result.raster?.filename).toBe("preview.tif");
+    expect(result.raster && decode(result.raster.data)).toBe("roll preview bytes");
+  });
+
+  it("names a raster with no file extension just 'preview'", async () => {
+    const fakeFilesystem: Record<string, Uint8Array> = { "/fake/frame1": new Uint8Array([1, 2, 3]) };
+    const result = await resolveDiagnosticBundleRaster(
+      { 1: { imagePath: "/fake/frame1" } },
+      (path) => fakeFilesystem[path] ?? null,
+    );
+    expect(result.raster?.filename).toBe("preview");
+  });
+
+  it("supports an async readFile, since the real implementation reads through a Tauri command", async () => {
+    const result = await resolveDiagnosticBundleRaster(
+      { 1: { imagePath: "/fake/frame1.tif" } },
+      async (path) => {
+        await Promise.resolve();
+        return path === "/fake/frame1.tif" ? new Uint8Array([7, 8, 9]) : null;
+      },
+    );
+    expect(result.raster && Array.from(result.raster.data)).toEqual([7, 8, 9]);
+  });
+});

--- a/ports/tauri/app/src/session/__tests__/diagnosticField.test.ts
+++ b/ports/tauri/app/src/session/__tests__/diagnosticField.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { formatDiagnosticFields, formatDiagnosticValue } from "../diagnosticField";
+
+describe("formatDiagnosticValue", () => {
+  it("renders strings verbatim", () => {
+    expect(formatDiagnosticValue("real")).toBe("real");
+  });
+
+  it("renders booleans as true/false", () => {
+    expect(formatDiagnosticValue(true)).toBe("true");
+    expect(formatDiagnosticValue(false)).toBe("false");
+  });
+
+  it("renders whole numbers without a trailing decimal", () => {
+    expect(formatDiagnosticValue(3)).toBe("3");
+    expect(formatDiagnosticValue(-12)).toBe("-12");
+  });
+
+  it("renders fractional numbers with their shortest representation", () => {
+    expect(formatDiagnosticValue(0.937)).toBe("0.937");
+  });
+
+  it("renders arrays as comma-joined, bracketed values", () => {
+    expect(formatDiagnosticValue([0.1, 0.5, 0.9])).toBe("[0.1,0.5,0.9]");
+  });
+
+  it("renders nested objects as comma-joined key=value pairs, sorted by key", () => {
+    expect(formatDiagnosticValue({ y: 20, x: 10, w: 30, h: 40 })).toBe("{h=40,w=30,x=10,y=20}");
+  });
+
+  it("renders null explicitly rather than dropping the field", () => {
+    expect(formatDiagnosticValue(null)).toBe("null");
+  });
+});
+
+describe("formatDiagnosticFields", () => {
+  it("is a generic key=value serializer with zero per-field-name coupling", () => {
+    // A mix of every value shape, including ones no current event actually
+    // emits -- this is exactly what "future instrumentation appears
+    // automatically" means: nothing here special-cases a key or event name.
+    const fields = {
+      confidence: 0.937,
+      boxCount: 3,
+      simulated: false,
+      box: { x: 10, y: 20, w: 30, h: 40 },
+      scores: [0.1, 0.5, 0.9],
+    };
+
+    expect(formatDiagnosticFields(fields)).toBe(
+      "box={h=40,w=30,x=10,y=20} boxCount=3 confidence=0.937 scores=[0.1,0.5,0.9] simulated=false",
+    );
+  });
+
+  it("returns an empty string for no fields", () => {
+    expect(formatDiagnosticFields({})).toBe("");
+  });
+});

--- a/ports/tauri/app/src/session/__tests__/diagnosticTimeline.test.ts
+++ b/ports/tauri/app/src/session/__tests__/diagnosticTimeline.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { DiagnosticTimeline, MAXIMUM_DIAGNOSTIC_ENTRIES, summaryLine } from "../diagnosticTimeline";
+
+describe("DiagnosticTimeline", () => {
+  it("bounds entries at 40 by default, matching the report's own event window", () => {
+    expect(MAXIMUM_DIAGNOSTIC_ENTRIES).toBe(40);
+    const timeline = new DiagnosticTimeline("session-test");
+    for (let index = 1; index <= 50; index++) {
+      timeline.record(`event-${index}`, {}, `2026-08-05T00:00:00Z-${index}`);
+    }
+
+    expect(timeline.entries).toHaveLength(40);
+    expect(timeline.entries[0].event).toBe("event-11");
+    expect(timeline.entries[39].event).toBe("event-50");
+  });
+
+  it("renders a stable structured summary line per entry", () => {
+    const timeline = new DiagnosticTimeline("session-test", 10);
+    timeline.record("device.connect.succeeded", { connected: true, kind: "real" }, "2026-07-28T00:08:18Z");
+    timeline.record("preview.requested", { uiConnected: true }, "2026-07-28T00:09:00Z");
+
+    expect(timeline.summaryLines).toEqual([
+      "2026-07-28T00:08:18Z device.connect.succeeded connected=true kind=real",
+      "2026-07-28T00:09:00Z preview.requested uiConnected=true",
+    ]);
+  });
+
+  it("renders an event with no fields as just the timestamp and event name", () => {
+    const timeline = new DiagnosticTimeline("session-test");
+    timeline.record("session.started", {}, "2026-07-28T00:00:00Z");
+    expect(timeline.summaryLines).toEqual(["2026-07-28T00:00:00Z session.started"]);
+  });
+
+  it("serializes to one JSON object per line, matching the mac build's durable log shape", () => {
+    const timeline = new DiagnosticTimeline("session-jsonl", 10);
+    timeline.record("preview.failed", { code: "NOT_CONNECTED", uiConnectedBefore: true }, "2026-07-28T00:09:01Z");
+
+    const lines = timeline.toJsonl().split("\n");
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed).toEqual({
+      timestamp: "2026-07-28T00:09:01Z",
+      sessionId: "session-jsonl",
+      event: "preview.failed",
+      fields: { code: "NOT_CONNECTED", uiConnectedBefore: true },
+    });
+  });
+
+  it("keeps numeric and boolean fields as real JSON types, not stringified text", () => {
+    const timeline = new DiagnosticTimeline("typed-fields", 10);
+    timeline.record("detector.scored", { confidence: 0.5, boxCount: 3, simulated: true });
+
+    const parsed = JSON.parse(timeline.toJsonl());
+    expect(parsed.fields.confidence).toBe(0.5);
+    expect(parsed.fields.boxCount).toBe(3);
+    expect(parsed.fields.simulated).toBe(true);
+  });
+
+  it("assigns every entry a session id, generating one when none is supplied", () => {
+    const timeline = new DiagnosticTimeline();
+    timeline.record("session.started");
+    expect(timeline.entries[0].sessionId).toBe(timeline.sessionId);
+    expect(timeline.sessionId.length).toBeGreaterThan(0);
+  });
+});
+
+describe("summaryLine", () => {
+  it("sorts fields by key, independent of insertion order", () => {
+    const line = summaryLine({
+      timestamp: "t",
+      sessionId: "s",
+      event: "e",
+      fields: { b: 2, a: 1 },
+    });
+    expect(line).toBe("t e a=1 b=2");
+  });
+});

--- a/ports/tauri/app/src/session/__tests__/errorReport.test.ts
+++ b/ports/tauri/app/src/session/__tests__/errorReport.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { buildErrorReportText, MAXIMUM_RECENT_DIAGNOSTIC_EVENTS } from "../errorReport";
+
+const baseContext = {
+  errorCode: "NOT_CONNECTED",
+  errorMessage: "NOT_CONNECTED: no device is open",
+  recentDiagnosticEvents: [] as string[],
+};
+
+describe("buildErrorReportText", () => {
+  it("starts with the exact report header line, matching the mac build byte-for-byte", () => {
+    const text = buildErrorReportText(baseContext);
+    expect(text.startsWith("ScanStudio error report\n")).toBe(true);
+  });
+
+  it("renders every build-identifying header field, falling back to unknown instead of omitting it", () => {
+    const text = buildErrorReportText({ ...baseContext, scanStudioVersion: "0.3.0-alpha.11" });
+
+    expect(text).toContain("ScanStudio version: 0.3.0-alpha.11");
+    expect(text).toContain("Operating system: unknown");
+    expect(text).toContain("CPU architecture: unknown");
+    expect(text).toContain("Scanner firmware: unknown");
+    expect(text).toContain("Adapter: unknown");
+    expect(text).toContain("Holder: unknown");
+  });
+
+  it("populates known scanner identity and holder state", () => {
+    const text = buildErrorReportText({
+      ...baseContext,
+      scanStudioVersion: "0.3.0-alpha.11",
+      operatingSystem: "Windows 10.0.22631",
+      cpuArchitecture: "x86_64",
+      scannerFirmware: "1.02",
+      scannerAdapter: "SA-21",
+      scannerHolder: "roll36",
+    });
+
+    expect(text).toContain("Operating system: Windows 10.0.22631");
+    expect(text).toContain("CPU architecture: x86_64");
+    expect(text).toContain("Scanner firmware: 1.02");
+    expect(text).toContain("Adapter: SA-21");
+    expect(text).toContain("Holder: roll36");
+  });
+
+  it("includes up to the last 40 diagnostic events, dropping older ones", () => {
+    const events = Array.from({ length: 50 }, (_, index) => `2026-08-05T00:00:00Z-${index + 1} event-${index + 1}`);
+    const text = buildErrorReportText({ ...baseContext, recentDiagnosticEvents: events });
+
+    expect(MAXIMUM_RECENT_DIAGNOSTIC_EVENTS).toBe(40);
+    expect(text).toContain("- 2026-08-05T00:00:00Z-50 event-50");
+    expect(text).toContain("- 2026-08-05T00:00:00Z-11 event-11");
+    expect(text).not.toContain("- 2026-08-05T00:00:00Z-10 event-10");
+  });
+
+  it("omits the Recent diagnostic events section entirely when there are none", () => {
+    const text = buildErrorReportText(baseContext);
+    expect(text).not.toContain("Recent diagnostic events:");
+  });
+
+  it("shows the local log path near the top when known, and nothing when unknown", () => {
+    const withPath = buildErrorReportText({
+      ...baseContext,
+      diagnosticLogPath: "/Users/tester/.scanstudio/diagnostics/session-1234.jsonl",
+    });
+    expect(withPath).toContain("Local log: /Users/tester/.scanstudio/diagnostics/session-1234.jsonl");
+    expect(withPath.indexOf("Local log:")).toBeLessThan(withPath.indexOf("Error code:"));
+
+    const withoutPath = buildErrorReportText(baseContext);
+    expect(withoutPath).not.toContain("Local log:");
+  });
+
+  it("appends the Windows setup check section only while probe results exist", () => {
+    const withProbes = buildErrorReportText({
+      ...baseContext,
+      setupCheckProbes: [
+        { id: "wsl-status", status: "Ok", detail: "WSL2 with Ubuntu-24.04 default" },
+        { id: "bridge-which", status: "Fail", detail: "scanstudio-bridge not found on PATH inside WSL" },
+      ],
+    });
+    expect(withProbes).toContain("Windows setup check:");
+    expect(withProbes).toContain("- wsl-status: Ok -- WSL2 with Ubuntu-24.04 default");
+    expect(withProbes).toContain("- bridge-which: Fail -- scanstudio-bridge not found on PATH inside WSL");
+
+    const withoutProbes = buildErrorReportText(baseContext);
+    expect(withoutProbes).not.toContain("Windows setup check:");
+
+    const withEmptyProbes = buildErrorReportText({ ...baseContext, setupCheckProbes: [] });
+    expect(withEmptyProbes).not.toContain("Windows setup check:");
+  });
+
+  it("always ends with the honest no-automatic-attachments footer", () => {
+    const text = buildErrorReportText(baseContext);
+    expect(text.trimEnd().endsWith("No images, receipts, or raw logs are attached automatically.")).toBe(true);
+  });
+
+  it("includes the error code and message", () => {
+    const text = buildErrorReportText({
+      ...baseContext,
+      errorCode: "REFEED_REQUIRED",
+      errorMessage: "REFEED_REQUIRED: refeed the strip and retry",
+    });
+    expect(text).toContain("Error code: REFEED_REQUIRED");
+    expect(text).toContain("Message:\nREFEED_REQUIRED: refeed the strip and retry");
+  });
+});

--- a/ports/tauri/app/src/session/__tests__/hostEnvironment.test.ts
+++ b/ports/tauri/app/src/session/__tests__/hostEnvironment.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { describeCpuArchitecture, describeOperatingSystem, getScanStudioVersion } from "../hostEnvironment";
+
+// hostEnvironment calls straight into @tauri-apps/api/app and
+// @tauri-apps/plugin-os. Mock both so no real Tauri runtime is needed, the
+// same pattern SetupChecker.test.tsx uses for @tauri-apps/api/core. Vitest
+// hoists vi.mock calls above every import in this file, so the mock is in
+// place before hostEnvironment.ts's own imports resolve.
+const mocks = vi.hoisted(() => ({
+  getVersion: vi.fn(),
+  platform: vi.fn(),
+  version: vi.fn(),
+  arch: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/app", () => ({ getVersion: mocks.getVersion }));
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: mocks.platform,
+  version: mocks.version,
+  arch: mocks.arch,
+}));
+
+afterEach(() => {
+  mocks.getVersion.mockReset();
+  mocks.platform.mockReset();
+  mocks.version.mockReset();
+  mocks.arch.mockReset();
+});
+
+describe("getScanStudioVersion", () => {
+  it("returns the packaged version", async () => {
+    mocks.getVersion.mockResolvedValue("0.3.0");
+    await expect(getScanStudioVersion()).resolves.toBe("0.3.0");
+  });
+
+  it("returns null (never a fabricated value) when the call fails", async () => {
+    mocks.getVersion.mockRejectedValue(new Error("no tauri runtime"));
+    await expect(getScanStudioVersion()).resolves.toBeNull();
+  });
+
+  it("returns null for an empty version string instead of an empty header field", async () => {
+    mocks.getVersion.mockResolvedValue("");
+    await expect(getScanStudioVersion()).resolves.toBeNull();
+  });
+});
+
+describe("describeOperatingSystem", () => {
+  it("combines the platform's friendly name and version", () => {
+    mocks.platform.mockReturnValue("windows");
+    mocks.version.mockReturnValue("10.0.22631");
+    expect(describeOperatingSystem()).toBe("Windows 10.0.22631");
+  });
+
+  it("maps macos to macOS", () => {
+    mocks.platform.mockReturnValue("macos");
+    mocks.version.mockReturnValue("15.4.1");
+    expect(describeOperatingSystem()).toBe("macOS 15.4.1");
+  });
+
+  it("maps linux to Linux", () => {
+    mocks.platform.mockReturnValue("linux");
+    mocks.version.mockReturnValue("6.8.0");
+    expect(describeOperatingSystem()).toBe("Linux 6.8.0");
+  });
+
+  it("returns null when the plugin is unavailable, never a guess", () => {
+    mocks.platform.mockImplementation(() => {
+      throw new Error("plugin unavailable outside a Tauri webview");
+    });
+    expect(describeOperatingSystem()).toBeNull();
+  });
+});
+
+describe("describeCpuArchitecture", () => {
+  it("returns the plugin-resolved architecture verbatim", () => {
+    mocks.arch.mockReturnValue("aarch64");
+    expect(describeCpuArchitecture()).toBe("aarch64");
+  });
+
+  it("returns null when unavailable instead of sniffing a user-agent string", () => {
+    mocks.arch.mockImplementation(() => {
+      throw new Error("plugin unavailable outside a Tauri webview");
+    });
+    expect(describeCpuArchitecture()).toBeNull();
+  });
+});

--- a/ports/tauri/app/src/session/__tests__/setupCheckResults.test.ts
+++ b/ports/tauri/app/src/session/__tests__/setupCheckResults.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatSetupCheckProbesAsText, setupCheckResults } from "../setupCheckResults";
+
+describe("setupCheckResults", () => {
+  it("starts null (never an empty array) until SetupChecker has run at least once", () => {
+    // The very first assertion in the file, before any test has called
+    // set() -- this is the singleton's true unstarted state, distinct from
+    // "ran once and found zero probes" ([]).
+    expect(setupCheckResults.get()).toBeNull();
+  });
+
+  it("notifies subscribers when results are set", () => {
+    const listener = vi.fn();
+    const unsubscribe = setupCheckResults.subscribe(listener);
+
+    setupCheckResults.set([{ id: "wsl-status", status: "Ok", detail: "fine", fixCommand: null }]);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(setupCheckResults.get()).toEqual([{ id: "wsl-status", status: "Ok", detail: "fine", fixCommand: null }]);
+    unsubscribe();
+  });
+
+  it("stops notifying an unsubscribed listener", () => {
+    const listener = vi.fn();
+    const unsubscribe = setupCheckResults.subscribe(listener);
+    unsubscribe();
+
+    setupCheckResults.set([{ id: "wsl-status", status: "Ok", detail: "fine", fixCommand: null }]);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("formatSetupCheckProbesAsText", () => {
+  it("renders id/status/detail and an optional fix command per line", () => {
+    const text = formatSetupCheckProbesAsText([
+      { id: "wsl-status", status: "Ok", detail: "WSL2 with Ubuntu-24.04 default", fixCommand: null },
+      {
+        id: "bridge-which",
+        status: "Fail",
+        detail: "scanstudio-bridge not found on PATH inside WSL",
+        fixCommand: "Run install-bridge-wsl.sh inside your WSL Ubuntu-24.04 distro",
+      },
+    ]);
+
+    expect(text).toBe(
+      "wsl-status: Ok -- WSL2 with Ubuntu-24.04 default\n" +
+        "bridge-which: Fail -- scanstudio-bridge not found on PATH inside WSL " +
+        "(fix: Run install-bridge-wsl.sh inside your WSL Ubuntu-24.04 distro)",
+    );
+  });
+});

--- a/ports/tauri/app/src/session/__tests__/zip.test.ts
+++ b/ports/tauri/app/src/session/__tests__/zip.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { createStoredZip, type ZipEntry } from "../zip";
+
+/** Minimal reader for the exact "stored" (uncompressed) ZIP shape
+ * createStoredZip produces -- enough to round-trip-verify contents without
+ * a third-party archive library in the test target. */
+function readStoredZipEntries(zip: Uint8Array): { name: string; data: Uint8Array }[] {
+  const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+  const entries: { name: string; data: Uint8Array }[] = [];
+  let offset = 0;
+
+  while (offset < zip.length) {
+    if (view.getUint32(offset, true) !== 0x04034b50) break;
+    const compressedSize = view.getUint32(offset + 18, true);
+    const nameLength = view.getUint16(offset + 26, true);
+    const extraLength = view.getUint16(offset + 28, true);
+    const nameStart = offset + 30;
+    const nameEnd = nameStart + nameLength;
+    const name = new TextDecoder().decode(zip.slice(nameStart, nameEnd));
+    const dataStart = nameEnd + extraLength;
+    const dataEnd = dataStart + compressedSize;
+    entries.push({ name, data: zip.slice(dataStart, dataEnd) });
+    offset = dataEnd;
+  }
+  return entries;
+}
+
+describe("createStoredZip", () => {
+  it("round-trips filenames and bytes exactly, including an empty entry", () => {
+    const entries: ZipEntry[] = [
+      { name: "diagnostics.jsonl", data: new TextEncoder().encode('{"event":"session.started"}') },
+      { name: "report.txt", data: new TextEncoder().encode("ScanStudio error report\n") },
+      { name: "empty.txt", data: new Uint8Array() },
+    ];
+
+    const zip = createStoredZip(entries);
+
+    expect(Array.from(zip.slice(0, 4))).toEqual([0x50, 0x4b, 0x03, 0x04]);
+    // The 22-byte End Of Central Directory record is the tail of the file
+    // whenever the (unused) archive comment is empty, as here -- its
+    // signature is the record's first 4 bytes, not the file's last 4.
+    expect(Array.from(zip.slice(zip.length - 22, zip.length - 18))).toEqual([0x50, 0x4b, 0x05, 0x06]);
+
+    const readBack = readStoredZipEntries(zip);
+    expect(readBack.map((entry) => entry.name)).toEqual(entries.map((entry) => entry.name));
+    readBack.forEach((entry, index) => {
+      expect(Array.from(entry.data)).toEqual(Array.from(entries[index].data));
+    });
+  });
+
+  it("produces a well-formed archive with zero entries", () => {
+    const zip = createStoredZip([]);
+    expect(zip.length).toBe(22);
+    expect(Array.from(zip.slice(0, 4))).toEqual([0x50, 0x4b, 0x05, 0x06]);
+    expect(readStoredZipEntries(zip)).toEqual([]);
+  });
+
+  it("supports multiple entries with distinct byte content", () => {
+    const zip = createStoredZip([
+      { name: "a.bin", data: new Uint8Array([1, 2, 3]) },
+      { name: "b.bin", data: new Uint8Array([4, 5, 6, 7]) },
+    ]);
+    const readBack = readStoredZipEntries(zip);
+    expect(readBack).toHaveLength(2);
+    expect(Array.from(readBack[0].data)).toEqual([1, 2, 3]);
+    expect(Array.from(readBack[1].data)).toEqual([4, 5, 6, 7]);
+  });
+});

--- a/ports/tauri/app/src/session/diagnosticBundle.ts
+++ b/ports/tauri/app/src/session/diagnosticBundle.ts
@@ -1,0 +1,91 @@
+import { createStoredZip, type ZipEntry } from "./zip";
+
+export interface PreviewRaster {
+  filename: string;
+  data: Uint8Array;
+}
+
+export interface DiagnosticBundleParams {
+  diagnosticsJsonl: string;
+  reportText: string;
+  previewRaster: PreviewRaster | null;
+  unavailableRasterReason?: string | null;
+}
+
+/** Assembles "Save Diagnostic Bundle..."'s contents (T-ERR-04) from
+ * already-in-memory data -- no filesystem access here, mirroring
+ * DiagnosticBundleBuilder
+ * (app/ScanStudio/Sources/ScanStudioKit/DiagnosticBundle.swift). */
+export function buildDiagnosticBundleEntries(params: DiagnosticBundleParams): ZipEntry[] {
+  const encoder = new TextEncoder();
+  const manifestLines = [
+    "ScanStudio diagnostic bundle",
+    "",
+    "diagnostics.jsonl: this session's diagnostic events, one JSON object per line",
+    "report.txt: the generated error report at the time of export",
+  ];
+  const entries: ZipEntry[] = [
+    { name: "diagnostics.jsonl", data: encoder.encode(params.diagnosticsJsonl) },
+    { name: "report.txt", data: encoder.encode(params.reportText) },
+  ];
+
+  if (params.previewRaster) {
+    manifestLines.push(`${params.previewRaster.filename}: the roll preview raster`);
+    entries.push({ name: params.previewRaster.filename, data: params.previewRaster.data });
+  } else {
+    const reason = params.unavailableRasterReason ?? "no roll preview in this session";
+    manifestLines.push(`raster: not available in this build (${reason})`);
+  }
+
+  entries.push({ name: "manifest.txt", data: encoder.encode(manifestLines.join("\n")) });
+  return entries;
+}
+
+/** The complete zip bytes for "Save Diagnostic Bundle...". */
+export function buildDiagnosticBundleZip(params: DiagnosticBundleParams): Uint8Array {
+  return createStoredZip(buildDiagnosticBundleEntries(params));
+}
+
+export interface RasterResolution {
+  raster: PreviewRaster | null;
+  unavailableReason: string | null;
+}
+
+/** Resolves the diagnostic bundle's preview raster from state the frontend
+ * already holds -- Thumbnail.imagePath, exactly what the contact sheet
+ * already reads (scanstudio-preview://) to render preview tiles -- never a
+ * new bridge/engine wire method. `readFile` is injectable (and may be
+ * async, since the real implementation reads through a Tauri command --
+ * the webview has no direct filesystem access) so this is testable against
+ * a fake filesystem with zero real disk I/O. Mirrors
+ * DiagnosticBundleRasterPolicy
+ * (app/ScanStudio/Sources/ScanStudioKit/DiagnosticBundle.swift): picks the
+ * lowest-indexed frame with a known, readable image path. */
+export async function resolveDiagnosticBundleRaster(
+  thumbnails: Record<number, { imagePath?: string | null }>,
+  readFile: (path: string) => Uint8Array | null | Promise<Uint8Array | null>,
+): Promise<RasterResolution> {
+  const indices = Object.keys(thumbnails)
+    .map(Number)
+    .filter((index) => Number.isFinite(index))
+    .sort((a, b) => a - b);
+  if (indices.length === 0) {
+    return { raster: null, unavailableReason: "no roll preview in this session" };
+  }
+
+  const imagePath = thumbnails[indices[0]]?.imagePath;
+  if (!imagePath) {
+    return { raster: null, unavailableReason: "the roll preview has no locally-known image path" };
+  }
+
+  const data = await readFile(imagePath);
+  if (data === null) {
+    return { raster: null, unavailableReason: "the roll preview image file is missing or unreadable" };
+  }
+
+  const dotIndex = imagePath.lastIndexOf(".");
+  const slashIndex = Math.max(imagePath.lastIndexOf("/"), imagePath.lastIndexOf("\\"));
+  const extension = dotIndex > slashIndex ? imagePath.slice(dotIndex + 1) : "";
+  const filename = extension.length === 0 ? "preview" : `preview.${extension}`;
+  return { raster: { filename, data }, unavailableReason: null };
+}

--- a/ports/tauri/app/src/session/diagnosticBundleIO.ts
+++ b/ports/tauri/app/src/session/diagnosticBundleIO.ts
@@ -1,0 +1,27 @@
+import { invoke } from "@tauri-apps/api/core";
+
+// Thin IPC wrappers around the diagnostics.rs commands (error report v2,
+// T-ERR-04). Kept separate from diagnosticBundle.ts / zip.ts so the
+// bundle-assembly logic itself stays a pure, Tauri-free unit -- only this
+// file talks to `invoke`.
+
+/** Reads the roll-preview raster's bytes via the read_preview_raster
+ * command -- the webview has no direct filesystem access, so this is the
+ * only way to get Thumbnail.imagePath's bytes into the bundle. Returns
+ * `null` on any failure (missing file, outside the allowed scope, no Tauri
+ * runtime) rather than throwing, matching resolveDiagnosticBundleRaster's
+ * `readFile` contract. */
+export async function readPreviewRasterBytes(path: string): Promise<Uint8Array | null> {
+  try {
+    const bytes = await invoke<number[]>("read_preview_raster", { path });
+    return new Uint8Array(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/** Writes the assembled bundle zip to `path` via the write_diagnostic_bundle
+ * command. */
+export async function writeDiagnosticBundleFile(path: string, bytes: Uint8Array): Promise<void> {
+  await invoke("write_diagnostic_bundle", { path, bytes: Array.from(bytes) });
+}

--- a/ports/tauri/app/src/session/diagnosticField.ts
+++ b/ports/tauri/app/src/session/diagnosticField.ts
@@ -1,0 +1,55 @@
+// A generic, JSON-shaped diagnostic field value. Event authors may record a
+// string, a number, a boolean, or a nested array/object without the report
+// renderer ever needing per-event or per-key knowledge of the shape --
+// future instrumentation (e.g. detector confidence scores) starts rendering
+// into every generated report the moment it starts recording a field, with
+// zero coupling to formatDiagnosticFields or the error-report builder.
+//
+// Mirrors ScanStudioKit's DiagnosticFieldValue (app/ScanStudio/Sources/
+// ScanStudioKit/SessionDiagnosticTimeline.swift) so both frontends render an
+// identical compact shape for the same kind of value.
+export type DiagnosticFieldValue =
+  | string
+  | number
+  | boolean
+  | null
+  | DiagnosticFieldValue[]
+  | { [key: string]: DiagnosticFieldValue };
+
+export type DiagnosticFields = Record<string, DiagnosticFieldValue>;
+
+/** Compact, single-line rendering of one field value. Never multi-line and
+ * never pretty-printed JSON -- nested values still collapse into one
+ * `key=value` diagnostic line. */
+export function formatDiagnosticValue(value: DiagnosticFieldValue): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return value;
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return formatNumber(value);
+  if (Array.isArray(value)) {
+    return "[" + value.map(formatDiagnosticValue).join(",") + "]";
+  }
+  const rendered = Object.keys(value)
+    .sort()
+    .map((key) => `${key}=${formatDiagnosticValue(value[key])}`)
+    .join(",");
+  return `{${rendered}}`;
+}
+
+function formatNumber(value: number): string {
+  if (Number.isFinite(value) && Number.isInteger(value)) {
+    return String(value);
+  }
+  return String(value);
+}
+
+/** Compact `key=value key2=value2` rendering of a whole fields object, keys
+ * sorted for stable output -- the generic serializer every diagnostic event
+ * (present or future) renders through, with no event-name or key-name
+ * special-casing anywhere in this function. */
+export function formatDiagnosticFields(fields: DiagnosticFields): string {
+  return Object.keys(fields)
+    .sort()
+    .map((key) => `${key}=${formatDiagnosticValue(fields[key])}`)
+    .join(" ");
+}

--- a/ports/tauri/app/src/session/diagnosticTimeline.ts
+++ b/ports/tauri/app/src/session/diagnosticTimeline.ts
@@ -1,0 +1,77 @@
+import type { DiagnosticFields } from "./diagnosticField";
+import { formatDiagnosticFields } from "./diagnosticField";
+
+export interface DiagnosticEntry {
+  timestamp: string;
+  sessionId: string;
+  event: string;
+  fields: DiagnosticFields;
+}
+
+/** Matches SessionDiagnosticEntry.summaryLine's exact shape:
+ * `<timestamp> <event>` when there are no fields, else
+ * `<timestamp> <event> key=value key2=value2` with keys sorted. */
+export function summaryLine(entry: DiagnosticEntry): string {
+  const details = formatDiagnosticFields(entry.fields);
+  return details.length === 0
+    ? `${entry.timestamp} ${entry.event}`
+    : `${entry.timestamp} ${entry.event} ${details}`;
+}
+
+function generateSessionId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Every environment this app ships to has Web Crypto, but tests and
+  // unusual embeddings should still get a usable, non-throwing id.
+  return `session-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** Both report outputs show at most this many of the most recent diagnostic
+ * events -- matches SessionDiagnosticTimeline's own default retention cap
+ * on the mac side, so raising one without the other cannot silently
+ * under-fill the report. */
+export const MAXIMUM_DIAGNOSTIC_ENTRIES = 40;
+
+/** A bounded, privacy-safe diagnostic timeline (T-ERR-02's Tauri
+ * counterpart of SessionDiagnosticTimeline). Callers supply only
+ * operational fields; paths, film metadata, and device identifiers do not
+ * belong here.
+ *
+ * Scope note: unlike the mac build, this does not yet persist to a durable
+ * on-disk log -- "Save Diagnostic Bundle..." (diagnosticBundle.ts) writes
+ * the current in-memory window directly into diagnostics.jsonl instead, and
+ * the error report's "Local log" line honestly renders "unknown" until a
+ * durable Tauri-side log lands as a follow-up. */
+export class DiagnosticTimeline {
+  readonly sessionId: string;
+  #maximumEntries: number;
+  #entries: DiagnosticEntry[] = [];
+
+  constructor(sessionId: string = generateSessionId(), maximumEntries: number = MAXIMUM_DIAGNOSTIC_ENTRIES) {
+    this.sessionId = sessionId;
+    this.#maximumEntries = Math.max(maximumEntries, 1);
+  }
+
+  record(event: string, fields: DiagnosticFields = {}, timestamp: string = new Date().toISOString()): void {
+    this.#entries.push({ timestamp, sessionId: this.sessionId, event, fields });
+    if (this.#entries.length > this.#maximumEntries) {
+      this.#entries = this.#entries.slice(this.#entries.length - this.#maximumEntries);
+    }
+  }
+
+  get entries(): readonly DiagnosticEntry[] {
+    return this.#entries;
+  }
+
+  get summaryLines(): string[] {
+    return this.#entries.map(summaryLine);
+  }
+
+  /** One JSON object per line, matching SessionDiagnosticTimeline's durable
+   * on-disk shape -- the exact bytes "Save Diagnostic Bundle..." writes into
+   * diagnostics.jsonl. */
+  toJsonl(): string {
+    return this.#entries.map((entry) => JSON.stringify(entry)).join("\n");
+  }
+}

--- a/ports/tauri/app/src/session/errorReport.ts
+++ b/ports/tauri/app/src/session/errorReport.ts
@@ -1,0 +1,102 @@
+// Builds "the report" text (error report v2, T-ERR-01/02/03/05): a
+// build-identifying header that never silently drops a field, up to the
+// last 40 diagnostic events, and -- when the Windows setup checker has run
+// this session -- its probe results. Pure and synchronous: callers resolve
+// every value (version, OS, diagnostics, probes) up front via
+// ErrorReportContext, mirroring ErrorPresentationPolicy.make's contract on
+// the mac side (app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift)
+// so both frontends render the same shape for the same inputs.
+
+/** Both report outputs show at most this many of the most recent diagnostic
+ * events -- matches DiagnosticTimeline's own retention cap. */
+export const MAXIMUM_RECENT_DIAGNOSTIC_EVENTS = 40;
+
+const UNKNOWN = "unknown";
+
+export interface SetupCheckProbeSummary {
+  id: string;
+  status: string;
+  detail: string;
+}
+
+export interface ErrorReportContext {
+  scanStudioVersion?: string | null;
+  operatingSystem?: string | null;
+  cpuArchitecture?: string | null;
+  scannerFirmware?: string | null;
+  scannerAdapter?: string | null;
+  scannerHolder?: string | null;
+  /** Local-only diagnostics log location. Tauri does not yet persist a
+   * durable on-disk log (see diagnosticTimeline.ts) -- omit or pass `null`
+   * until that lands, and this renders the header's honest "unknown" rather
+   * than a fabricated path. */
+  diagnosticLogPath?: string | null;
+  diagnosticSessionId?: string | null;
+  engineVersion?: string | null;
+  connectionSummary?: string | null;
+  errorCode: string;
+  errorMessage: string;
+  recentDiagnosticEvents: string[];
+  /** The Windows setup checker's most recent probe results, when it has run
+   * this session (item 5). Omitted entirely from the report when `null` or
+   * empty -- never an empty "Windows setup check:" section. */
+  setupCheckProbes?: SetupCheckProbeSummary[] | null;
+}
+
+function rendered(value: string | null | undefined): string {
+  const trimmed = (value ?? "").trim();
+  return trimmed.length === 0 ? UNKNOWN : trimmed;
+}
+
+export function buildErrorReportText(context: ErrorReportContext): string {
+  const lines: string[] = ["ScanStudio error report"];
+
+  // Build-identifying header (T-ERR-01): every field always renders,
+  // falling back to "unknown" rather than being silently omitted.
+  lines.push(`ScanStudio version: ${rendered(context.scanStudioVersion)}`);
+  lines.push(`Operating system: ${rendered(context.operatingSystem)}`);
+  lines.push(`CPU architecture: ${rendered(context.cpuArchitecture)}`);
+  lines.push(`Scanner firmware: ${rendered(context.scannerFirmware)}`);
+  lines.push(`Adapter: ${rendered(context.scannerAdapter)}`);
+  lines.push(`Holder: ${rendered(context.scannerHolder)}`);
+
+  // Near the top, per T-ERR-02, and only when actually known -- unlike the
+  // header fields above this is not forced to "unknown" when absent.
+  if (context.diagnosticLogPath) {
+    lines.push(`Local log: ${context.diagnosticLogPath}`);
+  }
+  if (context.diagnosticSessionId) {
+    lines.push(`Diagnostic session: ${context.diagnosticSessionId}`);
+  }
+  if (context.engineVersion) {
+    lines.push(`Engine version: ${context.engineVersion}`);
+  }
+  if (context.connectionSummary) {
+    lines.push(`Connection state: ${context.connectionSummary}`);
+  }
+  lines.push(`Error code: ${context.errorCode}`);
+  lines.push("");
+  lines.push("Message:");
+  lines.push(context.errorMessage);
+
+  if (context.recentDiagnosticEvents.length > 0) {
+    lines.push("");
+    lines.push("Recent diagnostic events:");
+    for (const event of context.recentDiagnosticEvents.slice(-MAXIMUM_RECENT_DIAGNOSTIC_EVENTS)) {
+      lines.push(`- ${event}`);
+    }
+  }
+
+  if (context.setupCheckProbes && context.setupCheckProbes.length > 0) {
+    lines.push("");
+    lines.push("Windows setup check:");
+    for (const probe of context.setupCheckProbes) {
+      lines.push(`- ${probe.id}: ${probe.status} -- ${probe.detail}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("No images, receipts, or raw logs are attached automatically.");
+
+  return lines.join("\n");
+}

--- a/ports/tauri/app/src/session/hostEnvironment.ts
+++ b/ports/tauri/app/src/session/hostEnvironment.ts
@@ -1,0 +1,57 @@
+import { getVersion } from "@tauri-apps/api/app";
+import { arch as pluginArch, platform as pluginPlatform, version as pluginVersion } from "@tauri-apps/plugin-os";
+
+const PLATFORM_NAMES: Record<string, string> = {
+  windows: "Windows",
+  macos: "macOS",
+  linux: "Linux",
+  ios: "iOS",
+  android: "Android",
+  freebsd: "FreeBSD",
+  dragonfly: "DragonFly BSD",
+  netbsd: "NetBSD",
+  openbsd: "OpenBSD",
+  solaris: "Solaris",
+};
+
+/** ScanStudio's own packaged version (tauri.conf.json's "version" field,
+ * read at runtime) -- the Tauri counterpart of the mac build's
+ * ScanStudioRelease stamp (T-ERR-01). `null` (never a fabricated string)
+ * when the plugin call fails for any reason, so the report renders its
+ * honest "unknown" instead. */
+export async function getScanStudioVersion(): Promise<string | null> {
+  try {
+    const version = await getVersion();
+    return version.length === 0 ? null : version;
+  } catch {
+    return null;
+  }
+}
+
+/** "<OS name> <OS version>", e.g. "Windows 10.0.22631" or "macOS 15.4.1".
+ * Both pieces come from @tauri-apps/plugin-os, resolved at compile time --
+ * deliberately not sniffed from navigator.userAgent, which is known to
+ * misreport CPU family on Apple Silicon Macs (WKWebView's UA string still
+ * says "Intel Mac OS X" there for web-compatibility reasons). `null` when
+ * the plugin is unavailable (e.g. running outside a Tauri webview, as in
+ * unit tests), never a guess. */
+export function describeOperatingSystem(): string | null {
+  try {
+    const name = PLATFORM_NAMES[pluginPlatform()] ?? pluginPlatform();
+    const osVersion = pluginVersion();
+    return osVersion.length === 0 ? name : `${name} ${osVersion}`;
+  } catch {
+    return null;
+  }
+}
+
+/** CPU architecture, e.g. "aarch64"/"x86_64" -- resolved by the OS plugin at
+ * compile time, not sniffed from a user-agent string. `null` when
+ * unavailable rather than a guess. */
+export function describeCpuArchitecture(): string | null {
+  try {
+    return pluginArch();
+  } catch {
+    return null;
+  }
+}

--- a/ports/tauri/app/src/session/index.ts
+++ b/ports/tauri/app/src/session/index.ts
@@ -1,3 +1,4 @@
+import { DiagnosticTimeline } from "./diagnosticTimeline";
 import { SessionStore } from "./store/session";
 import { createClientTransport } from "./wire/codec";
 
@@ -5,6 +6,13 @@ import { createClientTransport } from "./wire/codec";
 // wired to the Tauri invoke bridge (engine/client.ts via createClientTransport).
 // Component tests replace this module with a scripted-transport store.
 export const sessionStore = new SessionStore(createClientTransport());
+
+// Production diagnostic-events singleton for the error report (T-ERR-02).
+// Deliberately independent of SessionStore -- it is populated by observing
+// error state at the UI layer (see DiagnosticReportActions.tsx), never by
+// SessionStore itself, so this never touches SessionStore's engine-session
+// internals.
+export const diagnosticTimeline = new DiagnosticTimeline();
 
 export { SessionStore };
 export type { SessionState } from "./store/session";

--- a/ports/tauri/app/src/session/setupCheckResults.ts
+++ b/ports/tauri/app/src/session/setupCheckResults.ts
@@ -1,0 +1,50 @@
+export interface SetupCheckProbeResult {
+  id: string;
+  status: string;
+  detail: string;
+  fixCommand: string | null;
+}
+
+type Listener = () => void;
+
+/** Session-lifetime cache of the Windows setup checker's most recent probe
+ * results (error report v2, item 5). SetupChecker.tsx writes into this
+ * after every run; the error-report builder reads from it so a report
+ * generated "while setup-check results exist" includes them. A plain
+ * module-level singleton, deliberately kept outside SessionStore, so this
+ * never touches session/store/session.ts's engine-session surface. */
+class SetupCheckResultsStore {
+  #results: SetupCheckProbeResult[] | null = null;
+  #listeners = new Set<Listener>();
+
+  get(): SetupCheckProbeResult[] | null {
+    return this.#results;
+  }
+
+  set(results: SetupCheckProbeResult[]): void {
+    this.#results = results;
+    for (const listener of this.#listeners) listener();
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+}
+
+export const setupCheckResults = new SetupCheckResultsStore();
+
+/** Full "id: status -- detail (fix: ...)" text for the setup checker's own
+ * "Copy as text" affordance -- richer than the report's 3-field
+ * (id/status/detail) inclusion, since this is the primary, standalone view
+ * of the probe table itself. */
+export function formatSetupCheckProbesAsText(probes: SetupCheckProbeResult[]): string {
+  return probes
+    .map((probe) => {
+      const fix = probe.fixCommand ? ` (fix: ${probe.fixCommand})` : "";
+      return `${probe.id}: ${probe.status} -- ${probe.detail}${fix}`;
+    })
+    .join("\n");
+}

--- a/ports/tauri/app/src/session/zip.ts
+++ b/ports/tauri/app/src/session/zip.ts
@@ -1,0 +1,141 @@
+// A minimal, dependency-free ZIP writer using the uncompressed ("stored")
+// method only -- the Tauri counterpart of StoredZipWriter
+// (app/ScanStudio/Sources/ScanStudioKit/DiagnosticBundle.swift). "Save
+// Diagnostic Bundle..." (T-ERR-04) favors a small, easily-audited
+// implementation over a compression dependency: the JSONL log and report
+// text are already small, and a preview raster is already a compressed
+// image format (PNG/TIFF), so stored-only costs little.
+
+export interface ZipEntry {
+  name: string;
+  data: Uint8Array;
+}
+
+// A fixed, valid DOS date/time (1980-01-01, the DOS epoch) so archive bytes
+// are deterministic and never depend on wall-clock time -- the bundle's own
+// report.txt already timestamps the export.
+const DOS_TIME = 0;
+const DOS_DATE = 0x21;
+// General-purpose bit 11: filenames/comments are UTF-8, per the ZIP
+// appendix D "language encoding flag" -- entry names are never guaranteed
+// ASCII (e.g. a preview file's original extension).
+const UTF8_NAME_FLAG = 0x0800;
+
+const CRC_TABLE = buildCrcTable();
+
+function buildCrcTable(): Uint32Array {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < 256; index++) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit++) {
+      value = (value & 1) !== 0 ? (0xedb88320 ^ (value >>> 1)) : value >>> 1;
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+}
+
+function crc32(data: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of data) {
+    crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+class ByteWriter {
+  #chunks: Uint8Array[] = [];
+  #length = 0;
+
+  get length(): number {
+    return this.#length;
+  }
+
+  push(bytes: Uint8Array): void {
+    this.#chunks.push(bytes);
+    this.#length += bytes.length;
+  }
+
+  pushUint16LE(value: number): void {
+    this.push(new Uint8Array([value & 0xff, (value >>> 8) & 0xff]));
+  }
+
+  pushUint32LE(value: number): void {
+    this.push(
+      new Uint8Array([value & 0xff, (value >>> 8) & 0xff, (value >>> 16) & 0xff, (value >>> 24) & 0xff]),
+    );
+  }
+
+  toUint8Array(): Uint8Array {
+    const output = new Uint8Array(this.#length);
+    let offset = 0;
+    for (const chunk of this.#chunks) {
+      output.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return output;
+  }
+}
+
+export function createStoredZip(entries: ZipEntry[]): Uint8Array {
+  const output = new ByteWriter();
+  const central = new ByteWriter();
+  let recordCount = 0;
+  const nameEncoder = new TextEncoder();
+
+  for (const entry of entries) {
+    const nameBytes = nameEncoder.encode(entry.name);
+    const crc = crc32(entry.data);
+    const size = entry.data.length;
+    const localHeaderOffset = output.length;
+
+    output.pushUint32LE(0x04034b50);
+    output.pushUint16LE(20);
+    output.pushUint16LE(UTF8_NAME_FLAG);
+    output.pushUint16LE(0);
+    output.pushUint16LE(DOS_TIME);
+    output.pushUint16LE(DOS_DATE);
+    output.pushUint32LE(crc);
+    output.pushUint32LE(size);
+    output.pushUint32LE(size);
+    output.pushUint16LE(nameBytes.length);
+    output.pushUint16LE(0);
+    output.push(nameBytes);
+    output.push(entry.data);
+
+    central.pushUint32LE(0x02014b50);
+    central.pushUint16LE(20);
+    central.pushUint16LE(20);
+    central.pushUint16LE(UTF8_NAME_FLAG);
+    central.pushUint16LE(0);
+    central.pushUint16LE(DOS_TIME);
+    central.pushUint16LE(DOS_DATE);
+    central.pushUint32LE(crc);
+    central.pushUint32LE(size);
+    central.pushUint32LE(size);
+    central.pushUint16LE(nameBytes.length);
+    central.pushUint16LE(0);
+    central.pushUint16LE(0);
+    central.pushUint16LE(0);
+    central.pushUint16LE(0);
+    central.pushUint32LE(0);
+    central.pushUint32LE(localHeaderOffset);
+    central.push(nameBytes);
+
+    recordCount += 1;
+  }
+
+  const centralDirectoryOffset = output.length;
+  output.push(central.toUint8Array());
+
+  output.pushUint32LE(0x06054b50);
+  output.pushUint16LE(0);
+  output.pushUint16LE(0);
+  output.pushUint16LE(recordCount);
+  output.pushUint16LE(recordCount);
+  output.pushUint32LE(central.length);
+  output.pushUint32LE(centralDirectoryOffset);
+  output.pushUint16LE(0);
+
+  return output.toUint8Array();
+}

--- a/ports/tauri/app/src/views/DeviceBar.tsx
+++ b/ports/tauri/app/src/views/DeviceBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { sessionStore, type SessionState } from "../session";
 import type { DeviceInfo } from "../session/wire/types";
+import DiagnosticReportActions from "./DiagnosticReportActions";
 import HardwareErrorPanel from "./HardwareErrorPanel";
 import HardwareStatusChips from "./HardwareStatusChips";
 import styles from "./DeviceBar.module.css";
@@ -136,6 +137,15 @@ export default function DeviceBar() {
         thumbnailsFailed={
           state.previewOutcome === "failed" ? state.previewError : null
         }
+      />
+      <DiagnosticReportActions
+        error={state.filmFeedInterrupted}
+        thumbnailsFailed={
+          state.previewOutcome === "failed" ? state.previewError : null
+        }
+        device={device}
+        status={status}
+        thumbnails={state.thumbnails}
       />
     </div>
   );

--- a/ports/tauri/app/src/views/DiagnosticReportActions.tsx
+++ b/ports/tauri/app/src/views/DiagnosticReportActions.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import { save } from "@tauri-apps/plugin-dialog";
+import { diagnosticTimeline } from "../session";
+import { buildDiagnosticBundleZip, resolveDiagnosticBundleRaster } from "../session/diagnosticBundle";
+import { readPreviewRasterBytes, writeDiagnosticBundleFile } from "../session/diagnosticBundleIO";
+import { buildErrorReportText, type ErrorReportContext, type SetupCheckProbeSummary } from "../session/errorReport";
+import { describeCpuArchitecture, describeOperatingSystem, getScanStudioVersion } from "../session/hostEnvironment";
+import { setupCheckResults } from "../session/setupCheckResults";
+import type { DeviceInfo, EngineError, ScannerStatus, Thumbnail } from "../session/wire/types";
+
+export interface DiagnosticReportActionsProps {
+  error: EngineError | null;
+  thumbnailsFailed: { code: string; message: string } | null;
+  device: DeviceInfo | null;
+  status: ScannerStatus | null;
+  thumbnails: Record<number, Thumbnail>;
+}
+
+function timestampForFilename(): string {
+  return new Date().toISOString().replace(/:/g, "");
+}
+
+/** "Copy Report" and "Save Diagnostic Bundle..." (error report v2, T-ERR-01
+ * through T-ERR-04). Mounted next to HardwareErrorPanel, but deliberately a
+ * sibling component rather than an edit to it: HardwareErrorPanel's
+ * FEEDER_PARKED / HW_MOTION_NOT_ARMED branches carry careful
+ * never-offer-a-retry safety guidance (SAFE-02) that this feature has no
+ * reason to touch. Renders nothing while there is no active error, mirroring
+ * the mac build's WorkspaceErrorBanner (only shown for an active
+ * lastErrorMessage). */
+export default function DiagnosticReportActions({
+  error,
+  thumbnailsFailed,
+  device,
+  status,
+  thumbnails,
+}: DiagnosticReportActionsProps) {
+  const [didCopyReport, setDidCopyReport] = useState(false);
+  const [isSavingBundle, setIsSavingBundle] = useState(false);
+  const [didSaveBundle, setDidSaveBundle] = useState(false);
+
+  // thumbnailsFailed takes precedence over a typed request rejection,
+  // mirroring HardwareErrorPanel's own branch order.
+  const errorCode = thumbnailsFailed?.code ?? error?.code ?? null;
+  const errorMessage = thumbnailsFailed?.message ?? error?.message ?? null;
+
+  useEffect(() => {
+    if (errorCode === null) return;
+    diagnosticTimeline.record("error.surfaced", { code: errorCode });
+  }, [errorCode]);
+
+  if (errorCode === null || errorMessage === null) {
+    return null;
+  }
+
+  const buildReportContext = async (): Promise<ErrorReportContext> => {
+    const scanStudioVersion = await getScanStudioVersion();
+    const probes = setupCheckResults.get();
+    const setupCheckProbes: SetupCheckProbeSummary[] | null = probes
+      ? probes.map(({ id, status: probeStatus, detail }) => ({ id, status: probeStatus, detail }))
+      : null;
+    return {
+      scanStudioVersion,
+      operatingSystem: describeOperatingSystem(),
+      cpuArchitecture: describeCpuArchitecture(),
+      scannerFirmware: device?.firmware ?? null,
+      scannerAdapter: status?.adapter ?? null,
+      scannerHolder: status?.carrier ?? null,
+      // No durable on-disk diagnostics log on the Tauri side yet (see
+      // diagnosticTimeline.ts) -- rendering "unknown" here is honest, not a
+      // placeholder bug: "Save Diagnostic Bundle..." below still captures
+      // this session's full in-memory diagnostics.jsonl regardless.
+      diagnosticLogPath: null,
+      diagnosticSessionId: diagnosticTimeline.sessionId,
+      recentDiagnosticEvents: diagnosticTimeline.summaryLines,
+      errorCode,
+      errorMessage,
+      setupCheckProbes,
+    };
+  };
+
+  const handleCopyReport = async (): Promise<void> => {
+    const text = buildErrorReportText(await buildReportContext());
+    await navigator.clipboard.writeText(text);
+    setDidCopyReport(true);
+    setTimeout(() => setDidCopyReport(false), 1500);
+  };
+
+  const handleSaveDiagnosticBundle = async (): Promise<void> => {
+    setIsSavingBundle(true);
+    try {
+      const reportText = buildErrorReportText(await buildReportContext());
+      const { raster, unavailableReason } = await resolveDiagnosticBundleRaster(
+        thumbnails,
+        readPreviewRasterBytes,
+      );
+      const zipBytes = buildDiagnosticBundleZip({
+        diagnosticsJsonl: diagnosticTimeline.toJsonl(),
+        reportText,
+        previewRaster: raster,
+        unavailableRasterReason: unavailableReason,
+      });
+
+      const destination = await save({
+        title: "Save Diagnostic Bundle",
+        defaultPath: `ScanStudio-Diagnostics-${timestampForFilename()}.zip`,
+        filters: [{ name: "Zip Archive", extensions: ["zip"] }],
+      });
+      if (destination === null) return;
+
+      await writeDiagnosticBundleFile(destination, zipBytes);
+      setDidSaveBundle(true);
+      setTimeout(() => setDidSaveBundle(false), 1500);
+    } finally {
+      setIsSavingBundle(false);
+    }
+  };
+
+  return (
+    <div data-testid="diagnostic-report-actions">
+      <button type="button" onClick={() => void handleCopyReport()} data-testid="copy-report">
+        {didCopyReport ? "Copied" : "Copy Report"}
+      </button>
+      <button
+        type="button"
+        onClick={() => void handleSaveDiagnosticBundle()}
+        disabled={isSavingBundle}
+        data-testid="save-diagnostic-bundle"
+      >
+        {didSaveBundle ? "Saved" : "Save Diagnostic Bundle…"}
+      </button>
+    </div>
+  );
+}

--- a/ports/tauri/app/src/views/SetupChecker.test.tsx
+++ b/ports/tauri/app/src/views/SetupChecker.test.tsx
@@ -1,19 +1,31 @@
 /** @vitest-environment jsdom */
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { setupCheckResults } from "../session/setupCheckResults";
 import SetupChecker, { type MaxReadReport, type ProbeResult } from "./SetupChecker";
 
 // SetupChecker calls invoke from @tauri-apps/api/core. Mock the module so no
 // real Tauri runtime is needed; each test points invoke at controlled
 // resolved/rejected/pending promises.
-const mocks = vi.hoisted(() => ({ invoke: vi.fn() }));
+const mocks = vi.hoisted(() => ({ invoke: vi.fn(), writeText: vi.fn() }));
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
+
+// jsdom's Navigator.prototype defines "clipboard" as a getter that builds a
+// fresh (non-mockable) stub on every access, so a plain
+// `navigator.clipboard = ...` assignment silently lands on nothing.
+// Redefining it as an own data property on this navigator instance shadows
+// that getter for good.
+Object.defineProperty(navigator, "clipboard", {
+  configurable: true,
+  value: { writeText: mocks.writeText },
+});
 
 afterEach(() => {
   cleanup();
   mocks.invoke.mockReset();
+  mocks.writeText.mockReset();
 });
 
 const FIXTURE_PROBES: ProbeResult[] = [
@@ -80,5 +92,34 @@ describe("SetupChecker", () => {
     mocks.invoke.mockImplementation(() => new Promise(() => {}));
     render(<SetupChecker />);
     expect(screen.getByText("Checking...")).toBeInTheDocument();
+  });
+
+  it("shares its results with the error-report builder as soon as they load", async () => {
+    resolveAll(FIXTURE_PROBES, { maxBytes: null, entriesScanned: 0 }, WRITE_MODE_TEXT);
+    render(<SetupChecker />);
+
+    await screen.findByText("OK");
+
+    expect(setupCheckResults.get()).toEqual(FIXTURE_PROBES);
+  });
+
+  it("copies id/status/detail/fix as plain text and briefly confirms the copy", async () => {
+    resolveAll(FIXTURE_PROBES, { maxBytes: null, entriesScanned: 0 }, WRITE_MODE_TEXT);
+    mocks.writeText.mockResolvedValue(undefined);
+    render(<SetupChecker />);
+    await screen.findByText("OK");
+
+    // Plain fireEvent, not @testing-library/user-event: user-event's
+    // setup() installs its own navigator.clipboard stub for copy/paste
+    // simulation, silently shadowing the mock defined above.
+    fireEvent.click(screen.getByTestId("copy-probes-as-text"));
+
+    expect(mocks.writeText).toHaveBeenCalledWith(
+      "wsl-status: Ok -- WSL2 with Ubuntu-24.04 default\n" +
+        "bridge-which: Fail -- scanstudio-bridge not found on PATH inside WSL " +
+        "(fix: Run install-bridge-wsl.sh inside your WSL Ubuntu-24.04 distro)\n" +
+        "bridge-version: Unknown -- windows only",
+    );
+    await waitFor(() => expect(screen.getByTestId("copy-probes-as-text")).toHaveTextContent("Copied"));
   });
 });

--- a/ports/tauri/app/src/views/SetupChecker.tsx
+++ b/ports/tauri/app/src/views/SetupChecker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { formatSetupCheckProbesAsText, setupCheckResults } from "../session/setupCheckResults";
 import styles from "./SetupChecker.module.css";
 
 export type ProbeStatus = "Ok" | "Fail" | "Unknown";
@@ -35,6 +36,7 @@ export default function SetupChecker() {
   const [probes, setProbes] = useState<ProbeResult[] | null>(null);
   const [maxRead, setMaxRead] = useState<MaxReadReport | null>(null);
   const [writeMode, setWriteMode] = useState<string | null>(null);
+  const [didCopyProbes, setDidCopyProbes] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -48,6 +50,10 @@ export default function SetupChecker() {
         setProbes(probeResults);
         setMaxRead(maxReadReport);
         setWriteMode(mode);
+        // Shares this run's results with the error-report builder (item 5):
+        // any report generated while this session's probe results exist
+        // appends them, id/status/detail, with no further wiring needed.
+        setupCheckResults.set(probeResults);
       })
       .catch(() => {
         if (cancelled) return;
@@ -68,9 +74,25 @@ export default function SetupChecker() {
     );
   }
 
+  const copyProbesAsText = () => {
+    void navigator.clipboard.writeText(formatSetupCheckProbesAsText(probes)).then(() => {
+      setDidCopyProbes(true);
+      setTimeout(() => setDidCopyProbes(false), 1500);
+    });
+  };
+
   return (
     <div className={styles.viewShell} data-testid="setup-checker">
       <h2 className={styles.heading}>Windows Setup Checker</h2>
+      <button
+        type="button"
+        onClick={copyProbesAsText}
+        disabled={probes.length === 0}
+        data-testid="copy-probes-as-text"
+        aria-label="Copy probe results as text"
+      >
+        {didCopyProbes ? "Copied" : "Copy as text"}
+      </button>
       {writeMode !== "" && (
         <p className={styles.writeMode} data-testid="write-mode-row">
           <strong>Write mode:</strong> {writeMode}

--- a/ports/tauri/app/src/views/__tests__/DiagnosticReportActions.test.tsx
+++ b/ports/tauri/app/src/views/__tests__/DiagnosticReportActions.test.tsx
@@ -1,0 +1,206 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DiagnosticTimeline } from "../../session/diagnosticTimeline";
+import { setupCheckResults } from "../../session/setupCheckResults";
+import type { DeviceInfo, EngineError, ScannerStatus } from "../../session/wire/types";
+import DiagnosticReportActions from "../DiagnosticReportActions";
+
+// DiagnosticReportActions imports the production `diagnosticTimeline`
+// singleton from app/src/session/index.ts (which wraps the Tauri invoke
+// bridge indirectly through sessionStore's sibling exports) plus the
+// Tauri-facing dialog/bundle-IO/host-environment modules. Each is replaced
+// with a hoisted, live-mutable holder so a test can point it at whatever it
+// needs -- returning the holder object itself (not a new literal wrapping
+// it) is what makes later mutations (e.g. in afterEach) visible to the
+// mocked module's consumers; this mirrors DeviceBar.test.tsx's proven
+// `vi.mock("../../session", () => mocks)` pattern.
+const sessionMocks = vi.hoisted(() => ({ diagnosticTimeline: null as unknown }));
+vi.mock("../../session", () => sessionMocks);
+
+const dialogMocks = vi.hoisted(() => ({ save: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => dialogMocks);
+
+const bundleIOMocks = vi.hoisted(() => ({
+  readPreviewRasterBytes: vi.fn(),
+  writeDiagnosticBundleFile: vi.fn(),
+}));
+vi.mock("../../session/diagnosticBundleIO", () => bundleIOMocks);
+
+const hostEnvironmentMocks = vi.hoisted(() => ({
+  getScanStudioVersion: vi.fn(),
+  describeOperatingSystem: vi.fn(),
+  describeCpuArchitecture: vi.fn(),
+}));
+vi.mock("../../session/hostEnvironment", () => hostEnvironmentMocks);
+
+const clipboardMocks = vi.hoisted(() => ({ writeText: vi.fn() }));
+// jsdom's Navigator.prototype defines "clipboard" as a getter that builds a
+// fresh (non-mockable) stub on every access; redefine it as an own data
+// property to shadow that getter (see SetupChecker.test.tsx for the same
+// fix, and why plain fireEvent is used below instead of user-event --
+// user-event's setup() installs its own clipboard stub).
+Object.defineProperty(navigator, "clipboard", {
+  configurable: true,
+  value: { writeText: clipboardMocks.writeText },
+});
+
+const REAL_DEVICE: DeviceInfo = {
+  deviceId: "real-ls5000-0",
+  model: "Nikon LS-5000",
+  kind: "real",
+  firmware: "1.02",
+  connection: "usb",
+};
+
+const REAL_STATUS: ScannerStatus = {
+  connected: true,
+  adapter: "SA-21",
+  mediaLoaded: true,
+  carrier: "roll36",
+  frameCount: 36,
+  lamp: "stable",
+  transport: "idle",
+  activeJobId: null,
+};
+
+const NOT_CONNECTED_ERROR: EngineError = {
+  code: "NOT_CONNECTED",
+  message: "NOT_CONNECTED: no device is open",
+  recoverable: true,
+};
+
+function baseProps() {
+  return {
+    error: null as EngineError | null,
+    thumbnailsFailed: null as { code: string; message: string } | null,
+    device: null as DeviceInfo | null,
+    status: null as ScannerStatus | null,
+    thumbnails: {},
+  };
+}
+
+beforeEach(() => {
+  dialogMocks.save.mockReset();
+  bundleIOMocks.readPreviewRasterBytes.mockReset();
+  bundleIOMocks.writeDiagnosticBundleFile.mockReset();
+  clipboardMocks.writeText.mockReset();
+  hostEnvironmentMocks.getScanStudioVersion.mockReset();
+  hostEnvironmentMocks.describeOperatingSystem.mockReset();
+  hostEnvironmentMocks.describeCpuArchitecture.mockReset();
+  hostEnvironmentMocks.getScanStudioVersion.mockResolvedValue("0.3.0-alpha.11");
+  hostEnvironmentMocks.describeOperatingSystem.mockReturnValue("Windows 10.0.22631");
+  hostEnvironmentMocks.describeCpuArchitecture.mockReturnValue("x86_64");
+  clipboardMocks.writeText.mockResolvedValue(undefined);
+  sessionMocks.diagnosticTimeline = new DiagnosticTimeline("test-session", 40);
+  // setupCheckResults is a real, unmocked module-level singleton (error
+  // report v2, item 5) shared across every test in this file -- reset it so
+  // one test's probes never leak into the next.
+  setupCheckResults.set([]);
+});
+
+afterEach(cleanup);
+
+describe("DiagnosticReportActions", () => {
+  it("renders nothing while there is no active error", () => {
+    render(<DiagnosticReportActions {...baseProps()} />);
+    expect(screen.queryByTestId("diagnostic-report-actions")).toBeNull();
+  });
+
+  it("renders once a typed error is active", () => {
+    render(<DiagnosticReportActions {...baseProps()} error={NOT_CONNECTED_ERROR} />);
+    expect(screen.getByTestId("diagnostic-report-actions")).toBeInTheDocument();
+  });
+
+  it("prefers thumbnailsFailed over a typed request rejection, matching HardwareErrorPanel's precedence", async () => {
+    render(
+      <DiagnosticReportActions
+        {...baseProps()}
+        error={NOT_CONNECTED_ERROR}
+        thumbnailsFailed={{ code: "INTERNAL", message: "preview decode failed" }}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("copy-report"));
+    await waitFor(() => expect(clipboardMocks.writeText).toHaveBeenCalled());
+    const text = clipboardMocks.writeText.mock.calls[0][0] as string;
+    expect(text).toContain("Error code: INTERNAL");
+    expect(text).not.toContain("Error code: NOT_CONNECTED");
+  });
+
+  it("records exactly one diagnostic event with the error code when an error first appears", () => {
+    const timeline = new DiagnosticTimeline("test-session", 40);
+    sessionMocks.diagnosticTimeline = timeline;
+    render(<DiagnosticReportActions {...baseProps()} error={NOT_CONNECTED_ERROR} />);
+
+    expect(timeline.entries).toHaveLength(1);
+    expect(timeline.entries[0].event).toBe("error.surfaced");
+    expect(timeline.entries[0].fields).toEqual({ code: "NOT_CONNECTED" });
+  });
+
+  it("copies a report with the build header, scanner identity, and diagnostic events", async () => {
+    const timeline = new DiagnosticTimeline("test-session", 40);
+    timeline.record("device.connect.succeeded", { connected: true, kind: "real" }, "2026-08-05T00:00:00Z");
+    sessionMocks.diagnosticTimeline = timeline;
+
+    render(
+      <DiagnosticReportActions
+        {...baseProps()}
+        error={NOT_CONNECTED_ERROR}
+        device={REAL_DEVICE}
+        status={REAL_STATUS}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("copy-report"));
+    await waitFor(() => expect(clipboardMocks.writeText).toHaveBeenCalled());
+    const text = clipboardMocks.writeText.mock.calls[0][0] as string;
+
+    expect(text.startsWith("ScanStudio error report\n")).toBe(true);
+    expect(text).toContain("ScanStudio version: 0.3.0-alpha.11");
+    expect(text).toContain("Operating system: Windows 10.0.22631");
+    expect(text).toContain("CPU architecture: x86_64");
+    expect(text).toContain("Scanner firmware: 1.02");
+    expect(text).toContain("Adapter: SA-21");
+    expect(text).toContain("Holder: roll36");
+    expect(text).toContain("Diagnostic session: test-session");
+    expect(text).toContain("Error code: NOT_CONNECTED");
+    expect(text).toContain("2026-08-05T00:00:00Z device.connect.succeeded connected=true kind=real");
+    await waitFor(() => expect(screen.getByTestId("copy-report")).toHaveTextContent("Copied"));
+  });
+
+  it("appends the Windows setup check section while this session's probe results exist", async () => {
+    setupCheckResults.set([
+      { id: "wsl-status", status: "Ok", detail: "WSL2 with Ubuntu-24.04 default", fixCommand: null },
+    ]);
+
+    render(<DiagnosticReportActions {...baseProps()} error={NOT_CONNECTED_ERROR} />);
+    fireEvent.click(screen.getByTestId("copy-report"));
+    await waitFor(() => expect(clipboardMocks.writeText).toHaveBeenCalled());
+
+    const text = clipboardMocks.writeText.mock.calls[0][0] as string;
+    expect(text).toContain("Windows setup check:");
+    expect(text).toContain("- wsl-status: Ok -- WSL2 with Ubuntu-24.04 default");
+  });
+
+  it("saves a diagnostic bundle zip to the chosen path and skips writing when the dialog is cancelled", async () => {
+    bundleIOMocks.readPreviewRasterBytes.mockResolvedValue(null);
+    dialogMocks.save.mockResolvedValueOnce(null);
+    render(<DiagnosticReportActions {...baseProps()} error={NOT_CONNECTED_ERROR} />);
+
+    fireEvent.click(screen.getByTestId("save-diagnostic-bundle"));
+    await waitFor(() => expect(dialogMocks.save).toHaveBeenCalled());
+    expect(bundleIOMocks.writeDiagnosticBundleFile).not.toHaveBeenCalled();
+
+    dialogMocks.save.mockResolvedValueOnce("/chosen/ScanStudio-Diagnostics.zip");
+    fireEvent.click(screen.getByTestId("save-diagnostic-bundle"));
+    await waitFor(() => expect(bundleIOMocks.writeDiagnosticBundleFile).toHaveBeenCalledTimes(1));
+
+    const [path, bytes] = bundleIOMocks.writeDiagnosticBundleFile.mock.calls[0] as [string, Uint8Array];
+    expect(path).toBe("/chosen/ScanStudio-Diagnostics.zip");
+    // A stored-zip local file header signature ("PK\x03\x04") -- proves a
+    // real archive was assembled and handed to the writer, not empty bytes.
+    expect(Array.from(bytes.slice(0, 4))).toEqual([0x50, 0x4b, 0x03, 0x04]);
+    await waitFor(() => expect(screen.getByTestId("save-diagnostic-bundle")).toHaveTextContent("Saved"));
+  });
+});

--- a/ports/tauri/packaging/lib/common.sh
+++ b/ports/tauri/packaging/lib/common.sh
@@ -204,12 +204,32 @@ def digest(path: Path) -> str:
     return value.hexdigest()
 
 
-# @tauri-apps/plugin-dialog 2.7.2 publishes an SPDX copyright declaration but
-# not the full MIT/Apache terms. Its exact sibling @tauri-apps/api 2.11.1
-# package carries the reviewed full texts from the same Tauri project. Hashes
-# make this fallback fail closed if either upstream file changes.
+# @tauri-apps/plugin-dialog 2.7.2 and @tauri-apps/plugin-os 2.3.2 each publish
+# an SPDX copyright declaration but not the full MIT/Apache terms (same
+# byte-identical LICENSE.spdx boilerplate for both -- both are published from
+# the tauri-apps/plugins-workspace monorepo, whose root carries LICENSE_MIT
+# and LICENSE_APACHE-2.0; GitHub's own repo-level license detection confirms
+# "Apache-2.0, MIT licenses found" there). Their exact sibling @tauri-apps/api
+# 2.11.1 package -- published from the same monorepo -- carries those reviewed
+# full texts already. Hashes make this fallback fail closed if either upstream
+# file changes.
 reviewed_fallbacks = {
     ("@tauri-apps/plugin-dialog", "2.7.2"): {
+        "declaration": ("LICENSE.spdx", "eb8a6c84630461b352badcab1dbe5d0168c56d377358b2b8c86b51003272d5ef"),
+        "fullTexts": [
+            (
+                "node_modules/@tauri-apps/api/LICENSE_MIT",
+                "9dd42ea92cff2ede5cd477cbfcce051b2d0115c0ac7f368ee88cb545055dff1d",
+                "FALLBACK-LICENSE_MIT",
+            ),
+            (
+                "node_modules/@tauri-apps/api/LICENSE_APACHE-2.0",
+                "0d542e0c8804e39aa7f37eb00da5a762149dc682d7829451287e11b938e94594",
+                "FALLBACK-LICENSE_APACHE-2.0",
+            ),
+        ],
+    },
+    ("@tauri-apps/plugin-os", "2.3.2"): {
         "declaration": ("LICENSE.spdx", "eb8a6c84630461b352badcab1dbe5d0168c56d377358b2b8c86b51003272d5ef"),
         "fullTexts": [
             (


### PR DESCRIPTION
## Summary

Error reporting v2: five changes to the report both frontends generate, applied to mac and to Tauri wherever the concept exists.

1. **Build-identifying header, everywhere a report is generated.** Release stamp, OS name+version, CPU architecture, scanner firmware, adapter, and holder. Every field always renders; a value ScanStudio couldn't determine shows `unknown` instead of being silently dropped.
2. **Event window raised from ~10 to 40**, matching the diagnostic timeline's own retention cap, plus the local diagnostics-log path shown on its own labeled line near the top.
3. **Generic payload rendering.** Diagnostic event fields are now a JSON-shaped value (string/number/bool/array/object) with a compact `key=value` serializer that has no per-event or per-key knowledge of shape — future instrumentation (e.g. detector confidence scores) starts appearing in every generated report automatically.
4. **"Save Diagnostic Bundle…"** next to the existing copy-report affordance in both frontends: a zip with this session's `diagnostics.jsonl`, the generated `report.txt`, and — when the session had a roll preview and the frontend can already locate it from state it already holds — the preview raster. No new engine/bridge wire method or coolscanpy change anywhere in this PR.
5. **Windows setup-check integration** (Tauri only — mac has no Windows setup checker): the probe table gets a "Copy as text" affordance, and its most recent results are appended to any error report generated while they exist.

## Where each landed

| # | mac (`app/ScanStudio/Sources/ScanStudioKit/`) | Tauri (`ports/tauri/app/src/`) |
|---|---|---|
| 1 | `ErrorPresentation.swift` (`appendBuildHeader`), `SessionModel.swift` (release stamp, `HostArchitectureProvider`, `device.firmware`, `status.adapter`/`.carrier`) | `session/errorReport.ts`, `session/hostEnvironment.ts` (`@tauri-apps/plugin-os`, not `navigator.userAgent` — see Notes), `views/DiagnosticReportActions.tsx` |
| 2 | `ErrorPresentation.swift` (`maximumRecentDiagnosticEvents = 40`, absolute vs. home-relative log path split), `SessionModel.swift` (`diagnosticLogPath`) | `session/errorReport.ts` (`MAXIMUM_RECENT_DIAGNOSTIC_EVENTS = 40`), `session/diagnosticTimeline.ts` |
| 3 | `SessionDiagnosticTimeline.swift` (`DiagnosticFieldValue`, `compactDescription`) | `session/diagnosticField.ts` (`DiagnosticFieldValue`, `formatDiagnosticFields`) |
| 4 | `DiagnosticBundle.swift` (`StoredZipWriter`, `DiagnosticBundleBuilder`, `DiagnosticBundleRasterPolicy`), `SessionModel.makeDiagnosticBundleData()`, `ContentView.swift` (button + `NSSavePanel`) | `session/zip.ts`, `session/diagnosticBundle.ts`, `session/diagnosticBundleIO.ts`, `src-tauri/src/diagnostics.rs` (`write_diagnostic_bundle`, `read_preview_raster`), `views/DiagnosticReportActions.tsx` |
| 5 | n/a | `session/setupCheckResults.ts`, `views/SetupChecker.tsx` ("Copy as text" + result sharing), `session/errorReport.ts` (setup-check section) |

## Tests

- **mac** (`swift test`): 418 tests / 43 suites passing. New: `DiagnosticBundleTests.swift`; extended `ErrorPresentationPolicyTests.swift` and `SessionDiagnosticTimelineTests.swift`.
- **Tauri Rust** (`cargo test`, in `src-tauri`): 129 tests passing, including 5 new in `diagnostics::tests` (zip write / raster read scope-checking against a temp-dir fixture).
- **Tauri frontend** (`vitest`): 371 tests / 57 files passing on a clean run (`tsc --noEmit` and `vite build` both clean). One real-engine end-to-end test (`tests/e2e/sim-session.test.ts`) is flaky on this machine under concurrent build load from other in-flight branches — it failed at three different points across three separate runs (timing timeouts, never an assertion mismatch) while every other test, including all new ones, stayed green; it touches nothing this PR changes.

## Scope respected

Per coordination: no edits anywhere in a coolscanpy tree (canonical, vendored, or `ports/tauri/vendor/coolscanpy`), no edits to `roll_index.py`, no edits to the Tauri engine-session/handshake modules (`src-tauri/src/engine.rs`, `src/engine/client.ts`). Rebased onto `origin/main` after `fix/engine-hello-ordering` (PR #37) merged during this work; the only conflict was two independent `Cargo.toml` additions at the same line, resolved by keeping both.

## Follow-ups (not in this PR)

- **Tauri has no durable on-disk diagnostics log yet.** `SessionDiagnosticTimeline` on mac persists to `~/.scanstudio/diagnostics/<session>.jsonl` on every event; the Tauri `DiagnosticTimeline` is in-memory-only for this PR. The report's "Local log" line honestly renders `unknown` there rather than a fabricated path — "Save Diagnostic Bundle…" still captures the full in-memory `diagnostics.jsonl` regardless. Follow-up: add a durable write path once the concurrent Tauri work in this area has landed.
- **Tauri's diagnostic timeline is populated by observing error state at the UI layer** (one `error.surfaced` entry per distinct error, from `DiagnosticReportActions.tsx`), not instrumented at every operation call site the way mac's ~15 `recordDiagnostic` sites are. This was a deliberate boundary to avoid touching `session/store/session.ts`'s internals while `fix/engine-hello-ordering` was active in adjacent code. Follow-up: wire real per-operation diagnostic recording into `SessionStore` for parity with mac's event richness.
- **`read_preview_raster` only checks the home-directory scope.** On Windows, a real-hardware preview lives under the pinned WSL share (`crate::preview::handle_with_windows_wsl_share`) rather than the Windows home directory, so on Windows today the bundle's raster reports "not available" with an honest reason rather than being located. Documented in the function's doc comment. Follow-up: reuse the WSL-share scope for parity with the existing `scanstudio-preview://` handler.
