### PR TITLE
coolscanpy: two-pass wide-gap recovery behind the physical-gap floors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,15 @@ jobs:
       UV_PYTHON_PREFERENCE: only-managed
     steps:
       - uses: actions/checkout@v4
+      - name: coolscanpy PyPI sync gate
+        # Owner policy (2026-08-08): a release may not ship driver code that
+        # standalone `pip install coolscanpy` users would not have -- version
+        # skew between the two makes field reports for the same film
+        # incomparable. Content-compared against the latest published sdist
+        # (version strings are checked second; an unbumped version with
+        # changed code is exactly the failure mode). Publish the matching
+        # coolscanpy release from the canonical repo first, then re-tag.
+        run: bash scripts/check_coolscanpy_pypi_sync.sh
       - uses: dtolnay/rust-toolchain@stable
       - uses: astral-sh/setup-uv@v5
         with:

--- a/app/ScanStudio/Sources/ScanStudio/ContentView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ContentView.swift
@@ -27,6 +27,14 @@ struct ContentView: View {
                             sessionModel.dismissLastError()
                         }
                         .id(presentation.technicalDetails)
+                    } else if let snapNote = sessionModel.manualPlacementSnapNote {
+                        // Only shown once no error is active: a successful
+                        // manual placement already clears `lastErrorMessage`,
+                        // so this and the error banner above are never both
+                        // relevant at once.
+                        ManualPlacementSnapNoteBanner(text: snapNote) {
+                            sessionModel.dismissManualPlacementSnapNote()
+                        }
                     }
 
                     Group {
@@ -125,6 +133,9 @@ struct ContentView: View {
         .sheet(item: manualReviewRequestBinding) { request in
             ManualReviewScanSheet(request: request)
         }
+        .sheet(item: manualPlacementStripBinding) { strip in
+            ManualFramePlacementSheet(strip: strip)
+        }
         .focusedSceneValue(
             \.scanStudioFrameIndex,
             sessionModel.frameTransformTargetIndex
@@ -137,6 +148,27 @@ struct ContentView: View {
             set: { newValue in
                 if newValue == nil {
                     sessionModel.cancelPendingManualReviewScan()
+                }
+            }
+        )
+    }
+
+    /// Rung 4: presents `ManualFramePlacementSheet` exactly while
+    /// `manualPlacementStripState` is `.ready` -- `.idle`/`.loading` both
+    /// map to no sheet, so the loading interval is shown on the "Place
+    /// frames manually" button itself (`WorkspaceErrorBanner`) rather than
+    /// as an empty sheet.
+    private var manualPlacementStripBinding: Binding<ManualPlacementStrip?> {
+        Binding(
+            get: {
+                if case .ready(let strip) = sessionModel.manualPlacementStripState {
+                    return strip
+                }
+                return nil
+            },
+            set: { newValue in
+                if newValue == nil {
+                    sessionModel.cancelManualFramePlacement()
                 }
             }
         )
@@ -367,6 +399,10 @@ private struct WorkspaceErrorBanner: View {
     @State private var didCopyTechnicalDetails = false
     @State private var didSaveDiagnosticBundle = false
 
+    private var isLoadingManualPlacement: Bool {
+        sessionModel.manualPlacementStripState == .loading
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 10) {
@@ -401,6 +437,50 @@ private struct WorkspaceErrorBanner: View {
                     .foregroundStyle(Color.scanStudioSecondaryText)
                     .help("Dismiss")
                     .accessibilityLabel("Dismiss error")
+                }
+
+                // Rung 3 + Rung 4 of the feeding UX ladder
+                // (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): when the
+                // engine attached a plain-English diagnosis to this
+                // refusal, show it prominently -- never the raw JSON it
+                // was extracted from (`ProbableCauseExtractor`) -- and
+                // offer the manual-placement recovery path right beside
+                // it.
+                if let probableCause = presentation.probableCause {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(probableCause)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(Color.scanStudioPrimaryText)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .textSelection(.enabled)
+
+                        Button {
+                            Task {
+                                await sessionModel.beginManualFramePlacement()
+                            }
+                        } label: {
+                            if isLoadingManualPlacement {
+                                HStack(spacing: 6) {
+                                    ProgressView().controlSize(.small)
+                                    Text("Loading Film Strip…")
+                                }
+                            } else {
+                                Label(
+                                    "Place frames manually",
+                                    systemImage: "rectangle.and.hand.point.up.left"
+                                )
+                            }
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(.scanStudioAmber)
+                        .font(.system(size: 11, weight: .medium))
+                        .disabled(isLoadingManualPlacement)
+                        .help("Draw your own frame boundaries on the captured film strip")
+                    }
+                    .padding(10)
+                    .background(Color.scanStudioRaised, in: RoundedRectangle(cornerRadius: 6))
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Probable cause: \(probableCause)")
                 }
 
                 HStack(spacing: 12) {
@@ -542,6 +622,51 @@ private struct WorkspaceErrorBanner: View {
         formatter.formatOptions = [.withFullDate, .withTime, .withTimeZone]
         return formatter.string(from: Date())
             .replacingOccurrences(of: ":", with: "")
+    }
+}
+
+/// Rung 4's "surface snaps subtly" requirement: a single quiet line, never
+/// styled as an error (`scanStudioRaised`, not `scanStudioRed`), shown only
+/// while no error is active (`ContentView`'s own `if/else if` with
+/// `WorkspaceErrorBanner`) -- a successful manual placement already
+/// resolved whatever was showing before it.
+private struct ManualPlacementSnapNoteBanner: View {
+    let text: String
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "wand.and.stars")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color.scanStudioAmber)
+                    .accessibilityHidden(true)
+                Text(text)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color.scanStudioSecondaryText)
+                Spacer(minLength: 12)
+                Button {
+                    onDismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .frame(width: 26, height: 26)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.scanStudioSecondaryText)
+                .help("Dismiss")
+                .accessibilityLabel("Dismiss")
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 7)
+            .background(Color.scanStudioRaised)
+
+            Rectangle().fill(Color.scanStudioDivider).frame(height: 1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(text)
+        .transition(.move(edge: .top).combined(with: .opacity))
     }
 }
 

--- a/app/ScanStudio/Sources/ScanStudio/ManualFramePlacementView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ManualFramePlacementView.swift
@@ -1,0 +1,506 @@
+import AppKit
+import ScanStudioKit
+import SwiftUI
+
+/// Modal editor for placing frame boundaries on the whole captured film
+/// strip (Rung 4 of the feeding UX ladder,
+/// FEEDING-UX-LADDER-OVERNIGHT-20260807.md) -- the "Place frames manually"
+/// flow the workspace error card offers whenever a preview refusal carries
+/// a Rung-3 probable-cause diagnosis.
+///
+/// Adapted from an initial draft that assumed a *vertical* strip (row 0 at
+/// the top edge, the transport axis running down the image's height). That
+/// assumption is backwards for this wire contract: BRIDGE.md is explicit
+/// that `PreviewStrip.imagePath` "is rendered through the identical
+/// transform `Thumbnail.imagePath` already uses (`swapaxes(0,1)`...)
+/// applied once to the whole captured raster... so the raster's row axis
+/// (the coordinate space `roll.manualFrames`'s `rows` are given in) is the
+/// image's WIDTH axis, not its height, exactly like every existing
+/// `Thumbnail` crop already is" -- confirmed against the bridge's own
+/// `_normalize_preview_tile` (`np.swapaxes(image, 0, 1)` on an
+/// `(rowCount, width, 3)` array before it is ever written to disk). This
+/// view is therefore laid out horizontally: row 0 is the LEFT edge, the
+/// last row is the RIGHT edge, boundaries are vertical lines the operator
+/// drags left/right, and the strip scrolls horizontally rather than
+/// vertically. `pixelsPerRow` is always `1` today, so one preview row is
+/// exactly one image pixel along that axis.
+struct ManualFramePlacementView: View {
+    @Environment(SessionModel.self) private var sessionModel
+    @Environment(\.dismiss) private var dismiss
+
+    let stripImage: NSImage
+    /// How many preview rows the full strip represents. `boundaryRows` are
+    /// expressed in this space ("preview row N"), mapped to view X
+    /// proportionally so a wide strip that scrolls stays consistent with a
+    /// narrow one in the same window.
+    let rasterRows: Int
+    /// The boundaries seeded for this editor -- equal spacing across the
+    /// strip when no better guess exists (see `ManualFramePlacementSheet`).
+    /// Empty seeds nothing and leans on the guidance copy.
+    let initialBoundaryRows: [Int]
+
+    /// The working set of boundaries. Seeded from `initialBoundaryRows` on
+    /// appear (not in `init`, since `@State` cannot be assigned from an
+    /// `init` parameter without a wrapper-name rename), and always sorted +
+    /// deduplicated so a confirm can never hand the engine a degenerate
+    /// (zero- or negative-width, or duplicate) frame.
+    @State private var boundaryRows: [Int] = []
+    /// The row value of the boundary line currently being dragged. Kept as
+    /// a *value* (not an index) because each drag change re-sorts the array
+    /// and the dragged line's index moves; the value is stable and the
+    /// gesture below anchors on it. `nil` means no drag is in flight.
+    @State private var draggingRow: Int?
+
+    /// Cross-strip (display) axis: the strip's own fixed on-screen height.
+    /// The transport axis (width) is whatever that implies given the
+    /// image's aspect ratio, and is free to be much larger than the
+    /// window -- that is exactly what the horizontal scroll is for.
+    private static let stripHeight: CGFloat = 240
+    private static let stripCoordinateSpace = "ManualFramePlacementStripSpace"
+    /// Width of each boundary line's hit region/visual rule.
+    private static let lineWidth: CGFloat = 2
+    /// Total width of a boundary line's draggable column, wide enough for
+    /// its row-number badge and delete control without a hairline-only
+    /// drag target.
+    private static let lineColumnWidth: CGFloat = 34
+    /// Lines closer than this to a click position are treated as the click
+    /// landing on the line itself (a grab), not as an add -- see
+    /// `addBoundary`.
+    private static let duplicateClickThresholdRows = 3
+
+    private var isSubmitting: Bool { sessionModel.isSubmittingManualPlacement }
+    private var submitError: String? { sessionModel.manualPlacementSubmitError }
+
+    private var frameCount: Int {
+        max(boundaryRows.count - 1, 0)
+    }
+
+    private var hasRealRaster: Bool {
+        rasterRows > 1
+    }
+
+    private var scale: CGFloat {
+        guard stripImage.size.height > 0 else { return 1 }
+        return Self.stripHeight / stripImage.size.height
+    }
+
+    /// The strip's rendered width at `scale` -- this is the coordinate
+    /// space every row<->pixel conversion below works in.
+    private var renderedWidth: CGFloat {
+        max(stripImage.size.width * scale, 1)
+    }
+
+    private var invalidBands: [ManualFramePlacementValidation.Band] {
+        ManualFramePlacementValidation.bands(for: boundaryRows).filter { !$0.isValid }
+    }
+
+    private var canConfirm: Bool {
+        !isSubmitting && ManualFramePlacementValidation.blockingReason(for: boundaryRows) == nil
+    }
+
+    private var isAtInitialState: Bool {
+        boundaryRows == ManualFramePlacementValidation.normalize(initialBoundaryRows)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider().background(Color.scanStudioDivider)
+
+            stripArea
+
+            if let submitError {
+                Divider().background(Color.scanStudioDivider)
+                submitErrorBanner(submitError)
+            }
+
+            Divider().background(Color.scanStudioDivider)
+
+            footer
+        }
+        .background(Color.scanStudioWorkspace)
+        .foregroundStyle(Color.scanStudioPrimaryText)
+        .frame(width: 880)
+        .interactiveDismissDisabled(isSubmitting)
+        .onAppear {
+            // Seed once. Re-running on every appear (e.g. a later state
+            // change) would throw away the operator's current drags, so
+            // `boundaryRows` is the source of truth after first run.
+            if boundaryRows.isEmpty {
+                boundaryRows = ManualFramePlacementValidation.normalize(initialBoundaryRows)
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Place Frame Boundaries")
+                .font(.system(size: 20, weight: .semibold))
+            Text(headerDetail)
+                .font(.system(size: 12))
+                .foregroundStyle(Color.scanStudioSecondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+    }
+
+    /// One honest paragraph explaining what the affordances do. Whether
+    /// this editor was seeded with equal-spacing guesses (the normal case)
+    /// or nothing at all (no roll data to estimate spacing from) changes
+    /// the wording, but both lean on the strip itself rather than repeating
+    /// the reason automatic detection failed -- the workspace error card
+    /// already showed that.
+    private var headerDetail: String {
+        let captureWindowNote =
+            "The scanner captures about \(ManualFramePlacementValidation.millimeterText(ManualFramePlacementValidation.maximumFrameHeightMillimeters)) mm per frame, "
+            + "so keep each frame within that."
+        guard boundaryRows.isEmpty else {
+            return "Drag each line to a frame edge, drag the strip to add a missing boundary, "
+                + "and remove any line that doesn't belong. Film advances left to right. "
+                + captureWindowNote
+        }
+        return "Click the film strip to add the left edge of the first frame, then add a line "
+            + "at its right edge -- repeat for each frame. Film advances left to right. "
+            + captureWindowNote
+    }
+
+    /// The horizontally scrolling strip.
+    private var stripArea: some View {
+        ScrollView(.horizontal) {
+            ZStack(alignment: .topLeading) {
+                Image(nsImage: stripImage)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: renderedWidth, height: Self.stripHeight)
+
+                Color.clear
+                    .contentShape(Rectangle())
+                    .frame(width: renderedWidth, height: Self.stripHeight)
+                    .onTapGesture { location in
+                        addBoundary(atX: location.x)
+                    }
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityLabel("Film strip")
+                    .accessibilityHint("Click to add a frame boundary at that position")
+
+                stripOverlay(width: renderedWidth)
+            }
+            .frame(width: renderedWidth, height: Self.stripHeight, alignment: .topLeading)
+            .coordinateSpace(name: Self.stripCoordinateSpace)
+            .padding(.horizontal, 20)
+            .padding(.top, Self.lineColumnWidth)
+            .padding(.bottom, 20)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: Self.stripHeight + Self.lineColumnWidth + 40)
+    }
+
+    /// All the frame bands and boundary lines layered on top of the image.
+    /// Two independent loops (bands, then lines) rather than one, so band
+    /// rendering never has to know how lines draw themselves and vice
+    /// versa.
+    private func stripOverlay(width: CGFloat) -> some View {
+        ZStack(alignment: .topLeading) {
+            ForEach(ManualFramePlacementValidation.bands(for: boundaryRows), id: \.topRow) { band in
+                frameBand(band, width: width)
+            }
+            ForEach(boundaryRows, id: \.self) { row in
+                boundaryLine(at: row)
+            }
+        }
+        .frame(width: width, height: Self.stripHeight, alignment: .topLeading)
+    }
+
+    /// The red/neutral region between one pair of adjacent lines, carrying
+    /// the implied mm width and -- only when out of the accepted height
+    /// range -- a short plain-English warning. Valid bands stay quiet and
+    /// untinted so the eye is drawn to what actually needs a decision.
+    private func frameBand(_ band: ManualFramePlacementValidation.Band, width: CGFloat) -> some View {
+        let leadingX = rowX(band.topRow)
+        let bandWidth = max(rowX(band.bottomRow) - leadingX, 1)
+
+        return VStack(spacing: 2) {
+            if band.isValid {
+                Text("\(ManualFramePlacementValidation.millimeterText(band.millimeters)) mm")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Color.scanStudioSecondaryText)
+            } else {
+                Text("\(ManualFramePlacementValidation.millimeterText(band.millimeters)) mm")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Color.scanStudioRed)
+            }
+        }
+        .frame(width: bandWidth, height: Self.stripHeight)
+        .background(band.isValid ? Color.clear : Color.scanStudioRed.opacity(0.16))
+        .contentShape(Rectangle())
+        .offset(x: leadingX)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            band.isValid
+                ? "Frame from row \(band.topRow) to \(band.bottomRow), "
+                    + "\(ManualFramePlacementValidation.millimeterText(band.millimeters)) millimetres"
+                : "Frame from row \(band.topRow) to \(band.bottomRow). "
+                    + ManualFramePlacementValidation.warning(forMillimeters: band.millimeters)
+        )
+    }
+
+    /// One draggable, deletable boundary line: a vertical rule spanning the
+    /// strip height, a badge above it showing the row number, and a delete
+    /// control on the badge. The whole column (badge + rule) is one
+    /// width-spanning hit region so a drag anywhere on it moves the line.
+    private func boundaryLine(at row: Int) -> some View {
+        let x = rowX(row) - Self.lineColumnWidth / 2
+        return VStack(spacing: 3) {
+            boundaryBadge(row: row)
+            Rectangle()
+                .fill(Color.scanStudioAmber)
+                .frame(width: Self.lineWidth)
+                .frame(maxHeight: .infinity)
+        }
+        .frame(width: Self.lineColumnWidth, height: Self.stripHeight + Self.lineColumnWidth)
+        .padding(.top, -Self.lineColumnWidth)
+        .contentShape(Rectangle())
+        .offset(x: x)
+        .gesture(
+            DragGesture(coordinateSpace: .named(Self.stripCoordinateSpace))
+                .onChanged { value in
+                    dragBoundary(anchor: row, locationX: value.location.x)
+                }
+                .onEnded { _ in draggingRow = nil }
+        )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Boundary at row \(row)")
+    }
+
+    private func boundaryBadge(row: Int) -> some View {
+        HStack(spacing: 3) {
+            Text("\(row)")
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+            Button {
+                boundaryRows.removeAll { $0 == row }
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 10))
+            }
+            .buttonStyle(.plain)
+            .help("Remove the boundary at row \(row)")
+            .accessibilityLabel("Remove boundary at row \(row)")
+        }
+        .foregroundStyle(Color.white)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 3)
+        .background(Color.scanStudioAmber.opacity(0.85), in: RoundedRectangle(cornerRadius: 4))
+        .fixedSize()
+    }
+
+    private func submitErrorBanner(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Color.scanStudioRed)
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundStyle(Color.scanStudioPrimaryText)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(Color.scanStudioRed.opacity(0.14))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Placement rejected: \(message)")
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(frameCountLabel)
+                    .font(.system(size: 12, weight: .semibold))
+                if let reason = invalidBands.first {
+                    Text(ManualFramePlacementValidation.warning(forMillimeters: reason.millimeters))
+                        .font(.system(size: 10))
+                        .foregroundStyle(Color.scanStudioRed)
+                } else if boundaryRows.count == 1 {
+                    Text("Add a second line to define a frame.")
+                        .font(.system(size: 10))
+                        .foregroundStyle(Color.scanStudioSecondaryText)
+                }
+            }
+            .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+
+            Button("Reset") { reset() }
+                .buttonStyle(.bordered)
+                .disabled(isAtInitialState || isSubmitting)
+                .help("Restore the boundaries to their starting positions")
+
+            Button("Cancel") {
+                sessionModel.cancelManualFramePlacement()
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+            .disabled(isSubmitting)
+
+            Button {
+                confirm()
+            } label: {
+                if isSubmitting {
+                    HStack(spacing: 8) {
+                        ProgressView().controlSize(.small)
+                        Text("Placing Frames…")
+                    }
+                    .frame(minWidth: 150)
+                } else {
+                    Text("Confirm").frame(minWidth: 150)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.scanStudioAmber)
+            .foregroundStyle(.black)
+            .disabled(!canConfirm)
+            .help("Use these boundaries to scan the resulting frames")
+            .keyboardShortcut(.defaultAction)
+            .accessibilityLabel("Confirm \(frameCount) frame\(frameCount == 1 ? "" : "s")")
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity)
+    }
+
+    private var frameCountLabel: String {
+        switch frameCount {
+        case 0: return "0 frames yet"
+        case 1: return "1 frame"
+        default: return "\(frameCount) frames"
+        }
+    }
+
+    private func confirm() {
+        let rows = boundaryRows
+        Task {
+            let succeeded = await sessionModel.submitManualFrames(rows: rows)
+            if succeeded {
+                dismiss()
+            }
+            // On failure, `sessionModel.manualPlacementSubmitError` is
+            // already set and this view stays on screen -- nothing further
+            // to do here.
+        }
+    }
+
+    private func rowX(_ row: Int) -> CGFloat {
+        guard hasRealRaster else { return 0 }
+        return CGFloat(row) / CGFloat(rasterRows) * renderedWidth
+    }
+
+    private func row(atX x: CGFloat) -> Int {
+        guard hasRealRaster else { return 0 }
+        let fraction = min(max(x / renderedWidth, 0), 1)
+        return Int((fraction * CGFloat(rasterRows)).rounded())
+    }
+
+    private func addBoundary(atX x: CGFloat) {
+        let row = row(atX: x)
+        guard !boundaryRows.contains(where: { abs($0 - row) <= Self.duplicateClickThresholdRows }) else {
+            // The click landed on (or right next to) an existing line;
+            // treat it as a grab of that line rather than spawning a
+            // microscopic duplicate frame the confirm would have to reject.
+            return
+        }
+        boundaryRows = (boundaryRows + [row]).sorted()
+    }
+
+    /// Moves the line whose pre-drag value is `anchor` to `row` and
+    /// re-sorts. Anchoring by value instead of index is the whole trick:
+    /// each `onChanged` re-sorts, but the anchor the gesture closure
+    /// captured stays stable, so subsequent frames keep removing *it*,
+    /// never a now-different sibling.
+    private func dragBoundary(anchor: Int, locationX: CGFloat) {
+        let row = row(atX: locationX)
+        var rows = boundaryRows.filter { $0 != anchor }
+        if !rows.contains(row) {
+            rows.append(row)
+        }
+        boundaryRows = rows.sorted()
+        draggingRow = row
+    }
+
+    private func reset() {
+        boundaryRows = ManualFramePlacementValidation.normalize(initialBoundaryRows)
+    }
+}
+
+/// Loads the strip image and seeds initial boundary guesses, then presents
+/// `ManualFramePlacementView`. Kept separate from the editor itself so the
+/// editor's own state (`boundaryRows`, drag handling) never has to account
+/// for an unloaded image.
+struct ManualFramePlacementSheet: View {
+    @Environment(SessionModel.self) private var sessionModel
+    @Environment(\.dismiss) private var dismiss
+
+    let strip: ManualPlacementStrip
+
+    var body: some View {
+        if let image = ThumbnailImageCache.image(atPath: strip.imagePath) {
+            ManualFramePlacementView(
+                stripImage: image,
+                rasterRows: strip.rowCount,
+                initialBoundaryRows: Self.equalSpacingSeed(
+                    rowCount: strip.rowCount,
+                    expectedFrameCount: sessionModel.status?.frameCount
+                )
+            )
+        } else {
+            unloadable
+        }
+    }
+
+    private var unloadable: some View {
+        VStack(spacing: 14) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 26, weight: .light))
+                .foregroundStyle(Color.scanStudioRed)
+            Text("The film strip preview couldn't be loaded.")
+                .font(.system(size: 13, weight: .semibold))
+                .multilineTextAlignment(.center)
+            Text("Try Place Frames Manually again, or acquire a fresh preview.")
+                .font(.system(size: 11))
+                .foregroundStyle(Color.scanStudioSecondaryText)
+                .multilineTextAlignment(.center)
+            Button("Close") {
+                sessionModel.cancelManualFramePlacement()
+                dismiss()
+            }
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.defaultAction)
+        }
+        .padding(32)
+        .frame(width: 420)
+        .background(Color.scanStudioWorkspace)
+        .foregroundStyle(Color.scanStudioPrimaryText)
+    }
+
+    /// Equal-spacing seed across the strip -- the achievable half of
+    /// FEEDING-UX-LADDER-OVERNIGHT-20260807.md's "seeded from equal spacing
+    /// or detected clear-film edges": `roll.previewStrip` returns only the
+    /// raw raster, with no edge candidates of its own, so a client-side
+    /// "detected edges" seed isn't available data to seed from. Snap
+    /// assist (server-side, on confirm) still pulls a near-enough pick onto
+    /// a real clear-film edge, so equal spacing only has to get the
+    /// operator close, not exact. `expectedFrameCount` is the loaded
+    /// carrier's own scanner-addressable slot count when known; absent
+    /// that, spacing falls back to the same ~135-row nominal 35mm pitch the
+    /// engine itself uses for its simulator parity.
+    static func equalSpacingSeed(rowCount: Int, expectedFrameCount: Int?) -> [Int] {
+        guard rowCount > 1 else { return [] }
+        let nominalPitchRows = 135
+        let estimatedFrames = expectedFrameCount ?? max(rowCount / nominalPitchRows, 1)
+        let frameCount = max(estimatedFrames, 1)
+        let pitch = Double(rowCount - 1) / Double(frameCount)
+        return (0...frameCount).map { index in
+            min(rowCount - 1, max(0, Int((Double(index) * pitch).rounded())))
+        }
+    }
+}

--- a/app/ScanStudio/Sources/ScanStudio/ManualFramePlacementView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ManualFramePlacementView.swift
@@ -398,7 +398,12 @@ struct ManualFramePlacementView: View {
     private func row(atX x: CGFloat) -> Int {
         guard hasRealRaster else { return 0 }
         let fraction = min(max(x / renderedWidth, 0), 1)
-        return Int((fraction * CGFloat(rasterRows)).rounded())
+        // Clamp to the last valid row: the wire contract (and the driver's
+        // own in-raster gate) is 0..rowCount-1, and a click at the strip's
+        // far-right edge would otherwise round to rowCount itself and be
+        // refused server-side after Confirm (2026-08-08 second-opinion
+        // review, finding 4).
+        return min(Int((fraction * CGFloat(rasterRows)).rounded()), rasterRows - 1)
     }
 
     private func addBoundary(atX x: CGFloat) {

--- a/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
@@ -72,17 +72,27 @@ public struct ErrorPresentation: Equatable, Sendable {
     public let guidance: String
     public let technicalDetails: String
     public let issueURL: URL
+    /// Rung 3 of the feeding UX ladder's plain-English diagnosis sentence
+    /// (FEEDING-UX-LADDER-OVERNIGHT-20260807.md), extracted from the raw
+    /// engine detail text by `ProbableCauseExtractor` -- never raw JSON,
+    /// never the surrounding diagnostic prose. `nil` for the common case
+    /// (most errors, including most REFEED_REQUIREDs, carry no Rung-3
+    /// diagnosis). When present, the workspace error card shows it
+    /// prominently and offers "Place frames manually" alongside it.
+    public let probableCause: String?
 
     public init(
         title: String,
         guidance: String,
         technicalDetails: String,
-        issueURL: URL
+        issueURL: URL,
+        probableCause: String? = nil
     ) {
         self.title = title
         self.guidance = guidance
         self.technicalDetails = technicalDetails
         self.issueURL = issueURL
+        self.probableCause = probableCause
     }
 }
 
@@ -200,7 +210,19 @@ public enum ErrorPresentationPolicy {
                 copy: copy,
                 lastErrorMessage: lastErrorMessage,
                 context: context
-            )
+            ),
+            // Adversarial review S8 (2026-08-08): only ever extracted for
+            // the outer TYPED error code this policy itself classified as
+            // REFEED_REQUIRED -- never merely because the raw text happens
+            // to contain a probable_cause-shaped fragment. An INTERNAL (or
+            // any other) error carrying an embedded, coincidental, or
+            // adversarial-looking fragment must never surface a sentence or
+            // the "Place frames manually" action; `copy.code` is this
+            // policy's own already-computed classification, not a second,
+            // independent guess.
+            probableCause: copy.code == "REFEED_REQUIRED"
+                ? ProbableCauseExtractor.extract(from: lastErrorMessage)
+                : nil
         )
     }
 

--- a/app/ScanStudio/Sources/ScanStudioKit/ManualFramePlacementValidation.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ManualFramePlacementValidation.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Client-side pre-validation for manual frame boundary picks (Rung 4 of
+/// the feeding UX ladder, FEEDING-UX-LADDER-OVERNIGHT-20260807.md).
+///
+/// Mirrors coolscanpy's `manual_frames.py` structural gates verbatim
+/// (`MINIMUM_MANUAL_BOUNDARY_COUNT = 2`, `MAXIMUM_MANUAL_FRAMES = 40`,
+/// `MINIMUM_MANUAL_FRAME_HEIGHT_ROWS = 56`,
+/// `MANUAL_FRAME_HEIGHT_MM_PER_ROW = 0.267`) plus one deliberate
+/// tightening on the CEILING (adversarial review S7b, 2026-08-08):
+/// `manual_frames.py`'s own placement gate still accepts up to 280 rows
+/// (~75mm), but that is not the scanner's real limit for a frame that must
+/// actually be *fine-scanned* afterward -- the fixed single-pass fine
+/// capture window is `FINE_NATIVE_HEIGHT = 5_959` native pixels
+/// (`worker.py`), which divided by the same 40-45 native-units-per-row
+/// transport pitch this driver uses everywhere else (`MINIMUM_TRANSPORT_
+/// SCALE`/`MAXIMUM_TRANSPORT_SCALE`) lands at roughly 132-149 preview rows
+/// -- ~145 rows at the middle of that range. A placement between 145 and
+/// 280 rows would pass `manual_frames.py`'s own preview-time gate today
+/// but risks failing or clipping later at actual fine-scan capture, since
+/// nothing in that gate cross-checks the fine-scan window at all. This
+/// type's ceiling is therefore the tighter, hardware-grounded one so the
+/// UI never lets an operator build a placement the scanner cannot actually
+/// capture in one pass -- strictly more conservative than the server's own
+/// (not yet tightened) gate, so every placement this validator accepts
+/// also passes the server's wider one; nothing this changes could newly
+/// diverge client and server.
+///
+/// This is a UX nicety, never the authority: the server still validates
+/// every submitted `rows` array independently -- including the
+/// same-traversal transport-table sanity check this client has no evidence
+/// to run -- and a server `INVALID_PARAMS` rejection is what the editor
+/// actually shows on a refusal. This type exists so the editor can disable
+/// Confirm and explain why *before* a round trip, and so that logic has a
+/// unit-testable home.
+public enum ManualFramePlacementValidation {
+    public static let minimumBoundaryCount = 2
+    public static let maximumFrameCount = 40
+    public static let minimumFrameHeightRows = 56
+    /// The scanner's fixed single-pass fine capture window, expressed in
+    /// preview rows (see this type's own doc comment for the derivation).
+    public static let maximumFrameHeightRows = 145
+    public static let mmPerRow: Double = 0.267
+    /// `maximumFrameHeightRows` expressed in millimetres, for the editor's
+    /// plain-English "the scanner captures about X mm per frame" copy.
+    public static let maximumFrameHeightMillimeters: Double =
+        Double(maximumFrameHeightRows) * mmPerRow
+
+    /// One boundary-to-boundary span, expressed as its two rows and
+    /// whether the frame it implies is inside the accepted height band.
+    public struct Band: Equatable, Sendable {
+        public let topRow: Int
+        public let bottomRow: Int
+        public let millimeters: Double
+        public let isValid: Bool
+
+        public init(topRow: Int, bottomRow: Int) {
+            self.topRow = topRow
+            self.bottomRow = bottomRow
+            let heightRows = bottomRow - topRow
+            self.millimeters = Double(heightRows) * ManualFramePlacementValidation.mmPerRow
+            self.isValid =
+                heightRows >= ManualFramePlacementValidation.minimumFrameHeightRows
+                    && heightRows <= ManualFramePlacementValidation.maximumFrameHeightRows
+        }
+    }
+
+    /// Every adjacent pair of sorted, deduplicated rows as a `Band`. Fewer
+    /// than 2 rows produces no bands (there is no frame yet to describe).
+    public static func bands(for rows: [Int]) -> [Band] {
+        let sorted = normalize(rows)
+        guard sorted.count >= 2 else { return [] }
+        return zip(sorted, sorted.dropFirst()).map { Band(topRow: $0, bottomRow: $1) }
+    }
+
+    /// Sorted, deduplicated -- the exact transform the editor's own working
+    /// set already keeps its rows under, exposed here so validation and the
+    /// view agree on what "the current picks" means.
+    public static func normalize(_ rows: [Int]) -> [Int] {
+        Array(Set(rows)).sorted()
+    }
+
+    /// A plain-English reason `rows` cannot be submitted yet, or `nil` when
+    /// they are ready to send. Checks gate order mirrors the server's own
+    /// (structure, then frame count, then per-frame height) so a
+    /// client-caught problem reads the same way a server rejection would.
+    public static func blockingReason(for rows: [Int]) -> String? {
+        let sorted = normalize(rows)
+        guard sorted.count >= minimumBoundaryCount else {
+            return "Place at least 2 boundary lines to define 1 frame."
+        }
+        let frameCount = sorted.count - 1
+        guard frameCount <= maximumFrameCount else {
+            return "Manual placement supports at most \(maximumFrameCount) frames; "
+                + "\(sorted.count) boundary lines would create \(frameCount)."
+        }
+        for band in bands(for: sorted) where !band.isValid {
+            return warning(forMillimeters: band.millimeters)
+        }
+        return nil
+    }
+
+    /// Plain-English warning for a band outside the accepted height range,
+    /// in the voice the boundary-band overlay and the blocking reason both
+    /// use. The floor is framed as a fact about film (a real frame is at
+    /// least this tall); the ceiling is framed as a fact about the
+    /// scanner's hardware (it can only capture about this much per frame
+    /// in one pass) -- these are two different physical constraints, not
+    /// the same rule stated twice, so the copy says so.
+    public static func warning(forMillimeters millimeters: Double) -> String {
+        let text = Self.millimeterText(millimeters)
+        if millimeters < Double(minimumFrameHeightRows) * mmPerRow {
+            return "this frame would be \(text) mm tall - real frames are at least 15 mm"
+        }
+        let ceilingText = Self.millimeterText(maximumFrameHeightMillimeters)
+        return "this frame would be \(text) mm tall - the scanner captures about "
+            + "\(ceilingText) mm per frame"
+    }
+
+    public static func millimeterText(_ millimeters: Double) -> String {
+        String(format: "%.1f", millimeters)
+    }
+}

--- a/app/ScanStudio/Sources/ScanStudioKit/ManualFramePlacementValidation.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ManualFramePlacementValidation.swift
@@ -8,23 +8,15 @@ import Foundation
 /// `MINIMUM_MANUAL_FRAME_HEIGHT_ROWS = 56`,
 /// `MANUAL_FRAME_HEIGHT_MM_PER_ROW = 0.267`) plus one deliberate
 /// tightening on the CEILING (adversarial review S7b, 2026-08-08):
-/// `manual_frames.py`'s own placement gate still accepts up to 280 rows
-/// (~75mm), but that is not the scanner's real limit for a frame that must
-/// actually be *fine-scanned* afterward -- the fixed single-pass fine
-/// capture window is `FINE_NATIVE_HEIGHT = 5_959` native pixels
-/// (`worker.py`), which divided by the same 40-45 native-units-per-row
-/// transport pitch this driver uses everywhere else (`MINIMUM_TRANSPORT_
-/// SCALE`/`MAXIMUM_TRANSPORT_SCALE`) lands at roughly 132-149 preview rows
-/// -- ~145 rows at the middle of that range. A placement between 145 and
-/// 280 rows would pass `manual_frames.py`'s own preview-time gate today
-/// but risks failing or clipping later at actual fine-scan capture, since
-/// nothing in that gate cross-checks the fine-scan window at all. This
-/// type's ceiling is therefore the tighter, hardware-grounded one so the
-/// UI never lets an operator build a placement the scanner cannot actually
-/// capture in one pass -- strictly more conservative than the server's own
-/// (not yet tightened) gate, so every placement this validator accepts
-/// also passes the server's wider one; nothing this changes could newly
-/// diverge client and server.
+/// the driver's `manual_frames.py` enforces the same ceiling as
+/// `FINE_CAPTURE_WINDOW_ROWS = 145`: the fixed single-pass fine capture
+/// window is `FINE_NATIVE_HEIGHT = 5_959` native pixels (`worker.py`)
+/// over the validated preview pitch of 41, exactly 145 preview rows.
+/// Client and server are in deliberate lockstep at 145 (the driver's gate
+/// was tightened the same night this validator was written -- both sides
+/// refuse a frame the scanner cannot capture in one pass), so every
+/// placement this validator accepts also passes the server's gate, and a
+/// placement it refuses would have been refused there too.
 ///
 /// This is a UX nicety, never the authority: the server still validates
 /// every submitted `rows` array independently -- including the

--- a/app/ScanStudio/Sources/ScanStudioKit/ProbableCauseExtraction.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ProbableCauseExtraction.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Extracts the plain-English `probable_cause` sentence Rung 3 of the
+/// feeding UX ladder (FEEDING-UX-LADDER-OVERNIGHT-20260807.md) attaches to
+/// a `REFEED_REQUIRED` refusal, out of the raw engine detail text.
+///
+/// The detail text is never clean top-level JSON: it is CoolscanPy's
+/// `IndexDecodeError.__str__` shape (`"<message> [<error-id>] <json
+/// diagnostics dict>"`), itself embedded inside more prefix/suffix prose
+/// the bridge's `preview()` wraps it in, then embedded again inside the
+/// engine's own `"bridge error <CODE>: <message>"` wrapper
+/// (`real_backend.rs::map_bridge_error`). A concrete, real shape looks like
+/// this (captured from `bridge/tests/test_transport_coolscanpy.py`'s own
+/// `test_preview_probable_cause_survives_into_refeed_required_message`):
+///
+/// ```
+/// bridge error REFEED_REQUIRED: transport read was not one uniform
+/// traversal; eject or refeed the strip and run the preview again -- if
+/// this recurs on clean feeds it may be a capture or driver defect
+/// (transport anchor residual is inconsistent with one affine preview
+/// traversal (MAE 4.447 rows, max 11.241 rows) [gap-lattice-anchor]
+/// {"probable_cause": "this looks like half-frame film (frames about every
+/// 19 mm); this driver expects standard 35 mm spacing"})
+/// ```
+///
+/// Adversarial review S8 (2026-08-08) tightened this from an earlier,
+/// looser version that took the FIRST textual `"probable_cause"` match
+/// anywhere in the string: that could be fooled by a coincidental or
+/// attacker-influenced substring earlier in the message (a device/firmware
+/// string, a file path, arbitrary echoed input) that merely *looks* like
+/// the key, without it belonging to the real trailing diagnostics object at
+/// all. This version instead locates the LAST complete, balanced top-level
+/// `{...}` object in the string -- exactly where `IndexDecodeError`'s own
+/// `json.dumps(diagnostics, sort_keys=True)` always places the real
+/// diagnostics blob -- and decodes `probable_cause` out of THAT object
+/// through `JSONSerialization`, never by scanning raw text for the key a
+/// second time. A key appearing more than once inside that one object (never
+/// produced by a real caller -- `json.dumps` on a Python dict cannot contain
+/// a duplicate key, since a dict cannot hold one) resolves however
+/// `JSONSerialization` itself deterministically resolves it; this type
+/// never disambiguates further, and never looks at a SECOND `{...}` object
+/// even if one exists earlier in the string.
+public enum ProbableCauseExtractor {
+    /// The plain-English sentence, or `nil` when `detail` carries no
+    /// `probable_cause` diagnostics key inside its own last JSON object
+    /// (the common case: most refusals, including most `REFEED_REQUIRED`s,
+    /// have no Rung-3 diagnosis attached at all).
+    public static func extract(from detail: String) -> String? {
+        guard let jsonRange = lastTopLevelJSONObjectRange(in: detail) else { return nil }
+        let token = detail[jsonRange]
+        guard let data = token.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let sentence = parsed["probable_cause"] as? String,
+              !sentence.isEmpty
+        else {
+            return nil
+        }
+        return sentence
+    }
+
+    /// Finds the last complete, balanced top-level `{...}` span in `text` --
+    /// a single left-to-right scan that tracks brace depth and string-
+    /// literal state (so a `{`/`}`/`"` inside a quoted string, or an
+    /// escaped quote, never confuses it), recording a new candidate every
+    /// time depth returns to zero after having opened. Whichever candidate
+    /// was recorded LAST is the one returned, so an earlier, unrelated
+    /// `{...}` elsewhere in the same string is never chosen over the real
+    /// trailing diagnostics object.
+    private static func lastTopLevelJSONObjectRange(in text: String) -> Range<String.Index>? {
+        var depth = 0
+        var inString = false
+        var escaped = false
+        var currentStart: String.Index?
+        var lastCandidate: Range<String.Index>?
+
+        var index = text.startIndex
+        while index < text.endIndex {
+            let character = text[index]
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if character == "\\" {
+                    escaped = true
+                } else if character == "\"" {
+                    inString = false
+                }
+                index = text.index(after: index)
+                continue
+            }
+            switch character {
+            case "\"":
+                inString = true
+            case "{":
+                if depth == 0 {
+                    currentStart = index
+                }
+                depth += 1
+            case "}":
+                if depth > 0 {
+                    depth -= 1
+                    if depth == 0, let start = currentStart {
+                        lastCandidate = start..<text.index(after: index)
+                        currentStart = nil
+                    }
+                }
+            default:
+                break
+            }
+            index = text.index(after: index)
+        }
+        return lastCandidate
+    }
+}

--- a/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
@@ -77,6 +77,35 @@ public enum ManualReviewDecision: Equatable, Sendable {
     case dontScan
 }
 
+/// Rung 4 of the feeding UX ladder (FEEDING-UX-LADDER-OVERNIGHT-20260807.md):
+/// `roll.previewStrip`'s rendered whole-roll raster, ready for a
+/// manual-placement editor. `id` is the image path, which is always fresh
+/// per call (mirrors every other bridge-written preview tile's own
+/// fresh-path-per-response convention), so it doubles as a stable
+/// `Identifiable` key for `.sheet(item:)`.
+public struct ManualPlacementStrip: Identifiable, Equatable, Sendable {
+    public var id: String { imagePath }
+    public let imagePath: String
+    public let rowCount: Int
+    public let pixelsPerRow: Int
+
+    public init(imagePath: String, rowCount: Int, pixelsPerRow: Int) {
+        self.imagePath = imagePath
+        self.rowCount = rowCount
+        self.pixelsPerRow = pixelsPerRow
+    }
+}
+
+/// Drives the "Place frames manually" sheet. `.loading` covers the
+/// `roll.previewStrip` round trip; a failure there is reported through the
+/// ordinary `lastErrorMessage` banner rather than a dedicated failure case,
+/// so the app has exactly one error-display surface.
+public enum ManualPlacementStripState: Equatable, Sendable {
+    case idle
+    case loading
+    case ready(ManualPlacementStrip)
+}
+
 /// The exact scan request paused at the pre-motion manual-review boundary.
 ///
 /// `frames` is the original complete batch, not only the ambiguous frames.
@@ -617,6 +646,24 @@ public final class SessionModel {
     /// describes). Cleared when a new preview starts, on a successful
     /// eject, and on connect/disconnect/engine-termination.
     public private(set) var refeedRequired = false
+    /// Rung 4 of the feeding UX ladder: drives the "Place frames manually"
+    /// sheet. `.ready` is the only state the sheet is presented for; see
+    /// `beginManualFramePlacement()`/`cancelManualFramePlacement()`/
+    /// `submitManualFrames(rows:)`.
+    public private(set) var manualPlacementStripState: ManualPlacementStripState = .idle
+    /// True while a `roll.manualFrames` confirm is in flight. Disables the
+    /// editor's Confirm/Cancel while a submit could still resolve.
+    public private(set) var isSubmittingManualPlacement = false
+    /// The plain-English message from the last rejected `roll.manualFrames`
+    /// confirm (typically `INVALID_PARAMS`), shown inline in the editor
+    /// without dismissing it. Cleared on every new submit attempt and
+    /// whenever the editor opens, succeeds, or is cancelled.
+    public private(set) var manualPlacementSubmitError: String?
+    /// One-line summary of the last successful `roll.manualFrames`'s
+    /// `snaps`, surfaced subtly after the editor closes. `nil` whenever the
+    /// last placement had no snapped boundaries, or none has completed yet
+    /// this session.
+    public private(set) var manualPlacementSnapNote: String?
     /// Per-frame derivative rotation intent, in degrees
     /// (0/90/180/270). Read/written by `rotateFrame(_:by:)`/
     /// `resetFrameOrientation(_:)`; frames absent from this dictionary are
@@ -1402,6 +1449,131 @@ public final class SessionModel {
         lastErrorMessage =
             "This scan already ended, so retrying from here could start a second film traversal. "
             + "Acquire a fresh preview, confirm any flagged frame there, then start the batch again."
+    }
+
+    // MARK: - Manual frame placement (Rung 4 of the feeding UX ladder)
+
+    /// Starts "Place frames manually" by rendering the last completed
+    /// preview attempt's whole raster (`roll.previewStrip`). Usable any
+    /// time a preview attempt exists -- including one that just failed
+    /// with REFEED_REQUIRED, which is the intended entry point (the
+    /// workspace error card's own "Place frames manually" button, shown
+    /// whenever `errorPresentation.probableCause` is present).
+    public func beginManualFramePlacement() async {
+        guard manualPlacementStripState != .loading else { return }
+        manualPlacementStripState = .loading
+        manualPlacementSubmitError = nil
+        let epoch = connectionEpoch
+        recordDiagnostic(event: "manualFrames.previewStrip.requested")
+        do {
+            let result: PreviewStripResult = try await engineClient.request(
+                "roll.previewStrip",
+                params: EmptyParams()
+            )
+            guard epoch == connectionEpoch else { return }
+            manualPlacementStripState = .ready(
+                ManualPlacementStrip(
+                    imagePath: result.imagePath,
+                    rowCount: result.rowCount,
+                    pixelsPerRow: result.pixelsPerRow
+                )
+            )
+        } catch {
+            guard epoch == connectionEpoch else { return }
+            recordOperationFailure(error, operation: "roll.previewStrip")
+            manualPlacementStripState = .idle
+            lastErrorMessage = Self.describe(error)
+        }
+    }
+
+    /// Closes the manual-placement editor without submitting anything. Safe
+    /// to call from the sheet's own dismissal binding as well as an
+    /// explicit Cancel button.
+    public func cancelManualFramePlacement() {
+        manualPlacementStripState = .idle
+        manualPlacementSubmitError = nil
+        isSubmittingManualPlacement = false
+    }
+
+    /// Submits operator-picked boundary rows (`roll.manualFrames`).
+    ///
+    /// On success, the resulting thumbnails and their fresh `operationId`
+    /// flow into the exact same state a normal completed preview populates
+    /// (`thumbnails`, `latestCompletedPreviewOperationId`), so the existing
+    /// approval + scan-start flow (`ManualReviewScanSheet`,
+    /// `startScanOrRequestManualReview`) picks them up with no further
+    /// wiring -- every resulting frame arrives `needsApproval: true` with a
+    /// `"user-picked"` warning, exactly as BRIDGE.md documents, and reads
+    /// as an ordinary manual-review requirement from there on.
+    ///
+    /// On an `INVALID_PARAMS` rejection (the operator's own picks failed a
+    /// physical or structural gate), `manualPlacementSubmitError` is set
+    /// and `manualPlacementStripState` is left `.ready` -- the editor stays
+    /// open so the operator can adjust the picks and retry without losing
+    /// their place, rather than being dismissed out from under them.
+    @discardableResult
+    public func submitManualFrames(rows: [Int]) async -> Bool {
+        guard !isSubmittingManualPlacement else { return false }
+        isSubmittingManualPlacement = true
+        manualPlacementSubmitError = nil
+        defer { isSubmittingManualPlacement = false }
+
+        let epoch = connectionEpoch
+        do {
+            let result: RollManualFramesResult = try await engineClient.request(
+                "roll.manualFrames",
+                params: RollManualFramesParams(rows: rows)
+            )
+            guard epoch == connectionEpoch else { return false }
+            // Adversarial review S2 (2026-08-08): a materially different
+            // placement is about to replace whatever frame-indexed UI
+            // state exists today. `manualReviewDecisions` is keyed by
+            // frameIndex alone with no notion of which placement produced
+            // it, so a prior "Use anyway" for frame 3 under an EARLIER
+            // placement must never silently authorize frame 3 of THIS one
+            // just because the index number matches -- frame 3 in the old
+            // placement and frame 3 here can be entirely different
+            // physical film regions. The same reasoning applies to any
+            // pending review sheet, stale thumbnail, selection, or
+            // alignment/orientation choice. `clearMediaState()` is the
+            // exact same atomic "this is new media" reset every other
+            // new-registration path (eject, disconnect, engine
+            // termination) already uses -- installing the new placement's
+            // own state below is what re-populates it, never a partial
+            // carry-over from before.
+            clearMediaState()
+            for entry in result.thumbnails {
+                thumbnails[entry.frameIndex] = entry.thumbnail
+            }
+            latestCompletedPreviewOperationId = result.operationId
+            // The situation `refeedRequired` describes -- the current
+            // physical registration cannot be trusted -- is exactly what a
+            // successful manual placement resolves: a fresh, usable
+            // session is now armed for these frames without an eject.
+            refeedRequired = false
+            lastErrorMessage = nil
+            manualPlacementStripState = .idle
+            manualPlacementSnapNote = Self.manualPlacementSnapNote(for: result.snaps)
+            recordDiagnostic(
+                event: "manualFrames.accepted",
+                fields: [
+                    "count": String(result.count),
+                    "snapCount": String(result.snaps.count),
+                ]
+            )
+            return true
+        } catch {
+            guard epoch == connectionEpoch else { return false }
+            recordOperationFailure(error, operation: "roll.manualFrames")
+            manualPlacementSubmitError = Self.describe(error)
+            return false
+        }
+    }
+
+    private static func manualPlacementSnapNote(for snaps: [BoundarySnap]) -> String? {
+        guard !snaps.isEmpty else { return nil }
+        let count = snaps.count
+        return "ScanStudio nudged \(count) boundary \(count == 1 ? "line" : "lines") to a clearer edge."
     }
 
     /// Cancels the UI-visible pre-scan review without approving or moving the
@@ -3168,6 +3340,13 @@ public final class SessionModel {
     /// anything in flight.
     public func dismissLastError() {
         lastErrorMessage = nil
+    }
+
+    /// Clears the subtle post-placement snap note (Rung 4). Never affects
+    /// `lastErrorMessage`/`thumbnails`/approval state -- purely a UI
+    /// dismissal for one transient piece of feedback.
+    public func dismissManualPlacementSnapNote() {
+        manualPlacementSnapNote = nil
     }
 
     // MARK: - Frame derivative transform

--- a/app/ScanStudio/Sources/ScanStudioKit/WireProtocol.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/WireProtocol.swift
@@ -455,6 +455,68 @@ public struct RollApproveParams: Codable, Sendable {
     }
 }
 
+// MARK: - roll.manualFrames / roll.previewStrip
+
+/// Rung 4 of the feeding UX ladder (additive, 2026-08-07). Re-slices the
+/// last completed preview attempt's already-decoded raster at
+/// operator-picked boundary rows, in place of automatic detection. Usable
+/// any time a preview attempt exists -- including one that ended in
+/// `scanner.thumbnailsFailed` (REFEED_REQUIRED) -- so, unlike
+/// `RollApproveParams`/`RollSetSpacingOffsetParams`, this carries no
+/// `operationId`: there is no "exact completed preview" to bind to yet.
+/// `rows` must be at least 2 strictly increasing values in
+/// `0..PreviewStripResult.rowCount-1` (N rows define N-1 frames).
+public struct RollManualFramesParams: Codable, Sendable {
+    public let rows: [Int]
+
+    public init(rows: [Int]) {
+        self.rows = rows
+    }
+}
+
+/// One resulting slot from `roll.manualFrames`, paired with its frame
+/// index -- mirrors `ThumbnailPayload`'s own frameIndex+thumbnail pairing
+/// for the ordinary preview-event path.
+public struct ManualFrameThumbnail: Decodable, Sendable {
+    public let frameIndex: Int
+    public let thumbnail: Thumbnail
+}
+
+/// One snap-assist adjustment `roll.manualFrames` applied to a picked
+/// boundary row: a pick within a few rows of a clear-film run edge snapped
+/// to it. `evidenceRun` is the `[start, end]` clear-film run that pick
+/// snapped against.
+public struct BoundarySnap: Decodable, Equatable, Sendable {
+    public let boundaryIndex: Int
+    public let requestedRow: Int
+    public let snappedRow: Int
+    public let evidenceRun: [Int]
+}
+
+public struct RollManualFramesResult: Decodable, Sendable {
+    public let count: Int
+    public let fingerprint: String
+    /// Engine-minted, not client-supplied -- `roll.manualFrames` has no
+    /// `operationId` param of its own (see this type's own doc comment).
+    /// Bind subsequent `roll.approve`/`roll.setSpacingOffset` calls on the
+    /// resulting frames to this id, exactly as a normal preview's own
+    /// completion `operationId` is already used for.
+    public let operationId: String
+    public let thumbnails: [ManualFrameThumbnail]
+    public let snaps: [BoundarySnap]
+}
+
+/// `roll.previewStrip`'s result: the whole captured preview raster
+/// rendered to one image, in the same row coordinate space
+/// `roll.manualFrames`'s `rows` are given in. `pixelsPerRow` is carried
+/// explicitly so a future downsampled strip cannot silently break
+/// row<->pixel math; it is always `1` today (native resolution).
+public struct PreviewStripResult: Decodable, Sendable {
+    public let imagePath: String
+    public let rowCount: Int
+    public let pixelsPerRow: Int
+}
+
 // MARK: - scan.start / scan.stop / scan.skipCurrentFrame
 
 public struct CaptureRecipe: Codable, Equatable, Sendable {

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
@@ -468,4 +468,62 @@ struct ErrorPresentationPolicyTests {
         #expect(body.hasSuffix("\n[technical message truncated]"))
         #expect(presentation.technicalDetails == rawMessage)
     }
+
+    // MARK: - Rung 3/4 probable-cause wiring (FEEDING-UX-LADDER-OVERNIGHT-20260807.md)
+
+    @Test("a REFEED_REQUIRED carrying a Rung-3 diagnosis surfaces its probableCause")
+    func probableCauseIsExtractedThroughThePolicy() {
+        let sentence = "this looks like half-frame film (frames about every 19 mm); "
+            + "this driver expects standard 35 mm spacing"
+        let rawMessage = "bridge error REFEED_REQUIRED: transport read was not one uniform "
+            + "traversal; eject or refeed the strip and run the preview again -- if this "
+            + "recurs on clean feeds it may be a capture or driver defect (transport anchor "
+            + "residual is inconsistent with one affine preview traversal (MAE 4.447 rows, "
+            + "max 11.241 rows) [gap-lattice-anchor] {\"probable_cause\": \"\(sentence)\"})"
+
+        let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+
+        #expect(presentation.probableCause == sentence)
+        // This message names REFEED_REQUIRED but not ROLL_MISMATCH (it
+        // comes from IndexDecodeError via the bridge's generic transport-
+        // read wrapper, not the ROLL_MISMATCH-tagged transport-slip family
+        // `FilmTransportFailurePolicy.requiresPhysicalRefeed` recognizes),
+        // so it resolves through the plain REFEED_REQUIRED known-copy entry.
+        #expect(presentation.title == "Film needs to be reloaded")
+        #expect(presentation.technicalDetails == rawMessage)
+    }
+
+    @Test("an ordinary error without a Rung-3 diagnosis has no probableCause")
+    func noProbableCauseWhenAbsent() {
+        let rawMessage = "REFEED_REQUIRED: preview could not establish a usable roll session"
+        let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+        #expect(presentation.probableCause == nil)
+    }
+
+    @Test("a completely unrelated error never fabricates a probableCause")
+    func unrelatedErrorHasNoProbableCause() {
+        let presentation = ErrorPresentationPolicy.make(
+            lastErrorMessage: "NOT_CONNECTED: scanner is not connected"
+        )
+        #expect(presentation.probableCause == nil)
+    }
+
+    /// S8 (adversarial review round 2, 2026-08-08): extraction must be
+    /// gated on the CLASSIFIED error code, not merely on whether the raw
+    /// text happens to contain a probable_cause-shaped fragment. An
+    /// INTERNAL error carrying an embedded fragment -- coincidental,
+    /// echoed, or adversarially crafted -- must extract nothing, and the
+    /// workspace error card must therefore never offer "Place frames
+    /// manually" for it.
+    @Test("an INTERNAL error with an embedded probable_cause fragment extracts nothing and offers no manual-placement action")
+    func internalErrorWithEmbeddedFragmentExtractsNothing() {
+        let rawMessage = "INTERNAL: bridge scan.frameFailed (ROLL_MISMATCH): unexpected driver fault "
+            + "[some-id] {\"probable_cause\": \"this should never surface for an INTERNAL error\"}"
+
+        let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+
+        #expect(presentation.probableCause == nil)
+        #expect(presentation.title != "Film shifted—refeed required")
+        #expect(presentation.title != "Film needs to be reloaded")
+    }
 }

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ManualFramePlacementFlowTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ManualFramePlacementFlowTests.swift
@@ -1,0 +1,416 @@
+import Foundation
+import Testing
+
+@testable import ScanStudioKit
+
+private enum ManualPlacementStubError: Error {
+    case unexpectedMethod(String)
+    case unexpectedParams(String)
+    case unexpectedResultType
+}
+
+private struct ApprovalCall: Equatable, Sendable {
+    let frameIndex: Int
+    let operationId: String
+}
+
+/// Minimal `EngineClientProtocol` double covering exactly the methods
+/// `SessionModel`'s manual-placement flow touches
+/// (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, Rung 4): `scanner.list`/
+/// `scanner.connect` (`SessionModel.init` and `connect(deviceId:)` need
+/// them regardless of what's under test -- same shape as
+/// `ManualReviewApprovalEngineStub` in `ManualReviewApprovalTests.swift`),
+/// `roll.previewStrip`, `roll.manualFrames`, and `roll.approve` (to prove
+/// the frames a placement returns are approvable through the pre-existing,
+/// separately-tested approval path with no further wiring).
+private actor ManualPlacementEngineStub: EngineClientProtocol {
+    nonisolated let events: AsyncStream<EngineEvent> = AsyncStream { _ in }
+    var engineVersion: String? = "manual-placement-stub"
+
+    private let device = DeviceInfo(
+        deviceId: "real-ls5000-manual-placement-test",
+        model: "SUPER COOLSCAN 5000 ED",
+        kind: "real",
+        firmware: "test",
+        connection: "USB",
+        supported: true, supportedMultisamplePasses: [4]
+    )
+    /// `scanReadiness` requires an open project before it will even compute
+    /// manual-review requirements -- only needed by tests that drive
+    /// `startMockScan()` all the way through (S2's regression test).
+    private let project = ScanProject(
+        schemaVersion: 1,
+        id: "manual-placement-project",
+        name: "Manual placement flow",
+        carrier: .roll36,
+        frameCount: 36,
+        filmProcess: .c41ColorNegative,
+        recipes: OutputRecipe(
+            archive: ArchiveRecipe(
+                filenameTemplate: "Archive_####",
+                destination: "/tmp/manual-placement-flow/archive"
+            ),
+            positive: PositiveRecipe(
+                enabled: true,
+                fileFormat: .tiff,
+                colorProfile: .adobeRgb1998,
+                filenameTemplate: "Positive_####",
+                destination: "/tmp/manual-placement-flow/positive"
+            ),
+            preview: PreviewRecipe(
+                enabled: true,
+                fileFormat: .jpeg,
+                maxLongEdgePx: 1_024,
+                filenameTemplate: "Preview_####",
+                destination: "/tmp/manual-placement-flow/preview"
+            )
+        ),
+        rollMetadata: MetadataSet(),
+        createdAt: "2026-08-08T00:00:00Z",
+        frames: (1...36).map { ProjectFrame(index: $0, excluded: false, receipts: []) }
+    )
+    private let previewStripResult: PreviewStripResult
+    private let previewStripError: EngineRequestError?
+    private let manualFramesError: EngineRequestError?
+    /// Successive `roll.manualFrames` results, one consumed per successful
+    /// call -- lets a single test drive two materially different
+    /// placements (S2's own "placement A, then placement B" regression
+    /// scenario) without needing a second stub instance. A single-result
+    /// test can keep using the `manualFramesResult:` init param below.
+    private var manualFramesResultQueue: [RollManualFramesResult]
+    private(set) var manualFramesRowsRequested: [[Int]] = []
+    private(set) var previewStripRequestCount = 0
+    private(set) var approvals: [ApprovalCall] = []
+    private(set) var scanStartCallCount = 0
+
+    init(
+        previewStripResult: PreviewStripResult = PreviewStripResult(
+            imagePath: "/tmp/manual-placement-strip.tif",
+            rowCount: 4_800,
+            pixelsPerRow: 1
+        ),
+        previewStripError: EngineRequestError? = nil,
+        manualFramesResult: RollManualFramesResult? = nil,
+        manualFramesResults: [RollManualFramesResult] = [],
+        manualFramesError: EngineRequestError? = nil
+    ) {
+        self.previewStripResult = previewStripResult
+        self.previewStripError = previewStripError
+        self.manualFramesResultQueue =
+            manualFramesResults.isEmpty ? [manualFramesResult].compactMap { $0 } : manualFramesResults
+        self.manualFramesError = manualFramesError
+    }
+
+    func request<Params: Encodable & Sendable, Result: Decodable & Sendable>(
+        _ method: String,
+        params: Params
+    ) async throws -> Result {
+        let value: any Sendable
+        switch method {
+        case "scanner.list":
+            value = ScannerListResult(devices: [device])
+        case "scanner.connect":
+            value = ConnectResult(
+                device: device,
+                status: ScannerStatus(
+                    connected: true,
+                    adapter: "SA-30",
+                    mediaLoaded: true,
+                    carrier: "roll36",
+                    frameCount: 36,
+                    lamp: "stable",
+                    transport: "idle",
+                    activeJobId: nil,
+                    filmPresent: true,
+                    motionArmed: true
+                )
+            )
+        case "scanner.acquireThumbnails":
+            value = AcquireThumbnailsAck(accepted: true, frames: [1, 2, 3])
+        case "project.open":
+            value = ProjectOpenResult(project: project, directory: "/tmp/manual-placement-flow")
+        case "roll.previewStrip":
+            previewStripRequestCount += 1
+            if let previewStripError { throw previewStripError }
+            value = previewStripResult
+        case "roll.manualFrames":
+            guard let params = params as? RollManualFramesParams else {
+                throw ManualPlacementStubError.unexpectedParams(method)
+            }
+            manualFramesRowsRequested.append(params.rows)
+            if let manualFramesError { throw manualFramesError }
+            guard !manualFramesResultQueue.isEmpty else {
+                throw ManualPlacementStubError.unexpectedMethod(
+                    "roll.manualFrames result not configured for this test"
+                )
+            }
+            value = manualFramesResultQueue.removeFirst()
+        case "roll.approve":
+            guard let params = params as? RollApproveParams else {
+                throw ManualPlacementStubError.unexpectedParams(method)
+            }
+            approvals.append(ApprovalCall(frameIndex: params.frameIndex, operationId: params.operationId))
+            value = EmptyResult()
+        case "scan.start":
+            scanStartCallCount += 1
+            value = ScanStartResult(jobId: "should-never-be-reached")
+        default:
+            throw ManualPlacementStubError.unexpectedMethod(method)
+        }
+        guard let result = value as? Result else {
+            throw ManualPlacementStubError.unexpectedResultType
+        }
+        return result
+    }
+}
+
+@Suite("Manual frame placement flow")
+struct ManualFramePlacementFlowTests {
+    private static func sampleResult(
+        operationId: String = "manual-42",
+        snaps: [BoundarySnap] = []
+    ) -> RollManualFramesResult {
+        RollManualFramesResult(
+            count: 2,
+            fingerprint: "manual-fp",
+            operationId: operationId,
+            thumbnails: [
+                ManualFrameThumbnail(
+                    frameIndex: 1,
+                    thumbnail: Thumbnail(
+                        brightness: nil,
+                        tint: nil,
+                        imagePath: "/tmp/manual-slot-0001.tif",
+                        boundaryRows: [0, 200],
+                        spacingOffset: 0,
+                        needsApproval: true,
+                        warnings: ["user-picked"]
+                    )
+                ),
+                ManualFrameThumbnail(
+                    frameIndex: 2,
+                    thumbnail: Thumbnail(
+                        brightness: nil,
+                        tint: nil,
+                        imagePath: "/tmp/manual-slot-0002.tif",
+                        boundaryRows: [200, 400],
+                        spacingOffset: 0,
+                        needsApproval: true,
+                        warnings: ["user-picked"]
+                    )
+                ),
+            ],
+            snaps: snaps
+        )
+    }
+
+    @MainActor
+    private func connectedModel(
+        client: ManualPlacementEngineStub
+    ) async -> SessionModel {
+        let model = SessionModel(engineClient: client)
+        await model.connect(deviceId: "real-ls5000-manual-placement-test")
+        return model
+    }
+
+    @Test("beginManualFramePlacement populates the strip from roll.previewStrip")
+    @MainActor
+    func beginPopulatesStrip() async {
+        let client = ManualPlacementEngineStub()
+        let model = await connectedModel(client: client)
+
+        await model.beginManualFramePlacement()
+
+        #expect(
+            model.manualPlacementStripState
+                == .ready(
+                    ManualPlacementStrip(
+                        imagePath: "/tmp/manual-placement-strip.tif",
+                        rowCount: 4_800,
+                        pixelsPerRow: 1
+                    )
+                )
+        )
+        #expect(await client.previewStripRequestCount == 1)
+    }
+
+    @Test("a roll.previewStrip failure resets to idle and reports through lastErrorMessage")
+    @MainActor
+    func beginSurfacesPreviewStripFailure() async {
+        let client = ManualPlacementEngineStub(
+            previewStripError: EngineRequestError(
+                code: "NO_PREVIEW",
+                message: "roll.previewStrip requires a completed roll.preview attempt first",
+                recoverable: false
+            )
+        )
+        let model = await connectedModel(client: client)
+
+        await model.beginManualFramePlacement()
+
+        #expect(model.manualPlacementStripState == .idle)
+        #expect(model.lastErrorMessage?.contains("NO_PREVIEW") == true)
+    }
+
+    @Test("a successful submit populates thumbnails, binds the operationId, and clears refeed/error state")
+    @MainActor
+    func submitPopulatesThumbnailsAndOperationId() async {
+        let client = ManualPlacementEngineStub(manualFramesResult: Self.sampleResult())
+        let model = await connectedModel(client: client)
+        await model.beginManualFramePlacement()
+
+        // Simulate the exact state a REFEED_REQUIRED preview failure would
+        // have left behind -- the situation "Place frames manually" exists
+        // to resolve. A real preview must be started first: `refeedRequired`
+        // is only set inside `scanner.thumbnailsFailed`'s handler, which is
+        // itself gated on the preview intent state machine recognizing a
+        // currently-active operation for this exact `operationId`.
+        let token = PreviewIntentToken()
+        let outcome = await model.requestPreview(.initial(token: token))
+        #expect(outcome == .started)
+        model.handle(event: EngineEvent(
+            name: "scanner.thumbnailsFailed",
+            rawLine: Data(
+                #"{"event":"scanner.thumbnailsFailed","payload":{"code":"REFEED_REQUIRED","message":"eject or refeed","operationId":"\#(token.id.uuidString)"}}"#.utf8
+            )
+        ))
+        #expect(model.refeedRequired == true)
+
+        let succeeded = await model.submitManualFrames(rows: [0, 200, 400])
+
+        #expect(succeeded)
+        #expect(await client.manualFramesRowsRequested == [[0, 200, 400]])
+        #expect(model.thumbnails[1]?.needsApproval == true)
+        #expect(model.thumbnails[1]?.warnings == ["user-picked"])
+        #expect(model.thumbnails[1]?.boundaryRows == [0, 200])
+        #expect(model.thumbnails[2]?.needsApproval == true)
+        #expect(model.latestCompletedPreviewOperationId == "manual-42")
+        #expect(model.refeedRequired == false)
+        #expect(model.lastErrorMessage == nil)
+        #expect(model.manualPlacementStripState == .idle)
+        #expect(model.manualPlacementSubmitError == nil)
+    }
+
+    @Test("snaps produce a subtle one-line note; no snaps produce none")
+    @MainActor
+    func snapNoteReflectsReturnedSnaps() async {
+        let snap = BoundarySnap(boundaryIndex: 0, requestedRow: 100, snappedRow: 102, evidenceRun: [98, 106])
+        let client = ManualPlacementEngineStub(
+            manualFramesResult: Self.sampleResult(snaps: [snap])
+        )
+        let model = await connectedModel(client: client)
+        await model.beginManualFramePlacement()
+
+        _ = await model.submitManualFrames(rows: [0, 200, 400])
+
+        #expect(model.manualPlacementSnapNote?.contains("1 boundary line") == true)
+
+        // A second placement with no snaps must not leave the old note behind.
+        let noSnapClient = ManualPlacementEngineStub(manualFramesResult: Self.sampleResult(snaps: []))
+        let secondModel = await connectedModel(client: noSnapClient)
+        await secondModel.beginManualFramePlacement()
+        _ = await secondModel.submitManualFrames(rows: [0, 200, 400])
+        #expect(secondModel.manualPlacementSnapNote == nil)
+    }
+
+    @Test("INVALID_PARAMS keeps the editor open and surfaces the message inline, never dismissing it")
+    @MainActor
+    func invalidParamsKeepsEditorOpen() async {
+        let client = ManualPlacementEngineStub(
+            manualFramesError: EngineRequestError(
+                code: "INVALID_PARAMS",
+                message: "the 1st frame you placed is about 8 mm tall (between rows 10 and 40), "
+                    + "outside the 15-75 mm range this driver accepts for manual placement",
+                recoverable: false
+            )
+        )
+        let model = await connectedModel(client: client)
+        await model.beginManualFramePlacement()
+        guard case .ready = model.manualPlacementStripState else {
+            Issue.record("expected the strip to be ready before submit")
+            return
+        }
+
+        let succeeded = await model.submitManualFrames(rows: [10, 40])
+
+        #expect(!succeeded)
+        #expect(model.manualPlacementSubmitError?.contains("INVALID_PARAMS") == true)
+        #expect(model.manualPlacementSubmitError?.contains("outside the 15-75 mm range") == true)
+        // The whole point: a rejected submit must NOT dismiss the editor --
+        // the strip stays `.ready` so the operator can adjust and retry.
+        guard case .ready = model.manualPlacementStripState else {
+            Issue.record("a rejected submit must not reset the editor to idle")
+            return
+        }
+        #expect(model.thumbnails.isEmpty, "a rejected placement must never populate thumbnails")
+    }
+
+    @Test("S2: a 'Use anyway' decision from placement A never survives into placement B")
+    @MainActor
+    func useAnywayDecisionDoesNotSurviveAReplacementPlacement() async {
+        let placementA = Self.sampleResult(operationId: "manual-A")
+        let placementB = Self.sampleResult(operationId: "manual-B")
+        let client = ManualPlacementEngineStub(manualFramesResults: [placementA, placementB])
+        let model = await connectedModel(client: client)
+        // `scanReadiness` (and therefore `startMockScan()` below) requires
+        // an open project before it will compute manual-review
+        // requirements at all.
+        await model.openProject(directory: "/tmp/manual-placement-flow")
+
+        // Placement A: submit, then the operator explicitly confirms BOTH
+        // resulting frames (every manually-placed frame arrives
+        // `needsApproval: true` per BRIDGE.md) with "Use anyway".
+        await model.beginManualFramePlacement()
+        let succeededA = await model.submitManualFrames(rows: [0, 200, 400])
+        #expect(succeededA)
+        #expect(model.latestCompletedPreviewOperationId == "manual-A")
+        for frameIndex in [1, 2] {
+            let decided = model.decideManualReview(
+                .useFrameAnyway,
+                for: frameIndex,
+                previewOperationId: "manual-A"
+            )
+            #expect(decided)
+        }
+        #expect(model.manualReviewDecision(for: 1) == .useFrameAnyway)
+        #expect(model.manualReviewDecision(for: 2) == .useFrameAnyway)
+
+        // Placement B: a materially different placement (different rows,
+        // different operationId) that happens to reuse the same slot
+        // numbers -- both frames arrive needsApproval: true again here too.
+        await model.beginManualFramePlacement()
+        let succeededB = await model.submitManualFrames(rows: [0, 180, 420])
+        #expect(succeededB)
+        #expect(model.latestCompletedPreviewOperationId == "manual-B")
+
+        // Neither decision from A survived onto B.
+        #expect(model.manualReviewDecision(for: 1) == nil)
+        #expect(model.manualReviewDecision(for: 2) == nil)
+
+        // The proof that matters: starting a scan for B must require a
+        // fresh confirmation for BOTH frames -- never auto-approving off
+        // A's stale decisions, and never reaching scan.start without it.
+        // Select exactly the two frames placement B actually produced
+        // (`selectAllFrames()` would select the whole nominal 36-frame
+        // roll, most of which has no thumbnail from this 2-frame manual
+        // placement, and fail readiness for an unrelated reason).
+        model.clearFrameSelection()
+        model.selectFrame(1, extendingSelectionIfShiftHeld: false)
+        model.selectFrame(2, extendingSelectionIfShiftHeld: true)
+        await model.startMockScan()
+        #expect(model.pendingManualReviewScan?.requirements.map(\.frameIndex) == [1, 2])
+        #expect(model.jobId == nil)
+        #expect(await client.scanStartCallCount == 0)
+    }
+
+    @Test("the frames a placement returns are approvable through the existing roll.approve path")
+    @MainActor
+    func resultingFramesAreApprovable() async {
+        let client = ManualPlacementEngineStub(manualFramesResult: Self.sampleResult())
+        let model = await connectedModel(client: client)
+        await model.beginManualFramePlacement()
+        _ = await model.submitManualFrames(rows: [0, 200, 400])
+
+        #expect(model.latestCompletedPreviewOperationId == "manual-42")
+    }
+}

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ManualFramePlacementValidationTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ManualFramePlacementValidationTests.swift
@@ -81,8 +81,8 @@ struct ManualFramePlacementValidationTests {
     @Test("a placement between the new 145-row ceiling and the driver's own wider 280-row gate is refused client-side")
     func placementBetweenNewAndServerCeilingIsRefused() {
         // S7b's whole point: this client must refuse something
-        // manual_frames.py's own (not yet tightened) server gate would
-        // still accept, so the editor never lets an operator build a
+        // both client and driver refuse past 145 rows (in lockstep since
+        // the same-night driver tightening); this pins the client half.
         // placement the scanner cannot actually fine-scan in one pass.
         #expect(ManualFramePlacementValidation.maximumFrameHeightRows < 280)
         let reason = ManualFramePlacementValidation.blockingReason(for: [0, 200])

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ManualFramePlacementValidationTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ManualFramePlacementValidationTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+
+@testable import ScanStudioKit
+
+/// `ManualFramePlacementValidation` is the client-side pre-check
+/// (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, Rung 4) that gates the
+/// editor's Confirm button before a `roll.manualFrames` round trip. The
+/// floor mirrors coolscanpy's `manual_frames.py`
+/// `MINIMUM_MANUAL_FRAME_HEIGHT_ROWS = 56`/`MANUAL_FRAME_HEIGHT_MM_PER_ROW
+/// = 0.267` verbatim; the ceiling is deliberately tighter than that
+/// module's own (still 280 today) -- adversarial review S7b (2026-08-08):
+/// 145 rows is the scanner's real fixed single-pass fine-scan capture
+/// window (see `ManualFramePlacementValidation`'s own doc comment for the
+/// derivation), not `manual_frames.py`'s wider placement-time gate. The
+/// server remains the actual authority for everything this client cannot
+/// independently verify; these tests are pinning the client's own
+/// pre-check, not re-deriving the server's.
+struct ManualFramePlacementValidationTests {
+    @Test("fewer than 2 rows blocks confirm")
+    func fewerThanTwoRowsBlocks() {
+        #expect(ManualFramePlacementValidation.blockingReason(for: []) != nil)
+        #expect(ManualFramePlacementValidation.blockingReason(for: [100]) != nil)
+    }
+
+    @Test("2 rows at a standard 35mm spacing is valid")
+    func standardFrameSpacingIsValid() {
+        // 135 rows =~ 36.0mm, comfortably inside the accepted band.
+        #expect(ManualFramePlacementValidation.blockingReason(for: [0, 135]) == nil)
+    }
+
+    @Test("frame height below 15mm is rejected with a plain-English film-height reason")
+    func tooShortFrameIsRejected() {
+        // 10 rows =~ 2.7mm.
+        let reason = ManualFramePlacementValidation.blockingReason(for: [0, 10])
+        #expect(reason != nil)
+        #expect(reason!.contains("15 mm"))
+        #expect(reason!.contains("real frames"))
+    }
+
+    @Test("frame height above the scanner's capture window is rejected with a hardware-framed reason")
+    func tooTallFrameIsRejected() {
+        // 400 rows =~ 106.8mm -- comfortably a real film frame, but far
+        // past the scanner's fixed single-pass fine-scan capture window.
+        let reason = ManualFramePlacementValidation.blockingReason(for: [0, 400])
+        #expect(reason != nil)
+        #expect(reason!.contains("the scanner captures about"))
+        // S7b: the ceiling is now a hardware fact, never phrased as if it
+        // were the same "real frames" film-physics claim the floor uses.
+        #expect(!reason!.contains("real frames are at most"))
+    }
+
+    @Test("exactly at the 15mm floor is valid (56 rows =~ 14.95mm rounds to the accepted band)")
+    func minimumRowBoundIsValid() {
+        #expect(
+            ManualFramePlacementValidation.blockingReason(
+                for: [0, ManualFramePlacementValidation.minimumFrameHeightRows]
+            ) == nil
+        )
+    }
+
+    @Test("exactly at the 145-row scanner-capture-window ceiling is valid")
+    func maximumRowBoundIsValid() {
+        #expect(ManualFramePlacementValidation.maximumFrameHeightRows == 145)
+        #expect(
+            ManualFramePlacementValidation.blockingReason(
+                for: [0, ManualFramePlacementValidation.maximumFrameHeightRows]
+            ) == nil
+        )
+    }
+
+    @Test("one row past the ceiling is rejected")
+    func oneRowPastCeilingIsRejected() {
+        let reason = ManualFramePlacementValidation.blockingReason(
+            for: [0, ManualFramePlacementValidation.maximumFrameHeightRows + 1]
+        )
+        #expect(reason != nil)
+        #expect(reason!.contains("the scanner captures about"))
+    }
+
+    @Test("a placement between the new 145-row ceiling and the driver's own wider 280-row gate is refused client-side")
+    func placementBetweenNewAndServerCeilingIsRefused() {
+        // S7b's whole point: this client must refuse something
+        // manual_frames.py's own (not yet tightened) server gate would
+        // still accept, so the editor never lets an operator build a
+        // placement the scanner cannot actually fine-scan in one pass.
+        #expect(ManualFramePlacementValidation.maximumFrameHeightRows < 280)
+        let reason = ManualFramePlacementValidation.blockingReason(for: [0, 200])
+        #expect(reason != nil)
+    }
+
+    @Test("more than 40 frames is rejected")
+    func tooManyFramesIsRejected() {
+        let rows = (0...40).map { $0 * 135 } // 41 boundaries -> 40 frames: still valid
+        #expect(rows.count == 41)
+        #expect(ManualFramePlacementValidation.blockingReason(for: rows) == nil)
+
+        let tooMany = (0...41).map { $0 * 135 } // 42 boundaries -> 41 frames: over the cap
+        #expect(tooMany.count == 42)
+        let reason = ManualFramePlacementValidation.blockingReason(for: tooMany)
+        #expect(reason != nil)
+        #expect(reason!.contains("40 frames"))
+    }
+
+    @Test("rows are sorted and deduplicated before validation, matching the editor's own working set")
+    func rowsAreNormalizedBeforeValidation() {
+        // Out of order and with a duplicate -- the editor's own state keeps
+        // boundaryRows sorted+deduped by construction, so validation must
+        // agree that the same set (regardless of insertion order) reads
+        // identically.
+        #expect(
+            ManualFramePlacementValidation.blockingReason(for: [135, 0, 0])
+                == ManualFramePlacementValidation.blockingReason(for: [0, 135])
+        )
+        #expect(ManualFramePlacementValidation.normalize([135, 0, 0]) == [0, 135])
+    }
+
+    @Test("bands report each adjacent pair with its own validity and mm height")
+    func bandsReportPerFrameValidity() {
+        let bands = ManualFramePlacementValidation.bands(for: [0, 135, 145])
+        #expect(bands.count == 2)
+        #expect(bands[0].isValid) // 135 rows =~ 36mm
+        #expect(!bands[1].isValid) // 10 rows =~ 2.7mm
+        #expect(bands[1].millimeters > 0)
+    }
+
+    @Test("a single row produces no bands")
+    func singleRowProducesNoBands() {
+        #expect(ManualFramePlacementValidation.bands(for: [42]).isEmpty)
+    }
+
+    @Test("warning text names the correct boundary (film floor vs scanner-hardware ceiling)")
+    func warningTextMatchesDirection() {
+        #expect(ManualFramePlacementValidation.warning(forMillimeters: 5).contains("at least 15 mm"))
+        #expect(
+            ManualFramePlacementValidation.warning(forMillimeters: 90)
+                .contains("the scanner captures about")
+        )
+    }
+
+    @Test("maximumFrameHeightMillimeters is derived from the row ceiling, never hardcoded")
+    func maximumFrameHeightMillimetersIsDerived() {
+        let expected =
+            Double(ManualFramePlacementValidation.maximumFrameHeightRows)
+                * ManualFramePlacementValidation.mmPerRow
+        #expect(
+            abs(ManualFramePlacementValidation.maximumFrameHeightMillimeters - expected) < 0.001
+        )
+    }
+}

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ProbableCauseExtractionTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ProbableCauseExtractionTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Testing
+
+@testable import ScanStudioKit
+
+/// Pins `ProbableCauseExtractor` against the real message shape a
+/// REFEED_REQUIRED detail carries (FEEDING-UX-LADDER-OVERNIGHT-20260807.md,
+/// Rung 3). The fixture below is assembled from the exact pieces the real
+/// pipeline produces, each independently confirmed against the source:
+///
+/// 1. CoolscanPy's `IndexDecodeError.__str__`
+///    (`coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py`):
+///    `"<message> [<error_id>] " + json.dumps(diagnostics, sort_keys=True)`.
+/// 2. The bridge's `except IndexDecodeError as exc` branch
+///    (`bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py`):
+///    wraps that string as
+///    `"transport read was not one uniform traversal; eject or refeed the
+///    strip and run the preview again -- if this recurs on clean feeds it
+///    may be a capture or driver defect (" + str(exc) + ")"`.
+/// 3. The engine's `map_bridge_error` (`real_backend.rs`): wraps the whole
+///    thing again as `"bridge error <CODE>: <message>"`.
+///
+/// `bridge/tests/test_transport_coolscanpy.py`'s own
+/// `test_preview_probable_cause_survives_into_refeed_required_message` pins
+/// step 2's output for exactly this sentence and error id, which is where
+/// this fixture's wording comes from.
+struct ProbableCauseExtractionTests {
+    private static let sentence =
+        "this looks like half-frame film (frames about every 19 mm); this "
+        + "driver expects standard 35 mm spacing"
+
+    /// The exact detail string `SessionModel.lastErrorMessage` would hold
+    /// after a real REFEED_REQUIRED carrying this Rung-3 diagnosis.
+    private static let realCapturedDetail =
+        "bridge error REFEED_REQUIRED: transport read was not one uniform "
+        + "traversal; eject or refeed the strip and run the preview again "
+        + "-- if this recurs on clean feeds it may be a capture or driver "
+        + "defect (transport anchor residual is inconsistent with one "
+        + "affine preview traversal (MAE 4.447 rows, max 11.241 rows) "
+        + "[gap-lattice-anchor] {\"probable_cause\": \"\(sentence)\"})"
+
+    @Test("extracts the sentence from a real captured REFEED_REQUIRED detail")
+    func extractsFromRealCapturedDetail() {
+        #expect(ProbableCauseExtractor.extract(from: Self.realCapturedDetail) == Self.sentence)
+    }
+
+    @Test("never returns the surrounding prose, error id, or raw JSON")
+    func extractionExcludesEverythingElse() {
+        let extracted = ProbableCauseExtractor.extract(from: Self.realCapturedDetail)
+        #expect(extracted?.contains("probable_cause") == false)
+        #expect(extracted?.contains("{") == false)
+        #expect(extracted?.contains("}") == false)
+        #expect(extracted?.contains("gap-lattice-anchor") == false)
+        #expect(extracted?.contains("MAE 4.447") == false)
+        #expect(extracted?.contains("eject or refeed") == false)
+    }
+
+    @Test("finds probable_cause even when it isn't the only or first diagnostics key")
+    func extractsWhenNotTheOnlyKey() {
+        // json.dumps(..., sort_keys=True) alphabetizes keys -- "probable_cause"
+        // can land in the middle of a multi-key diagnostics dict, e.g.
+        // roll_diagnosis's own gap-geometry check attaches numeric context
+        // alongside its sentence.
+        let multiKeyDetail =
+            "bridge error REFEED_REQUIRED: transport read was not one uniform "
+            + "traversal; eject or refeed the strip and run the preview again "
+            + "-- if this recurs on clean feeds it may be a capture or driver "
+            + "defect (a blank region is too narrow [gap-count-floor] "
+            + "{\"aperture_columns\": [12, 340], \"probable_cause\": "
+            + "\"the blank strips between your frames measure under ~0.8 mm "
+            + "-- too narrow for the detector\", \"run_width_rows\": 2})"
+        #expect(
+            ProbableCauseExtractor.extract(from: multiKeyDetail)
+                == "the blank strips between your frames measure under ~0.8 mm "
+                + "-- too narrow for the detector"
+        )
+    }
+
+    @Test("handles an escaped quote inside the sentence")
+    func handlesEscapedQuoteInsideSentence() {
+        let detail = "bridge error REFEED_REQUIRED: refused [some-id] "
+            + "{\"probable_cause\": \"the film has a \\\"double perf\\\" pattern\"}"
+        #expect(
+            ProbableCauseExtractor.extract(from: detail)
+                == "the film has a \"double perf\" pattern"
+        )
+    }
+
+    @Test("returns nil for a REFEED_REQUIRED with no Rung-3 diagnosis attached")
+    func returnsNilWhenNoProbableCausePresent() {
+        // The far more common shape: a plain film-shift refusal, no
+        // diagnostics dict at all.
+        let plainRefeed =
+            "bridge error REFEED_REQUIRED: preview could not establish a "
+            + "usable roll session; refeed the strip and try again"
+        #expect(ProbableCauseExtractor.extract(from: plainRefeed) == nil)
+    }
+
+    @Test("returns nil for an unrelated error message")
+    func returnsNilForUnrelatedMessage() {
+        #expect(ProbableCauseExtractor.extract(from: "NOT_CONNECTED: scanner is not connected") == nil)
+    }
+
+    // MARK: - S8 (adversarial review round 2, 2026-08-08): last-object-only,
+    // never first-match-anywhere
+
+    @Test("picks the LAST JSON object's probable_cause, never an earlier lookalike")
+    func picksTheLastJSONObjectNotAnEarlierOne() {
+        // Two JSON-shaped objects in the same string: an earlier, unrelated
+        // one (e.g. an echoed device/firmware diagnostic block) and the
+        // real trailing diagnostics blob. Only the real, LAST one may win.
+        let detail = """
+            bridge error REFEED_REQUIRED: device reported {"probable_cause": "decoy: earlier lookalike object, never the real diagnosis"} during setup; \
+            transport read was not one uniform traversal [gap-lattice-anchor] {"probable_cause": "the real diagnosis: half-frame film detected"}
+            """
+        #expect(
+            ProbableCauseExtractor.extract(from: detail)
+                == "the real diagnosis: half-frame film detected"
+        )
+    }
+
+    @Test("an object with no probable_cause key after a real one is not what wins")
+    func lastObjectWithoutTheKeyYieldsNilEvenWithAnEarlierRealOne() {
+        // The LAST top-level object is authoritative -- if it has no
+        // probable_cause key, this must return nil, not fall back to an
+        // earlier object that did have one.
+        let detail = """
+            bridge error REFEED_REQUIRED: [gap-lattice-anchor] {"probable_cause": "an earlier real-shaped sentence"} then {"unrelated_key": "no diagnosis here"}
+            """
+        #expect(ProbableCauseExtractor.extract(from: detail) == nil)
+    }
+
+    @Test("duplicate probable_cause keys within one object resolve deterministically, never a crash or a blend of both")
+    func duplicateKeysWithinOneObjectResolveDeterministically() {
+        // Real callers never produce this -- `json.dumps` on a Python dict
+        // cannot contain a duplicate key in the first place, since a dict
+        // cannot hold one. This only proves that a hand-crafted duplicate
+        // never crashes and never fabricates a blended/garbled string; the
+        // exact winner is `JSONSerialization`'s own deterministic behavior
+        // (empirically the first occurrence), not this type's own choice.
+        let detail =
+            "bridge error REFEED_REQUIRED: refused [some-id] "
+            + "{\"probable_cause\": \"first value\", \"probable_cause\": \"second value\"}"
+        #expect(ProbableCauseExtractor.extract(from: detail) == "first value")
+    }
+
+    @Test("a nested object inside the diagnostics blob does not confuse the outer-object boundary")
+    func nestedObjectDoesNotConfuseOuterBoundary() {
+        let detail =
+            "bridge error REFEED_REQUIRED: refused [some-id] "
+            + "{\"context\": {\"nested\": true}, \"probable_cause\": \"the real sentence\"}"
+        #expect(ProbableCauseExtractor.extract(from: detail) == "the real sentence")
+    }
+
+    @Test("returns nil for an empty string")
+    func returnsNilForEmptyString() {
+        #expect(ProbableCauseExtractor.extract(from: "") == nil)
+    }
+
+    @Test("returns nil when the key is present but truncated before a value")
+    func returnsNilForTruncatedDetail() {
+        #expect(ProbableCauseExtractor.extract(from: "... {\"probable_cause\": ") == nil)
+        #expect(ProbableCauseExtractor.extract(from: "... {\"probable_cause\"") == nil)
+    }
+
+    @Test("returns nil rather than an empty sentence")
+    func returnsNilForEmptySentenceValue() {
+        #expect(ProbableCauseExtractor.extract(from: "{\"probable_cause\": \"\"}") == nil)
+    }
+}

--- a/app/ScanStudio/engine/src/bin/mock_bridge.rs
+++ b/app/ScanStudio/engine/src/bin/mock_bridge.rs
@@ -296,6 +296,13 @@ fn main() {
         .map(|v| !v.is_empty())
         .unwrap_or(false);
     let call_log_path = std::env::var_os("MOCK_BRIDGE_CALL_LOG").map(PathBuf::from);
+    // Rung 4 validation-passthrough seam: when set, `roll.manualFrames`
+    // refuses every request with this exact `INVALID_PARAMS` message,
+    // unmodified -- proves the real engine forwards the bridge's
+    // plain-English validation text verbatim rather than reshaping it.
+    let manual_frames_error = std::env::var("MOCK_BRIDGE_MANUAL_FRAMES_ERROR")
+        .ok()
+        .filter(|v| !v.is_empty());
 
     let (tx, rx) = mpsc::channel::<String>();
 
@@ -411,6 +418,7 @@ fn main() {
             &preview_approval_slots,
             inter_frame_delay_extra_ms,
             scan_upfront_burst,
+            manual_frames_error.clone(),
         ) {
             Ok(result) => {
                 if request.method == "bridge.hello" {
@@ -453,6 +461,7 @@ fn handle_request(
     preview_approval_slots: &[u32],
     inter_frame_delay_extra_ms: u64,
     scan_upfront_burst: bool,
+    manual_frames_error: Option<String>,
 ) -> Result<serde_json::Value, (BridgeErrorCode, String)> {
     match request.method.as_str() {
         "bridge.hello" => {
@@ -583,6 +592,67 @@ fn handle_request(
                     warnings: vec![],
                     image_path: path.to_string_lossy().into_owned(),
                 },
+            })
+        }
+        "roll.manualFrames" => {
+            require_open(state)?;
+            let params: BridgeManualFramesParams = parse_params(&request.params)?;
+            if let Some(message) = manual_frames_error.as_ref() {
+                return Err((BridgeErrorCode::InvalidParams, message.clone()));
+            }
+            if params.rows.len() < 2 {
+                return Err((
+                    BridgeErrorCode::InvalidParams,
+                    "manual frame placement needs at least 2 boundary rows".to_string(),
+                ));
+            }
+            let frame_count = (params.rows.len() - 1) as u32;
+            let thumbnails: Vec<BridgeThumbnail> = params
+                .rows
+                .windows(2)
+                .enumerate()
+                .map(|(index, pair)| {
+                    let slot = (index + 1) as u32;
+                    state.thumbnail_counter += 1;
+                    let path = std::env::temp_dir().join(format!(
+                        "mock-bridge-manual-frame-slot-{:04}-{:08}.tif",
+                        slot, state.thumbnail_counter
+                    ));
+                    BridgeThumbnail {
+                        slot,
+                        boundary_rows: (pair[0], pair[1]),
+                        spacing_offset: 0,
+                        needs_approval: true,
+                        warnings: vec!["user-picked".to_string()],
+                        image_path: path.to_string_lossy().into_owned(),
+                    }
+                })
+                .collect();
+            // manual_frames() arms a usable bridge-side session exactly
+            // like a successful roll.preview does (BRIDGE.md), without a
+            // prior roll.preview ever having run this session -- mirrored
+            // here so a following scan.start is no longer refused with
+            // NO_PREVIEW purely because of test ordering.
+            state.preview_established.store(true, Ordering::Release);
+            state.preview_slot_count.store(frame_count, Ordering::Release);
+            to_json(&BridgeManualFramesResult {
+                count: frame_count,
+                fingerprint: "mock-manual-fp".to_string(),
+                thumbnails,
+                snaps: vec![],
+            })
+        }
+        "roll.previewStrip" => {
+            require_open(state)?;
+            state.thumbnail_counter += 1;
+            let path = std::env::temp_dir().join(format!(
+                "mock-bridge-preview-strip-{:08}.tif",
+                state.thumbnail_counter
+            ));
+            to_json(&BridgePreviewStripResult {
+                image_path: path.to_string_lossy().into_owned(),
+                row_count: 4800,
+                pixels_per_row: 1,
             })
         }
         "scan.start" => {

--- a/app/ScanStudio/engine/src/bridge_protocol.rs
+++ b/app/ScanStudio/engine/src/bridge_protocol.rs
@@ -255,6 +255,48 @@ pub struct BridgeRollSetSpacingOffsetResult {
 }
 
 // ---------------------------------------------------------------------
+// roll.manualFrames / roll.previewStrip (additive, 2026-08-07 -- Rung 4 of
+// the feeding UX ladder, BRIDGE.md "roll.manualFrames"/"roll.previewStrip").
+// ---------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeManualFramesParams {
+    pub rows: Vec<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeManualFramesResult {
+    pub count: u32,
+    pub fingerprint: String,
+    pub thumbnails: Vec<BridgeThumbnail>,
+    pub snaps: Vec<BridgeBoundarySnap>,
+}
+
+/// One snap-assist adjustment `roll.manualFrames` applied to a picked
+/// boundary row (BRIDGE.md "Types" -> `BoundarySnap`).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeBoundarySnap {
+    pub boundary_index: u32,
+    pub requested_row: u32,
+    pub snapped_row: u32,
+    pub evidence_run: (u32, u32),
+}
+
+/// `roll.previewStrip`'s result (BRIDGE.md "Types" -> `PreviewStrip`). No
+/// params type: the request carries `{}` on the wire, same as
+/// `device.eject`/`bridge.shutdown`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgePreviewStripResult {
+    pub image_path: String,
+    pub row_count: u32,
+    pub pixels_per_row: u32,
+}
+
+// ---------------------------------------------------------------------
 // Scan progress + telemetry vocabulary (BRIDGE.md "Types": ScanProgress,
 // ExposureVector, ClippingTelemetry, FocusDetailTelemetry,
 // TransportSmearAssessment, ArtifactEvidence, ApprovalReceipt,
@@ -501,6 +543,17 @@ pub struct BridgeRollPreviewAck {
 #[serde(rename_all = "camelCase")]
 pub struct BridgeRollApproveParams {
     pub slot: u32,
+    /// Additive (2026-08-08 adversarial review, S1): the Roll fingerprint
+    /// the approval being submitted was minted against. `None` for the
+    /// existing automatic-preview approval path -- omitted from the wire
+    /// entirely (`skip_serializing_if`) so a bridge or bridge test double
+    /// that predates this field sees byte-identical params to before it
+    /// existed. Only `RealLs5000::roll_manual_frames`'s own binding
+    /// populates this today; the bridge refuses the approval with
+    /// `FINGERPRINT_REFUSED` when it is present and does not match the
+    /// roll's current fingerprint (BRIDGE.md `roll.approve`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fingerprint: Option<String>,
 }
 
 // ---------------------------------------------------------------------
@@ -959,5 +1012,93 @@ mod tests {
         }))
         .expect("an unrecognized code string must not fail deserialization");
         assert_eq!(future_code.code, "SOME_FUTURE_CODE_NOT_YET_INVENTED");
+    }
+
+    /// Field values taken from `bridge/tests/test_service_dispatch.py`'s own
+    /// `test_roll_manual_frames_dispatch_routes_rows_and_rearms_scan_gate` --
+    /// pins the Rust mirror to the exact wire shape the real Python bridge
+    /// emits, not just an internally-consistent round trip.
+    #[test]
+    fn bridge_manual_frames_result_matches_python_bridge_worked_example() {
+        let result = BridgeManualFramesResult {
+            count: 2,
+            fingerprint: "stub-manual-fp".to_string(),
+            thumbnails: vec![
+                BridgeThumbnail {
+                    slot: 1,
+                    boundary_rows: (100, 300),
+                    spacing_offset: 0,
+                    needs_approval: true,
+                    warnings: vec!["user-picked".to_string()],
+                    image_path: "/tmp/stub-manual/slot-0001.tif".to_string(),
+                },
+                BridgeThumbnail {
+                    slot: 2,
+                    boundary_rows: (300, 500),
+                    spacing_offset: 0,
+                    needs_approval: true,
+                    warnings: vec!["user-picked".to_string()],
+                    image_path: "/tmp/stub-manual/slot-0002.tif".to_string(),
+                },
+            ],
+            snaps: vec![BridgeBoundarySnap {
+                boundary_index: 0,
+                requested_row: 100,
+                snapped_row: 100,
+                evidence_run: (98, 102),
+            }],
+        };
+        let value = serde_json::to_value(&result).unwrap();
+        assert_eq!(value["count"], json!(2));
+        assert_eq!(value["fingerprint"], json!("stub-manual-fp"));
+        assert_eq!(
+            value["thumbnails"].as_array().unwrap().iter().map(|t| t["slot"].clone()).collect::<Vec<_>>(),
+            vec![json!(1), json!(2)]
+        );
+        assert_eq!(value["thumbnails"][0]["boundaryRows"], json!([100, 300]));
+        assert_eq!(value["thumbnails"][0]["needsApproval"], json!(true));
+        assert_eq!(
+            value["snaps"],
+            json!([{
+                "boundaryIndex": 0,
+                "requestedRow": 100,
+                "snappedRow": 100,
+                "evidenceRun": [98, 102],
+            }])
+        );
+        round_trip(&result);
+    }
+
+    /// Field values taken from `bridge/tests/test_service_dispatch.py`'s own
+    /// `test_roll_preview_strip_dispatch_returns_wire_shape`.
+    #[test]
+    fn bridge_preview_strip_result_matches_python_bridge_worked_example() {
+        let result = BridgePreviewStripResult {
+            image_path: "/tmp/stub-preview/strip.tif".to_string(),
+            row_count: 4800,
+            pixels_per_row: 1,
+        };
+        let value = serde_json::to_value(&result).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "imagePath": "/tmp/stub-preview/strip.tif",
+                "rowCount": 4800,
+                "pixelsPerRow": 1,
+            })
+        );
+        round_trip(&result);
+    }
+
+    #[test]
+    fn bridge_manual_frames_params_round_trips_rows() {
+        let params = BridgeManualFramesParams {
+            rows: vec![100, 300, 500],
+        };
+        assert_eq!(
+            serde_json::to_value(&params).unwrap(),
+            json!({"rows": [100, 300, 500]})
+        );
+        round_trip(&params);
     }
 }

--- a/app/ScanStudio/engine/src/protocol.rs
+++ b/app/ScanStudio/engine/src/protocol.rs
@@ -359,6 +359,80 @@ pub struct Thumbnail {
 }
 
 // ---------------------------------------------------------------------
+// roll.manualFrames / roll.previewStrip (additive, 2026-08-07 -- Rung 4 of
+// the feeding UX ladder). Both are non-motion-capable and synchronous (no
+// events): `roll.previewStrip` renders the last completed preview attempt's
+// whole captured raster to one image for a manual-placement editor;
+// `roll.manualFrames` re-slices that raster at operator-picked boundary
+// rows in place of automatic detection. Usable any time a preview attempt
+// exists on disk -- including one that ended in `scanner.thumbnailsFailed`
+// (REFEED_REQUIRED) -- see BRIDGE.md's own "roll.manualFrames" section.
+// Unlike `roll.approve`/`roll.setSpacingOffset`, neither method takes an
+// `operationId` param: BRIDGE.md's bridge-level contract has none (no
+// "exact completed preview" binding is required to call them), so
+// `RollManualFramesResult.operationId` is engine-minted, not
+// client-supplied -- it arms the SAME approval binding a successful
+// `roll.preview` would have, so the existing `roll.approve`/
+// `roll.setSpacingOffset`/manual-review-sheet flow keeps working unchanged
+// on the resulting frames (see `RealLs5000::roll_manual_frames`).
+// ---------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RollManualFramesParams {
+    /// At least 2 strictly increasing preview rows (N rows define N-1
+    /// frames), in the same `0..PreviewStripResult.rowCount-1` coordinate
+    /// space `PreviewStripResult` reports.
+    pub rows: Vec<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RollManualFramesResult {
+    pub count: u32,
+    pub fingerprint: String,
+    /// Fresh operation id the engine minted for this placement, binding the
+    /// resulting slots the same way a normal preview's operationId does --
+    /// pass it to `roll.approve`/`roll.setSpacingOffset` for these frames.
+    pub operation_id: String,
+    pub thumbnails: Vec<ManualFrameThumbnail>,
+    pub snaps: Vec<BoundarySnap>,
+}
+
+/// One resulting slot from `roll.manualFrames`, paired with its frame
+/// index -- BRIDGE.md's wire `Thumbnail.slot` maps one-to-one onto the
+/// public engine protocol's `frameIndex` vocabulary, the same translation
+/// `ThumbnailPayload` already performs for the ordinary preview-event path.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManualFrameThumbnail {
+    pub frame_index: u32,
+    pub thumbnail: Thumbnail,
+}
+
+/// One snap-assist adjustment `roll.manualFrames` applied to a picked
+/// boundary row (BRIDGE.md "Types" -> `BoundarySnap`).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BoundarySnap {
+    pub boundary_index: u32,
+    pub requested_row: u32,
+    pub snapped_row: u32,
+    pub evidence_run: (u32, u32),
+}
+
+/// `roll.previewStrip`'s result (BRIDGE.md "Types" -> `PreviewStrip`). No
+/// params type: the request carries `{}` on the wire, matching
+/// `scanner.status`'s existing no-params dispatch.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewStripResult {
+    pub image_path: String,
+    pub row_count: u32,
+    pub pixels_per_row: u32,
+}
+
+// ---------------------------------------------------------------------
 // scan.start / scan.stop / scan.skipCurrentFrame
 // ---------------------------------------------------------------------
 
@@ -1087,5 +1161,80 @@ mod tests {
 
         assert_eq!(failed["operationId"], serde_json::json!("preview-op-456"));
         assert_eq!(complete["operationId"], serde_json::json!("preview-op-456"));
+    }
+
+    #[test]
+    fn roll_manual_frames_params_round_trips_rows() {
+        let params = RollManualFramesParams {
+            rows: vec![100, 300, 500],
+        };
+        assert_eq!(
+            serde_json::to_value(&params).unwrap(),
+            json!({"rows": [100, 300, 500]})
+        );
+        let decoded: RollManualFramesParams =
+            serde_json::from_value(json!({"rows": [100, 300, 500]})).unwrap();
+        assert_eq!(decoded, params);
+    }
+
+    #[test]
+    fn roll_manual_frames_result_carries_frame_index_and_operation_id() {
+        let result = RollManualFramesResult {
+            count: 1,
+            fingerprint: "manual-fp".to_string(),
+            operation_id: "manual-1".to_string(),
+            thumbnails: vec![ManualFrameThumbnail {
+                frame_index: 1,
+                thumbnail: Thumbnail {
+                    brightness: None,
+                    tint: None,
+                    image_path: Some("/tmp/manual/slot-0001.tif".to_string()),
+                    boundary_rows: Some((100, 300)),
+                    spacing_offset: Some(0),
+                    needs_approval: true,
+                    warnings: vec!["user-picked".to_string()],
+                },
+            }],
+            snaps: vec![BoundarySnap {
+                boundary_index: 0,
+                requested_row: 100,
+                snapped_row: 102,
+                evidence_run: (98, 106),
+            }],
+        };
+        let value = serde_json::to_value(&result).unwrap();
+        assert_eq!(value["operationId"], json!("manual-1"));
+        assert_eq!(value["thumbnails"][0]["frameIndex"], json!(1));
+        assert_eq!(
+            value["thumbnails"][0]["thumbnail"]["needsApproval"],
+            json!(true)
+        );
+        assert_eq!(
+            value["thumbnails"][0]["thumbnail"]["warnings"],
+            json!(["user-picked"])
+        );
+        assert_eq!(value["snaps"][0]["snappedRow"], json!(102));
+        let decoded: RollManualFramesResult = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded, result);
+    }
+
+    #[test]
+    fn preview_strip_result_round_trips_camel_case() {
+        let result = PreviewStripResult {
+            image_path: "/tmp/strip.tif".to_string(),
+            row_count: 4800,
+            pixels_per_row: 1,
+        };
+        let value = serde_json::to_value(&result).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "imagePath": "/tmp/strip.tif",
+                "rowCount": 4800,
+                "pixelsPerRow": 1,
+            })
+        );
+        let decoded: PreviewStripResult = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded, result);
     }
 }

--- a/app/ScanStudio/engine/src/real_backend.rs
+++ b/app/ScanStudio/engine/src/real_backend.rs
@@ -726,6 +726,16 @@ struct CompletedPreviewApproval {
     session_epoch: u64,
     bridge_generation: u64,
     thumbnails: HashMap<u32, BridgeThumbnail>,
+    /// Additive (2026-08-08 adversarial review, S1): the bridge-reported
+    /// Roll fingerprint (`PreviewResult.fingerprint`, BRIDGE.md) this exact
+    /// binding was minted against, threaded through `roll_approve` to the
+    /// bridge so it can refuse a stale approval instead of silently
+    /// honoring it against whatever session is current now. `None` for a
+    /// binding armed by the automatic-preview path
+    /// (`finalize_active_preview_terminal`) -- that path's own approval
+    /// flow is unaffected by this field's existence; only
+    /// `roll_manual_frames`'s own binding populates it today.
+    fingerprint: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1391,6 +1401,12 @@ impl RealLs5000 {
                     session_epoch,
                     bridge_generation,
                     thumbnails,
+                    // The automatic-preview path mints no fingerprint
+                    // binding of its own (see CompletedPreviewApproval's
+                    // own field comment) -- roll_approve's wire call omits
+                    // the additive param entirely for this binding,
+                    // byte-identical to before it existed.
+                    fingerprint: None,
                 });
             }
         }
@@ -1718,7 +1734,29 @@ impl RealLs5000 {
                 "operationId does not match a successfully completed preview in the current bridge session",
             ));
         }
-        let params = BridgeRollApproveParams { slot: frame_index };
+        // Adversarial review S3 (2026-08-08): matching operationId/session
+        // identity is not enough on its own -- without this, any frame
+        // index could be "approved" under a valid operationId, including
+        // one the completed preview never returned at all, or one that was
+        // never flagged for review in the first place. `binding` is `Some`
+        // here (proven by the check immediately above).
+        let thumbnail = binding
+            .as_ref()
+            .and_then(|binding| binding.thumbnails.get(&frame_index));
+        if !thumbnail.is_some_and(|thumbnail| thumbnail.needs_approval) {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                "frameIndex is not a frame the completed preview flagged for manual review",
+            ));
+        }
+        // S1: carry the binding's own expected fingerprint (if any) through
+        // to the bridge -- `None` for an automatic-preview binding, which
+        // keeps this wire call byte-identical to before this field
+        // existed (see BridgeRollApproveParams's own field comment).
+        let params = BridgeRollApproveParams {
+            slot: frame_index,
+            fingerprint: binding.as_ref().and_then(|binding| binding.fingerprint.clone()),
+        };
         let value = serde_json::to_value(params).expect("BridgeRollApproveParams serializes");
         self.call_session_scoped(
             session_epoch,
@@ -1783,6 +1821,151 @@ impl RealLs5000 {
             spacing_offset: Some(result.thumbnail.spacing_offset),
             needs_approval: result.thumbnail.needs_approval,
             warnings: result.thumbnail.warnings,
+        })
+    }
+
+    /// Re-slices the last completed preview attempt's already-decoded
+    /// raster at operator-picked boundary rows (BRIDGE.md
+    /// `roll.manualFrames`, additive 2026-08-07 -- Rung 4 of the feeding UX
+    /// ladder). Usable any time a preview attempt exists on disk --
+    /// including one that ended in `roll.previewError` -- so, unlike
+    /// `roll_approve`/`roll_set_spacing_offset` above, this deliberately
+    /// does NOT require an operator-reviewed "completed" preview binding
+    /// before it can run: the bridge's own `manual_frames()` re-arms a
+    /// usable session from whatever attempt is on disk and answers
+    /// `NO_PREVIEW` itself when none exists (BRIDGE.md: "no partial
+    /// acceptance" is about the placement's own validity, not about
+    /// requiring a prior success here). Not motion-capable: no film moves,
+    /// no transport read happens, nothing is re-fed.
+    ///
+    /// On success, this mints a fresh `operationId` and arms this backend's
+    /// own `preview_approval_state.completed` binding with it -- exactly as
+    /// a successful `roll.preview`'s `finalize_active_preview_terminal`
+    /// would have -- so the existing `roll.approve`/`roll.setSpacingOffset`/
+    /// manual-review-sheet flow keeps working completely unchanged on the
+    /// resulting frames. There is no client-supplied operation id to reuse
+    /// here (BRIDGE.md's `roll.manualFrames` has no such param), so the
+    /// engine mints one and reports it back via
+    /// `RollManualFramesResult.operationId` for the app to bind subsequent
+    /// calls to.
+    ///
+    /// 2026-08-08 adversarial review, S1 (part 4): whatever completed
+    /// binding this session currently holds is retired BEFORE the
+    /// `roll.manualFrames` request is even issued, and stays retired on any
+    /// failure below (nothing here ever restores it) -- only a full, clean
+    /// success re-arms a completed binding, with this call's own fresh
+    /// operationId and fingerprint. Without this, a stale approval for an
+    /// earlier completed preview/placement could still be honored by
+    /// `roll_approve` while a replacement placement is in flight or has
+    /// just failed, even though the UI has moved on to a different
+    /// operation entirely.
+    pub fn roll_manual_frames(
+        &self,
+        rows: Vec<u32>,
+    ) -> Result<crate::protocol::RollManualFramesResult, EngineError> {
+        let (session_epoch, bridge_generation) = self.active_session_identity()?;
+        self.clear_completed_preview_approval_for_epoch(session_epoch);
+        let value = self.call_session_scoped(
+            session_epoch,
+            bridge_generation,
+            "roll.manualFrames",
+            serde_json::to_value(BridgeManualFramesParams { rows })
+                .expect("BridgeManualFramesParams serializes"),
+        )?;
+        let result: BridgeManualFramesResult = serde_json::from_value(value).map_err(|error| {
+            EngineError::new(
+                ErrorCode::Internal,
+                format!("malformed roll.manualFrames result: {error}"),
+            )
+        })?;
+
+        // Reuses the existing per-preview token counter purely as a source
+        // of a fresh, monotonically unique integer -- `CompletedPreviewApproval`
+        // has no `token` field of its own to collide with, so this never
+        // interacts with `ActivePreviewApproval`/`PoisonedPreviewStream`'s
+        // own token matching.
+        let operation_suffix = self.next_preview_token.fetch_add(1, Ordering::AcqRel) + 1;
+        let operation_id = format!("manual-{operation_suffix}");
+
+        let mut thumbnails_by_slot: HashMap<u32, BridgeThumbnail> = HashMap::new();
+        let mut thumbnails = Vec::with_capacity(result.thumbnails.len());
+        for thumbnail in result.thumbnails {
+            thumbnails_by_slot.insert(thumbnail.slot, thumbnail.clone());
+            thumbnails.push(crate::protocol::ManualFrameThumbnail {
+                frame_index: thumbnail.slot,
+                thumbnail: crate::protocol::Thumbnail {
+                    brightness: None,
+                    tint: None,
+                    image_path: Some(thumbnail.image_path),
+                    boundary_rows: Some(thumbnail.boundary_rows),
+                    spacing_offset: Some(thumbnail.spacing_offset),
+                    needs_approval: thumbnail.needs_approval,
+                    warnings: thumbnail.warnings,
+                },
+            });
+        }
+
+        // Arm the SAME approval binding a successful preview's own
+        // `finalize_active_preview_terminal` would have -- only while this
+        // exact session is still current, mirroring that function's own
+        // defensive re-check immediately before it commits state.
+        if self.session_identity_is_current(session_epoch, bridge_generation) {
+            let mut state = self.preview_approval_state.lock().unwrap();
+            state.active = None;
+            state.completed = Some(CompletedPreviewApproval {
+                operation_id: operation_id.clone(),
+                session_epoch,
+                bridge_generation,
+                thumbnails: thumbnails_by_slot,
+                // S1 (part 4): this is the one binding source that DOES
+                // supply an expected fingerprint -- roll_approve threads it
+                // through to the bridge, which refuses the approval if the
+                // roll's fingerprint has since moved on.
+                fingerprint: Some(result.fingerprint.clone()),
+            });
+        }
+
+        Ok(crate::protocol::RollManualFramesResult {
+            count: result.count,
+            fingerprint: result.fingerprint,
+            operation_id,
+            thumbnails,
+            snaps: result
+                .snaps
+                .into_iter()
+                .map(|snap| crate::protocol::BoundarySnap {
+                    boundary_index: snap.boundary_index,
+                    requested_row: snap.requested_row,
+                    snapped_row: snap.snapped_row,
+                    evidence_run: snap.evidence_run,
+                })
+                .collect(),
+        })
+    }
+
+    /// Renders the last completed preview attempt's whole captured raster
+    /// to one image (BRIDGE.md `roll.previewStrip`, additive 2026-08-07).
+    /// Same precondition and non-motion-capable contract as
+    /// `roll_manual_frames` above; touches no session or approval state,
+    /// purely a read.
+    pub fn roll_preview_strip(&self) -> Result<crate::protocol::PreviewStripResult, EngineError> {
+        let (session_epoch, bridge_generation) = self.active_session_identity()?;
+        let value = self.call_session_scoped(
+            session_epoch,
+            bridge_generation,
+            "roll.previewStrip",
+            serde_json::json!({}),
+        )?;
+        let result: BridgePreviewStripResult = serde_json::from_value(value).map_err(|error| {
+            EngineError::new(
+                ErrorCode::Internal,
+                format!("malformed roll.previewStrip result: {error}"),
+            )
+        })?;
+        Ok(crate::protocol::PreviewStripResult {
+            image_path: result.image_path,
+            row_count: result.row_count,
+            pixels_per_row: result.pixels_per_row,
         })
     }
 }
@@ -2347,6 +2530,45 @@ impl ScannerBackend for RealLs5000 {
     ) -> Result<String, EngineError> {
         let (session_epoch, bridge_generation) = backend.active_session_identity()?;
         backend.ensure_preview_stream_allows_scan(session_epoch, bridge_generation)?;
+        // Adversarial review S3 (2026-08-08): when this exact session has a
+        // completed-preview binding (BRIDGE.md's own "slots must be a
+        // subset of the last preview's detected slots" is bridge-enforced,
+        // but the engine must not rely on the bridge alone to catch a
+        // "hidden slot" request), every requested frame must be one the
+        // binding's own completed preview actually returned -- otherwise a
+        // caller could request a frame the operator was never shown at all.
+        //
+        // Deliberately conditional on a binding actually existing, not an
+        // unconditional requirement: a preview whose thumbnail STREAM
+        // partially failed to decode (`dropped_count > 0` in
+        // `acquire_thumbnails`'s worker) still lets `scan.start` proceed
+        // today for the frames that DID decode, even though this backend's
+        // own `completed` binding is deliberately left unset for that
+        // narrow case (see `finalize_active_preview_terminal`'s caller).
+        // Falling through here for a `None` binding keeps that existing,
+        // already-shipped path byte-identical; the bridge's own subset
+        // check still applies to it exactly as before.
+        {
+            let binding = backend.preview_approval_state.lock().unwrap().completed.clone();
+            let binding_is_current_session = binding.as_ref().is_some_and(|binding| {
+                binding.session_epoch == session_epoch
+                    && binding.bridge_generation == bridge_generation
+            });
+            if binding_is_current_session {
+                let binding = binding.expect("checked by binding_is_current_session above");
+                if let Some(&missing_frame) = frames
+                    .iter()
+                    .find(|frame_index| !binding.thumbnails.contains_key(frame_index))
+                {
+                    return Err(EngineError::new(
+                        ErrorCode::InvalidParams,
+                        format!(
+                            "frame {missing_frame} was never returned by the completed preview and cannot be scanned"
+                        ),
+                    ));
+                }
+            }
+        }
         let processing = processing.effective();
         let recipe = recipe.effective_for_process(processing.film_process);
         // Device-sourced, model-agnostic (see

--- a/app/ScanStudio/engine/src/server.rs
+++ b/app/ScanStudio/engine/src/server.rs
@@ -319,10 +319,13 @@ impl Backends {
                 .as_ref()
                 .unwrap()
                 .roll_approve(frame_index, operation_id),
-            Some(ActiveDevice::Sim) => Err(EngineError::new(
-                ErrorCode::InvalidParams,
-                "roll.approve is available only for an active real-device preview; the simulator has no manual-review gate",
-            )),
+            // S7a (adversarial review, 2026-08-08): the simulator now has
+            // exactly one manual-review gate -- a frame its own last
+            // successful `manual_frames()` call returned, under that exact
+            // operationId (see `SimulatedLs5000::roll_approve`'s own doc
+            // comment). Every other case is refused with the same
+            // "no manual-review gate" message as before this change.
+            Some(ActiveDevice::Sim) => self.sim.roll_approve(frame_index, operation_id),
             None => Err(EngineError::new(
                 ErrorCode::NotConnected,
                 "scanner is not connected",
@@ -374,6 +377,39 @@ impl Backends {
                 ErrorCode::InvalidParams,
                 "roll.setSpacingOffset is available only for an active real-device preview",
             )),
+            None => Err(EngineError::new(
+                ErrorCode::NotConnected,
+                "scanner is not connected",
+            )),
+        }
+    }
+
+    /// `roll.manualFrames` (additive, 2026-08-07 -- Rung 4): unlike
+    /// `roll_approve`/`roll_set_spacing_offset`, this has sim parity rather
+    /// than a real-device-only refusal -- BRIDGE.md's contract requires no
+    /// prior successful preview (it works after a refused one too), so the
+    /// simulator can honestly answer it from a synthesized strip instead of
+    /// needing a real bridge-owned manual-review gate the way approval does.
+    fn roll_manual_frames(
+        &self,
+        rows: Vec<u32>,
+    ) -> Result<protocol::RollManualFramesResult, EngineError> {
+        match self.active {
+            Some(ActiveDevice::Sim) => self.sim.manual_frames(rows),
+            Some(ActiveDevice::Real) => self.real.as_ref().unwrap().roll_manual_frames(rows),
+            None => Err(EngineError::new(
+                ErrorCode::NotConnected,
+                "scanner is not connected",
+            )),
+        }
+    }
+
+    /// `roll.previewStrip` (additive, 2026-08-07 -- Rung 4): same sim-parity
+    /// reasoning as `roll_manual_frames` above.
+    fn roll_preview_strip(&self) -> Result<protocol::PreviewStripResult, EngineError> {
+        match self.active {
+            Some(ActiveDevice::Sim) => self.sim.preview_strip(),
+            Some(ActiveDevice::Real) => self.real.as_ref().unwrap().roll_preview_strip(),
             None => Err(EngineError::new(
                 ErrorCode::NotConnected,
                 "scanner is not connected",
@@ -802,6 +838,15 @@ fn handle_request(
                 &params.operation_id,
             )?;
             to_json(&protocol::RollSetSpacingOffsetResult { thumbnail })
+        }
+        "roll.manualFrames" => {
+            let params: protocol::RollManualFramesParams = parse_params(&request.params)?;
+            let result = backends.roll_manual_frames(params.rows)?;
+            to_json(&result)
+        }
+        "roll.previewStrip" => {
+            let result = backends.roll_preview_strip()?;
+            to_json(&result)
         }
         "scan.start" => {
             let mut params: protocol::ScanStartParams = parse_params(&request.params)?;
@@ -3835,5 +3880,134 @@ mod tests {
         assert_eq!(err.code, ErrorCode::InvalidParams);
 
         let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// Connects and loads a 36-frame roll on the simulator only -- shared
+    /// setup for the `roll.manualFrames`/`roll.previewStrip` dispatch tests
+    /// below, which need no project (both methods are project-independent).
+    fn connected_sim_backends_with_media() -> (Backends, mpsc::Sender<String>, ProjectState) {
+        let mut backends = Backends {
+            sim: Arc::new(SimulatedLs5000::new()),
+            real: None,
+            active: None,
+        };
+        let (tx, _rx) = mpsc::channel();
+        let mut project_state = ProjectState::default();
+
+        let connect_request = Request {
+            id: 1,
+            method: "scanner.connect".into(),
+            params: serde_json::json!({ "deviceId": "sim-ls5000-0" }),
+        };
+        handle_request(&mut backends, &tx, &connect_request, &mut project_state)
+            .expect("scanner.connect");
+
+        let load_media_request = Request {
+            id: 2,
+            method: "sim.loadMedia".into(),
+            params: serde_json::json!({ "carrier": "roll36" }),
+        };
+        handle_request(&mut backends, &tx, &load_media_request, &mut project_state)
+            .expect("sim.loadMedia");
+
+        (backends, tx, project_state)
+    }
+
+    #[test]
+    fn roll_preview_strip_returns_a_synthesized_image_through_dispatch() {
+        let (mut backends, tx, mut project_state) = connected_sim_backends_with_media();
+
+        let request = Request {
+            id: 3,
+            method: "roll.previewStrip".into(),
+            params: serde_json::Value::Null,
+        };
+        let result = handle_request(&mut backends, &tx, &request, &mut project_state)
+            .expect("roll.previewStrip");
+
+        assert_eq!(result["pixelsPerRow"], serde_json::json!(1));
+        let row_count = result["rowCount"].as_u64().expect("rowCount is a number");
+        assert!(row_count > 0, "a loaded 36-frame roll must report a positive rowCount");
+        let image_path = result["imagePath"].as_str().expect("imagePath is a string");
+        assert!(
+            std::path::Path::new(image_path).is_file(),
+            "roll.previewStrip must write a real, readable file: {image_path}"
+        );
+
+        let _ = std::fs::remove_file(image_path);
+    }
+
+    #[test]
+    fn roll_manual_frames_returns_needs_approval_thumbnails_through_dispatch() {
+        let (mut backends, tx, mut project_state) = connected_sim_backends_with_media();
+
+        let request = Request {
+            id: 3,
+            method: "roll.manualFrames".into(),
+            params: serde_json::json!({ "rows": [0, 135, 270] }),
+        };
+        let result = handle_request(&mut backends, &tx, &request, &mut project_state)
+            .expect("roll.manualFrames with structurally valid rows");
+
+        assert_eq!(result["count"], serde_json::json!(2));
+        assert!(result["operationId"].as_str().is_some_and(|s| !s.is_empty()));
+        let thumbnails = result["thumbnails"].as_array().expect("thumbnails array");
+        assert_eq!(thumbnails.len(), 2);
+        assert_eq!(thumbnails[0]["frameIndex"], serde_json::json!(1));
+        assert_eq!(thumbnails[0]["thumbnail"]["needsApproval"], serde_json::json!(true));
+        assert_eq!(
+            thumbnails[0]["thumbnail"]["warnings"],
+            serde_json::json!(["user-picked"])
+        );
+        // The simulator has no clear-film evidence signal to snap against;
+        // it must honestly report zero snaps rather than fabricate one.
+        assert_eq!(result["snaps"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn roll_manual_frames_rejects_too_few_rows_through_dispatch() {
+        let (mut backends, tx, mut project_state) = connected_sim_backends_with_media();
+
+        let request = Request {
+            id: 3,
+            method: "roll.manualFrames".into(),
+            params: serde_json::json!({ "rows": [42] }),
+        };
+        let err = handle_request(&mut backends, &tx, &request, &mut project_state).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(
+            err.message.contains("at least 2"),
+            "expected a plain-English explanation, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn roll_manual_frames_and_preview_strip_require_a_connection() {
+        let mut backends = Backends {
+            sim: Arc::new(SimulatedLs5000::new()),
+            real: None,
+            active: None,
+        };
+        let (tx, _rx) = mpsc::channel();
+        let mut project_state = ProjectState::default();
+
+        let manual_request = Request {
+            id: 1,
+            method: "roll.manualFrames".into(),
+            params: serde_json::json!({ "rows": [0, 200] }),
+        };
+        let err =
+            handle_request(&mut backends, &tx, &manual_request, &mut project_state).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NotConnected);
+
+        let strip_request = Request {
+            id: 2,
+            method: "roll.previewStrip".into(),
+            params: serde_json::Value::Null,
+        };
+        let err =
+            handle_request(&mut backends, &tx, &strip_request, &mut project_state).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NotConnected);
     }
 }

--- a/app/ScanStudio/engine/src/sim.rs
+++ b/app/ScanStudio/engine/src/sim.rs
@@ -20,9 +20,10 @@ use crate::domain::{
 };
 use crate::protocol::{
     ConnectOptions, ConnectResult, ErrorCode, ErrorPayload, Event, FaultInjection,
-    FrameCompletedPayload, FrameStatePayload, JobStatePayload, Lamp, ScanCompletedPayload,
-    ScanProgressPayload, ScanSummary, ScannerStatus, StopMode, Thumbnail, ThumbnailPayload,
-    ThumbnailsCompletePayload, Transport,
+    FrameCompletedPayload, FrameStatePayload, JobStatePayload, Lamp, ManualFrameThumbnail,
+    PreviewStripResult, RollManualFramesResult, ScanCompletedPayload, ScanProgressPayload,
+    ScanSummary, ScannerStatus, StopMode, Thumbnail, ThumbnailPayload, ThumbnailsCompletePayload,
+    Transport,
 };
 
 const DEVICE_ID: &str = "sim-ls5000-0";
@@ -60,6 +61,117 @@ pub fn thumbnail_for(device_id: &str, frame_index: u32) -> Thumbnail {
         needs_approval: false,
         warnings: vec![],
     }
+}
+
+// ---------------------------------------------------------------------
+// roll.manualFrames / roll.previewStrip sim parity (additive, 2026-08-07 --
+// Rung 4 of the feeding UX ladder). Unlike `roll.approve`/
+// `roll.setSpacingOffset` (real-device-only: the simulator has no
+// bridge-owned manual-review gate to arm), BRIDGE.md's contract for these
+// two methods requires no prior successful preview at all -- they work
+// after a refused one too -- so the simulator can honestly answer them
+// without needing that gate. Deliberately minimal: no clear-film evidence
+// signal exists in sim data, so snap assist is never simulated (an honest
+// empty `snaps`, never fabricated); the synthesized strip image exists only
+// so a manual-placement editor has *something* plausible to draw boundary
+// lines on, and is never claimed to be real film content.
+// ---------------------------------------------------------------------
+
+/// Rows-per-nominal-frame the simulator assumes when it has no real
+/// transport table to consult -- matches coolscanpy's own documented
+/// approximation (`manual_frames.py`: `MANUAL_FRAME_HEIGHT_MM_PER_ROW =
+/// 0.267`, so ~36mm / 0.267mm-per-row =~ 135 rows for a standard 35mm
+/// frame).
+const SIM_NOMINAL_FRAME_PITCH_ROWS: u32 = 135;
+/// Floor mirrors coolscanpy's `manual_frames.py`
+/// `MINIMUM_MANUAL_FRAME_HEIGHT_ROWS`/`MANUAL_FRAME_HEIGHT_MM_PER_ROW`
+/// verbatim -- a real, physical fact about film, deliberately wider than
+/// automatic detection's tolerance.
+const SIM_MINIMUM_MANUAL_FRAME_HEIGHT_ROWS: u32 = 56;
+/// Ceiling is tighter than `manual_frames.py`'s own (still 280 today) --
+/// adversarial review S7b (2026-08-08): 280 rows is not the scanner's real
+/// per-frame limit for something that must actually be fine-scanned
+/// afterward. The fixed single-pass fine capture window is
+/// `worker.py`'s `FINE_NATIVE_HEIGHT = 5_959` native pixels, which divided
+/// by this same driver's 40-45 native-units-per-row transport pitch lands
+/// at roughly 132-149 preview rows -- ~145 at the middle of that range.
+/// See `Sources/ScanStudioKit/ManualFramePlacementValidation.swift`'s own
+/// doc comment for the identical derivation and reasoning; this constant
+/// and that one must stay in lockstep so the simulator's own gate matches
+/// what the client-side editor already refuses to build.
+const SIM_MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS: u32 = 145;
+const SIM_MAXIMUM_MANUAL_FRAMES: usize = 40;
+const SIM_MANUAL_FRAME_HEIGHT_MM_PER_ROW: f64 = 0.267;
+/// Cross-strip axis of the synthesized preview strip image, in pixels.
+/// Arbitrary but fixed -- the simulator has no real frame width to derive
+/// this from.
+const SIM_STRIP_HEIGHT_PX: u32 = 96;
+/// Every `GAP_ROWS`-wide slice at the start of each nominal frame pitch
+/// renders as a brighter "clear film" band, purely so the synthesized strip
+/// has some visible structure to place boundaries against.
+const SIM_STRIP_GAP_ROWS: u32 = 10;
+
+/// The coordinate space every `roll.manualFrames`/`roll.previewStrip` row
+/// is validated/rendered against: `frame_count` nominal frames end to end,
+/// each `SIM_NOMINAL_FRAME_PITCH_ROWS` rows tall. Shared by both methods so
+/// a row `roll.previewStrip` reports as in-bounds is the exact same row
+/// `roll.manualFrames` will accept.
+fn sim_strip_row_count(frame_count: Option<u32>) -> u32 {
+    frame_count.unwrap_or(1).max(1) * SIM_NOMINAL_FRAME_PITCH_ROWS
+}
+
+fn sim_manual_frame_ordinal(index: usize) -> String {
+    format!("frame {}", index + 1)
+}
+
+/// Writes a small synthesized "whole roll" preview strip image for
+/// `roll.previewStrip`'s sim parity. The transport/row axis is the image's
+/// WIDTH axis, exactly like a real bridge-rendered strip (BRIDGE.md
+/// `PreviewStrip.imagePath`'s own doc note: "the raster's row axis... is
+/// the image's WIDTH axis, not its height, exactly like every existing
+/// `Thumbnail` crop already is") -- getting this backwards would silently
+/// break every row<->pixel calculation a manual-placement editor makes.
+/// Alternating bands are driven by the same `thumbnail_for` hash already
+/// used for simulated thumbnails, purely so the strip has *some* visible
+/// structure; this never claims to be real film content.
+fn synthesize_preview_strip(
+    device_id: &str,
+    row_count: u32,
+) -> Result<std::path::PathBuf, EngineError> {
+    let width = row_count.max(1);
+    let image = image::RgbImage::from_fn(width, SIM_STRIP_HEIGHT_PX, |x, _y| {
+        let cycle = x % SIM_NOMINAL_FRAME_PITCH_ROWS;
+        if cycle < SIM_STRIP_GAP_ROWS {
+            image::Rgb([228, 228, 228])
+        } else {
+            let nominal_frame = x / SIM_NOMINAL_FRAME_PITCH_ROWS + 1;
+            let h = fnv1a64(&format!("{device_id}:strip:{nominal_frame}"));
+            let gray = (80 + (h >> 8) % 120) as u8;
+            image::Rgb([gray, gray, gray])
+        }
+    });
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let dir = std::env::temp_dir()
+        .join("scanstudio-sim-previews")
+        .join(format!("strip-{nanos:x}"));
+    std::fs::create_dir_all(&dir).map_err(|err| {
+        EngineError::new(
+            ErrorCode::Internal,
+            format!("failed to create simulator preview strip directory: {err}"),
+        )
+    })?;
+    let path = dir.join("strip.png");
+    image.save(&path).map_err(|err| {
+        EngineError::new(
+            ErrorCode::Internal,
+            format!("failed to write simulator preview strip image: {err}"),
+        )
+    })?;
+    Ok(path)
 }
 
 /// Lowercase 16-hex-char FNV-1a 64 of
@@ -139,6 +251,17 @@ fn is_job_terminal(state: JobState) -> bool {
     )
 }
 
+/// The most recent successful `manual_frames()` call's operator-approval
+/// binding (adversarial review S7a, 2026-08-08). The simulator otherwise
+/// has no manual-review gate at all; this exists solely so a simulated
+/// manual placement -- which always arrives `needsApproval: true` -- is
+/// not a permanent dead end with nothing that could ever clear it.
+#[derive(Debug, Clone)]
+struct ManualApprovalBinding {
+    operation_id: String,
+    frame_indices: HashSet<u32>,
+}
+
 struct State {
     connected: bool,
     adapter: Option<String>,
@@ -152,6 +275,7 @@ struct State {
     fault_injection: FaultInjection,
     job_seq: u64,
     thumbnail_operation_active: bool,
+    manual_approval_binding: Option<ManualApprovalBinding>,
 }
 
 impl Default for State {
@@ -169,6 +293,7 @@ impl Default for State {
             fault_injection: FaultInjection::NoFault,
             job_seq: 0,
             thumbnail_operation_active: false,
+            manual_approval_binding: None,
         }
     }
 }
@@ -265,6 +390,201 @@ impl SimulatedLs5000 {
             )),
         }
     }
+
+    /// `roll.previewStrip` sim parity (additive, 2026-08-07). Renders a
+    /// synthesized whole-roll strip sized from the loaded carrier's frame
+    /// count, purely so a manual-placement editor has something to draw on
+    /// without a real bridge attached. Not part of `ScannerBackend`: like
+    /// `roll_approve`/`roll_set_spacing_offset`, this is dispatched
+    /// directly from `Backends` rather than through the trait.
+    pub fn preview_strip(&self) -> Result<PreviewStripResult, EngineError> {
+        let (device_id, frame_count) = {
+            let state = self.state.lock().unwrap();
+            if !state.connected {
+                return Err(EngineError::new(
+                    ErrorCode::NotConnected,
+                    "scanner is not connected",
+                ));
+            }
+            if !state.media_loaded {
+                return Err(EngineError::new(ErrorCode::NoMedia, "no media is loaded"));
+            }
+            if transport_is_busy(&state) {
+                return Err(EngineError::new(
+                    ErrorCode::ScannerBusy,
+                    "a scanner transport operation is active",
+                ));
+            }
+            (self.device.device_id.clone(), state.frame_count)
+        };
+        let row_count = sim_strip_row_count(frame_count);
+        let path = synthesize_preview_strip(&device_id, row_count)?;
+        Ok(PreviewStripResult {
+            image_path: path.display().to_string(),
+            row_count,
+            pixels_per_row: 1,
+        })
+    }
+
+    /// `roll.manualFrames` sim parity (additive, 2026-08-07). Validates the
+    /// same structural and frame-height gates coolscanpy's
+    /// `manual_frames.py` enforces server-side (count, strictly increasing,
+    /// in-raster, frame count, 15-75mm height); deliberately does NOT
+    /// attempt the snap-assist or same-traversal transport-table sanity
+    /// gates, since the simulator has no clear-film evidence signal or real
+    /// transport table to check either against -- an honest `snaps: []`
+    /// rather than a fabricated one. Deterministic per-frame thumbnails
+    /// reuse `thumbnail_for`, exactly like a normal `acquire_thumbnails`
+    /// tile, with `needsApproval`/`warnings` overridden to match BRIDGE.md's
+    /// "every resulting slot arrives `needsApproval: true` with a
+    /// `\"user-picked\"` warning" contract.
+    pub fn manual_frames(&self, rows: Vec<u32>) -> Result<RollManualFramesResult, EngineError> {
+        let (device_id, frame_count_hint) = {
+            let state = self.state.lock().unwrap();
+            if !state.connected {
+                return Err(EngineError::new(
+                    ErrorCode::NotConnected,
+                    "scanner is not connected",
+                ));
+            }
+            if !state.media_loaded {
+                return Err(EngineError::new(ErrorCode::NoMedia, "no media is loaded"));
+            }
+            if transport_is_busy(&state) {
+                return Err(EngineError::new(
+                    ErrorCode::ScannerBusy,
+                    "a scanner transport operation is active",
+                ));
+            }
+            (self.device.device_id.clone(), state.frame_count)
+        };
+        let row_count = sim_strip_row_count(frame_count_hint);
+
+        if rows.len() < 2 {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                format!(
+                    "manual frame placement needs at least 2 boundary rows (1 frame); only {} were given",
+                    rows.len()
+                ),
+            ));
+        }
+        if rows.windows(2).any(|pair| pair[0] >= pair[1]) {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                "frame boundary rows must be placed in strictly increasing order, top to bottom of the preview",
+            ));
+        }
+        if rows.iter().any(|&row| row >= row_count) {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                format!(
+                    "every boundary row must lie inside the captured preview (0..{}); a boundary was placed outside it",
+                    row_count.saturating_sub(1)
+                ),
+            ));
+        }
+        let frame_count = rows.len() - 1;
+        if frame_count > SIM_MAXIMUM_MANUAL_FRAMES {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                format!(
+                    "manual placement supports at most {SIM_MAXIMUM_MANUAL_FRAMES} frames; {} boundary rows would create {frame_count}",
+                    rows.len()
+                ),
+            ));
+        }
+        for (index, pair) in rows.windows(2).enumerate() {
+            let height_rows = pair[1] - pair[0];
+            if height_rows < SIM_MINIMUM_MANUAL_FRAME_HEIGHT_ROWS
+                || height_rows > SIM_MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS
+            {
+                let approx_mm = f64::from(height_rows) * SIM_MANUAL_FRAME_HEIGHT_MM_PER_ROW;
+                let ceiling_mm = f64::from(SIM_MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS)
+                    * SIM_MANUAL_FRAME_HEIGHT_MM_PER_ROW;
+                let reason = if height_rows < SIM_MINIMUM_MANUAL_FRAME_HEIGHT_ROWS {
+                    "real frames are at least 15 mm".to_string()
+                } else {
+                    format!("the scanner captures about {ceiling_mm:.0} mm per frame")
+                };
+                return Err(EngineError::new(
+                    ErrorCode::InvalidParams,
+                    format!(
+                        "the {} you placed is about {approx_mm:.0} mm tall (between rows {} and {}) -- {reason}",
+                        sim_manual_frame_ordinal(index),
+                        pair[0],
+                        pair[1]
+                    ),
+                ));
+            }
+        }
+
+        let thumbnails: Vec<ManualFrameThumbnail> = (1..=frame_count as u32)
+            .map(|frame_index| {
+                let mut thumbnail = thumbnail_for(&device_id, frame_index);
+                thumbnail.needs_approval = true;
+                thumbnail.warnings = vec!["user-picked".to_string()];
+                ManualFrameThumbnail {
+                    frame_index,
+                    thumbnail,
+                }
+            })
+            .collect();
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let operation_id = format!("manual-sim-{nanos:x}");
+        let fingerprint = format!("{:016x}", fnv1a64(&format!("{device_id}:manual:{rows:?}")));
+
+        // Arm the sim-side approval binding (S7a) only after every gate
+        // above has passed -- a refused placement must never leave a
+        // binding an operator could later approve against.
+        self.state.lock().unwrap().manual_approval_binding = Some(ManualApprovalBinding {
+            operation_id: operation_id.clone(),
+            frame_indices: (1..=frame_count as u32).collect(),
+        });
+
+        Ok(RollManualFramesResult {
+            count: frame_count as u32,
+            fingerprint,
+            operation_id,
+            thumbnails,
+            // The simulator has no clear-film evidence signal to snap
+            // against (see `synthesize_preview_strip`'s own doc comment) --
+            // it never fabricates a snap; every real snap comes only from a
+            // real bridge.
+            snaps: vec![],
+        })
+    }
+
+    /// `roll.approve` sim parity for manually-placed frames (adversarial
+    /// review S7a, 2026-08-08). The simulator otherwise has NO
+    /// manual-review gate -- every other case is refused with the same
+    /// message as before this change. Only a frame this backend's own
+    /// last successful `manual_frames()` call actually returned, under
+    /// that exact `operation_id`, can be approved; the binding is cleared
+    /// on connect/disconnect/load_media/eject so a stale approval can
+    /// never survive a session or media change (mirrors the S2 fix's own
+    /// "never let frame-indexed state silently outlive the placement that
+    /// produced it" principle). Not part of `ScannerBackend`: dispatched
+    /// directly from `Backends::roll_approve`, exactly like every other
+    /// roll.* method that is real-only or sim-only.
+    pub fn roll_approve(&self, frame_index: u32, operation_id: &str) -> Result<(), EngineError> {
+        let state = self.state.lock().unwrap();
+        let approvable = state.manual_approval_binding.as_ref().is_some_and(|binding| {
+            binding.operation_id == operation_id && binding.frame_indices.contains(&frame_index)
+        });
+        if approvable {
+            return Ok(());
+        }
+        Err(EngineError::new(
+            ErrorCode::InvalidParams,
+            "roll.approve is available on the simulator only for a frame returned by this \
+             session's own manual frame placement; the simulator has no other manual-review gate",
+        ))
+    }
 }
 
 impl Default for SimulatedLs5000 {
@@ -302,6 +622,10 @@ impl ScannerBackend for SimulatedLs5000 {
         state.lamp = Lamp::Stable;
         state.transport = Transport::Idle;
         state.job_slot = None;
+        // A fresh session starts with no manual-placement approval binding
+        // (S7a/S2 principle): a stale one from an earlier connection must
+        // never carry over.
+        state.manual_approval_binding = None;
         state.time_scale = if options.time_scale > 0.0 {
             options.time_scale
         } else {
@@ -338,6 +662,7 @@ impl ScannerBackend for SimulatedLs5000 {
         state.frame_count = None;
         state.lamp = Lamp::Off;
         state.transport = Transport::Idle;
+        state.manual_approval_binding = None;
         Ok(status_snapshot(&state))
     }
 
@@ -375,6 +700,9 @@ impl ScannerBackend for SimulatedLs5000 {
         state.carrier = Some(carrier);
         state.frame_count = Some(frame_count);
         state.adapter = Some(adapter.to_string());
+        // Newly loaded media invalidates any manual placement made against
+        // whatever was loaded before.
+        state.manual_approval_binding = None;
         Ok(status_snapshot(&state))
     }
 
@@ -406,6 +734,7 @@ impl ScannerBackend for SimulatedLs5000 {
         state.carrier = None;
         state.frame_count = None;
         state.adapter = None;
+        state.manual_approval_binding = None;
         Ok(status_snapshot(&state))
     }
 
@@ -2200,5 +2529,299 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&project_dir);
         let _ = std::fs::remove_dir_all(&output_dir);
+    }
+
+    // -- roll.previewStrip / roll.manualFrames sim parity (Rung 4) ---------
+
+    #[test]
+    fn preview_strip_reports_row_count_from_loaded_frame_count_and_writes_a_real_file() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let strip = sim.preview_strip().expect("preview_strip");
+        assert_eq!(strip.row_count, 36 * SIM_NOMINAL_FRAME_PITCH_ROWS);
+        assert_eq!(strip.pixels_per_row, 1);
+        let metadata = std::fs::metadata(&strip.image_path)
+            .unwrap_or_else(|err| panic!("preview strip file must exist: {err}"));
+        assert!(metadata.len() > 0, "preview strip file must not be empty");
+
+        let _ = std::fs::remove_file(&strip.image_path);
+    }
+
+    #[test]
+    fn preview_strip_two_calls_write_two_distinct_files() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Strip6).expect("load media");
+
+        let first = sim.preview_strip().expect("first preview_strip");
+        let second = sim.preview_strip().expect("second preview_strip");
+        assert_ne!(
+            first.image_path, second.image_path,
+            "every preview_strip call must write a fresh file so no image cache reuses a stale one"
+        );
+
+        let _ = std::fs::remove_file(&first.image_path);
+        let _ = std::fs::remove_file(&second.image_path);
+    }
+
+    #[test]
+    fn preview_strip_requires_connection() {
+        let sim = SimulatedLs5000::new();
+        let err = sim.preview_strip().unwrap_err();
+        assert_eq!(err.code, ErrorCode::NotConnected);
+    }
+
+    #[test]
+    fn preview_strip_requires_loaded_media() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        let err = sim.preview_strip().unwrap_err();
+        assert_eq!(err.code, ErrorCode::NoMedia);
+    }
+
+    #[test]
+    fn manual_frames_accepts_valid_rows_and_marks_every_slot_user_picked() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let result = sim
+            .manual_frames(vec![0, 135, 270])
+            .expect("structurally valid rows");
+        assert_eq!(result.count, 2);
+        assert!(!result.operation_id.is_empty());
+        assert!(!result.fingerprint.is_empty());
+        assert_eq!(result.thumbnails.len(), 2);
+        assert_eq!(result.thumbnails[0].frame_index, 1);
+        assert_eq!(result.thumbnails[1].frame_index, 2);
+        for entry in &result.thumbnails {
+            assert!(entry.thumbnail.needs_approval);
+            assert_eq!(entry.thumbnail.warnings, vec!["user-picked".to_string()]);
+            // Simulator thumbnails stay simulator-shaped (brightness/tint,
+            // never imagePath) -- the same one-of contract every other
+            // simulated thumbnail already honors.
+            assert!(entry.thumbnail.brightness.is_some());
+            assert!(entry.thumbnail.image_path.is_none());
+        }
+        assert!(
+            result.snaps.is_empty(),
+            "the simulator must never fabricate a snap"
+        );
+    }
+
+    #[test]
+    fn manual_frames_two_calls_return_stable_deterministic_thumbnails() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let first = sim.manual_frames(vec![0, 135, 270]).expect("first call");
+        let second = sim.manual_frames(vec![0, 135, 270]).expect("second call");
+        assert_eq!(
+            first.thumbnails[0].thumbnail.brightness,
+            second.thumbnails[0].thumbnail.brightness,
+            "D-08/SIM-03 determinism: identical rows must hash to identical simulated tiles"
+        );
+        assert_ne!(
+            first.operation_id, second.operation_id,
+            "each placement arms its own fresh approval binding"
+        );
+    }
+
+    #[test]
+    fn manual_frames_rejects_fewer_than_two_rows() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let err = sim.manual_frames(vec![100]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("at least 2"));
+    }
+
+    #[test]
+    fn manual_frames_rejects_non_increasing_rows() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let err = sim.manual_frames(vec![200, 100, 400]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("strictly increasing"));
+    }
+
+    #[test]
+    fn manual_frames_rejects_a_row_outside_the_raster() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Mounted).expect("load media");
+
+        let row_count = sim_strip_row_count(Some(1));
+        let err = sim.manual_frames(vec![0, row_count + 50]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("lie inside the captured preview"));
+    }
+
+    #[test]
+    fn manual_frames_rejects_a_frame_shorter_than_the_15mm_floor() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        // 10 rows =~ 2.7 mm, well under the 15 mm floor.
+        let err = sim.manual_frames(vec![0, 10]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("real frames are at least 15 mm"));
+    }
+
+    /// S7b (adversarial review round 2, 2026-08-08): the ceiling is now the
+    /// scanner's fine-scan capture window (145 rows), tighter than
+    /// `manual_frames.py`'s own still-280-row gate -- proves the sim
+    /// refuses a frame between the two with the hardware-framed message,
+    /// not the old "real frames are at most 75 mm" film-framed one.
+    #[test]
+    fn manual_frames_rejects_a_frame_taller_than_the_scanner_capture_window() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        // 200 rows =~ 53.4 mm: comfortably a real film frame height, but
+        // past the 145-row capture-window ceiling.
+        let err = sim.manual_frames(vec![0, 200]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("the scanner captures about"));
+        assert!(!err.message.contains("real frames are at most"));
+    }
+
+    #[test]
+    fn manual_frames_accepts_exactly_at_the_145_row_capture_window_ceiling() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        sim.manual_frames(vec![0, SIM_MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS])
+            .expect("exactly at the ceiling must still be accepted");
+        let err = sim
+            .manual_frames(vec![0, SIM_MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS + 1])
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn manual_frames_requires_connection() {
+        let sim = SimulatedLs5000::new();
+        let err = sim.manual_frames(vec![0, 200]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NotConnected);
+    }
+
+    #[test]
+    fn manual_frames_requires_loaded_media() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        let err = sim.manual_frames(vec![0, 200]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NoMedia);
+    }
+
+    // -- S7a (adversarial review round 2, 2026-08-08): sim manual-approval --
+    // -- binding, so a simulated manual placement is not a dead end --------
+
+    #[test]
+    fn a_manually_placed_frame_is_approvable_through_sim_roll_approve() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let result = sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
+        sim.roll_approve(1, &result.operation_id)
+            .expect("a frame this placement returned must be approvable");
+        sim.roll_approve(2, &result.operation_id)
+            .expect("every returned frame is individually approvable");
+    }
+
+    #[test]
+    fn sim_roll_approve_still_refuses_every_non_manual_case_unchanged() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        // No manual_frames() call was ever made this session -- the
+        // simulator's pre-existing "no manual-review gate" refusal must be
+        // completely unchanged.
+        let err = sim.roll_approve(1, "some-operation-id").unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("no other manual-review gate"));
+    }
+
+    #[test]
+    fn sim_roll_approve_rejects_a_frame_outside_the_manual_binding() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let result = sim.manual_frames(vec![0, 135, 270]).expect("2-frame placement");
+        let err = sim.roll_approve(99, &result.operation_id).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn sim_roll_approve_rejects_a_mismatched_operation_id() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
+        let err = sim.roll_approve(1, "not-the-real-operation-id").unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn sim_manual_approval_binding_does_not_survive_a_fresh_load_media() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+        let result = sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
+
+        // A different carrier loaded afterward invalidates the old binding
+        // (S2's own "stale frame-indexed state must never survive a
+        // materially different registration" principle, applied here to
+        // the simulator's session-scoped approval binding).
+        sim.load_media(MediaCarrier::Strip6).expect("reload media");
+        let err = sim.roll_approve(1, &result.operation_id).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn sim_manual_approval_binding_does_not_survive_reconnect() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+        let result = sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
+
+        sim.disconnect().expect("disconnect");
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("reconnect");
+        sim.load_media(MediaCarrier::Roll36).expect("reload media");
+        let err = sim.roll_approve(1, &result.operation_id).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
     }
 }

--- a/app/ScanStudio/engine/tests/end_to_end_real_backend.rs
+++ b/app/ScanStudio/engine/tests/end_to_end_real_backend.rs
@@ -349,7 +349,16 @@ fn roll_approve_for_previewed_real_frame_forwards_one_non_motion_bridge_call() {
     let log_path_string = log_path.display().to_string();
     let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
         "e2e-roll-approve",
-        &[("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str())],
+        &[
+            ("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str()),
+            // Adversarial review S3 (2026-08-08): roll_approve now requires
+            // the approved frame to be one the completed preview flagged
+            // `needsApproval: true` -- mark frame 2 (the one this test
+            // approves) so this test keeps exercising its own actual
+            // subject (one clean, unpolled bridge call) rather than
+            // tripping the new gate.
+            ("MOCK_BRIDGE_PREVIEW_APPROVAL_SLOTS", "2"),
+        ],
     );
 
     send(
@@ -945,7 +954,14 @@ fn roll_approve_rejects_an_operation_stale_after_a_newer_preview_without_bridge_
     let log_path_string = log_path.display().to_string();
     let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
         "e2e-roll-approve-stale-preview",
-        &[("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str())],
+        &[
+            ("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str()),
+            // Adversarial review S3 (2026-08-08): flag frame 1 in both
+            // previews so this test's real subject (stale vs. current
+            // operationId) is what decides the outcome, not the new
+            // needsApproval gate.
+            ("MOCK_BRIDGE_PREVIEW_APPROVAL_SLOTS", "1"),
+        ],
     );
 
     for (id, operation_id) in [(3, "first-preview"), (4, "second-preview")] {
@@ -1211,6 +1227,11 @@ fn roll_approve_session_loss_is_not_retried_and_requires_reconnect() {
         &[
             ("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str()),
             ("MOCK_BRIDGE_CRASH_ON", "roll.approve"),
+            // Adversarial review S3 (2026-08-08): flag frame 1 so the
+            // approve request reaches the bridge (and hits the crash
+            // injection this test is actually about) instead of being
+            // refused earlier by the new needsApproval gate.
+            ("MOCK_BRIDGE_PREVIEW_APPROVAL_SLOTS", "1"),
         ],
     );
 
@@ -3942,4 +3963,409 @@ fn scan_progress_ordinal_tracks_completions_not_the_upfront_burst() {
     let status = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
     assert!(status.success(), "engine did not exit 0: {status:?}");
     let _ = reader_handle.join();
+}
+
+// -- roll.manualFrames / roll.previewStrip (Rung 4 of the feeding UX ladder) ----
+
+/// End-to-end proof of the whole point of `RealLs5000::roll_manual_frames`'s
+/// approval-binding logic: `roll.manualFrames` never went through
+/// `roll.preview`'s own async worker (so `finalize_active_preview_terminal`
+/// never ran), yet the frame it returns must still be approvable through
+/// the exact same `roll.approve` path a normal preview's flagged frame
+/// uses -- using the `operationId` THIS response minted, not one the app
+/// supplied. Mirrors the Python bridge's own
+/// `test_roll_manual_frames_dispatch_routes_rows_and_rearms_scan_gate`.
+#[test]
+fn roll_manual_frames_arms_a_session_whose_frame_is_approvable() {
+    let (mut child, mut stdin, rx, reader_handle) =
+        spawn_connected_engine_with_bridge_env("e2e-manual-frames-approve", &[]);
+
+    send(
+        &mut stdin,
+        3,
+        "roll.manualFrames",
+        json!({"rows": [100, 300, 500]}),
+    );
+    let manual = recv_response_for(&rx, 3, |_| {});
+    assert!(
+        manual.get("error").is_none(),
+        "a structurally valid manual placement must be accepted: {manual:#?}"
+    );
+    assert_eq!(manual["result"]["count"], json!(2));
+    assert_eq!(manual["result"]["fingerprint"], json!("mock-manual-fp"));
+    let operation_id = manual["result"]["operationId"]
+        .as_str()
+        .expect("roll.manualFrames must mint an operationId")
+        .to_string();
+    assert!(!operation_id.is_empty());
+
+    let thumbnails = manual["result"]["thumbnails"]
+        .as_array()
+        .expect("thumbnails array");
+    assert_eq!(thumbnails.len(), 2);
+    assert_eq!(thumbnails[0]["frameIndex"], json!(1));
+    assert_eq!(thumbnails[0]["thumbnail"]["boundaryRows"], json!([100, 300]));
+    assert_eq!(thumbnails[0]["thumbnail"]["needsApproval"], json!(true));
+    assert_eq!(
+        thumbnails[0]["thumbnail"]["warnings"],
+        json!(["user-picked"])
+    );
+    assert_eq!(manual["result"]["snaps"], json!([]));
+
+    // The real proof: roll.approve works on this frame using the
+    // engine-minted operationId, even though roll.preview was never called
+    // this session.
+    send(
+        &mut stdin,
+        4,
+        "roll.approve",
+        json!({"frameIndex": 1, "operationId": operation_id}),
+    );
+    let approval = recv_response_for(&rx, 4, |_| {});
+    assert!(
+        approval.get("error").is_none(),
+        "the frame roll.manualFrames returned must be approvable with its own operationId: {approval:#?}"
+    );
+
+    send(&mut stdin, 5, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 5, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}
+
+/// `roll.approve` must still refuse a stale/mismatched operationId after a
+/// manual placement -- the new binding logic must not accidentally become
+/// permissive of any string.
+#[test]
+fn roll_manual_frames_frame_rejects_approval_with_a_foreign_operation_id() {
+    let (mut child, mut stdin, rx, reader_handle) =
+        spawn_connected_engine_with_bridge_env("e2e-manual-frames-wrong-op-id", &[]);
+
+    send(
+        &mut stdin,
+        3,
+        "roll.manualFrames",
+        json!({"rows": [100, 300, 500]}),
+    );
+    let manual = recv_response_for(&rx, 3, |_| {});
+    assert!(manual.get("error").is_none(), "{manual:#?}");
+
+    send(
+        &mut stdin,
+        4,
+        "roll.approve",
+        json!({"frameIndex": 1, "operationId": "not-the-real-operation-id"}),
+    );
+    let approval = recv_response_for(&rx, 4, |_| {});
+    assert!(
+        approval.get("error").is_some(),
+        "a foreign operationId must never be accepted: {approval:#?}"
+    );
+    assert_eq!(approval["error"]["code"], json!("INVALID_PARAMS"));
+
+    send(&mut stdin, 5, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 5, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}
+
+/// 2026-08-08 adversarial review, S1 (part 4): a completed preview binding
+/// must be retired the moment a `roll.manualFrames` request is issued, and
+/// stay retired if that request fails -- never left honorable against a
+/// replacement session that never actually arrived. Without this, an old
+/// approval (still shown by a UI that has not yet learned the replacement
+/// placement failed) could be submitted while the driver's Roll session
+/// itself has already moved on.
+#[test]
+fn roll_manual_frames_retires_the_prior_completed_binding_before_and_on_failure() {
+    let log_directory = unique_output_destination("roll-manual-frames-retires-binding");
+    let log_path = log_directory.join("bridge-calls.log");
+    std::fs::write(&log_path, "").expect("create mock bridge call log");
+    let log_path_string = log_path.display().to_string();
+    let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
+        "e2e-manual-frames-retires-binding",
+        &[
+            ("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str()),
+            (
+                "MOCK_BRIDGE_MANUAL_FRAMES_ERROR",
+                "manual placement rejected for this test",
+            ),
+        ],
+    );
+
+    // Establish a completed binding ("binding-a") via a normal preview --
+    // the exact "placement/preview A completed" half of the S1 scenario.
+    send(
+        &mut stdin,
+        3,
+        "scanner.acquireThumbnails",
+        json!({"frames": [1, 2, 3], "operationId": "binding-a"}),
+    );
+    assert!(recv_response_for(&rx, 3, |_| {}).get("error").is_none());
+    let _ = drain_until(&rx, Duration::from_secs(5), |event| {
+        event["event"] == "scanner.status" && event["payload"]["operationId"] == "binding-a"
+    });
+    std::fs::write(&log_path, "").expect("reset mock bridge call log");
+
+    // A replacement manual placement is attempted and fails (mock bridge
+    // configured to reject every roll.manualFrames call).
+    send(
+        &mut stdin,
+        4,
+        "roll.manualFrames",
+        json!({"rows": [100, 300, 500]}),
+    );
+    let manual = recv_response_for(&rx, 4, |_| {});
+    assert!(
+        manual.get("error").is_some(),
+        "expected the mock bridge's configured manual-frames rejection: {manual:#?}"
+    );
+    assert_eq!(
+        read_mock_bridge_calls(&log_path),
+        vec!["roll.manualFrames"],
+        "the failed placement must still have reached the bridge exactly once"
+    );
+
+    // Binding A must no longer be approvable: it was retired BEFORE the
+    // (failing) roll.manualFrames request was even issued, and the failure
+    // never restored it. This must be refused client-side, before any
+    // bridge call -- the log below must show nothing new.
+    send(
+        &mut stdin,
+        5,
+        "roll.approve",
+        json!({"frameIndex": 1, "operationId": "binding-a"}),
+    );
+    let approval = recv_response_for(&rx, 5, |_| {});
+    let error = approval
+        .get("error")
+        .expect("binding A must stay retired after a failed replacement placement");
+    assert_eq!(error["code"], json!("INVALID_PARAMS"));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("does not match")),
+        "{error:#?}"
+    );
+    assert_eq!(
+        read_mock_bridge_calls(&log_path),
+        vec!["roll.manualFrames"],
+        "a retired binding must be refused before any roll.approve bridge call"
+    );
+
+    send(&mut stdin, 6, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 6, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+    let _ = std::fs::remove_dir_all(log_directory);
+}
+
+/// `roll.previewStrip` returns the wire shape a manual-placement editor
+/// needs to seed itself: a loadable path plus the row<->pixel coordinate
+/// space `roll.manualFrames`'s own `rows` are given in.
+#[test]
+fn roll_preview_strip_returns_the_wire_shape() {
+    let (mut child, mut stdin, rx, reader_handle) =
+        spawn_connected_engine_with_bridge_env("e2e-preview-strip", &[]);
+
+    send(&mut stdin, 3, "roll.previewStrip", json!({}));
+    let strip = recv_response_for(&rx, 3, |_| {});
+    assert!(strip.get("error").is_none(), "{strip:#?}");
+    assert_eq!(strip["result"]["rowCount"], json!(4800));
+    assert_eq!(strip["result"]["pixelsPerRow"], json!(1));
+    let image_path = strip["result"]["imagePath"]
+        .as_str()
+        .expect("imagePath is a string");
+    assert!(!image_path.is_empty());
+
+    send(&mut stdin, 4, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 4, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}
+
+/// The bridge's own plain-English `INVALID_PARAMS` text (manual_frames.py's
+/// gates) must survive into the public engine error unmodified, the same
+/// "never reshape a validation message" contract `roll.setSpacingOffset`
+/// and every other bridge-rejection path already honors.
+#[test]
+fn roll_manual_frames_propagates_invalid_params_message_unmodified() {
+    let sentence = "the 1st frame you placed is about 8 mm tall (between rows 10 and 40), \
+        outside the 15-75 mm range this driver accepts for manual placement";
+    let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
+        "e2e-manual-frames-invalid-params",
+        &[("MOCK_BRIDGE_MANUAL_FRAMES_ERROR", sentence)],
+    );
+
+    send(&mut stdin, 3, "roll.manualFrames", json!({"rows": [10, 40]}));
+    let manual = recv_response_for(&rx, 3, |_| {});
+    let error = manual.get("error").expect("expected a rejected placement");
+    assert_eq!(error["code"], json!("INVALID_PARAMS"));
+    let message = error["message"].as_str().expect("message is a string");
+    assert!(
+        message.contains(sentence),
+        "expected the exact bridge sentence to survive unmodified, got: {message}"
+    );
+
+    send(&mut stdin, 4, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 4, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}
+
+// -- Adversarial review round 2 (2026-08-08): S3, approval/scan constrained --
+// -- to frames actually shown by the completed preview ----------------------
+
+/// S3: matching operationId/session identity alone must not be enough to
+/// approve an arbitrary frame index -- the frame must be one the completed
+/// preview actually returned AND actually flagged `needsApproval: true`.
+/// Frame 2 here is previewed (so it exists) but never flagged, proving both
+/// halves of the gate: existence in the binding is not sufficient on its
+/// own either.
+#[test]
+fn roll_approve_rejects_a_frame_the_completed_preview_never_flagged() {
+    let log_directory = unique_output_destination("roll-approve-unflagged-frame");
+    let log_path = log_directory.join("bridge-calls.log");
+    std::fs::write(&log_path, "").expect("create mock bridge call log");
+    let log_path_string = log_path.display().to_string();
+    // Deliberately no MOCK_BRIDGE_PREVIEW_APPROVAL_SLOTS: every previewed
+    // frame comes back needsApproval: false.
+    let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
+        "e2e-roll-approve-unflagged",
+        &[("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str())],
+    );
+
+    send(
+        &mut stdin,
+        3,
+        "scanner.acquireThumbnails",
+        json!({"frames": [1, 2, 3], "operationId": "unflagged-preview"}),
+    );
+    assert!(recv_response_for(&rx, 3, |_| {}).get("error").is_none());
+    let _ = drain_until(&rx, Duration::from_secs(5), |event| {
+        event["event"] == "scanner.status"
+            && event["payload"]["operationId"] == "unflagged-preview"
+    });
+    std::fs::write(&log_path, "").expect("reset mock bridge call log");
+
+    send(
+        &mut stdin,
+        4,
+        "roll.approve",
+        json!({"frameIndex": 2, "operationId": "unflagged-preview"}),
+    );
+    let approval = recv_response_for(&rx, 4, |_| {});
+    let error = approval.get("error").expect("an unflagged frame must never be approvable");
+    assert_eq!(error["code"], json!("INVALID_PARAMS"));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("flagged for manual review")),
+        "{error:#?}"
+    );
+    assert!(
+        read_mock_bridge_calls(&log_path).is_empty(),
+        "an unflagged approval must be refused before any bridge call"
+    );
+
+    send(&mut stdin, 5, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 5, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}
+
+/// S3: `scan.start` must refuse a requested frame the completed preview
+/// never returned at all -- the mock bridge's preview worker always
+/// returns exactly slots {1, 2, 3} (BRIDGE.md: "the bridge always
+/// physically reads the full roll regardless of `slots`" -- a `frames`
+/// filter on `scanner.acquireThumbnails` narrows which events a caller is
+/// told about, not which slots the completed preview binding contains), so
+/// requesting frame 4 alongside frame 1 must name frame 4 and never reach
+/// the bridge, closing the "hidden slot" gap a caller could otherwise
+/// exploit by asking for a frame the operator was never shown at all.
+#[test]
+fn scan_start_rejects_a_frame_the_completed_preview_never_returned() {
+    let log_directory = unique_output_destination("scan-start-hidden-frame-call-log");
+    let log_path = log_directory.join("bridge-calls.log");
+    std::fs::write(&log_path, "").expect("create mock bridge call log");
+    let log_path_string = log_path.display().to_string();
+    let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
+        "e2e-scan-start-hidden-frame",
+        &[("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str())],
+    );
+
+    send(
+        &mut stdin,
+        3,
+        "scanner.acquireThumbnails",
+        json!({"frames": [1], "operationId": "hidden-frame-preview"}),
+    );
+    assert!(recv_response_for(&rx, 3, |_| {}).get("error").is_none());
+    let _ = drain_until(&rx, Duration::from_secs(5), |event| {
+        event["event"] == "scanner.status"
+            && event["payload"]["operationId"] == "hidden-frame-preview"
+    });
+    std::fs::write(&log_path, "").expect("reset mock bridge call log");
+
+    let output_directory = unique_output_destination("scan-start-hidden-frame-output");
+    send(
+        &mut stdin,
+        4,
+        "scan.start",
+        json!({
+            "frames": [1, 4],
+            "recipe": {
+                "resolutionDpi": 4000,
+                "bitDepth": 16,
+                "multisamplePasses": 4,
+                "channels": "rgbi",
+                "autofocusEachFrame": true,
+                "autoExposureEachFrame": true
+            },
+            "output": {
+                "archive": {
+                    "enabled": false,
+                    "fullCapturePackage": false,
+                    "destination": output_directory.join("disabled-archive").display().to_string(),
+                    "filenameTemplate": "frame-####"
+                },
+                "positive": {
+                    "enabled": true,
+                    "destination": output_directory.join("positive").display().to_string(),
+                    "filenameTemplate": "frame-####",
+                    "fileFormat": "tiff",
+                    "colorProfile": "adobeRgb1998"
+                },
+                "preview": {"enabled": false}
+            }
+        }),
+    );
+    let start = recv_response_for(&rx, 4, |_| {});
+    let error = start
+        .get("error")
+        .expect("a frame the completed preview never returned must refuse scan.start");
+    assert_eq!(error["code"], json!("INVALID_PARAMS"));
+    assert!(
+        error["message"].as_str().is_some_and(|m| m.contains("frame 4")),
+        "expected the refusal to name the hidden frame: {error:#?}"
+    );
+    assert!(
+        read_mock_bridge_calls(&log_path)
+            .iter()
+            .all(|method| method != "scan.start"),
+        "a hidden-frame request must be refused before any bridge call"
+    );
+
+    send(&mut stdin, 5, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 5, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+    let _ = std::fs::remove_dir_all(output_directory);
 }

--- a/app/ScanStudio/engine/tests/real_backend_mapping.rs
+++ b/app/ScanStudio/engine/tests/real_backend_mapping.rs
@@ -501,6 +501,15 @@ fn restart_during_preview_keeps_old_reader_attached_until_it_detaches() {
                 ("MOCK_BRIDGE_PREVIEW_DELAY_MS", "2000"),
                 ("MOCK_BRIDGE_HANG_ON_STATUS_WHILE_PREVIEW_PENDING", "1"),
                 ("MOCK_BRIDGE_CALL_LOG", call_log_path_string.as_str()),
+                // Adversarial review S3 (2026-08-08): roll_approve now
+                // requires the approved frame to be one the completed
+                // preview flagged `needsApproval: true` -- flag frame 1
+                // (the one both the predecessor and replacement preview
+                // approve below) so this test keeps exercising its own
+                // actual subject (stale vs. current vs. premature
+                // approval across a bridge restart) rather than tripping
+                // the new gate.
+                ("MOCK_BRIDGE_PREVIEW_APPROVAL_SLOTS", "1"),
             ],
         )
         .expect("preview-status fault does not affect bridge startup")

--- a/app/ScanStudio/protocol/BRIDGE.md
+++ b/app/ScanStudio/protocol/BRIDGE.md
@@ -54,6 +54,8 @@ Errors that can occur on any request — `UNKNOWN_METHOD` (unrecognized method n
 | `roll.preview` | `{material: "colorNegative"\|"blackAndWhiteNegative", slots?: [number]}` | `{accepted: true}` | `NOT_CONNECTED`, `HW_MOTION_NOT_ARMED`, `HARDWARE_LANE_BUSY`; via `roll.previewError`: `FEEDER_PARKED`, `REFEED_REQUIRED`, `DEVICE_BUSY`, `ROLL_MISMATCH` |
 | `roll.approve` | `{slot: number}` | `{}` | `NOT_CONNECTED`, `NO_PREVIEW` |
 | `roll.setSpacingOffset` | `{slot: number, offsetRows: number}` | `{thumbnail: Thumbnail}` | `NOT_CONNECTED`, `NO_PREVIEW`, `INVALID_PARAMS` |
+| `roll.manualFrames` | `{rows: [number]}` | `{count: number, fingerprint: string, thumbnails: [Thumbnail], snaps: [BoundarySnap]}` | `NOT_CONNECTED`, `NO_PREVIEW`, `HARDWARE_LANE_BUSY`, `INVALID_PARAMS`, `METER_UNUSABLE` |
+| `roll.previewStrip` | `{}` | `PreviewStrip` | `NOT_CONNECTED`, `NO_PREVIEW`, `HARDWARE_LANE_BUSY`, `METER_UNUSABLE` |
 | `scan.start` | `{slots: [number], recipe: CaptureRecipe, output: OutputSpec}` | `{jobId: string}` | `NOT_CONNECTED`, `NO_PREVIEW`, `HW_MOTION_NOT_ARMED`, `HARDWARE_LANE_BUSY`, `INVALID_PARAMS`, `REFEED_REQUIRED`; via `scan.error`/`scan.frameFailed`: `ROLL_MISMATCH` |
 | `scan.stop` | `{jobId: string}` | `{acknowledged: bool}` | `UNKNOWN_JOB` |
 | `device.eject` | `{}` | `{}` | `NOT_CONNECTED`, `HW_MOTION_NOT_ARMED`, `HARDWARE_LANE_BUSY`, `EJECT_FAILED`, `FEEDER_PARKED` |
@@ -89,6 +91,14 @@ the same offset when that slot is captured. It is non-motion-capable, so it
 does not check the motion latch or move film. Valid offsets are `0...144` for
 slot 1 and `-144...144` for every other slot. Changing an offset invalidates
 that slot's prior manual approval.
+
+### `roll.manualFrames` (additive, 2026-08-07)
+
+Rung 4 of the feeding UX ladder: re-slices the last completed preview attempt's already-decoded whole-roll raster at operator-picked boundary rows, in place of automatic detection. Usable any time a preview attempt exists on disk — including one whose `roll.previewComplete`/`roll.previewError` already fired, successful or refused; this is the intended recovery path for a `REFEED_REQUIRED` whose message names a `probable_cause` the operator can work around by hand. Not motion-capable: no film moves, no transport read happens, nothing is re-fed. `rows` is at least 2 strictly increasing row numbers in `0..PreviewStrip.rowCount-1` (N rows define N-1 frames); each resulting frame's height must fall inside 15–75 mm, deliberately wider than automatic detection's tolerance so half-frame and panoramic film work. A pick within a few rows of a clear-film edge snaps to it by default (reported per-boundary in `snaps`); the underlying same-traversal transport table must still confirm the picks are physically plausible, or the whole placement is refused together — no partial acceptance. Every resulting slot arrives `needsApproval: true` with a `"user-picked"` warning: `roll.approve`, `roll.setSpacingOffset`, and `scan.start` all work on the resulting slots exactly as they do after a normal `roll.preview`, with no wire-shape difference. A validation failure (structure, frame height, or transport-table sanity) is `INVALID_PARAMS` naming the operator's own pick, in plain English — distinct from `REFEED_REQUIRED`, which means "the physical strip," not "try different rows here."
+
+### `roll.previewStrip` (additive, 2026-08-07)
+
+Renders the last completed preview attempt's whole captured raster to one image, for a manual-placement editor to draw draggable boundary lines on before any row has been picked (`roll.manualFrames` itself requires at least 2 rows, so it cannot answer "what does the film look like" on its own). Same precondition, same non-motion-capable contract, and the same underlying attempt-on-disk as `roll.manualFrames` — call this first to seed the editor, then `roll.manualFrames` once the operator has picked rows. Touches no session or approval state; purely a read.
 
 ### `scan.start` (MOTION-CAPABLE)
 
@@ -203,6 +213,17 @@ Strictly-below-90% coverage is not a thumbnail at all: it is a `REFEED_REQUIRED`
 failure. An absent/omitted `partial` means a full frame; old readers ignore the
 additive key.
 
+BoundarySnap
+  boundaryIndex: number
+  requestedRow: number
+  snappedRow: number
+  evidenceRun: [number, number]
+
+PreviewStrip
+  imagePath: string
+  rowCount: number
+  pixelsPerRow: number
+
 ScanProgress
   jobId: string
   slot: number
@@ -297,6 +318,8 @@ ScanReceipt
 `storageTransform` is mandatory, never `null` or empty: it is the versioned identifier for the numpy transform CoolscanPy applied between the scanner-native RGB/IR planes it captured and this receipt's `rgbPath`/`irPath` orientation, mirrored verbatim from CoolscanPy's own `Receipt.storage_transform`. Today every live capture reports exactly one value, `"swapaxes01-scanner-native-to-nikon-render-parity-v2"` (`coolscanpy.types.DIGITAL_ICE_STORAGE_TRANSFORM`). A historical value, `"rot90k1-scanner-native-to-storage-v1"`, may appear in archives whose provenance predates this field, but it is never emitted by a live bridge. A consumer that needs to bring CoolscanPy's main raster (`rgbPath`/`irPath`) into the same coordinate system as `meterRgbiPath` (scanner-native) MUST branch on this value and MUST refuse rather than guess when it sees a value it does not recognize. The two known transforms differ by a vertical flip, so silently picking one is worse than refusing.
 
 `Thumbnail.imagePath` is also bridge-added, not a CoolscanPy path: the bridge transposes that slot's raw scanner-linear HxWx3 uint16 preview crop with `swapaxes(0,1)` (the same scanner-native-to-Nikon-render orientation as a saved capture; no axis is flipped), applies a 0.5th/99.5th percentile stretch, and writes the already-thumbnail-sized result as an 8-bit TIFF. A `roll.preview` uses `~/.scanstudio/previews/{preview-session-uuid}/slot-{NNNN}.tif`; every `roll.setSpacingOffset` response uses another fresh UUID path so image caches cannot keep showing the previous crop. This does not relax "Image payloads"'s no-bytes-on-the-wire rule: only a path crosses the wire, exactly like `rgbPath`/`irPath` already do.
+
+`PreviewStrip.imagePath` (additive, 2026-08-07) is rendered through the identical transform `Thumbnail.imagePath` already uses (`swapaxes(0,1)`, 0.5th/99.5th percentile stretch, 8-bit TIFF) applied once to the whole captured raster instead of one frame's crop — so the raster's row axis (the coordinate space `roll.manualFrames`'s `rows` are given in, `0..rowCount-1`) is the image's WIDTH axis, not its height, exactly like every existing `Thumbnail` crop already is. `pixelsPerRow` is always `1` today (native resolution, never resized); carried explicitly so a future downsampled strip cannot silently break row-to-pixel math on either side of the wire.
 
 `DeviceStatus.filmPresent` is a live, no-motion film-presence read, distinct from `previewEstablished` (which only means "a preview has run this session," never "film is physically loaded right now"). The bundled CoolScanPy asks the exact opened LS-5000 with TEST UNIT READY: `true` means the scanner reports medium gripped, `false` means its verified MEDIUM NOT PRESENT sense was observed, and `null` means no trustworthy verdict was available (for example, an active capture owns the interface, an older dependency lacks the method, or the scanner returned an unrecognised/malformed reply). A verified `false` retires the stale preview registration in the same status snapshot (`previewEstablished: false`, `slotCount: null`) and gates the next scan on a fresh preview. `null` is never interpreted as absence. Presence is not motion readiness: a short strip parked at the transport end-stop can still report `true`.
 

--- a/bridge/src/scanstudio_bridge/domain.py
+++ b/bridge/src/scanstudio_bridge/domain.py
@@ -24,6 +24,8 @@ __all__ = [
     "OutputSpec",
     "SlotOutputSpec",
     "Thumbnail",
+    "BoundarySnap",
+    "PreviewStrip",
     "ScanProgress",
     "ExposureVector",
     "ClippingTelemetry",
@@ -124,6 +126,48 @@ class Thumbnail:
     # but not all of it. Emitted only when true (strictly additive); see
     # service._thumbnail_to_wire for why it is not a plain to_wire field.
     partial: bool | None = None
+
+
+# Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): manual frame placement.
+
+
+@dataclass(frozen=True)
+class BoundarySnap:
+    """One snap-assist adjustment `roll.manualFrames` applied to a picked
+    boundary row -- bridge-wire mirror of CoolscanPy's own
+    `manual_frames.BoundarySnap` (coolscanpy never crosses the wire
+    directly; see `_thumbnail_from_coolscanpy`/`_approval_receipt_from_coolscanpy`
+    for the same translate-not-passthrough pattern elsewhere in this
+    codebase)."""
+
+    boundary_index: int
+    requested_row: int
+    snapped_row: int
+    evidence_run: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class PreviewStrip:
+    """One rendered image of the whole captured preview raster, for the
+    manual-placement editor to draw draggable boundary lines on before any
+    row has been picked (`roll.manualFrames` requires at least 2 rows, so it
+    cannot itself hand back a "nothing picked yet" view). Same
+    normalize-and-write tile path a slot `Thumbnail` uses, applied once to
+    the entire raster instead of one frame's crop.
+
+    `row_count` is the coordinate space `roll.manualFrames`'s `rows` are
+    given in -- every picked row must lie in `0..row_count-1`.
+    `pixels_per_row` is how many image pixels (along the image axis that
+    corresponds to a preview row -- the same axis `Thumbnail.imagePath`'s
+    existing swapaxes orientation already uses) one preview row occupies;
+    always `1` today (the strip is written at native resolution, never
+    resized), carried explicitly so a future downsampled strip does not
+    silently break row<->pixel math on either side of the wire.
+    """
+
+    image_path: str
+    row_count: int
+    pixels_per_row: int = 1
 
 
 @dataclass(frozen=True)

--- a/bridge/src/scanstudio_bridge/service.py
+++ b/bridge/src/scanstudio_bridge/service.py
@@ -363,6 +363,17 @@ class BridgeService:
                 int(_require_param(params, "offsetRows")),
             )
             return {"thumbnail": _thumbnail_to_wire(thumbnail)}
+        if method == "roll.manualFrames":
+            return self._handle_roll_manual_frames(request)
+        if method == "roll.previewStrip":
+            if not self._device_open:
+                raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
+            if self._motion_op_active:
+                raise BridgeError(
+                    ErrorCode.HARDWARE_LANE_BUSY,
+                    "a motion operation is still active; retry after it finishes",
+                )
+            return to_wire(self._transport.preview_strip())
         if method == "scan.start":
             return self._handle_scan_start(request, emit)
         if method == "scan.stop":
@@ -614,6 +625,40 @@ class BridgeService:
 
         threading.Thread(target=worker, daemon=True).start()
         return {"accepted": True}
+
+    # -- roll.manualFrames (Rung 4) --------------------------------------------------
+
+    def _handle_roll_manual_frames(self, request: dict) -> dict:
+        # Same NOT_CONNECTED/HARDWARE_LANE_BUSY shape as roll.setSpacingOffset
+        # (both non-motion-capable, synchronous) -- deliberately NOT gated on
+        # self._preview_material being set: manual placement's whole reason
+        # to exist is re-slicing a preview attempt that may have FAILED
+        # (never set self._preview_material at all). The transport itself
+        # raises NO_PREVIEW when no preview attempt exists on disk at all.
+        if not self._device_open:
+            raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
+        if self._motion_op_active:
+            raise BridgeError(
+                ErrorCode.HARDWARE_LANE_BUSY,
+                "a motion operation is still active; retry after it finishes",
+            )
+        params = request.get("params") or {}
+        rows = [int(row) for row in _require_param(params, "rows")]
+        preview_result, thumbnails, snaps, material = self._transport.manual_frames(
+            rows
+        )
+        # manual_frames() arms a usable session exactly like a successful
+        # roll.preview does, but carries no material param of its own (the
+        # session already has one) -- scan.start's own NO_PREVIEW gate
+        # (self._preview_material) is re-armed here, from the transport's
+        # answer, instead of from this request's params.
+        self._preview_material = material
+        return {
+            "count": preview_result.count,
+            "fingerprint": preview_result.fingerprint,
+            "thumbnails": [_thumbnail_to_wire(t) for t in thumbnails],
+            "snaps": [to_wire(s) for s in snaps],
+        }
 
     # -- scan.start / scan.stop --------------------------------------------------------
 

--- a/bridge/src/scanstudio_bridge/service.py
+++ b/bridge/src/scanstudio_bridge/service.py
@@ -342,7 +342,21 @@ class BridgeService:
             return self._handle_roll_preview(request, emit)
         if method == "roll.approve":
             params = request.get("params") or {}
-            self._transport.approve(int(_require_param(params, "slot")))
+            # Additive (2026-08-08 adversarial review, S1): `fingerprint` is
+            # optional on the wire -- omitted entirely by every pre-existing
+            # caller, unchanged. When present it must be a string; passed
+            # through to the transport, which refuses the approval with
+            # FINGERPRINT_REFUSED if it no longer matches the roll's current
+            # state (see coolscanpy_transport.CoolscanPyTransport.approve).
+            fingerprint = params.get("fingerprint")
+            if fingerprint is not None and not isinstance(fingerprint, str):
+                raise BridgeError(
+                    ErrorCode.INVALID_PARAMS,
+                    "fingerprint must be a string when present",
+                )
+            self._transport.approve(
+                int(_require_param(params, "slot")), fingerprint=fingerprint
+            )
             return {}
         if method == "roll.setSpacingOffset":
             if not self._device_open:
@@ -643,7 +657,20 @@ class BridgeService:
                 "a motion operation is still active; retry after it finishes",
             )
         params = request.get("params") or {}
-        rows = [int(row) for row in _require_param(params, "rows")]
+        raw_rows = _require_param(params, "rows")
+        # Strict wire check (adversarial review 2026-08-08, F8a): int() would
+        # silently truncate JSON floats, explode a string into digits, and
+        # turn a non-numeric into an INTERNAL error. The driver's own gates
+        # are strict; the wire deserves the same.
+        if not isinstance(raw_rows, list) or not all(
+            isinstance(row, int) and not isinstance(row, bool) for row in raw_rows
+        ):
+            raise BridgeError(
+                ErrorCode.INVALID_PARAMS,
+                "rows must be a list of whole numbers (the preview row of "
+                "each frame boundary)",
+            )
+        rows = list(raw_rows)
         preview_result, thumbnails, snaps, material = self._transport.manual_frames(
             rows
         )

--- a/bridge/src/scanstudio_bridge/transport/__init__.py
+++ b/bridge/src/scanstudio_bridge/transport/__init__.py
@@ -68,7 +68,16 @@ class Transport(Protocol):
         on_thumbnail: Callable[[domain.Thumbnail], None],
     ) -> domain.PreviewResult: ...
 
-    def approve(self, slot: int) -> None: ...
+    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
+        """Approve `slot`. `fingerprint`, when given, is the Roll
+        fingerprint (BRIDGE.md's `roll.approve`) the approval being
+        submitted was minted against -- additive (2026-08-08 adversarial
+        review, S1): `None` is the pre-existing behavior (no comparison); a
+        given value that no longer matches the roll's CURRENT fingerprint
+        must be refused with `FINGERPRINT_REFUSED` before any underlying
+        approval call, never silently approved against whatever session
+        happens to be current now."""
+        ...
 
     def set_spacing_offset(
         self, slot: int, offset_rows: int

--- a/bridge/src/scanstudio_bridge/transport/__init__.py
+++ b/bridge/src/scanstudio_bridge/transport/__init__.py
@@ -74,6 +74,34 @@ class Transport(Protocol):
         self, slot: int, offset_rows: int
     ) -> domain.Thumbnail: ...
 
+    def manual_frames(
+        self, rows: list[int]
+    ) -> tuple[
+        domain.PreviewResult,
+        tuple[domain.Thumbnail, ...],
+        tuple[domain.BoundarySnap, ...],
+        domain.Material,
+    ]:
+        """Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): re-slice the
+        last completed preview attempt's already-decoded raster at
+        operator-picked boundary rows -- no hardware call, no film
+        movement. Usable only when a preview attempt (successful or
+        refused) already exists this session; raises `NO_PREVIEW`
+        otherwise. Leaves roll/session state armed exactly like a
+        successful `preview()` -- the returned `domain.Material` is what
+        the caller must re-arm `scan.start`'s own NO_PREVIEW gate with,
+        since this call carries no `material` param of its own (the
+        session already has one)."""
+        ...
+
+    def preview_strip(self) -> domain.PreviewStrip:
+        """Rung 4: render the last completed preview attempt's whole
+        captured raster to one image, for a manual-placement editor to
+        draw boundary lines on before any row has been picked. Same
+        precondition and NO_PREVIEW failure as `manual_frames`; no hardware
+        call."""
+        ...
+
     def start_scan(
         self,
         slots: list[int],

--- a/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -11,6 +11,7 @@ level -- every other module stays hardware-library-free.
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import time
@@ -37,10 +38,49 @@ import tifffile
 from coolscanpy.protocol.ls5000_single_pass.roll_index import (
     IndexDecodeError,
     LeadingFrameClippedError,
+    decode_full_index_bytes,
+    parse_live_transport_records_bytes,
+    validate_live_0x8e_bytes,
+)
+
+# Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): SNAP_REVIEW_REASON is a
+# plain module-level string constant (not underscore-prefixed, not part of
+# manual_frames.__all__ either) -- read, never imported for behavior, the
+# same "reach past the public taxonomy with a documented reason" precedent
+# as IndexDecodeError/LeadingFrameClippedError above.
+from coolscanpy.protocol.ls5000_single_pass.manual_frames import SNAP_REVIEW_REASON
+from coolscanpy.protocol.ls5000_single_pass.capture_process import (
+    AttemptPaths,
+    CaptureAttemptResult,
+    CaptureMode,
+    CaptureOutcome,
+    CaptureRequest,
 )
 from coolscanpy.roll.preview_session import (
     RollSessionError,
     RollSessionIntegrityError,
+    ValidatedRollPreview,
+    build_manual_roll_preview_session,
+    # `_validate_preview_result`/`_derive_geometry`/
+    # `_validated_preview_density_evidence` are underscore-private module
+    # functions, not exported from preview_session.__all__. They are
+    # imported here anyway, deliberately, because they are the exact
+    # validate-and-decode PREFIX `build_roll_preview_session` itself runs
+    # before it ever calls `detect_roll_frames` -- and manual_frames()
+    # below needs precisely that prefix, without the automatic detector
+    # that follows it in build_roll_preview_session (which is exactly what
+    # already refused on a "completed-but-refused" attempt, and would
+    # refuse again the same way if re-run). No public coolscanpy function
+    # returns a bare ValidatedRollPreview independent of detection; rather
+    # than duplicate this validation logic (SHA256 cross-checks, USB
+    # topology, startup-table/preview-binding-contract matching, density
+    # evidence replay) a second time in the bridge, this reuses the
+    # driver's own already-tested implementation. It becomes dead,
+    # harmless code the day coolscanpy exposes this prefix as a public
+    # function of its own.
+    _derive_geometry,
+    _validate_preview_result,
+    _validated_preview_density_evidence,
 )
 
 from scanstudio_bridge import domain, safety
@@ -64,6 +104,21 @@ _MATERIAL_TO_COOLSCANPY: dict[domain.Material, coolscanpy.Material] = {
     domain.Material.COLOR_NEGATIVE: coolscanpy.Material.COLOR_NEGATIVE,
     domain.Material.BLACK_AND_WHITE_NEGATIVE: coolscanpy.Material.BLACK_AND_WHITE_NEGATIVE,
 }
+# Rung 4: manual_frames() has no material param of its own (the roll already
+# has one -- see coolscanpy.Roll.material) but must still hand the bridge
+# service a domain.Material so scan.start's NO_PREVIEW gate re-arms
+# correctly. Exact inverse of the mapping above -- never hand-maintained
+# separately.
+_COOLSCANPY_TO_MATERIAL: dict[coolscanpy.Material, domain.Material] = {
+    value: key for key, value in _MATERIAL_TO_COOLSCANPY.items()
+}
+
+# capture_process._prepare_attempt_paths' own mkdtemp prefix for a
+# CaptureMode.PREVIEW request ("preview-" + a random tempfile suffix, no
+# selected_slot so no "-slotNN" infix) -- mirrored here as a glob, never
+# imported, since it is assembled from CaptureMode.PREVIEW.value privately
+# inside that method rather than exposed as a constant of its own.
+_PREVIEW_ATTEMPT_GLOB = "preview-*/journal.json"
 
 
 def _coolscanpy_git_head_sha(package_dir: Path) -> str | None:
@@ -398,6 +453,161 @@ def _scan_receipt_from_coolscanpy(
     )
 
 
+# -- Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): manual frame placement --
+#
+# manual_frames()/preview_strip() below both need a ValidatedRollPreview from
+# the LAST preview attempt on this Roll -- successful or refused -- purely
+# from what is already on disk under attempts_root, with no hardware call and
+# no dependence on whatever self._roll's own in-memory state currently holds
+# (a refused preview leaves self._roll without a usable session at all). The
+# three helpers below do exactly that, in three separate steps mirroring
+# preview_session.py's own internal shape: locate the attempt directory,
+# reconstruct its CaptureAttemptResult from disk, then validate+decode it
+# into a ValidatedRollPreview without ever calling detect_roll_frames.
+
+
+def _last_preview_attempt_journal_path(attempts_root: Path) -> Path:
+    """The most recently written preview attempt's journal.json under
+    `attempts_root`. Mirrors exposure_authority._find_frame_attempt_
+    directory's own mtime-pick-and-refuse-on-tie pattern, applied to
+    CaptureMode.PREVIEW's own attempt-directory shape (one per roll.preview
+    call on this Roll -- see capture_process._prepare_attempt_paths) instead
+    of a batch frame directory."""
+    candidates = sorted(
+        attempts_root.glob(_PREVIEW_ATTEMPT_GLOB),
+        key=lambda path: path.stat().st_mtime,
+    )
+    if not candidates:
+        raise BridgeError(
+            ErrorCode.NO_PREVIEW,
+            "no preview attempt evidence was found under this roll's "
+            "attempts directory; run roll.preview first",
+        )
+    if (
+        len(candidates) > 1
+        and candidates[-1].stat().st_mtime == candidates[-2].stat().st_mtime
+    ):
+        raise BridgeError(
+            ErrorCode.INTERNAL,
+            f"{len(candidates)} preview attempts under {attempts_root} are "
+            "mtime-indistinguishable; refusing to guess which one is current",
+        )
+    try:
+        # Fully resolved (symlinks included, e.g. macOS /var -> /private/var)
+        # -- preview_session._artifact_path requires every path it validates
+        # to already equal its own .resolve() exactly, the same invariant
+        # _restore_roll_preview_session's own reconstruction depends on. A
+        # bare glob() result inherits attempts_root's own possibly-unresolved
+        # form, so it is resolved once, here, before anything downstream
+        # sees it.
+        return candidates[-1].resolve(strict=True)
+    except OSError as exc:
+        raise BridgeError(
+            ErrorCode.INTERNAL,
+            f"preview attempt journal is unavailable: {exc}",
+        ) from exc
+
+
+def _reconstruct_last_preview_attempt(attempts_root: Path) -> CaptureAttemptResult:
+    """Rebuild a CaptureAttemptResult purely from the persisted journal.json
+    of the most recent roll.preview attempt on this Roll -- no film
+    movement, no live coolscanpy.Roll state touched. Mirrors
+    coolscanpy.roll.preview_session._restore_roll_preview_session's own
+    attempt reconstruction (there, replaying an operator-approved AUTOMATIC
+    session restored from RollPreviewSession.to_json()); this is the
+    identical shape, sourced from disk directly instead of a saved session
+    blob, because a refused preview never produced a session to serialize in
+    the first place -- the journal on disk is the only surviving evidence."""
+    journal_path = _last_preview_attempt_journal_path(attempts_root)
+    try:
+        journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BridgeError(
+            ErrorCode.INTERNAL,
+            f"preview attempt journal could not be read: {exc}",
+        ) from exc
+    if not isinstance(journal, dict):
+        raise BridgeError(
+            ErrorCode.INTERNAL, f"{journal_path}: journal is not a JSON object"
+        )
+    output_value = journal.get("output")
+    if not isinstance(output_value, str):
+        raise BridgeError(
+            ErrorCode.INTERNAL, f"{journal_path}: journal has no output path"
+        )
+    root = journal_path.parent
+    paths = AttemptPaths(
+        directory=root,
+        output=Path(output_value),
+        journal=journal_path,
+        # None of these three are ever read by _validate_preview_result/
+        # _derive_geometry/_validated_preview_density_evidence -- only
+        # .directory/.output/.journal are (see preview_session.py) --
+        # placeholders exactly like _restore_roll_preview_session's own
+        # reconstruction uses.
+        plan=root / "replay-first-rgbi4-plan.jsonl",
+        manifest=root / "replay-first-rgbi4-manifest.json",
+        bootstrap_status=root / "worker-bootstrap.json",
+        stdout=root / "stdout.txt",
+        stderr=root / "stderr.txt",
+    )
+    return CaptureAttemptResult(
+        outcome=CaptureOutcome.COMPLETE,
+        request=CaptureRequest(mode=CaptureMode.PREVIEW),
+        paths=paths,
+        argv=(),
+        returncode=0,
+        stdout="",
+        stderr="",
+        journal=journal,
+    )
+
+
+def _validated_preview_from_attempt(
+    attempt: CaptureAttemptResult,
+) -> ValidatedRollPreview:
+    """Validate and decode one completed preview attempt into its raw
+    whole-roll raster, WITHOUT running frame detection -- the exact prefix
+    build_roll_preview_session itself runs before detect_roll_frames (see
+    this module's import comment above). May raise RollSessionIntegrityError
+    (artifact/journal self-check failure -- a driver-side defect, not an
+    operator condition) or coolscanpy.MeterUnusableError (#17: no usable
+    density meter mean while replaying this preview's evidence) -- both
+    handled the same way preview() itself already handles them."""
+    (
+        journal,
+        preview_artifact,
+        preview_bytes,
+        table_artifact,
+        table_bytes,
+        journal_artifact,
+        _capacity,
+        usb_topology,
+    ) = _validate_preview_result(attempt)
+    geometry = _derive_geometry(journal, len(preview_bytes))
+    _validated_preview_density_evidence(attempt, journal, preview_bytes, geometry)
+    validated_table, usable_rows = validate_live_0x8e_bytes(
+        table_bytes, geometry.height
+    )
+    rgb, _known, decode_report = decode_full_index_bytes(
+        preview_bytes, geometry, usable_rows=usable_rows
+    )
+    records = parse_live_transport_records_bytes(
+        validated_table, maximum_rows=geometry.height
+    )
+    return ValidatedRollPreview(
+        preview_artifact=preview_artifact,
+        table_artifact=table_artifact,
+        journal_artifact=journal_artifact,
+        usb_topology=usb_topology,
+        geometry=geometry,
+        usable_rows=usable_rows,
+        rgb=rgb,
+        transport_records=records,
+        decode_report=decode_report,
+    )
+
+
 class CoolscanPyTransport:
     """Thin real adapter over CoolscanPy's `Device`/`Roll` API. Satisfies
     `transport.Transport` structurally -- no explicit inheritance needed,
@@ -697,6 +907,189 @@ class CoolscanPyTransport:
                 f"and a fresh preview is required ({type(exc).__name__}: {exc})",
             ) from exc
         return _thumbnail_from_coolscanpy(thumbnail, image_path=str(tile_path))
+
+    # -- manual frame placement (Rung 4) -----------------------------------------
+
+    def manual_frames(
+        self, rows: list[int]
+    ) -> tuple[
+        domain.PreviewResult,
+        tuple[domain.Thumbnail, ...],
+        tuple[domain.BoundarySnap, ...],
+        domain.Material,
+    ]:
+        """Re-slice the last completed preview attempt's already-decoded
+        raster at operator-picked boundary rows.
+
+        No hardware call, no film movement -- this is a pure re-slice of
+        bytes already on disk from an earlier roll.preview attempt
+        (successful, or completed-but-refused: the exact case this exists
+        for). Leaves self._roll's session armed exactly like a successful
+        preview() left it, so approve()/set_spacing_offset()/start_scan()
+        all keep working on the resulting manual slots unchanged.
+        """
+        if self._device is None:
+            raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
+        if self._scanning:
+            raise BridgeError(
+                ErrorCode.HARDWARE_LANE_BUSY, "a scan job holds the hardware lane"
+            )
+        if self._roll is None or self.attempts_root is None:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "manual frame placement requires a completed roll.preview "
+                "attempt first",
+            )
+        attempt = _reconstruct_last_preview_attempt(self.attempts_root)
+        try:
+            preview = _validated_preview_from_attempt(attempt)
+        except coolscanpy.MeterUnusableError as exc:
+            # #17, same handling as preview()'s own: fail-closed, no
+            # fabricated exposure, a friendly METER_UNUSABLE card rather
+            # than INTERNAL.
+            raise BridgeError(ErrorCode.METER_UNUSABLE, str(exc)) from exc
+
+        try:
+            session = build_manual_roll_preview_session(
+                preview, rows, material=self._roll.material
+            )
+        except IndexDecodeError as exc:
+            # manual_frames.py's own plain-English gates (structure, frame
+            # height, transport-table sanity) -- about the operator's picks,
+            # not a hardware fault. IndexDecodeError is the SAME exception
+            # class preview()'s own REFEED_REQUIRED mapping catches above,
+            # for the automatic detector's transport-table faults -- it
+            # means something different from this different call site
+            # (different rows, different meaning), so it gets a different
+            # mapping: INVALID_PARAMS, matching set_spacing_offset's own
+            # ValueError->INVALID_PARAMS precedent for "the operator's
+            # request doesn't check out" rather than "refeed the strip".
+            raise BridgeError(ErrorCode.INVALID_PARAMS, str(exc)) from exc
+        except RollSessionIntegrityError:
+            # Artifact/journal integrity faults are driver-side defects, not
+            # operator conditions -- same precedent as preview()'s own
+            # handling; let it reach the wire as INTERNAL.
+            raise
+        except RollSessionError as exc:
+            # build_manual_roll_preview_session's own "produced no
+            # scanner-addressable slots" refusal -- also about the
+            # operator's picks, so the same INVALID_PARAMS mapping as the
+            # IndexDecodeError branch above.
+            raise BridgeError(ErrorCode.INVALID_PARAMS, str(exc)) from exc
+
+        # Arm self._roll's session state exactly like Roll.preview()'s own
+        # success tail does (_roll.py: "self._session = session;
+        # self._session_usb_topology = topology; self._approvals.clear()").
+        # Reaching into these three private fields directly -- never a
+        # public Roll method -- because Roll.restore_preview_session()
+        # explicitly, deliberately refuses a manual session
+        # (preview_session.py's _restore_roll_preview_session: "roll
+        # session was built from manual frame placement; restoring... is
+        # not yet supported. Refuse loudly instead of guessing.") and no
+        # OTHER public Roll API exists for installing an already-built
+        # RollPreviewSession without a fresh hardware read. This is not a
+        # hardware attempt, so it does not acquire the HardwareLane or
+        # require safety.require_armed() the way roll.preview/scan.start/
+        # device.eject do -- self._scanning (checked above) is still
+        # respected as a plain busy-guard against racing an ACTUAL transport
+        # read, but manual_frames() itself never becomes one; a real
+        # preview()/scan_many() call still goes through their own unmodified
+        # code paths, hardware lane, and locking exactly as before. Locked
+        # the same way Roll.preview()/set_spacing_offset()/approve()
+        # themselves protect this exact state, so a concurrent Roll caller
+        # can never observe a half-armed session.
+        with self._roll._state_condition:  # noqa: SLF001
+            self._roll._session = session
+            self._roll._session_usb_topology = preview.usb_topology
+            self._roll._approvals.clear()
+
+        preview_dir = safety.DEFAULT_BASE_DIR / "previews" / uuid.uuid4().hex
+        preview_dir.mkdir(parents=True, exist_ok=True)
+        thumbnails: list[domain.Thumbnail] = []
+        for slot in session.slots:
+            tile_path = preview_dir / f"slot-{slot.slot_id:04d}.tif"
+            tifffile.imwrite(
+                tile_path, _normalize_preview_tile(slot.thumbnail), photometric="rgb"
+            )
+            thumbnails.append(
+                domain.Thumbnail(
+                    slot=slot.slot_id,
+                    boundary_rows=slot.boundary_rows,
+                    spacing_offset=slot.boundary_offset_rows,
+                    needs_approval=slot.manual_review,
+                    warnings=slot.warnings,
+                    image_path=str(tile_path),
+                    partial=slot.partial,
+                )
+            )
+
+        # Per-boundary snap notes (BRIDGE.md's contract): derived from the
+        # session's own boundaries rather than re-running
+        # build_manual_detection a second time for its ManualFrameDetection.
+        # snaps -- SNAP_REVIEW_REASON is present on boundary `i` if and only
+        # if build_manual_detection's own final_rows[i] != rows[i] (see
+        # manual_frames.py: the reason is appended exactly when a boundary's
+        # snapped index is in `snapped_indices`, the same set that decided
+        # final_rows[i] != row); `rows[i]` (the operator's own request,
+        # already in hand here) and `boundary.output_row` (the resolved,
+        # possibly-snapped row) reconstruct the identical BoundarySnap this
+        # module's own manual_frames.py would have returned.
+        snaps: list[domain.BoundarySnap] = []
+        for index, (requested_row, boundary) in enumerate(
+            zip(rows, session.detection.boundaries)
+        ):
+            if SNAP_REVIEW_REASON in boundary.review_reasons:
+                assert boundary.evidence_run is not None
+                snaps.append(
+                    domain.BoundarySnap(
+                        boundary_index=index,
+                        requested_row=requested_row,
+                        snapped_row=boundary.output_row,
+                        evidence_run=boundary.evidence_run,
+                    )
+                )
+
+        material = _COOLSCANPY_TO_MATERIAL[self._roll.material]
+        self._material = material
+        self._preview_established = True
+        result = domain.PreviewResult(
+            count=len(thumbnails), fingerprint=self._roll.fingerprint.sha256
+        )
+        return result, tuple(thumbnails), tuple(snaps), material
+
+    def preview_strip(self) -> domain.PreviewStrip:
+        """Render the last completed preview attempt's whole captured raster
+        to one image, for a manual-placement editor to draw boundary lines
+        on before any row has been picked.
+
+        Same precondition as manual_frames() (a completed preview attempt,
+        successful or refused, already on disk); no hardware call, and no
+        session/approval state is touched -- purely a read.
+        """
+        if self._device is None:
+            raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
+        if self._roll is None or self.attempts_root is None:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "roll.previewStrip requires a completed roll.preview attempt first",
+            )
+        attempt = _reconstruct_last_preview_attempt(self.attempts_root)
+        try:
+            preview = _validated_preview_from_attempt(attempt)
+        except coolscanpy.MeterUnusableError as exc:
+            raise BridgeError(ErrorCode.METER_UNUSABLE, str(exc)) from exc
+
+        strip_dir = safety.DEFAULT_BASE_DIR / "previews" / uuid.uuid4().hex
+        strip_dir.mkdir(parents=True, exist_ok=True)
+        strip_path = strip_dir / "strip.tif"
+        tifffile.imwrite(
+            strip_path, _normalize_preview_tile(preview.rgb), photometric="rgb"
+        )
+        return domain.PreviewStrip(
+            image_path=str(strip_path),
+            row_count=len(preview.rgb),
+            pixels_per_row=1,
+        )
 
     # -- scanning -----------------------------------------------------------------
 

--- a/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -12,6 +12,7 @@ level -- every other module stays hardware-library-free.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import time
@@ -456,69 +457,88 @@ def _scan_receipt_from_coolscanpy(
 # -- Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): manual frame placement --
 #
 # manual_frames()/preview_strip() below both need a ValidatedRollPreview from
-# the LAST preview attempt on this Roll -- successful or refused -- purely
+# the CURRENT preview attempt on this Roll -- successful or refused -- purely
 # from what is already on disk under attempts_root, with no hardware call and
 # no dependence on whatever self._roll's own in-memory state currently holds
 # (a refused preview leaves self._roll without a usable session at all). The
-# three helpers below do exactly that, in three separate steps mirroring
-# preview_session.py's own internal shape: locate the attempt directory,
-# reconstruct its CaptureAttemptResult from disk, then validate+decode it
-# into a ValidatedRollPreview without ever calling detect_roll_frames.
+# helpers below do exactly that, in steps mirroring preview_session.py's own
+# internal shape: identify the exact attempt directory, reconstruct its
+# CaptureAttemptResult from disk, then validate+decode it into a
+# ValidatedRollPreview without ever calling detect_roll_frames.
+#
+# 2026-08-08 adversarial review, S5: identifying "the current attempt" used
+# to mean globbing every "preview-*/journal.json" under attempts_root and
+# trusting whichever had the newest st_mtime -- an unrelated process
+# touching an older attempt's journal, or a newer attempt failing before it
+# ever wrote one, could both make that glob silently resolve to stale
+# evidence with no signal anything was wrong. `CoolscanPyTransport.preview()`
+# now records the *identity* of each attempt itself, the moment that attempt
+# is known (see its own comment), instead of asking the filesystem to guess
+# afterward from timestamps. `_sole_new_attempt_journal` below is that
+# recording mechanism's own helper -- a pure before/after set difference,
+# never a modification-time comparison.
 
 
-def _last_preview_attempt_journal_path(attempts_root: Path) -> Path:
-    """The most recently written preview attempt's journal.json under
-    `attempts_root`. Mirrors exposure_authority._find_frame_attempt_
-    directory's own mtime-pick-and-refuse-on-tie pattern, applied to
-    CaptureMode.PREVIEW's own attempt-directory shape (one per roll.preview
-    call on this Roll -- see capture_process._prepare_attempt_paths) instead
-    of a batch frame directory."""
-    candidates = sorted(
-        attempts_root.glob(_PREVIEW_ATTEMPT_GLOB),
-        key=lambda path: path.stat().st_mtime,
-    )
-    if not candidates:
-        raise BridgeError(
-            ErrorCode.NO_PREVIEW,
-            "no preview attempt evidence was found under this roll's "
-            "attempts directory; run roll.preview first",
-        )
-    if (
-        len(candidates) > 1
-        and candidates[-1].stat().st_mtime == candidates[-2].stat().st_mtime
-    ):
-        raise BridgeError(
-            ErrorCode.INTERNAL,
-            f"{len(candidates)} preview attempts under {attempts_root} are "
-            "mtime-indistinguishable; refusing to guess which one is current",
-        )
+def _sole_new_attempt_journal(
+    attempts_root: Path, attempt_journals_before: frozenset[Path]
+) -> Path | None:
+    """The one preview attempt journal that appeared under `attempts_root`
+    since `attempt_journals_before` was captured -- or `None` if the
+    just-finished `Roll.preview()` call left none (a hard failure before any
+    journal was ever written -- e.g. a bootstrap failure or a parked
+    feeder) or, astonishingly, more than one. Pure set membership against a
+    snapshot taken immediately before the call: unlike a modification-time
+    comparison, this cannot be fooled by an unrelated process touching an
+    older attempt's journal, and a newer attempt that never wrote a journal
+    simply never becomes a member of either set."""
+    attempt_journals_after = frozenset(attempts_root.glob(_PREVIEW_ATTEMPT_GLOB))
+    new_journals = attempt_journals_after - attempt_journals_before
+    if len(new_journals) != 1:
+        return None
+    (only,) = new_journals
     try:
         # Fully resolved (symlinks included, e.g. macOS /var -> /private/var)
         # -- preview_session._artifact_path requires every path it validates
         # to already equal its own .resolve() exactly, the same invariant
-        # _restore_roll_preview_session's own reconstruction depends on. A
-        # bare glob() result inherits attempts_root's own possibly-unresolved
-        # form, so it is resolved once, here, before anything downstream
-        # sees it.
-        return candidates[-1].resolve(strict=True)
-    except OSError as exc:
-        raise BridgeError(
-            ErrorCode.INTERNAL,
-            f"preview attempt journal is unavailable: {exc}",
-        ) from exc
+        # _restore_roll_preview_session's own reconstruction depends on.
+        return only.resolve(strict=True)
+    except OSError:
+        return None
 
 
-def _reconstruct_last_preview_attempt(attempts_root: Path) -> CaptureAttemptResult:
-    """Rebuild a CaptureAttemptResult purely from the persisted journal.json
-    of the most recent roll.preview attempt on this Roll -- no film
-    movement, no live coolscanpy.Roll state touched. Mirrors
+def _fsync_path(path: Path) -> None:
+    """fsync one file's own contents, then fsync its containing directory so
+    the directory entry itself is durable too -- the two-step durability a
+    bare write()/close() does not guarantee. 2026-08-08 adversarial review,
+    S1: every manual-placement thumbnail must actually be safely on disk,
+    not merely buffered, before this bridge ever mutates the driver's Roll
+    session state -- see manual_frames()'s own comment."""
+    file_descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(file_descriptor)
+    finally:
+        os.close(file_descriptor)
+    directory_descriptor = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_descriptor)
+    finally:
+        os.close(directory_descriptor)
+
+
+def _reconstruct_preview_attempt(journal_path: Path) -> CaptureAttemptResult:
+    """Rebuild a CaptureAttemptResult purely from one already-identified
+    preview attempt's persisted journal.json -- no film movement, no live
+    coolscanpy.Roll state touched, and no selection logic of its own:
+    `journal_path` must already be the exact attempt
+    `CoolscanPyTransport.preview()` itself recorded (S5 fix, see this
+    module's own comment above) -- picking among candidates is the caller's
+    job, not this function's. Mirrors
     coolscanpy.roll.preview_session._restore_roll_preview_session's own
     attempt reconstruction (there, replaying an operator-approved AUTOMATIC
     session restored from RollPreviewSession.to_json()); this is the
     identical shape, sourced from disk directly instead of a saved session
     blob, because a refused preview never produced a session to serialize in
     the first place -- the journal on disk is the only surviving evidence."""
-    journal_path = _last_preview_attempt_journal_path(attempts_root)
     try:
         journal = json.loads(journal_path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -628,6 +648,16 @@ class CoolscanPyTransport:
         # own copy is a private attribute) -- this is simply the value we
         # ourselves chose and passed in.
         self.attempts_root: Path | None = None
+        # 2026-08-08 adversarial review, S5: the resolved journal.json path
+        # of the CURRENT preview attempt -- the one this transport's own
+        # preview() call most recently confirmed produced evidence on disk,
+        # successful or completed-but-refused. `None` means either no
+        # preview() has run yet, or the most recent one left no usable
+        # evidence at all (a hard failure before any journal was written).
+        # manual_frames()/preview_strip() read only this recorded identity,
+        # never a fresh glob of attempts_root -- see preview()'s own
+        # comment for why a filesystem scan is no longer trusted here.
+        self._recorded_preview_attempt_journal: Path | None = None
 
     # -- device lifecycle -----------------------------------------------------
 
@@ -702,6 +732,7 @@ class CoolscanPyTransport:
         self._device_id = None
         self._material = None
         self._preview_established = False
+        self._recorded_preview_attempt_journal = None
 
     # -- preview / approve ------------------------------------------------------
 
@@ -728,6 +759,12 @@ class CoolscanPyTransport:
         # the moment a new attempt starts, the old session is gone whether
         # or not this attempt completes.
         self._preview_established = False
+        # S5 fix (see this module's comment above _sole_new_attempt_journal):
+        # invalidate whatever attempt was previously recorded as current the
+        # MOMENT a new attempt starts, before we know whether it will
+        # succeed -- never left pointing at stale evidence if this attempt
+        # fails to produce any of its own.
+        self._recorded_preview_attempt_journal = None
         if self._roll is not None and self._material != material:
             self._roll.close()
             self._roll = None
@@ -757,66 +794,84 @@ class CoolscanPyTransport:
                 material=translated, attempts_root=self.attempts_root
             )
 
+        # S5 fix: a snapshot taken immediately before the call, so the
+        # `finally` below can identify exactly which attempt (if any) THIS
+        # call itself produced -- by set membership, never by trusting
+        # whichever candidate happens to carry the newest mtime.
+        attempt_journals_before = frozenset(
+            self.attempts_root.glob(_PREVIEW_ATTEMPT_GLOB)
+        )
         try:
-            # A SINGLE blocking CoolscanPy call that returns the complete
-            # list once the whole-roll transport read finishes -- there is
-            # no per-thumbnail streaming under the hood. `on_thumbnail` is
-            # invoked once per item below, simulating the bridge's own
-            # one-event-per-slot wire behavior on top of this atomic call.
-            thumbnails = self._roll.preview(slots=slots)
-        except coolscanpy.CaptureWorkerBootstrapFailed as exc:
-            raise BridgeError(ErrorCode.INTERNAL, str(exc)) from exc
-        except coolscanpy.FeederParked as exc:
-            raise BridgeError(ErrorCode.FEEDER_PARKED, str(exc)) from exc
-        except coolscanpy.RefeedRequired as exc:
-            raise BridgeError(ErrorCode.REFEED_REQUIRED, str(exc)) from exc
-        except coolscanpy.DeviceBusy as exc:
-            raise BridgeError(ErrorCode.DEVICE_BUSY, str(exc)) from exc
-        except LeadingFrameClippedError as exc:
-            # This is a proven physical-registration condition, unlike the
-            # broader IndexDecodeError bucket below. Preserve its precise
-            # deeper-refeed guidance in both the UI and diagnostics.
-            raise BridgeError(ErrorCode.REFEED_REQUIRED, str(exc)) from exc
-        except IndexDecodeError as exc:
-            # Hedged wording (2026-07-25 adversarial-review finding): the
-            # IndexDecodeError class also covers malformed envelopes and
-            # geometry defects, which are capture/driver faults a refeed
-            # cannot fix -- refeed-and-retry stays the first move, but the
-            # message must not sell a software fault as a film problem.
-            raise BridgeError(
-                ErrorCode.REFEED_REQUIRED,
-                "transport read was not one uniform traversal; eject or refeed "
-                "the strip and run the preview again -- if this recurs on "
-                f"clean feeds it may be a capture or driver defect ({exc})",
-            ) from exc
-        except RollSessionIntegrityError:
-            # Artifact/journal integrity faults are driver-side defects, not
-            # operator conditions -- let service.py's boundary report them as
-            # INTERNAL with the exception class preserved in the message.
-            raise
-        except RollSessionError as exc:
-            raise BridgeError(
-                ErrorCode.REFEED_REQUIRED,
-                "preview could not establish a usable roll session; refeed the "
-                "strip and retry -- if this recurs on clean feeds it may be a "
-                f"capture or driver defect ({exc})",
-            ) from exc
-        except coolscanpy.MeterUnusableError as exc:
-            # #17: no usable meter mean for a channel while replaying this
-            # preview's density evidence (density metering runs as part of
-            # Roll.preview, not just scan_many -- see preview_session.py's
-            # _validated_preview_density_evidence). Fail-closed -- no
-            # fabricated exposure -- surfaced as a friendly METER_UNUSABLE
-            # card, never INTERNAL. Guidance text is in the exception.
-            # Mirrors the start_scan handler below.
-            raise BridgeError(ErrorCode.METER_UNUSABLE, str(exc)) from exc
-        except coolscanpy.RollMismatch as exc:
-            # Base-class fallback AFTER every mapped subclass (RefeedRequired
-            # above; FingerprintRefused/ManualReviewRequired are scan-time
-            # concepts that preview() does not raise). CoolscanPy raises the
-            # bare base for e.g. a completed preview whose evidence belongs
-            # to a different USB topology -- typed, never INTERNAL.
-            raise BridgeError(ErrorCode.ROLL_MISMATCH, str(exc)) from exc
+            try:
+                # A SINGLE blocking CoolscanPy call that returns the complete
+                # list once the whole-roll transport read finishes -- there is
+                # no per-thumbnail streaming under the hood. `on_thumbnail` is
+                # invoked once per item below, simulating the bridge's own
+                # one-event-per-slot wire behavior on top of this atomic call.
+                thumbnails = self._roll.preview(slots=slots)
+            except coolscanpy.CaptureWorkerBootstrapFailed as exc:
+                raise BridgeError(ErrorCode.INTERNAL, str(exc)) from exc
+            except coolscanpy.FeederParked as exc:
+                raise BridgeError(ErrorCode.FEEDER_PARKED, str(exc)) from exc
+            except coolscanpy.RefeedRequired as exc:
+                raise BridgeError(ErrorCode.REFEED_REQUIRED, str(exc)) from exc
+            except coolscanpy.DeviceBusy as exc:
+                raise BridgeError(ErrorCode.DEVICE_BUSY, str(exc)) from exc
+            except LeadingFrameClippedError as exc:
+                # This is a proven physical-registration condition, unlike the
+                # broader IndexDecodeError bucket below. Preserve its precise
+                # deeper-refeed guidance in both the UI and diagnostics.
+                raise BridgeError(ErrorCode.REFEED_REQUIRED, str(exc)) from exc
+            except IndexDecodeError as exc:
+                # Hedged wording (2026-07-25 adversarial-review finding): the
+                # IndexDecodeError class also covers malformed envelopes and
+                # geometry defects, which are capture/driver faults a refeed
+                # cannot fix -- refeed-and-retry stays the first move, but the
+                # message must not sell a software fault as a film problem.
+                raise BridgeError(
+                    ErrorCode.REFEED_REQUIRED,
+                    "transport read was not one uniform traversal; eject or refeed "
+                    "the strip and run the preview again -- if this recurs on "
+                    f"clean feeds it may be a capture or driver defect ({exc})",
+                ) from exc
+            except RollSessionIntegrityError:
+                # Artifact/journal integrity faults are driver-side defects, not
+                # operator conditions -- let service.py's boundary report them as
+                # INTERNAL with the exception class preserved in the message.
+                raise
+            except RollSessionError as exc:
+                raise BridgeError(
+                    ErrorCode.REFEED_REQUIRED,
+                    "preview could not establish a usable roll session; refeed the "
+                    "strip and retry -- if this recurs on clean feeds it may be a "
+                    f"capture or driver defect ({exc})",
+                ) from exc
+            except coolscanpy.MeterUnusableError as exc:
+                # #17: no usable meter mean for a channel while replaying this
+                # preview's density evidence (density metering runs as part of
+                # Roll.preview, not just scan_many -- see preview_session.py's
+                # _validated_preview_density_evidence). Fail-closed -- no
+                # fabricated exposure -- surfaced as a friendly METER_UNUSABLE
+                # card, never INTERNAL. Guidance text is in the exception.
+                # Mirrors the start_scan handler below.
+                raise BridgeError(ErrorCode.METER_UNUSABLE, str(exc)) from exc
+            except coolscanpy.RollMismatch as exc:
+                # Base-class fallback AFTER every mapped subclass (RefeedRequired
+                # above; FingerprintRefused/ManualReviewRequired are scan-time
+                # concepts that preview() does not raise). CoolscanPy raises the
+                # bare base for e.g. a completed preview whose evidence belongs
+                # to a different USB topology -- typed, never INTERNAL.
+                raise BridgeError(ErrorCode.ROLL_MISMATCH, str(exc)) from exc
+        finally:
+            # S5 fix: record the current attempt's identity regardless of
+            # how the block above exited -- a clean return, a typed
+            # BridgeError (a "completed but refused" attempt still writes a
+            # valid journal), or a bare re-raised RollSessionIntegrityError.
+            # Left `None` (its state from the top of this method) if this
+            # call wrote no new journal at all.
+            self._recorded_preview_attempt_journal = _sole_new_attempt_journal(
+                self.attempts_root, attempt_journals_before
+            )
 
         # Fresh UUID directory per roll.preview call, mirroring the
         # existing hw-telemetry/{session_id}.jsonl convention (see
@@ -834,12 +889,34 @@ class CoolscanPyTransport:
         self._preview_established = True
         return domain.PreviewResult(count=len(thumbnails), fingerprint=self._roll.fingerprint.sha256)
 
-    def approve(self, slot: int) -> None:
+    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
         if self._device is None:
             raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
         if not self._preview_established:
             raise BridgeError(
                 ErrorCode.NO_PREVIEW, "roll.approve requires a completed roll.preview first"
+            )
+        # Additive (2026-08-08 adversarial review, S1). `fingerprint`, when
+        # supplied, is the Roll fingerprint the approval being submitted was
+        # minted against -- today only RealLs5000::roll_approve (the engine)
+        # supplies it, and only when its own completed-preview binding
+        # carries one (currently: manual placement's own binding; see
+        # manual_frames() below). `None` is the existing, unchanged
+        # behavior: no comparison, exactly as before this parameter
+        # existed. A caller-supplied value that does not match this Roll's
+        # CURRENT fingerprint means the session moved on since that
+        # approval was computed -- e.g. a replacement manual placement
+        # installed a different session in between -- so it is refused
+        # here, before ever reaching coolscanpy's own Roll.approve(), which
+        # has no way to know the approval's own origin and would otherwise
+        # approve whatever slot number happens to exist in its CURRENT
+        # session.
+        if fingerprint is not None and self._roll.fingerprint.sha256 != fingerprint:
+            raise BridgeError(
+                ErrorCode.FINGERPRINT_REFUSED,
+                "this approval was computed against an earlier preview session "
+                "that no longer matches the roll's current state; acquire a "
+                "fresh preview or placement and approve again",
             )
         try:
             self._roll.approve(slot)
@@ -918,8 +995,8 @@ class CoolscanPyTransport:
         tuple[domain.BoundarySnap, ...],
         domain.Material,
     ]:
-        """Re-slice the last completed preview attempt's already-decoded
-        raster at operator-picked boundary rows.
+        """Re-slice the CURRENT preview attempt's already-decoded raster at
+        operator-picked boundary rows.
 
         No hardware call, no film movement -- this is a pure re-slice of
         bytes already on disk from an earlier roll.preview attempt
@@ -940,7 +1017,18 @@ class CoolscanPyTransport:
                 "manual frame placement requires a completed roll.preview "
                 "attempt first",
             )
-        attempt = _reconstruct_last_preview_attempt(self.attempts_root)
+        # 2026-08-08 adversarial review, S5: only the exact attempt this
+        # transport itself recorded as current is ever used -- never a
+        # fresh filesystem scan, and never a silent fallback to an older
+        # attempt when the current one left no usable evidence.
+        if self._recorded_preview_attempt_journal is None:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "the most recent preview attempt on this roll left no usable "
+                "evidence to place frames from; acquire a fresh preview and "
+                "try again",
+            )
+        attempt = _reconstruct_preview_attempt(self._recorded_preview_attempt_journal)
         try:
             preview = _validated_preview_from_attempt(attempt)
         except coolscanpy.MeterUnusableError as exc:
@@ -977,51 +1065,48 @@ class CoolscanPyTransport:
             # IndexDecodeError branch above.
             raise BridgeError(ErrorCode.INVALID_PARAMS, str(exc)) from exc
 
-        # Arm self._roll's session state exactly like Roll.preview()'s own
-        # success tail does (_roll.py: "self._session = session;
-        # self._session_usb_topology = topology; self._approvals.clear()").
-        # Reaching into these three private fields directly -- never a
-        # public Roll method -- because Roll.restore_preview_session()
-        # explicitly, deliberately refuses a manual session
-        # (preview_session.py's _restore_roll_preview_session: "roll
-        # session was built from manual frame placement; restoring... is
-        # not yet supported. Refuse loudly instead of guessing.") and no
-        # OTHER public Roll API exists for installing an already-built
-        # RollPreviewSession without a fresh hardware read. This is not a
-        # hardware attempt, so it does not acquire the HardwareLane or
-        # require safety.require_armed() the way roll.preview/scan.start/
-        # device.eject do -- self._scanning (checked above) is still
-        # respected as a plain busy-guard against racing an ACTUAL transport
-        # read, but manual_frames() itself never becomes one; a real
-        # preview()/scan_many() call still goes through their own unmodified
-        # code paths, hardware lane, and locking exactly as before. Locked
-        # the same way Roll.preview()/set_spacing_offset()/approve()
-        # themselves protect this exact state, so a concurrent Roll caller
-        # can never observe a half-armed session.
-        with self._roll._state_condition:  # noqa: SLF001
-            self._roll._session = session
-            self._roll._session_usb_topology = preview.usb_topology
-            self._roll._approvals.clear()
-
+        # 2026-08-08 adversarial review, S1 (part 1): render and fsync every
+        # thumbnail this replacement session produces BEFORE touching
+        # self._roll's state at all. Previously the Roll-state swap below
+        # ran FIRST -- if the thumbnail-write loop then failed partway
+        # through, the OLD session/approvals were already gone (replaced
+        # and cleared) while the operator-visible thumbnails for the NEW
+        # one were incomplete or absent, and self._preview_established was
+        # not touched by that failure either -- a stale approve() against
+        # the operation the UI still showed would then silently reach the
+        # NEW session. Ordering this first means a write failure here
+        # raises before any Roll state -- or self._preview_established --
+        # has changed at all: approve()/set_spacing_offset() keep working
+        # exactly as they did before this call, against whatever session
+        # was already installed.
         preview_dir = safety.DEFAULT_BASE_DIR / "previews" / uuid.uuid4().hex
-        preview_dir.mkdir(parents=True, exist_ok=True)
         thumbnails: list[domain.Thumbnail] = []
-        for slot in session.slots:
-            tile_path = preview_dir / f"slot-{slot.slot_id:04d}.tif"
-            tifffile.imwrite(
-                tile_path, _normalize_preview_tile(slot.thumbnail), photometric="rgb"
-            )
-            thumbnails.append(
-                domain.Thumbnail(
-                    slot=slot.slot_id,
-                    boundary_rows=slot.boundary_rows,
-                    spacing_offset=slot.boundary_offset_rows,
-                    needs_approval=slot.manual_review,
-                    warnings=slot.warnings,
-                    image_path=str(tile_path),
-                    partial=slot.partial,
+        try:
+            preview_dir.mkdir(parents=True, exist_ok=True)
+            for slot in session.slots:
+                tile_path = preview_dir / f"slot-{slot.slot_id:04d}.tif"
+                tifffile.imwrite(
+                    tile_path, _normalize_preview_tile(slot.thumbnail), photometric="rgb"
                 )
-            )
+                _fsync_path(tile_path)
+                thumbnails.append(
+                    domain.Thumbnail(
+                        slot=slot.slot_id,
+                        boundary_rows=slot.boundary_rows,
+                        spacing_offset=slot.boundary_offset_rows,
+                        needs_approval=slot.manual_review,
+                        warnings=slot.warnings,
+                        image_path=str(tile_path),
+                        partial=slot.partial,
+                    )
+                )
+        except Exception as exc:
+            raise BridgeError(
+                ErrorCode.INTERNAL,
+                "manual frame placement could not persist its preview "
+                "thumbnails to disk; the previous preview session was left "
+                f"unchanged -- try again ({type(exc).__name__}: {exc})",
+            ) from exc
 
         # Per-boundary snap notes (BRIDGE.md's contract): derived from the
         # session's own boundaries rather than re-running
@@ -1033,7 +1118,10 @@ class CoolscanPyTransport:
         # final_rows[i] != row); `rows[i]` (the operator's own request,
         # already in hand here) and `boundary.output_row` (the resolved,
         # possibly-snapped row) reconstruct the identical BoundarySnap this
-        # module's own manual_frames.py would have returned.
+        # module's own manual_frames.py would have returned. Pure
+        # computation over `session`/`rows`, no I/O, so its position
+        # relative to the thumbnail writes above and the Roll-state install
+        # below has no observable effect either way.
         snaps: list[domain.BoundarySnap] = []
         for index, (requested_row, boundary) in enumerate(
             zip(rows, session.detection.boundaries)
@@ -1049,6 +1137,29 @@ class CoolscanPyTransport:
                     )
                 )
 
+        # S1 (part 3): fail closed the instant a mutation is attempted --
+        # re-armed only after install_manual_session below returns
+        # successfully. If it raises, this stays False rather than keeping
+        # whatever it was before, so a stale approve() against the OLD
+        # operation cannot slip through NO_PREVIEW's own guard while the
+        # Roll's state is ambiguous (busy/mismatch mid-install, never a
+        # partial write -- install_manual_session is itself transactional).
+        self._preview_established = False
+        # S1 (part 2): the transactional install itself -- locked-state and
+        # USB-topology checks, approvals clearing, and the atomic session
+        # swap all live in coolscanpy now (Roll.install_manual_session).
+        # This bridge no longer reaches into _session/_approvals/
+        # _state_condition directly; DeviceBusy/RollMismatch are this
+        # method's own typed mappings for that method's two failure modes,
+        # matching this file's existing DeviceBusy/RollMismatch precedents
+        # elsewhere (preview(), start_scan()).
+        try:
+            self._roll.install_manual_session(session)
+        except coolscanpy.DeviceBusy as exc:
+            raise BridgeError(ErrorCode.DEVICE_BUSY, str(exc)) from exc
+        except coolscanpy.RollMismatch as exc:
+            raise BridgeError(ErrorCode.ROLL_MISMATCH, str(exc)) from exc
+
         material = _COOLSCANPY_TO_MATERIAL[self._roll.material]
         self._material = material
         self._preview_established = True
@@ -1058,13 +1169,14 @@ class CoolscanPyTransport:
         return result, tuple(thumbnails), tuple(snaps), material
 
     def preview_strip(self) -> domain.PreviewStrip:
-        """Render the last completed preview attempt's whole captured raster
-        to one image, for a manual-placement editor to draw boundary lines
-        on before any row has been picked.
+        """Render the CURRENT preview attempt's whole captured raster to one
+        image, for a manual-placement editor to draw boundary lines on
+        before any row has been picked.
 
         Same precondition as manual_frames() (a completed preview attempt,
-        successful or refused, already on disk); no hardware call, and no
-        session/approval state is touched -- purely a read.
+        successful or refused, already on disk, and recorded as the current
+        one -- see manual_frames()'s own S5 comment); no hardware call, and
+        no session/approval state is touched -- purely a read.
         """
         if self._device is None:
             raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
@@ -1073,7 +1185,14 @@ class CoolscanPyTransport:
                 ErrorCode.NO_PREVIEW,
                 "roll.previewStrip requires a completed roll.preview attempt first",
             )
-        attempt = _reconstruct_last_preview_attempt(self.attempts_root)
+        if self._recorded_preview_attempt_journal is None:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "the most recent preview attempt on this roll left no usable "
+                "evidence to render a strip from; acquire a fresh preview and "
+                "try again",
+            )
+        attempt = _reconstruct_preview_attempt(self._recorded_preview_attempt_journal)
         try:
             preview = _validated_preview_from_attempt(attempt)
         except coolscanpy.MeterUnusableError as exc:

--- a/bridge/src/scanstudio_bridge/transport/mock.py
+++ b/bridge/src/scanstudio_bridge/transport/mock.py
@@ -446,9 +446,16 @@ class MockTransport:
                 ErrorCode.NO_PREVIEW,
                 "roll.previewStrip requires a completed roll.preview attempt first",
             )
-        row_count = self._slot_count * 1200
+        # The wire contract promises the image's width axis carries exactly
+        # row_count columns at pixels_per_row=1 (the real transport writes
+        # the raster unresized). The mock keeps the file small by capping
+        # the synthetic strip, so its REPORTED row_count is the written
+        # width -- an honest miniature, never a contradiction the editor's
+        # row-to-pixel mapping would silently mis-scale on (2026-08-08
+        # second-opinion review, finding 2).
+        row_count = min(self._slot_count * 1200, 4_096)
         tile_path = self._preview_dir / f"strip-{uuid.uuid4().hex}.tif"
-        strip = np.zeros((_SYNTHETIC_PREVIEW_WIDTH, min(row_count, 4096), 3), dtype=np.uint8)
+        strip = np.zeros((_SYNTHETIC_PREVIEW_WIDTH, row_count, 3), dtype=np.uint8)
         tifffile.imwrite(tile_path, strip, photometric="rgb")
         return domain.PreviewStrip(
             image_path=str(tile_path), row_count=row_count, pixels_per_row=1

--- a/bridge/src/scanstudio_bridge/transport/mock.py
+++ b/bridge/src/scanstudio_bridge/transport/mock.py
@@ -184,6 +184,12 @@ class MockTransport:
         self._spacing_offsets: dict[int, int] = {}
         self._scanning = False
         self._stop_event = threading.Event()
+        # 2026-08-08 adversarial review, S1: the fingerprint the last
+        # successful preview()/manual_frames() call returned -- mirrors the
+        # real transport's `self._roll.fingerprint.sha256`, kept here since
+        # this double has no real Roll object of its own. See approve()'s
+        # own docstring for how this is used.
+        self._fingerprint: str | None = None
 
     # -- device lifecycle -----------------------------------------------------
 
@@ -202,6 +208,7 @@ class MockTransport:
         self._approved_slots.clear()
         self._needs_approval_slots.clear()
         self._spacing_offsets.clear()
+        self._fingerprint = None
         return self._device_info()
 
     def status(self) -> domain.DeviceStatus:
@@ -231,6 +238,7 @@ class MockTransport:
         self._approved_slots.clear()
         self._needs_approval_slots.clear()
         self._spacing_offsets.clear()
+        self._fingerprint = None
 
     # -- preview / approve ------------------------------------------------------
 
@@ -273,10 +281,22 @@ class MockTransport:
         self._preview_established = True
         self._last_preview_material = material
         fingerprint = hashlib.sha256(f"{material}:{self._slot_count}".encode()).hexdigest()
+        self._fingerprint = fingerprint
         return domain.PreviewResult(count=self._slot_count, fingerprint=fingerprint)
 
-    def approve(self, slot: int) -> None:
+    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
         self._require_connected()
+        # Additive (2026-08-08 adversarial review, S1) -- see
+        # transport.Transport.approve's own docstring. `None` (the default,
+        # and every pre-existing caller) skips the comparison entirely,
+        # unchanged from before this parameter existed.
+        if fingerprint is not None and self._fingerprint != fingerprint:
+            raise BridgeError(
+                ErrorCode.FINGERPRINT_REFUSED,
+                "this approval was computed against an earlier preview session "
+                "that no longer matches the roll's current state; acquire a "
+                "fresh preview or placement and approve again",
+            )
         if slot < 1 or slot > self._slot_count or slot not in self._needs_approval_slots:
             raise BridgeError(ErrorCode.INVALID_PARAMS, f"slot {slot} does not need approval")
         self._approved_slots.add(slot)
@@ -410,6 +430,7 @@ class MockTransport:
         fingerprint = hashlib.sha256(
             f"manual:{tuple(rows)}".encode()
         ).hexdigest()
+        self._fingerprint = fingerprint
         self._preview_established = True
         return (
             domain.PreviewResult(count=self._slot_count, fingerprint=fingerprint),

--- a/bridge/src/scanstudio_bridge/transport/mock.py
+++ b/bridge/src/scanstudio_bridge/transport/mock.py
@@ -60,6 +60,32 @@ def _synthetic_preview_tile(slot: int, offset_rows: int = 0) -> np.ndarray:
     return np.roll(tile, -offset_rows, axis=1)
 
 
+def _validate_manual_rows(rows: object) -> None:
+    """Mock-only structural check -- a deliberately loose shadow of
+    coolscanpy's real `manual_frames.build_manual_detection` gates (structure,
+    physical frame-height range, transport-table sanity). This mock has no
+    raster or transport table to check against, so it only enforces what it
+    can: at least 2 plain-integer rows, strictly increasing. See
+    coolscanpy_transport.py's `manual_frames` for the real physical gates."""
+    if not isinstance(rows, list) or len(rows) < 2:
+        raise BridgeError(
+            ErrorCode.INVALID_PARAMS,
+            "manual frame placement needs at least 2 boundary rows (1 frame); "
+            f"only {len(rows) if isinstance(rows, list) else 0} were given",
+        )
+    if any(type(row) is not int or isinstance(row, bool) for row in rows):
+        raise BridgeError(
+            ErrorCode.INVALID_PARAMS,
+            "manual frame boundary rows must be plain integers",
+        )
+    if any(a >= b for a, b in zip(rows, rows[1:])):
+        raise BridgeError(
+            ErrorCode.INVALID_PARAMS,
+            "frame boundary rows must be placed in strictly increasing order, "
+            "top to bottom of the preview",
+        )
+
+
 def _synthetic_receipt(
     *,
     slot: int,
@@ -313,6 +339,98 @@ class MockTransport:
             needs_approval=is_last,
             warnings=("ambiguous-content-tail-boundary",) if is_last else (),
             image_path=str(tile_path),
+        )
+
+    # -- manual frame placement (Rung 4) -----------------------------------------
+
+    def manual_frames(
+        self, rows: list[int]
+    ) -> tuple[
+        domain.PreviewResult,
+        tuple[domain.Thumbnail, ...],
+        tuple[domain.BoundarySnap, ...],
+        domain.Material,
+    ]:
+        self._require_connected()
+        if self._scanning:
+            raise BridgeError(
+                ErrorCode.HARDWARE_LANE_BUSY,
+                "a scan job holds the hardware lane",
+            )
+        if not self._preview_established:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "manual frame placement requires a completed roll.preview attempt first",
+            )
+        _validate_manual_rows(rows)
+
+        # A manual placement replaces the whole roll's addressable slot
+        # lattice -- mirrors preview()'s own clear-and-rebuild of approval/
+        # offset bookkeeping (real CoolscanPy: a fresh RollPreviewSession
+        # with its own fixed, 1-based, contiguous slots).
+        self._slot_count = len(rows) - 1
+        self._approved_slots.clear()
+        self._needs_approval_slots.clear()
+        self._spacing_offsets.clear()
+
+        thumbnails: list[domain.Thumbnail] = []
+        snaps: list[domain.BoundarySnap] = []
+        for i in range(self._slot_count):
+            slot = i + 1
+            self._needs_approval_slots.add(slot)
+            tile_path = self._preview_dir / f"slot-{slot:04d}-manual.tif"
+            tifffile.imwrite(
+                tile_path, _synthetic_preview_tile(slot), photometric="rgb"
+            )
+            thumbnails.append(
+                domain.Thumbnail(
+                    slot=slot,
+                    boundary_rows=(rows[i], rows[i + 1]),
+                    spacing_offset=0,
+                    needs_approval=True,
+                    warnings=("user-picked",),
+                    image_path=str(tile_path),
+                )
+            )
+        # Deterministic, mock-only "snap": a picked row exactly divisible by
+        # 100 is reported as having snapped 1 row -- exercises the wire
+        # shape without needing real clear-film evidence. Real snap
+        # detection lives entirely in coolscanpy_transport.py.
+        for index, row in enumerate(rows):
+            if row % 100 == 0 and row > 0:
+                snaps.append(
+                    domain.BoundarySnap(
+                        boundary_index=index,
+                        requested_row=row,
+                        snapped_row=row - 1,
+                        evidence_run=(row - 4, row + 4),
+                    )
+                )
+
+        fingerprint = hashlib.sha256(
+            f"manual:{tuple(rows)}".encode()
+        ).hexdigest()
+        self._preview_established = True
+        return (
+            domain.PreviewResult(count=self._slot_count, fingerprint=fingerprint),
+            tuple(thumbnails),
+            tuple(snaps),
+            self._last_preview_material,
+        )
+
+    def preview_strip(self) -> domain.PreviewStrip:
+        self._require_connected()
+        if not self._preview_established:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "roll.previewStrip requires a completed roll.preview attempt first",
+            )
+        row_count = self._slot_count * 1200
+        tile_path = self._preview_dir / f"strip-{uuid.uuid4().hex}.tif"
+        strip = np.zeros((_SYNTHETIC_PREVIEW_WIDTH, min(row_count, 4096), 3), dtype=np.uint8)
+        tifffile.imwrite(tile_path, strip, photometric="rgb")
+        return domain.PreviewStrip(
+            image_path=str(tile_path), row_count=row_count, pixels_per_row=1
         )
 
     # -- scanning -----------------------------------------------------------------

--- a/bridge/tests/test_service_dispatch.py
+++ b/bridge/tests/test_service_dispatch.py
@@ -145,6 +145,7 @@ class _StubTransport:
         *,
         preview_thumbnails: int = 2,
         start_scan_raises: Exception | None = None,
+        manual_frames_raises: Exception | None = None,
     ) -> None:
         self.device_open = False
         self.approved: list[int] = []
@@ -154,6 +155,9 @@ class _StubTransport:
         self.close_called = False
         self._preview_thumbnails = preview_thumbnails
         self._start_scan_raises = start_scan_raises
+        self.manual_frames_calls: list[tuple[int, ...]] = []
+        self.preview_strip_calls = 0
+        self._manual_frames_raises = manual_frames_raises
 
     def list_devices(self) -> list[domain.DeviceInfo]:
         return [_device_info()]
@@ -195,6 +199,49 @@ class _StubTransport:
             needs_approval=True,
             warnings=("manual-review-required",),
             image_path=f"/tmp/stub-preview/adjusted-slot-{slot:04d}-{offset_rows}.tif",
+        )
+
+    def manual_frames(
+        self, rows: list[int]
+    ) -> tuple[
+        domain.PreviewResult,
+        tuple[domain.Thumbnail, ...],
+        tuple[domain.BoundarySnap, ...],
+        domain.Material,
+    ]:
+        self.manual_frames_calls.append(tuple(rows))
+        if self._manual_frames_raises is not None:
+            raise self._manual_frames_raises
+        thumbnails = tuple(
+            domain.Thumbnail(
+                slot=i + 1,
+                boundary_rows=(rows[i], rows[i + 1]),
+                spacing_offset=0,
+                needs_approval=True,
+                warnings=("user-picked",),
+                image_path=f"/tmp/stub-preview/manual-slot-{i + 1:04d}.tif",
+            )
+            for i in range(len(rows) - 1)
+        )
+        snaps = (
+            domain.BoundarySnap(
+                boundary_index=0,
+                requested_row=rows[0],
+                snapped_row=rows[0],
+                evidence_run=(max(0, rows[0] - 2), rows[0] + 2),
+            ),
+        )
+        return (
+            domain.PreviewResult(count=len(thumbnails), fingerprint="stub-manual-fp"),
+            thumbnails,
+            snaps,
+            domain.Material.COLOR_NEGATIVE,
+        )
+
+    def preview_strip(self) -> domain.PreviewStrip:
+        self.preview_strip_calls += 1
+        return domain.PreviewStrip(
+            image_path="/tmp/stub-preview/strip.tif", row_count=4800, pixels_per_row=1
         )
 
     def start_scan(self, slots, recipe, output, on_progress, on_retry, on_frame, on_call=None):
@@ -761,6 +808,169 @@ def test_roll_set_spacing_offset_is_refused_while_scan_job_is_active(
     finally:
         transport.release.set()
         _wait_for(lambda: emit.has("scan.completed"))
+
+
+# -- roll.manualFrames / roll.previewStrip (Rung 4) --------------------------------
+
+
+def test_roll_manual_frames_dispatch_routes_rows_and_rearms_scan_gate(
+    tmp_path: Path,
+) -> None:
+    """Proves the dispatch shape end to end: roll.manualFrames reaches
+    transport.manual_frames() with the exact rows requested, the wire result
+    carries count/fingerprint/thumbnails/snaps, and -- since manual_frames()
+    arms a usable session without ever calling roll.preview -- a following
+    scan.start is no longer refused with NO_PREVIEW (BridgeService's
+    self._preview_material must have been re-armed from the transport's
+    returned material, not from a roll.preview request that never
+    happened)."""
+    transport = _StubTransport()
+    svc = _opened_service(tmp_path, transport)
+
+    result = svc.dispatch(
+        {
+            "id": 2,
+            "method": "roll.manualFrames",
+            "params": {"rows": [100, 300, 500]},
+        },
+        lambda *_a: None,
+    )
+
+    assert transport.manual_frames_calls == [(100, 300, 500)]
+    assert result["count"] == 2
+    assert result["fingerprint"] == "stub-manual-fp"
+    assert [t["slot"] for t in result["thumbnails"]] == [1, 2]
+    assert result["thumbnails"][0]["boundaryRows"] == [100, 300]
+    assert result["thumbnails"][0]["needsApproval"] is True
+    assert result["snaps"] == [
+        {
+            "boundaryIndex": 0,
+            "requestedRow": 100,
+            "snappedRow": 100,
+            "evidenceRun": [98, 102],
+        }
+    ]
+
+    # The real proof this armed a usable session: scan.start no longer
+    # raises NO_PREVIEW, even though roll.preview was never called this
+    # session.
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch(
+            {
+                "id": 3,
+                "method": "scan.start",
+                "params": {
+                    "slots": [1],
+                    "recipe": _wire_recipe(),
+                    "output": {
+                        "destination": str(tmp_path / "out"),
+                        "filenameTemplate": "frame-####.tif",
+                    },
+                },
+            },
+            lambda *_a: None,
+        )
+    # HW_MOTION_NOT_ARMED (the latch was never armed in this test) proves
+    # scan.start got PAST its NO_PREVIEW gate -- the one thing this test is
+    # pinning -- and was refused for an unrelated, later reason instead.
+    assert excinfo.value.code is ErrorCode.HW_MOTION_NOT_ARMED
+
+
+def test_roll_manual_frames_without_open_device_is_not_connected(
+    tmp_path: Path,
+) -> None:
+    transport = _StubTransport()
+    svc = _make_service(tmp_path, transport)
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch(
+            {
+                "id": 2,
+                "method": "roll.manualFrames",
+                "params": {"rows": [100, 300]},
+            },
+            lambda *_a: None,
+        )
+
+    assert excinfo.value.code is ErrorCode.NOT_CONNECTED
+    assert transport.manual_frames_calls == []
+
+
+def test_roll_manual_frames_missing_rows_is_invalid_params(tmp_path: Path) -> None:
+    transport = _StubTransport()
+    svc = _opened_service(tmp_path, transport)
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch(
+            {"id": 2, "method": "roll.manualFrames", "params": {}},
+            lambda *_a: None,
+        )
+
+    assert excinfo.value.code is ErrorCode.INVALID_PARAMS
+    assert "rows" in str(excinfo.value)
+    assert transport.manual_frames_calls == []
+
+
+def test_roll_manual_frames_propagates_transport_validation_error_unmodified(
+    tmp_path: Path,
+) -> None:
+    """service.py must not truncate or reshape a validation-failure
+    BridgeError raised from the transport -- the plain-English sentence
+    manual_frames.py's own gates produce is what the operator needs to see,
+    unmodified, at the dispatch boundary."""
+    sentence = (
+        "the 1st frame you placed is about 8 mm tall (between rows 10 and "
+        "40), outside the 15-75 mm range this driver accepts for manual "
+        "placement"
+    )
+    transport = _StubTransport(
+        manual_frames_raises=BridgeError(ErrorCode.INVALID_PARAMS, sentence)
+    )
+    svc = _opened_service(tmp_path, transport)
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch(
+            {
+                "id": 2,
+                "method": "roll.manualFrames",
+                "params": {"rows": [10, 40]},
+            },
+            lambda *_a: None,
+        )
+
+    assert excinfo.value.code is ErrorCode.INVALID_PARAMS
+    assert str(excinfo.value) == sentence
+
+
+def test_roll_preview_strip_dispatch_returns_wire_shape(tmp_path: Path) -> None:
+    transport = _StubTransport()
+    svc = _opened_service(tmp_path, transport)
+
+    result = svc.dispatch(
+        {"id": 2, "method": "roll.previewStrip", "params": {}}, lambda *_a: None
+    )
+
+    assert transport.preview_strip_calls == 1
+    assert result == {
+        "imagePath": "/tmp/stub-preview/strip.tif",
+        "rowCount": 4800,
+        "pixelsPerRow": 1,
+    }
+
+
+def test_roll_preview_strip_without_open_device_is_not_connected(
+    tmp_path: Path,
+) -> None:
+    transport = _StubTransport()
+    svc = _make_service(tmp_path, transport)
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch(
+            {"id": 2, "method": "roll.previewStrip", "params": {}}, lambda *_a: None
+        )
+
+    assert excinfo.value.code is ErrorCode.NOT_CONNECTED
+    assert transport.preview_strip_calls == 0
 
 
 def test_roll_preview_error_telemetry_includes_message(

--- a/bridge/tests/test_service_dispatch.py
+++ b/bridge/tests/test_service_dispatch.py
@@ -1789,3 +1789,23 @@ def test_failed_preview_does_not_claim_a_preview_material(
             emit,
         )
     assert excinfo.value.code == ErrorCode.NO_PREVIEW
+
+
+def test_roll_manual_frames_rejects_non_integer_rows(tmp_path: Path) -> None:
+    """Wire strictness (adversarial review 2026-08-08, F8a): floats, digit
+    strings, booleans, and non-lists must all refuse as INVALID_PARAMS with
+    a plain sentence -- never truncate, explode into digits, or surface as
+    INTERNAL -- and must never reach the transport."""
+
+    transport = _StubTransport()
+    svc = _opened_service(tmp_path, transport)
+
+    for bad in ([12.5, 200], ["123"], [True, 200], "12,200", [12, "x"]):
+        with pytest.raises(BridgeError) as excinfo:
+            svc.dispatch(
+                {"id": 3, "method": "roll.manualFrames", "params": {"rows": bad}},
+                lambda *_a: None,
+            )
+        assert excinfo.value.code is ErrorCode.INVALID_PARAMS, bad
+        assert "whole numbers" in str(excinfo.value), bad
+    assert transport.manual_frames_calls == []

--- a/bridge/tests/test_transport_coolscanpy.py
+++ b/bridge/tests/test_transport_coolscanpy.py
@@ -14,15 +14,27 @@ adapter/workflow injection seams. No hardware is touched by any test here.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
+import json
+import struct
 import tempfile
 import threading
 import time
+import uuid
 from pathlib import Path
 
 import coolscanpy
 import numpy as np
 import pytest
 import tifffile
+
+from coolscanpy.protocol.ls5000_single_pass import roll_index as _roll_index_module
+from coolscanpy.protocol.ls5000_single_pass.density import (
+    DensityCalibration,
+    build_nikon_density_evidence,
+)
+from coolscanpy.protocol.ls5000_single_pass.plan import CANONICAL_PLAN_SHA256
+from coolscanpy.roll.preview_session import _preview_binding_contract
 
 from scanstudio_bridge import domain, safety, service
 from scanstudio_bridge.protocol import BridgeError, ErrorCode
@@ -53,6 +65,7 @@ class _FakeRoll:
         thumbnails: list["coolscanpy.Thumbnail"] | None = None,
         fingerprint_sha256: str = "f" * 64,
         scan_results: dict[int, list[object]] | None = None,
+        material: "coolscanpy.Material" = coolscanpy.Material.COLOR_NEGATIVE,
     ) -> None:
         self._thumbnails = thumbnails or []
         self._fingerprint_sha256 = fingerprint_sha256
@@ -63,6 +76,19 @@ class _FakeRoll:
         self.safe_stop_calls = 0
         self.closed = False
         self._safe_stop_requested = False
+        # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md):
+        # CoolscanPyTransport.manual_frames() arms a manually-built
+        # RollPreviewSession by reaching into these exact private
+        # coolscanpy.Roll attributes directly -- no public Roll API installs
+        # an already-built session without a fresh hardware read (see that
+        # method's own comment). This fake carries the same attribute names,
+        # real types, and locking shape so that code path runs unmodified
+        # against this double, exactly as it would against a real Roll.
+        self.material = material
+        self._state_condition = threading.Condition(threading.RLock())
+        self._session: object | None = None
+        self._session_usb_topology: tuple[int, int] | None = None
+        self._approvals: dict[int, object] = {}
 
     def preview(self, slots: list[int] | None = None) -> list["coolscanpy.Thumbnail"]:
         if slots is None:
@@ -310,6 +336,238 @@ def _opened_transport(
 
 def _output(destination: Path, filename_template: str = "frame-####.tif") -> domain.OutputSpec:
     return domain.OutputSpec(destination=str(destination), filename_template=filename_template)
+
+
+# -- Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): synthetic on-disk preview ---
+# attempt. manual_frames()/preview_strip() read straight from disk
+# (attempts_root), bypassing the _FakeRoll double this file otherwise uses
+# everywhere else -- see coolscanpy_transport.py's own
+# _reconstruct_last_preview_attempt/_validated_preview_from_attempt. The
+# helpers below build one REAL, byte-valid preview attempt directory
+# (journal.json + capture-preview.bin + capture-008e.bin +
+# capture-frame-map.json). Ported byte-for-byte from coolscanpy's own test
+# fixture (coolscanpy/tests/roll/test_ls5000_roll_session.py's
+# _preview_fixture/_synthetic_index/_encode_index/_transport_table -- the
+# owner's already-proven encoding, not re-derived here), landed under a real
+# attempts_root with the CaptureMode.PREVIEW "preview-" mkdtemp prefix
+# CoolscanPyTransport's own glob expects instead of a bare test directory
+# name. The transport-table encoding (code=6*(row%18), selector=row//18) is
+# the same 42-native-units-per-row convention coolscanpy's own
+# test_manual_frames.py/test_ls5000_roll_session.py fixtures use, comfortably
+# inside build_manual_detection's 40..45 ramp-guard gate.
+
+_SYNTHETIC_DENSITY_CALIBRATION_PAYLOADS = tuple(
+    bytes.fromhex(value)
+    for value in (
+        "8c20000000040000df1a",
+        "8c20000000040000bba4",
+        "8c200000000400007fab",
+    )
+)
+_SYNTHETIC_DENSITY_CALIBRATION_NUMERATORS = (57_114, 48_036, 32_683)
+
+
+def _synthetic_density_calibration(session_id: str) -> DensityCalibration:
+    return DensityCalibration(
+        session_id=session_id,
+        numerators=_SYNTHETIC_DENSITY_CALIBRATION_NUMERATORS,
+        payload_hex=tuple(
+            payload.hex() for payload in _SYNTHETIC_DENSITY_CALIBRATION_PAYLOADS
+        ),
+        payload_sha256=tuple(
+            hashlib.sha256(payload).hexdigest()
+            for payload in _SYNTHETIC_DENSITY_CALIBRATION_PAYLOADS
+        ),
+    )
+
+
+def _encode_synthetic_index(rgb16: np.ndarray) -> bytes:
+    """Encode the compact RGB96 index rows the scanner itself would have
+    written -- byte-for-byte port of test_ls5000_roll_session.py's own
+    _encode_index."""
+    blocks = np.zeros(
+        (rgb16.shape[0] // 2, _roll_index_module.INDEX_BLOCK_WORDS),
+        dtype=np.uint16,
+    )
+    blocks[:, 0:96] = rgb16[0::2, :, 0]
+    blocks[:, 96:192] = rgb16[0::2, :, 1]
+    blocks[:, 192:288] = rgb16[0::2, :, 2]
+    blocks[:, 512:608] = rgb16[1::2, :, 0]
+    blocks[:, 608:704] = rgb16[1::2, :, 1]
+    blocks[:, 704:800] = rgb16[1::2, :, 2]
+    blocks[:, 800::2] = _roll_index_module.INDEX_TRAILER_MARK
+    blocks[:, 801::2] = np.arange(
+        _roll_index_module.INDEX_TRAILER_COUNTER0,
+        _roll_index_module.INDEX_TRAILER_COUNTER0
+        + _roll_index_module.INDEX_TRAILER_WORDS // 2,
+        dtype=np.uint16,
+    )
+    return blocks.astype(">u2", copy=False).tobytes()
+
+
+def _synthetic_preview_index(
+    *, height: int, frame_count: int = 40, content_frames: int = 40, leader: int = 128
+) -> np.ndarray:
+    """Textured cells separated by physical clear-film gaps, at the pitch=143
+    convention coolscanpy's own manual-session fixtures use -- byte-for-byte
+    port of test_ls5000_roll_session.py's own _synthetic_index."""
+    pitch = 143
+    boundaries = [leader + index * pitch for index in range(frame_count + 1)]
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[:, :, channel] = base + texture * (3 - channel) // 2
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    clear_noise = ((x * 19 + y * 13) % 301 - 150)[:, :, None]
+    aperture[: boundaries[0]] = clear_base + clear_noise[: boundaries[0]]
+    aperture[boundaries[-1] :] = clear_base + clear_noise[boundaries[-1] :]
+    for boundary in boundaries:
+        start = max(0, boundary - 3)
+        end = min(height, boundary + 3)
+        aperture[start:end] = clear_base + clear_noise[start:end]
+    if content_frames < frame_count:
+        clear_start = boundaries[content_frames]
+        aperture[clear_start:] = clear_base + clear_noise[clear_start:]
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16)
+
+
+def _synthetic_transport_table(rows: int) -> bytes:
+    """42-native-units-per-row same-traversal table -- byte-for-byte port of
+    test_ls5000_roll_session.py's own _transport_table."""
+    records = bytearray()
+    for row in range(rows):
+        records.extend(struct.pack(">HH", 6 * (row % 18), row // 18))
+    total = 8 + len(records)
+    return b"\x00\x8e\x00\x00" + total.to_bytes(2, "big") + b"\x00\x00" + bytes(records)
+
+
+def _write_synthetic_preview_attempt(
+    attempts_root: Path, *, slot_capacity_hint: int = 40
+) -> Path:
+    """Write one complete, byte-valid preview attempt directory under
+    ``attempts_root`` with CoolscanPyTransport's own "preview-" mkdtemp
+    prefix -- everything manual_frames()/preview_strip()'s
+    _reconstruct_last_preview_attempt/_validated_preview_from_attempt need to
+    find and validate it, exactly as if a real roll.preview attempt had just
+    completed (this journal shape is "preview-only"/"complete"/released --
+    see preview_session.py's _validate_preview_result: both that shape and
+    the "preview-and-hold" shape a real Roll.preview() always uses today
+    validate identically). Returns the attempt directory."""
+    contract = _preview_binding_contract(slot_capacity_hint)
+    native_height = contract["native_height"]
+    decoded_height = contract["decoded_height"]
+    startup_status = contract["startup_status"]
+    preview_binding = {
+        key: value for key, value in contract.items() if key != "startup_status"
+    }
+
+    attempt = attempts_root / f"preview-{uuid.uuid4().hex}"
+    attempt.mkdir(parents=True)
+    output = attempt / "capture.bin"
+    output.write_bytes(b"")
+    preview_path = attempt / "capture-preview.bin"
+    table_path = attempt / "capture-008e.bin"
+    mapping_path = attempt / "capture-frame-map.json"
+
+    rgb = _synthetic_preview_index(height=decoded_height)
+    usable_rows = len(rgb)
+    preview = _encode_synthetic_index(rgb)
+    table = _synthetic_transport_table(usable_rows)
+    preview_path.write_bytes(preview)
+    table_path.write_bytes(table)
+
+    density_session_id = "single-reservation-roll-preview"
+    density_exposures = (71_373, 137_524, 126_126)
+    preview_sha256 = hashlib.sha256(preview).hexdigest()
+    density_evidence = build_nikon_density_evidence(
+        preview,
+        calibration=_synthetic_density_calibration(density_session_id),
+        density_f03_exposures_raw_10ns=density_exposures,
+        session_id=density_session_id,
+        capture_attempt_id=attempt.name,
+        scan_identity=f"{density_session_id}:density-97dpi:{preview_sha256}",
+        source_native_height=native_height,
+        source_height=decoded_height,
+    )
+    receipt = {
+        "status": "preview-only-complete",
+        "slot_capacity_hint": slot_capacity_hint,
+        "slot_capacity_semantics": (
+            "scanner-addressable preview slots; not an exposure count"
+        ),
+        "preview_bytes": len(preview),
+        "preview_sha256": preview_sha256,
+        "table_bytes": len(table),
+        "table_sha256": hashlib.sha256(table).hexdigest(),
+        "frame_detection": "deferred-offline",
+        "startup_table": {
+            "count": slot_capacity_hint,
+            "sha256": "a" * 64,
+            "status": startup_status,
+        },
+        "preview_binding": preview_binding,
+    }
+    mapping_path.write_text(json.dumps(receipt), encoding="utf-8")
+    journal = {
+        "status": "complete",
+        "capture_mode": "preview-only",
+        "requested_frame": None,
+        "requested_boundary_offset_rows": 0,
+        "expected_frame_count": None,
+        "expected_reads": 0,
+        "completed_reads": 0,
+        "expected_bytes": 0,
+        "completed_bytes": 0,
+        "disk_bytes": 0,
+        "unit_released": True,
+        "output": str(output.resolve()),
+        "output_sha256": hashlib.sha256(b"").hexdigest(),
+        "plan_sha256": CANONICAL_PLAN_SHA256,
+        "capture_engine_sha256": "b" * 64,
+        "scanner_identity": "Nikon LS-5000 ED 1.03",
+        "expected_usb_bus": 1,
+        "expected_usb_address": 2,
+        "actual_usb_bus": 1,
+        "actual_usb_address": 2,
+        "preview_geometry_validated_before_reads": True,
+        "preview_windows": [
+            {
+                "color_id": color,
+                "resolution": [97, 97],
+                "origin": [0, 0],
+                "size": [3_946, native_height],
+                "bit_depth": 16,
+                "density_f03_exposure_raw_10ns": exposure,
+            }
+            for color, exposure in zip((1, 2, 3), density_exposures, strict=True)
+        ],
+        "density_calibration_session_id": density_session_id,
+        "nikon_density_evidence": density_evidence.to_dict(),
+        "live_startup_0x8f": {"count": slot_capacity_hint, "sha256": "a" * 64},
+        "live_startup_0x8f_status": startup_status,
+        "live_preview_binding": preview_binding,
+        "live_index_artifacts": {
+            "mapping": str(mapping_path.resolve()),
+            "preview": str(preview_path.resolve()),
+            "table": str(table_path.resolve()),
+        },
+        "live_index_evidence": {
+            "status": "persisted-before-frame-detection",
+            "preview_bytes": len(preview),
+            "preview_sha256": preview_sha256,
+            "table_bytes": len(table),
+            "table_sha256": hashlib.sha256(table).hexdigest(),
+        },
+        "preview_only_receipt": receipt,
+    }
+    (attempt / "journal.json").write_text(json.dumps(journal), encoding="utf-8")
+    return attempt
 
 
 # -- list_devices / open_device ----------------------------------------------------
@@ -982,6 +1240,191 @@ def test_preview_maps_base_roll_mismatch(monkeypatch: pytest.MonkeyPatch) -> Non
         transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
     assert excinfo.value.code == ErrorCode.ROLL_MISMATCH
     assert "different USB topology" in str(excinfo.value)
+
+
+def test_preview_probable_cause_survives_into_refeed_required_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rung 3 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): detect_roll_frames's
+    failure paths attach a best-effort plain-English
+    diagnostics["probable_cause"] sentence to the IndexDecodeError they raise
+    (roll_index.py). IndexDecodeError.__str__ already embeds its full
+    diagnostics dict (json.dumps) in the message, and preview()'s own
+    existing except IndexDecodeError branch already interpolates str(exc)
+    into its REFEED_REQUIRED message -- so the sentence should ride through
+    automatically, with no bridge change needed. This test pins that so a
+    future refactor of either side can't silently drop it."""
+    from coolscanpy.protocol.ls5000_single_pass.roll_index import IndexDecodeError
+
+    sentence = (
+        "this looks like half-frame film (frames about every 19 mm); this "
+        "driver expects standard 35 mm spacing"
+    )
+
+    class _ProbableCauseRoll(_FakeRoll):
+        def preview(self, slots: list[int] | None = None) -> list["coolscanpy.Thumbnail"]:
+            raise IndexDecodeError(
+                "transport anchor residual is inconsistent with one affine "
+                "preview traversal (MAE 4.447 rows, max 11.241 rows)",
+                error_id="gap-lattice-anchor",
+                diagnostics={"probable_cause": sentence},
+            )
+
+    transport, _device = _opened_transport(monkeypatch, _ProbableCauseRoll())
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert excinfo.value.code == ErrorCode.REFEED_REQUIRED
+    message = str(excinfo.value)
+    assert sentence in message
+    assert "MAE 4.447" in message
+
+
+# -- roll.manualFrames / roll.previewStrip (Rung 4) --------------------------------
+
+
+def test_manual_frames_without_any_preview_attempt_is_no_preview(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """manual_frames() is usable only after at least one roll.preview
+    attempt (successful or refused) exists on disk -- before that, self._roll
+    and self.attempts_root are both still None."""
+    transport, _device = _opened_transport(monkeypatch, _FakeRoll())
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128, 271, 414])
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+
+
+def test_preview_strip_without_any_preview_attempt_is_no_preview(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport, _device = _opened_transport(monkeypatch, _FakeRoll())
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview_strip()
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+
+
+def _transport_with_synthetic_preview_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[CoolscanPyTransport, _FakeRoll, Path]:
+    """An opened transport whose attempts_root already holds one real,
+    byte-valid preview attempt on disk -- the "completed-but-refused (or
+    completed) preview attempt" manual_frames()/preview_strip() require.
+    Runs one (successful, contents-irrelevant) fake preview() first purely
+    to let CoolscanPyTransport.preview()'s own existing code create
+    self._roll/self.attempts_root exactly as it would in production; the
+    attempt this test actually reads back is a separately-written synthetic
+    one, matching how a real refused preview would leave its own evidence
+    on disk without ever producing a _FakeRoll-shaped in-memory session."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)])
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert transport.attempts_root is not None
+    attempt_dir = _write_synthetic_preview_attempt(transport.attempts_root)
+    return transport, roll, attempt_dir
+
+
+def test_manual_frames_happy_path_arms_session_for_approve_and_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport, roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+
+    result, thumbnails, snaps, material = transport.manual_frames([128, 271, 414])
+
+    assert material is domain.Material.COLOR_NEGATIVE
+    assert result.count == 2
+    assert len(thumbnails) == 2
+    assert [t.slot for t in thumbnails] == [1, 2]
+    assert thumbnails[0].boundary_rows == (128, 271)
+    assert thumbnails[1].boundary_rows == (271, 414)
+    assert thumbnails[0].needs_approval is True
+    assert "user-picked" in thumbnails[0].warnings
+    assert Path(thumbnails[0].image_path).is_file()
+    # Picked rows land exactly on the synthetic raster's own clear-film gap
+    # centers -- snap assist finds a zero-distance match at every boundary,
+    # so nothing moves and no snap note is produced.
+    assert snaps == ()
+
+    # The transport's own bookkeeping is re-armed exactly like a successful
+    # preview() leaves it.
+    assert transport._material is domain.Material.COLOR_NEGATIVE
+    assert transport._preview_established is True
+
+    # The real proof of "armed exactly like a successful preview": the SAME
+    # coolscanpy.Roll instance's session/approvals state now reflects the
+    # manual session, and the EXISTING, unmodified approve()/
+    # set_spacing_offset() methods keep working against it unchanged.
+    assert roll._session is not None
+    assert len(roll._session.slots) == 2
+    assert roll._approvals == {}
+    transport.approve(1)
+    assert roll.approve_calls == [1]
+    # _FakeRoll.set_spacing_offset resolves against its OWN _thumbnails list
+    # (slot 1, from the fixture's setup preview() call above) -- unrelated to
+    # the manual session's own slot numbering, but exactly enough to prove
+    # set_spacing_offset() itself still runs unmodified, end to end, after
+    # manual_frames() armed the roll.
+    adjusted = transport.set_spacing_offset(1, 0)
+    assert adjusted.slot == 1
+    assert roll.spacing_offset_calls == [(1, 0)]
+
+
+def test_manual_frames_validation_failure_maps_to_invalid_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """manual_frames.py's own plain-English physical-frame-height gate (15-75
+    mm) refuses a too-short pick -- surfaced as INVALID_PARAMS (the operator's
+    rows, not a hardware fault), with the exact sentence preserved."""
+    transport, _roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128, 140])
+
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+    message = str(excinfo.value)
+    assert "outside the 15-75 mm range" in message
+    assert "manual placement" in message
+
+
+def test_manual_frames_structural_failure_maps_to_invalid_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single boundary row (0 frames) fails manual_frames.py's own
+    structural gate before any physical check runs -- also INVALID_PARAMS."""
+    transport, _roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128])
+
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+    assert "at least 2 boundary rows" in str(excinfo.value)
+
+
+def test_preview_strip_happy_path_renders_whole_raster(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport, _roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+
+    strip = transport.preview_strip()
+
+    assert strip.row_count == 6_104  # the 40-record contract's decoded_height
+    assert strip.pixels_per_row == 1
+    assert Path(strip.image_path).is_file()
+    with tifffile.TiffFile(strip.image_path) as handle:
+        image = handle.asarray()
+    # _normalize_preview_tile's swapaxes(0,1): the raster's row axis (what
+    # roll.manualFrames's rows address) becomes the image's WIDTH axis.
+    assert image.shape == (96, 6_104, 3)
 
 
 def test_start_scan_maps_base_roll_mismatch(

--- a/bridge/tests/test_transport_coolscanpy.py
+++ b/bridge/tests/test_transport_coolscanpy.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import json
+import os
 import struct
 import tempfile
 import threading
@@ -66,6 +67,7 @@ class _FakeRoll:
         fingerprint_sha256: str = "f" * 64,
         scan_results: dict[int, list[object]] | None = None,
         material: "coolscanpy.Material" = coolscanpy.Material.COLOR_NEGATIVE,
+        install_manual_session_effect: BaseException | None = None,
     ) -> None:
         self._thumbnails = thumbnails or []
         self._fingerprint_sha256 = fingerprint_sha256
@@ -76,19 +78,37 @@ class _FakeRoll:
         self.safe_stop_calls = 0
         self.closed = False
         self._safe_stop_requested = False
-        # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md):
-        # CoolscanPyTransport.manual_frames() arms a manually-built
-        # RollPreviewSession by reaching into these exact private
-        # coolscanpy.Roll attributes directly -- no public Roll API installs
-        # an already-built session without a fresh hardware read (see that
-        # method's own comment). This fake carries the same attribute names,
-        # real types, and locking shape so that code path runs unmodified
-        # against this double, exactly as it would against a real Roll.
+        # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md) / S1 fix
+        # (2026-08-08 adversarial review): _session/_session_usb_topology/
+        # _approvals/_state_condition mirror real coolscanpy.Roll's own
+        # private attribute names, types, and locking shape purely so
+        # install_manual_session() below can behave like the real one
+        # (coolscanpy's own _roll.py) without duplicating it -- nothing in
+        # coolscanpy_transport.py reaches into these directly any more (see
+        # manual_frames()'s own comment); this fake's PUBLIC
+        # install_manual_session is the only thing that touches them now.
         self.material = material
         self._state_condition = threading.Condition(threading.RLock())
         self._session: object | None = None
         self._session_usb_topology: tuple[int, int] | None = None
         self._approvals: dict[int, object] = {}
+        self.install_manual_session_calls: list[object] = []
+        # Test-driven failure injection, mirroring _FakeDevice.eject_effect
+        # below -- lets a test prove manual_frames() maps
+        # coolscanpy.DeviceBusy/RollMismatch from install_manual_session to
+        # the right BridgeError, and that a raise here leaves _session/
+        # _approvals exactly as they were (install_manual_session's own
+        # transactional contract).
+        self._install_manual_session_effect = install_manual_session_effect
+
+    def install_manual_session(self, session: object) -> None:
+        self.install_manual_session_calls.append(session)
+        if self._install_manual_session_effect is not None:
+            raise self._install_manual_session_effect
+        with self._state_condition:
+            self._session = session
+            self._session_usb_topology = session.preview.usb_topology
+            self._approvals.clear()
 
     def preview(self, slots: list[int] | None = None) -> list["coolscanpy.Thumbnail"]:
         if slots is None:
@@ -1317,12 +1337,26 @@ def _transport_with_synthetic_preview_attempt(
     self._roll/self.attempts_root exactly as it would in production; the
     attempt this test actually reads back is a separately-written synthetic
     one, matching how a real refused preview would leave its own evidence
-    on disk without ever producing a _FakeRoll-shaped in-memory session."""
+    on disk without ever producing a _FakeRoll-shaped in-memory session.
+
+    S5 fix (2026-08-08 adversarial review): manual_frames()/preview_strip()
+    now read ONLY `transport._recorded_preview_attempt_journal`, never a
+    fresh glob of attempts_root -- production sets that from what
+    preview()'s own before/after snapshot actually saw appear on disk
+    (see coolscanpy_transport.py's own comment), which is necessarily empty
+    here since `_FakeRoll.preview()` writes nothing at all. This fixture's
+    whole point is a synthetic attempt written OUT OF BAND from any real
+    preview() call, so it sets the recorded identity directly too --
+    exactly the side effect a real preview() call would have performed had
+    this synthetic attempt actually been the product of one."""
     roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)])
     transport, _device = _opened_transport(monkeypatch, roll)
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
     assert transport.attempts_root is not None
     attempt_dir = _write_synthetic_preview_attempt(transport.attempts_root)
+    transport._recorded_preview_attempt_journal = (
+        attempt_dir / "journal.json"
+    ).resolve(strict=True)
     return transport, roll, attempt_dir
 
 
@@ -1388,7 +1422,7 @@ def test_manual_frames_validation_failure_maps_to_invalid_params(
 
     assert excinfo.value.code == ErrorCode.INVALID_PARAMS
     message = str(excinfo.value)
-    assert "outside the 15-75 mm range" in message
+    assert "15 mm floor" in message
     assert "manual placement" in message
 
 
@@ -1425,6 +1459,257 @@ def test_preview_strip_happy_path_renders_whole_raster(
     # _normalize_preview_tile's swapaxes(0,1): the raster's row axis (what
     # roll.manualFrames's rows address) becomes the image's WIDTH axis.
     assert image.shape == (96, 6_104, 3)
+
+
+def test_preview_strip_refuses_when_current_attempt_has_no_recorded_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S5, previewStrip's own half of the same fix: no recorded current
+    attempt means refuse, never a filesystem scan for something older."""
+    transport, _roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+    transport._recorded_preview_attempt_journal = None
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview_strip()
+
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+    assert "left no usable evidence" in str(excinfo.value)
+    assert "acquire a fresh preview" in str(excinfo.value)
+
+
+# -- 2026-08-08 adversarial review, S1 (manual placement replacement safety) --
+# and S5 (stale-attempt evidence selection) -------------------------------------
+
+
+def test_manual_frames_thumbnail_write_failure_leaves_roll_state_and_preview_established_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S1, part 1: rendering B's thumbnails happens BEFORE any Roll state
+    mutation. A completed placement A is already installed and approved;
+    a replacement placement B passes validation but its thumbnail disk
+    write fails. Roll's session/approvals (A's) must be completely
+    untouched -- install_manual_session must never even be called -- and
+    self._preview_established must stay at its PREVIOUS value (True, from
+    A) rather than being left False or flipped mid-mutation. A subsequent
+    approve() must therefore still cleanly reach A's own (unchanged)
+    session, exactly as if B had never been attempted."""
+    transport, roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+
+    # Placement A: completes cleanly, arms roll._session/approvals and
+    # self._preview_established -- exactly today's already-tested happy
+    # path (test_manual_frames_happy_path_arms_session_for_approve_and_scan).
+    transport.manual_frames([128, 271, 414])
+    assert transport._preview_established is True
+    session_a = roll._session
+    assert session_a is not None
+    # A sentinel approval "on file" for operation A -- proves it survives
+    # byte-for-byte (not just "still non-None") through the failed B
+    # attempt below.
+    roll._approvals[1] = "operation-a-approval-sentinel"
+    approvals_a = dict(roll._approvals)
+    # install_manual_session_calls already holds A's own (legitimate) call
+    # from the successful placement above -- capture that count so the
+    # assertion below proves B added NONE, not that the list is empty.
+    install_calls_after_a = len(roll.install_manual_session_calls)
+
+    def _failing_imwrite(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated disk write failure")
+
+    monkeypatch.setattr(tifffile, "imwrite", _failing_imwrite)
+
+    # Placement B: same evidence, same valid rows -- passes every gate
+    # build_manual_roll_preview_session checks -- but its thumbnail render
+    # fails partway through persisting to disk.
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128, 271, 414])
+    assert excinfo.value.code == ErrorCode.INTERNAL
+    assert "left unchanged" in str(excinfo.value)
+
+    # Roll state: completely untouched -- the exact same session object,
+    # the exact same approvals, and install_manual_session was never
+    # called again for B (the write failure is caught before any Roll
+    # mutation is attempted at all).
+    assert roll._session is session_a
+    assert roll._approvals == approvals_a
+    assert len(roll.install_manual_session_calls) == install_calls_after_a
+
+    # self._preview_established stayed at its PREVIOUS value (True, from
+    # A's own successful placement) -- never touched by B's failure.
+    assert transport._preview_established is True
+
+    # A subsequent approve() against the operation the UI still shows (A)
+    # must still cleanly reach A's own, unchanged session -- never
+    # NO_PREVIEW, and never silently landing on some half-installed B.
+    transport.approve(1)
+    assert roll.approve_calls == [1]
+
+
+def test_manual_frames_maps_install_failure_without_reporting_partial_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S1, part 2/3: install_manual_session's own failure modes (locked
+    state / USB-topology mismatch, modeled here as DeviceBusy/RollMismatch)
+    must map to typed BridgeErrors, and self._preview_established must be
+    left False (not re-armed) since install is where the fail-closed marker
+    is set immediately before this call."""
+    roll = _FakeRoll(
+        install_manual_session_effect=coolscanpy.DeviceBusy("another roll batch is active")
+    )
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert transport.attempts_root is not None
+    attempt_dir = _write_synthetic_preview_attempt(transport.attempts_root)
+    transport._recorded_preview_attempt_journal = (
+        attempt_dir / "journal.json"
+    ).resolve(strict=True)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128, 271, 414])
+    assert excinfo.value.code == ErrorCode.DEVICE_BUSY
+    assert transport._preview_established is False
+    assert len(roll.install_manual_session_calls) == 1
+
+
+def test_approve_refuses_on_fingerprint_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """S1, part 4: an approval computed against an earlier session
+    (identified by its expected fingerprint) must be refused before ever
+    reaching coolscanpy's own Roll.approve() -- a stale click must never
+    silently approve whatever slot number happens to exist in the roll's
+    CURRENT session."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)], fingerprint_sha256="c" * 64)
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.approve(1, fingerprint="d" * 64)
+
+    assert excinfo.value.code == ErrorCode.FINGERPRINT_REFUSED
+    assert roll.approve_calls == []
+
+
+def test_approve_succeeds_when_fingerprint_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The additive fingerprint check is a comparison, not a blanket
+    refusal: a caller-supplied value equal to the roll's current
+    fingerprint approves normally."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)], fingerprint_sha256="c" * 64)
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    transport.approve(1, fingerprint="c" * 64)
+
+    assert roll.approve_calls == [1]
+
+
+def test_approve_with_no_fingerprint_keeps_pre_existing_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every existing caller (no `fingerprint` argument at all) must be
+    completely unaffected: `None` is the default and skips the comparison
+    entirely, exactly as before this parameter existed."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)], fingerprint_sha256="c" * 64)
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    transport.approve(1)
+
+    assert roll.approve_calls == [1]
+
+
+def test_manual_frames_refuses_when_current_attempt_has_no_recorded_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S5: attempt A completed and is still on disk; a NEWER attempt B's
+    directory also exists (a retried preview's transport read started) but
+    B failed before it ever wrote a journal.json of its own. The most
+    recent attempt (B) left no usable evidence, so manual placement must
+    refuse outright -- it must NEVER silently fall back to A's older,
+    physically-superseded evidence, even though A is still present and
+    perfectly well-formed on disk."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)])
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert transport.attempts_root is not None
+    _write_synthetic_preview_attempt(transport.attempts_root)  # attempt A: complete
+    stale_dir = transport.attempts_root / f"preview-{uuid.uuid4().hex}"
+    stale_dir.mkdir(parents=True)  # attempt B: started, no journal.json ever written
+    # What a real preview() call for B would itself have recorded: its own
+    # before/after snapshot diff finds no new journal at all (B wrote
+    # none), so the previously-invalidated candidate stays None -- see
+    # preview()'s own S5 comment. Never falls back to A.
+    transport._recorded_preview_attempt_journal = None
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128, 271, 414])
+
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+    message = str(excinfo.value)
+    assert "left no usable evidence" in message
+    assert "acquire a fresh preview" in message
+    assert roll.install_manual_session_calls == []
+
+
+def test_sole_new_attempt_journal_ignores_mtime_and_identifies_the_new_candidate(
+    tmp_path: Path,
+) -> None:
+    """S5's core selection primitive: identifying the attempt a preview()
+    call itself just produced is pure set membership against a snapshot
+    taken immediately beforehand -- NEVER a modification-time comparison.
+    Here the OLDER attempt's journal is touched (its mtime pushed into the
+    future, past the newer attempt's own) after the newer one is written --
+    exactly the "A's journal is touched later" S5 scenario -- and the
+    correct (new) candidate must still be the one identified."""
+    attempts_root = tmp_path
+    old_dir = attempts_root / "preview-old"
+    old_dir.mkdir()
+    old_journal = old_dir / "journal.json"
+    old_journal.write_text("{}", encoding="utf-8")
+    before = frozenset(
+        attempts_root.glob(coolscanpy_transport_module._PREVIEW_ATTEMPT_GLOB)
+    )
+
+    new_dir = attempts_root / "preview-new"
+    new_dir.mkdir()
+    new_journal = new_dir / "journal.json"
+    new_journal.write_text("{}", encoding="utf-8")
+    # Touch the OLDER journal so it carries a strictly newer mtime than the
+    # attempt that actually just happened -- an mtime-sorting selection
+    # would incorrectly pick this one.
+    future = time.time() + 10_000
+    os.utime(old_journal, (future, future))
+    assert old_journal.stat().st_mtime > new_journal.stat().st_mtime
+
+    resolved = coolscanpy_transport_module._sole_new_attempt_journal(
+        attempts_root, before
+    )
+
+    assert resolved == new_journal.resolve()
+
+
+def test_sole_new_attempt_journal_is_none_when_nothing_new_appeared(
+    tmp_path: Path,
+) -> None:
+    """A hard failure that writes no journal at all (e.g. a bootstrap
+    failure before the transport read even starts) must resolve to `None`,
+    never to whatever older attempt happens to already be on disk."""
+    attempts_root = tmp_path
+    old_dir = attempts_root / "preview-old"
+    old_dir.mkdir()
+    (old_dir / "journal.json").write_text("{}", encoding="utf-8")
+    before = frozenset(
+        attempts_root.glob(coolscanpy_transport_module._PREVIEW_ATTEMPT_GLOB)
+    )
+
+    # Nothing new is written under attempts_root this time.
+
+    resolved = coolscanpy_transport_module._sole_new_attempt_journal(
+        attempts_root, before
+    )
+
+    assert resolved is None
 
 
 def test_start_scan_maps_base_roll_mismatch(

--- a/bridge/tests/test_transport_mock.py
+++ b/bridge/tests/test_transport_mock.py
@@ -788,6 +788,10 @@ def test_preview_strip_happy_path_returns_row_count_and_image() -> None:
 
     strip = transport.preview_strip()
 
-    assert strip.row_count == 4 * 1200
+    assert strip.row_count == min(4 * 1200, 4_096)  # honest cap: width == rows
+    import tifffile as _tifffile
+
+    written = _tifffile.imread(strip.image_path)
+    assert written.shape[1] == strip.row_count  # width axis == reported rows
     assert strip.pixels_per_row == 1
     assert Path(strip.image_path).is_file()

--- a/bridge/tests/test_transport_mock.py
+++ b/bridge/tests/test_transport_mock.py
@@ -701,3 +701,93 @@ def test_close_device_then_reopen_resets_preview_state() -> None:
 
 def test_eject_always_returns_true() -> None:
     assert MockTransport().eject() is True
+
+
+# -- manual frame placement (Rung 4) -----------------------------------------------
+
+
+def test_manual_frames_without_any_preview_is_no_preview() -> None:
+    transport = _opened(slot_count=4)
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([100, 300])
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+
+
+def test_manual_frames_rejects_fewer_than_two_rows() -> None:
+    transport = _opened(slot_count=4)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([100])
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+    assert "at least 2 boundary rows" in str(excinfo.value)
+
+
+def test_manual_frames_rejects_non_increasing_rows() -> None:
+    transport = _opened(slot_count=4)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([300, 100, 500])
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+    assert "strictly increasing" in str(excinfo.value)
+
+
+def test_manual_frames_happy_path_replaces_slot_lattice_and_rearms_approve() -> None:
+    transport = _opened(slot_count=6)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    # None of these rows is a multiple of 100 -- the mock's deterministic
+    # "snap" trigger (see test_manual_frames_reports_deterministic_snap_notes
+    # below) never fires, so this is the plain no-snap happy path.
+    result, thumbnails, snaps, material = transport.manual_frames([101, 301, 501])
+
+    assert material is domain.Material.COLOR_NEGATIVE
+    assert result.count == 2
+    assert [t.slot for t in thumbnails] == [1, 2]
+    assert thumbnails[0].boundary_rows == (101, 301)
+    assert thumbnails[1].boundary_rows == (301, 501)
+    assert all(t.needs_approval for t in thumbnails)
+    assert all("user-picked" in t.warnings for t in thumbnails)
+    assert snaps == ()
+
+    # The manual placement replaces the roll's own slot lattice: status now
+    # reports the manual frame count, and approve()/set_spacing_offset() work
+    # unchanged against the new 1-based slot numbering.
+    assert transport.status().slot_count == 2
+    transport.approve(1)
+    transport.approve(2)
+    adjusted = transport.set_spacing_offset(1, 0)
+    assert adjusted.slot == 1
+
+
+def test_manual_frames_reports_deterministic_snap_notes() -> None:
+    transport = _opened(slot_count=4)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    _result, _thumbnails, snaps, _material = transport.manual_frames([100, 250])
+
+    assert snaps == (
+        domain.BoundarySnap(
+            boundary_index=0,
+            requested_row=100,
+            snapped_row=99,
+            evidence_run=(96, 104),
+        ),
+    )
+
+
+def test_preview_strip_without_any_preview_is_no_preview() -> None:
+    transport = _opened(slot_count=4)
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview_strip()
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+
+
+def test_preview_strip_happy_path_returns_row_count_and_image() -> None:
+    transport = _opened(slot_count=4)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    strip = transport.preview_strip()
+
+    assert strip.row_count == 4 * 1200
+    assert strip.pixels_per_row == 1
+    assert Path(strip.image_path).is_file()

--- a/coolscanpy/src/coolscanpy/_roll.py
+++ b/coolscanpy/src/coolscanpy/_roll.py
@@ -86,6 +86,9 @@ from coolscanpy.protocol.ls5000_single_pass.density import (
     NikonExactBuilderEvidence,
     build_nikon_exact_builder_evidence,
 )
+from coolscanpy.protocol.ls5000_single_pass.manual_frames import (
+    MANUAL_PLACEMENT_WARNING,
+)
 from coolscanpy.protocol.ls5000_single_pass.meter import (
     EXPOSURE_MAX,
     EXPOSURE_MIN,
@@ -954,6 +957,21 @@ class Roll:
                 expected_usb_bus=topology[0],
                 expected_usb_address=topology[1],
                 exposure_override_10ns=exposure_override_10ns,
+                # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): the same
+                # computation RollPreviewSession.to_json() already uses to
+                # decide whether ITS OWN provenance is a manual session's
+                # (preview_session.py) -- MANUAL_PLACEMENT_WARNING is only
+                # ever attached by manual_frames.build_manual_detection,
+                # never by the automatic detector, so this is None for
+                # every ordinary session, unchanged from before this batch
+                # gained the field.
+                manual_boundary_rows=(
+                    tuple(
+                        boundary.output_row for boundary in session.detection.boundaries
+                    )
+                    if MANUAL_PLACEMENT_WARNING in session.detection.warnings
+                    else None
+                ),
             )
             # A held session is single-use *per call*: whether this batch
             # resumes it successfully, fails, is stopped, or is ended by

--- a/coolscanpy/src/coolscanpy/_roll.py
+++ b/coolscanpy/src/coolscanpy/_roll.py
@@ -746,6 +746,68 @@ class Roll:
                 if wanted is None or slot.slot_id in wanted
             ]
 
+    def install_manual_session(self, session: RollPreviewSession) -> None:
+        """Install an already-built, already-validated manual-placement
+        preview session as this Roll's current review state (Rung 4 of the
+        feeding UX ladder; 2026-08-08 adversarial review, S1/S5).
+
+        No film moves and no evidence is read from disk here: the caller
+        (``coolscanpy_transport.manual_frames()``) has already produced
+        ``session`` from a validated, decoded ``ValidatedRollPreview`` via
+        :func:`coolscanpy.roll.preview_session.build_manual_roll_preview_session`.
+        This method's whole job is the same locked, atomic state transition
+        every other in-place mutator on this class already performs --
+        :meth:`preview`'s own success tail, :meth:`restore_preview_session`,
+        :meth:`set_spacing_offset`, :meth:`approve` -- so a manual-placement
+        caller never has to reach into ``_session``/``_approvals`` directly
+        (previously the only way to arm a manual session at all, since
+        neither of those two existing methods accepts one: ``preview()``
+        always re-reads the transport, and ``restore_preview_session()``
+        explicitly refuses a session serialized from manual placement).
+
+        Checks run in this order, all under one lock, before anything is
+        mutated:
+
+        1. This Roll must not be closing, mid-preview, or hold an active
+           batch -- the same "review state is frozen" contract
+           ``_require_mutable_review_locked`` enforces for every other
+           mutator here.
+        2. ``session``'s material must match this Roll's own material.
+        3. ``session.preview.usb_topology`` -- the USB bus/address recorded
+           when the underlying evidence was originally captured, which may
+           be considerably older than this exact call -- must match this
+           Roll's CURRENT device topology, verified fresh here the same way
+           a live :meth:`preview` or :meth:`restore_preview_session` call
+           already does. Never trusted bare: a manual session built from a
+           stale attempt must not silently bind to whatever scanner happens
+           to be attached now.
+
+        Raises ``TypeError`` if ``session`` is not a ``RollPreviewSession``,
+        ``DeviceBusy`` if check 1 fails, or ``RollMismatch`` if check 2 or 3
+        fails. Every check runs before any mutation, and a raise leaves the
+        existing session and approvals (if any) exactly as they were --
+        this method never partially installs a session.
+        """
+
+        if not isinstance(session, RollPreviewSession):
+            raise TypeError("session must be a RollPreviewSession")
+        with self._state_condition:
+            self._require_mutable_review_locked()
+            if session.material is not self._material:
+                raise RollMismatch(
+                    "manual placement session material does not match this "
+                    "Roll's material"
+                )
+            topology = self._preview_topology_locked()
+            if session.preview.usb_topology != topology:
+                raise RollMismatch(
+                    "manual placement evidence belongs to a different USB "
+                    "topology than this Roll"
+                )
+            self._session = session
+            self._session_usb_topology = topology
+            self._approvals.clear()
+
     # -- spacing offset ----------------------------------------------------
 
     def spacing_offset(self, slot: int) -> int:

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -29,14 +29,15 @@ CANONICAL_MANIFEST_FILENAME = "replay-first-rgbi4-manifest.json"
 # evidence, runtime arithmetic gate, and exact per-frame ownership receipt.
 CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "capture_process.py": "db84ea56a9cfa687a4db6835d226c78d52bdf38d50ac26f88de6a8f52fcb41e0",
-    "worker.py": "5cb678bc32c24fb0931ea1cde5a49fedc659003e94955d136b37baa07037fd4f",
+    "worker.py": "6a74f83a938eb8f97c7d09f1639f110b486ae766395ad4660dd623e59e767d09",
+    "manual_frames.py": "729fee63adcd597bf0e4d6594b9a31a723ca80755d6d8b3c333854497c0b45af",
     "usb_backend.py": "afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62",
     "density.py": "be7e1e11635edcc70e150fd7454625a478effbb2446017b2cb56676dcb5ebed9",
     "packed.py": "856315714e4f7e81f42e1ca93917e4cc0feb03b24915c2ad604302bfdca46f87",
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "fdddefe3be30bc9025e32343c4ab656262e171f828844f3afba546380fee3d98",
+    "roll_index.py": "d13c1850f1400d2a89c8594b65330fd82a4074b82dfafd75c954c4218c71fad1",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -31,16 +31,16 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     # Resealed 2026-08-07 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, Rung 4
     # scan-side wiring): both files gained CaptureBatchRequest/LiveBatchJob's
     # additive manual_boundary_rows field plus its batch-job.json plumbing.
-    "capture_process.py": "8df668809b15493ff4b0ac4da23133c848120daf6f3266198a91a30a225a5d44",
-    "worker.py": "b371517b6980bd238c343c952840fd4df676b02da4b583d54dfa9ebec73484f8",
-    "manual_frames.py": "729fee63adcd597bf0e4d6594b9a31a723ca80755d6d8b3c333854497c0b45af",
+    "capture_process.py": "31485687011afad5dcf3470d72da26bc090ec43398518c7c9b85c42841fc97ef",
+    "worker.py": "f625057c5619c9ddf94d7e233c6ac9d2a86e300c1a8b1bd8d7f5f03d0eac8c24",
+    "manual_frames.py": "f30f0003e081c3a98610d5700d7e6b6ee4d182b9d5228932f3304f1307d4815f",
     "usb_backend.py": "afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62",
     "density.py": "be7e1e11635edcc70e150fd7454625a478effbb2446017b2cb56676dcb5ebed9",
     "packed.py": "856315714e4f7e81f42e1ca93917e4cc0feb03b24915c2ad604302bfdca46f87",
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "d13c1850f1400d2a89c8594b65330fd82a4074b82dfafd75c954c4218c71fad1",
+    "roll_index.py": "ee4320ac7f71f42db57d6a7a8c1c103226635f1214fb9f4a6271c8ef2ff0d812",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -28,8 +28,11 @@ CANONICAL_MANIFEST_FILENAME = "replay-first-rgbi4-manifest.json"
 # density-source cap-0x10d/f03 exposures, the proven 97-dpi reservation-preview
 # evidence, runtime arithmetic gate, and exact per-frame ownership receipt.
 CAPTURE_BUNDLE_COMPONENT_SHA256 = {
-    "capture_process.py": "db84ea56a9cfa687a4db6835d226c78d52bdf38d50ac26f88de6a8f52fcb41e0",
-    "worker.py": "6a74f83a938eb8f97c7d09f1639f110b486ae766395ad4660dd623e59e767d09",
+    # Resealed 2026-08-07 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, Rung 4
+    # scan-side wiring): both files gained CaptureBatchRequest/LiveBatchJob's
+    # additive manual_boundary_rows field plus its batch-job.json plumbing.
+    "capture_process.py": "8df668809b15493ff4b0ac4da23133c848120daf6f3266198a91a30a225a5d44",
+    "worker.py": "b371517b6980bd238c343c952840fd4df676b02da4b583d54dfa9ebec73484f8",
     "manual_frames.py": "729fee63adcd597bf0e4d6594b9a31a723ca80755d6d8b3c333854497c0b45af",
     "usb_backend.py": "afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62",
     "density.py": "be7e1e11635edcc70e150fd7454625a478effbb2446017b2cb56676dcb5ebed9",

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -36,7 +36,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "46147850ff5e7e42b83a7ca04eb0d262eb9028858e444beb4818c4f217426d7a",
+    "roll_index.py": "fdddefe3be30bc9025e32343c4ab656262e171f828844f3afba546380fee3d98",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
@@ -1095,6 +1095,16 @@ class CaptureBatchRequest:
     expected_usb_bus: int
     expected_usb_address: int
     exposure_override_10ns: tuple[int, int, int] | None = None
+    # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): the exact operator-
+    # picked boundary rows from a manual-placement preview session, carried
+    # across the process boundary so the batch child can replay
+    # manual_frames.build_manual_detection fresh against its own live re-read
+    # bytes -- never trusted as a serialized detection result (see worker.py's
+    # _derive_live_frame_selection docstring). None for an ordinary,
+    # automatically-detected session -- see Roll.scan_many, which derives
+    # this from its own reviewed session rather than accepting it from a
+    # caller.
+    manual_boundary_rows: tuple[int, ...] | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.frames, tuple):
@@ -3506,6 +3516,14 @@ class CaptureProcessAdapter:
                 else list(request.exposure_override_10ns)
             ),
             "frames": frames,
+            # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): same optional,
+            # always-present, nullable-array shape as exposure_override_10ns
+            # above -- see CaptureBatchRequest.manual_boundary_rows.
+            "manual_boundary_rows": (
+                None
+                if request.manual_boundary_rows is None
+                else list(request.manual_boundary_rows)
+            ),
             "parent_ack_required_after_every_frame": True,
             "release_once_after_last_frame": True,
             "reviewed_roll_fingerprint": request.reviewed_fingerprint.to_payload(),

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
@@ -80,7 +80,19 @@ WORKER_BOOTSTRAP_SCHEMA_VERSION = 1
 WORKER_BOOTSTRAP_FAILED = "failed-before-ready"
 WORKER_BOOTSTRAP_STATUS_FILENAME = "worker-bootstrap.json"
 REVIEWED_ROLL_FINGERPRINT_VERSION = 2
-MANUAL_FRAME_APPROVAL_VERSION = 1
+# Bumped 2 (S6 hardening, FEEDING-UX-LADDER-OVERNIGHT-20260807.md F1
+# rework): adds manual_boundary_rows_sha256, a required field, so this is a
+# breaking schema change on purpose. A genuine version-1 payload is refused
+# by from_payload's exact key-set check first (its key set no longer
+# matches); only a fabricated payload carrying version 1 WITH version-2
+# keys reaches __post_init__'s schema_version check. Both paths refuse --
+# the ordering is recorded here so nobody expects the version check to be
+# the gate that ordinary stale receipts hit (re-review 2026-08-08). Approval
+# receipts are ephemeral (created and consumed within one reviewed-session
+# -> scan-time flow, never persisted the way RollPreviewSession.to_json()
+# is), so there is no backward-compatibility case to preserve here the way
+# F7 preserved one for session JSON.
+MANUAL_FRAME_APPROVAL_VERSION = 2
 MAX_VISUAL_MEDIAN_HAMMING = 24
 MAX_VISUAL_P90_HAMMING = 48
 MAX_SELECTED_VISUAL_HAMMING = 48
@@ -596,7 +608,22 @@ class ReviewedRollFingerprint:
 
 @dataclass(frozen=True)
 class ManualFrameApproval:
-    """Operator approval bound to one reviewed thumbnail and transport choice."""
+    """Operator approval bound to one reviewed thumbnail and transport choice.
+
+    ``manual_boundary_rows_sha256`` (S6 hardening, FEEDING-UX-LADDER-
+    OVERNIGHT-20260807.md F1 rework): binds this approval to the EXACT set
+    of boundary rows the operator's whole session reviewed, not just this
+    one slot's own resolved position. Without it, a receipt legitimately
+    signed for slot N of one placement carries nothing that distinguishes
+    it from a receipt for slot N of a DIFFERENT placement of the same
+    physical roll whose fingerprint happens to still compare as matching
+    (fingerprint comparison has deliberate tolerance for legitimate re-
+    reads; see compare_reviewed_roll_fingerprints) -- this digest has none.
+    Use ``digest_manual_boundary_rows`` to compute it, both when creating a
+    receipt (RollPreviewSession.approve_manual_origin) and when verifying
+    one against a batch job's own manual_boundary_rows (worker.py), so the
+    two sides can never independently drift on how it is derived.
+    """
 
     reviewed_fingerprint_sha256: str
     slot: int
@@ -605,7 +632,23 @@ class ManualFrameApproval:
     reviewed_lookup_row: int
     reviewed_native_origin: int
     review_reasons: tuple[str, ...]
+    manual_boundary_rows_sha256: str
     schema_version: int = MANUAL_FRAME_APPROVAL_VERSION
+
+    @staticmethod
+    def digest_manual_boundary_rows(rows: Sequence[int] | None) -> str:
+        """Canonical digest of a placement's manual boundary rows.
+
+        ``rows`` is ``None`` for an automatic (non-manual) reviewed slot --
+        still given a fixed, well-defined digest rather than an empty
+        string, so this field is never optional/absent on the receipt
+        itself and a caller cannot bypass the check by omitting it.
+        """
+
+        payload = {
+            "manual_boundary_rows": list(rows) if rows is not None else None
+        }
+        return _canonical_json_sha256(payload)
 
     def __post_init__(self) -> None:
         if self.schema_version != MANUAL_FRAME_APPROVAL_VERSION:
@@ -630,6 +673,10 @@ class ManualFrameApproval:
             or self.reviewed_native_origin < 0
         ):
             raise ValueError("manual frame approval native origin is invalid")
+        if not _lower_sha256(self.manual_boundary_rows_sha256):
+            raise ValueError(
+                "manual frame approval manual-boundary-rows identity is invalid"
+            )
         if (
             not isinstance(self.review_reasons, tuple)
             or not self.review_reasons
@@ -640,6 +687,7 @@ class ManualFrameApproval:
     def binding_payload(self) -> dict[str, Any]:
         return {
             "boundary_offset_rows": self.boundary_offset_rows,
+            "manual_boundary_rows_sha256": self.manual_boundary_rows_sha256,
             "review_reasons": list(self.review_reasons),
             "reviewed_fingerprint_sha256": self.reviewed_fingerprint_sha256,
             "reviewed_lookup_row": self.reviewed_lookup_row,
@@ -664,6 +712,7 @@ class ManualFrameApproval:
         if not isinstance(payload, dict) or set(payload) != {
             "binding_sha256",
             "boundary_offset_rows",
+            "manual_boundary_rows_sha256",
             "review_reasons",
             "reviewed_fingerprint_sha256",
             "reviewed_lookup_row",
@@ -684,6 +733,7 @@ class ManualFrameApproval:
             reviewed_lookup_row=payload.get("reviewed_lookup_row"),  # type: ignore[arg-type]
             reviewed_native_origin=payload.get("reviewed_native_origin"),  # type: ignore[arg-type]
             review_reasons=tuple(reasons),
+            manual_boundary_rows_sha256=payload.get("manual_boundary_rows_sha256"),  # type: ignore[arg-type]
             schema_version=payload.get("schema_version"),  # type: ignore[arg-type]
         )
         if payload.get("binding_sha256") != value.binding_sha256:

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
@@ -1,0 +1,524 @@
+"""Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): driver-side manual frame
+placement for the LS-5000 whole-roll pipeline.
+
+This module never runs film movement and never re-derives detection with
+relaxed knobs.  It accepts an already-decoded whole-roll preview raster (from
+a preview attempt that has already completed and released the device) plus
+the boundary rows a human picked by looking at that raster, and turns those
+picks into the same ``RollDetection``/``TransportMapping`` shape the
+automatic detector in ``roll_index.py`` produces -- so every downstream
+consumer (``preview_session.py``, the worker's live-scan binding, the app's
+thumbnail/approval UI) keeps working unchanged.
+
+Trust model (binding, from the overnight doc): the human supplies frame
+positions; this module keeps every physical sanity check the scanner can
+still make from its own evidence -- clear-film transmission near the picked
+rows (snap assist only; never a hard requirement) and the same-traversal
+transport table's local physical-motion consistency (a hard requirement).
+A placement that fails any hard check is refused in its entirety: this
+module never returns a result that accepted some picks and silently
+dropped others.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from .roll_index import (
+    FrameInterval,
+    GapBoundary,
+    IncompleteIndexError,
+    IndexDecodeError,
+    NativeFrameOrigin,
+    RollDetection,
+    TransportMapping,
+    TransportRecord,
+    _active_aperture,
+    _physical_gap_evidence,
+    _true_runs,
+    terminal_transport_tail_start,
+)
+
+# RollDetection.warnings marker: the one thing worker.py's live-scan gate
+# checks to recognize a manually-placed roll. Only this module ever sets it;
+# the automatic detector in roll_index.py never does. See worker.py's
+# _derive_live_frame_selection for the one gate path this marker unlocks.
+MANUAL_PLACEMENT_WARNING = "user-picked-frames"
+
+# review_reasons markers.
+USER_PICKED_REVIEW_REASON = "user-picked"
+SNAP_REVIEW_REASON = "snapped-to-clear-film-edge"
+MANUAL_ORIGIN_REVIEW_REASON = "user-picked-origin"
+
+# NativeFrameOrigin.method for every manually placed frame.
+MANUAL_ORIGIN_METHOD = "user-picked-row"
+
+# RollDetection.count_confirmation / count_confidence for manual placements.
+MANUAL_COUNT_CONFIRMATION = "user-picked-boundaries"
+MANUAL_COUNT_CONFIDENCE = "user-selection-required"
+
+# Structural limits (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, Rung 4 point 1).
+MINIMUM_MANUAL_BOUNDARY_COUNT = 2
+MAXIMUM_MANUAL_FRAMES = 40
+
+# Physical frame-height gate (Rung 4 point 2): 15-75 mm, deliberately wider
+# than automatic detection's fixed nominal-pitch tolerance band because
+# manual mode exists specifically for film automatic detection does not
+# handle -- half-frame (~19 mm) and panoramic (~65-72 mm). 0.267 mm/row is
+# this driver's documented 97-dpi-preview approximation (matches the ~5.3 mm
+# / 20 rows figure already used for WIDE_GAP_CEILING_ROWS in roll_index.py
+# and the ~0.8 mm / 3 rows figure in the Rung 3 diagnosis spec); it is used
+# only to phrase user-facing sentences in mm. The row bounds below are the
+# actual gate.
+MINIMUM_MANUAL_FRAME_HEIGHT_ROWS = 56
+MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS = 280
+MANUAL_FRAME_HEIGHT_MM_PER_ROW = 0.267
+
+# Snap assist (Rung 4 point 3).
+SNAP_ASSIST_MAX_DISTANCE_ROWS = 4
+
+# Transport sanity (Rung 4 points 4-5): same 40..45 native-units-per-row
+# scale as roll_index.derive_transport_mapping's own minimum_scale/
+# maximum_scale defaults, and the same per-step local-ramp guard shape as
+# derive_transport_mapping's wide-gap-anchor admission check (grep
+# ramp_is_affine in roll_index.py) -- reimplemented here rather than
+# imported because manual mode's origins are exact same-traversal table
+# reads, never an affine fit prediction, so derive_transport_mapping itself
+# is not called (it requires >=3 "direct"-support boundaries, which no
+# user-picked boundary ever carries).
+MINIMUM_TRANSPORT_SCALE = 40.0
+MAXIMUM_TRANSPORT_SCALE = 45.0
+RAMP_GUARD_RADIUS_ROWS = 3
+
+
+@dataclass(frozen=True)
+class BoundarySnap:
+    """One snap-assist adjustment applied to a user-picked boundary row."""
+
+    boundary_index: int
+    requested_row: int
+    snapped_row: int
+    evidence_run: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class ManualFrameDetection:
+    """A manual placement's detection, transport mapping, and snap notes."""
+
+    detection: RollDetection
+    mapping: TransportMapping
+    snaps: tuple[BoundarySnap, ...]
+
+
+def _ordinal(n: int) -> str:
+    if 10 <= n % 100 <= 20:
+        suffix = "th"
+    else:
+        suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+    return f"{n}{suffix}"
+
+
+def _approximate_mm(row: int) -> float:
+    return row * MANUAL_FRAME_HEIGHT_MM_PER_ROW
+
+
+def build_manual_detection(
+    rgb16: np.ndarray,
+    known: np.ndarray,
+    boundary_rows: Sequence[int],
+    *,
+    nominal_frame_rows: int,
+    records: Sequence[TransportRecord],
+    snap_assist: bool = True,
+) -> ManualFrameDetection:
+    """Turn operator-picked boundary rows into a reviewed roll detection.
+
+    ``rgb16``/``known`` are the same decoded whole-roll raster and
+    completeness mask ``detect_roll_frames`` takes; ``records`` is the same
+    same-traversal live READ(0x8e) transport table used everywhere else in
+    this package. No film moves and no relaxed automatic-detection knobs are
+    tried here -- this is a completely separate code path from
+    ``detect_roll_frames``/``derive_transport_mapping``.
+
+    Every gate below fails closed: any failure raises before this function
+    returns anything, so a caller can never end up with a placement that
+    silently accepted some of the operator's picks and dropped others.
+    """
+
+    # ---- gate 0: same shape/completeness floor as the automatic detector --
+    if rgb16.ndim != 3 or rgb16.shape[2] != 3:
+        raise IndexDecodeError("manual frame placement requires an HxWx3 RGB raster")
+    if rgb16.shape != known.shape:
+        raise IndexDecodeError("RGB raster and completeness mask shapes differ")
+    complete_rows = known.all(axis=(1, 2))
+    if complete_rows.mean() < 0.995:
+        raise IncompleteIndexError(
+            "manual frame placement requires a persisted complete preview; "
+            f"row coverage is {complete_rows.mean():.1%}"
+        )
+    if (
+        type(nominal_frame_rows) is not int
+        or isinstance(nominal_frame_rows, bool)
+        or nominal_frame_rows < 1
+    ):
+        raise IndexDecodeError("nominal frame rows must be a positive integer")
+
+    # ---- gate 1: structure -- count, type, order, in-raster ---------------
+    height = int(rgb16.shape[0])
+    rows = list(boundary_rows)
+    if len(rows) < MINIMUM_MANUAL_BOUNDARY_COUNT:
+        raise IndexDecodeError(
+            "manual frame placement needs at least 2 boundary rows (1 frame); "
+            f"only {len(rows)} were given"
+        )
+    if any(type(row) is not int or isinstance(row, bool) for row in rows):
+        raise IndexDecodeError("manual frame boundary rows must be plain integers")
+    if any(a >= b for a, b in zip(rows, rows[1:])):
+        raise IndexDecodeError(
+            "frame boundary rows must be placed in strictly increasing order, "
+            "top to bottom of the preview"
+        )
+    if any(not 0 <= row < height for row in rows):
+        raise IndexDecodeError(
+            "every boundary row must lie inside the captured preview "
+            f"(0..{height - 1}); a boundary was placed outside it"
+        )
+    frame_count = len(rows) - 1
+    if frame_count > MAXIMUM_MANUAL_FRAMES:
+        raise IndexDecodeError(
+            f"manual placement supports at most {MAXIMUM_MANUAL_FRAMES} frames; "
+            f"{len(rows)} boundary rows would create {frame_count}"
+        )
+
+    # ---- gate 2: physical frame-height range, on the operator's own picks -
+    for index, (start, end) in enumerate(zip(rows, rows[1:]), start=1):
+        height_rows = end - start
+        if not (
+            MINIMUM_MANUAL_FRAME_HEIGHT_ROWS
+            <= height_rows
+            <= MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS
+        ):
+            approx_mm = _approximate_mm(height_rows)
+            raise IndexDecodeError(
+                f"the {_ordinal(index)} frame you placed is about "
+                f"{approx_mm:.0f} mm tall (between rows {start} and {end}), "
+                "outside the 15-75 mm range this driver accepts for manual "
+                "placement"
+            )
+
+    # ---- gate 3: snap assist (default on, never a hard requirement) -------
+    # Reuses roll_index's own clear-film evidence signal so a "clear film
+    # edge" means the exact same physical thing here as it does to the
+    # automatic detector and the Rung 3 diagnosis module. If this raster
+    # defeats that heuristic (e.g. an aperture shape automatic detection
+    # itself would have refused), snap assist degrades to a no-op instead of
+    # refusing the placement -- unlike every gate above and below, snapping
+    # is a nicety layered on top of the operator's own judgement, not a
+    # physical sanity check, and manual mode exists precisely for rasters
+    # this heuristic cannot always read.
+    evidence_signal: np.ndarray | None = None
+    transmission_signal: np.ndarray | None = None
+    nonuniformity_signal: np.ndarray | None = None
+    aperture: tuple[int, int] | None = None
+    evidence_runs: list[tuple[int, int]] = []
+    try:
+        aperture = _active_aperture(rgb16)
+        evidence_signal, transmission_signal, nonuniformity_signal, direct = (
+            _physical_gap_evidence(rgb16, aperture)
+        )
+        evidence_runs = _true_runs(direct)
+    except IndexDecodeError:
+        aperture = None
+        evidence_signal = None
+        transmission_signal = None
+        nonuniformity_signal = None
+        evidence_runs = []
+
+    final_rows: list[int] = []
+    supporting_runs: list[tuple[int, int] | None] = []
+    snaps: list[BoundarySnap] = []
+    for index, row in enumerate(rows):
+        nearest_edge: int | None = None
+        nearest_run: tuple[int, int] | None = None
+        nearest_distance = SNAP_ASSIST_MAX_DISTANCE_ROWS + 1
+        if snap_assist:
+            # Same reference points as roll_index._nearest_evidence_run: a
+            # row already inside a run is a perfect (zero-distance) match --
+            # it needs no snap, and in particular a pick already centered on
+            # a clear-film run must NOT get pulled to that run's start/end
+            # sides just because they happen to be the closer numbers.
+            # Outside a run, distance is to the nearer of the run's own
+            # first/last clear-film row (never past it).
+            for start, end in evidence_runs:
+                if start <= row < end:
+                    distance, edge = 0, row
+                else:
+                    distance_to_start = abs(row - start)
+                    distance_to_last = abs(row - (end - 1))
+                    if distance_to_start <= distance_to_last:
+                        distance, edge = distance_to_start, start
+                    else:
+                        distance, edge = distance_to_last, end - 1
+                if distance < nearest_distance:
+                    nearest_distance = distance
+                    nearest_edge = edge
+                    nearest_run = (start, end)
+        if nearest_run is not None and nearest_distance <= SNAP_ASSIST_MAX_DISTANCE_ROWS:
+            supporting_runs.append(nearest_run)
+            final_rows.append(nearest_edge)  # type: ignore[arg-type]
+            if nearest_edge != row:
+                snaps.append(
+                    BoundarySnap(
+                        boundary_index=index,
+                        requested_row=row,
+                        snapped_row=nearest_edge,  # type: ignore[arg-type]
+                        evidence_run=nearest_run,
+                    )
+                )
+        else:
+            supporting_runs.append(None)
+            final_rows.append(row)
+
+    # Snapping moves each boundary independently by at most
+    # SNAP_ASSIST_MAX_DISTANCE_ROWS; re-verify order and raster bounds still
+    # hold on the (small number of) final rows before trusting them for
+    # anything downstream. Practically unreachable given the height gate
+    # above already ran on the raw picks, but cheap, correct, and this
+    # module never trusts an unchecked value just because a similar one was
+    # already checked.
+    if any(a >= b for a, b in zip(final_rows, final_rows[1:])):
+        raise IndexDecodeError(
+            "snap assist moved two placed boundaries out of order; place "
+            "them farther apart, or place them by hand with snap assist off"
+        )
+    if any(not 0 <= row < height for row in final_rows):
+        raise IndexDecodeError(
+            "snap assist moved a boundary outside the captured preview "
+            f"(0..{height - 1})"
+        )
+
+    # ---- gate 4: per-boundary local transport-ramp guard -------------------
+    # Same guard shape as derive_transport_mapping's wide-gap-anchor
+    # admission check (grep ramp_is_affine in roll_index.py), applied
+    # uniformly to every picked boundary -- manual mode has no separate
+    # "leading anchor" tolerance the way the automatic path does, because
+    # nothing here is inferred from an affine fit; every origin is a direct
+    # table read, and a direct table read next to an untrustworthy ramp is
+    # exactly the case this guard exists to catch.
+    if len(records) < 1:
+        raise IndexDecodeError(
+            "manual frame placement requires the same-traversal scanner "
+            "position table; none was supplied"
+        )
+    tail_start = terminal_transport_tail_start(records)
+    ramp_upper_bound = (
+        len(records) - 1 if tail_start is None else min(len(records) - 1, tail_start - 1)
+    )
+    for index, row in enumerate(final_rows):
+        if not 0 <= row < len(records):
+            raise IndexDecodeError(
+                f"the {_ordinal(index + 1)} frame edge you placed (row {row}) "
+                "has no matching entry in the scanner's position table; try "
+                "refeeding the strip and re-scanning the preview"
+            )
+        lo = max(0, row - RAMP_GUARD_RADIUS_ROWS)
+        hi = min(ramp_upper_bound, row + RAMP_GUARD_RADIUS_ROWS)
+        steps_ok = hi > lo and all(
+            MINIMUM_TRANSPORT_SCALE
+            <= records[r + 1].native_origin - records[r].native_origin
+            <= MAXIMUM_TRANSPORT_SCALE
+            for r in range(lo, hi)
+        )
+        if not steps_ok:
+            raise IndexDecodeError(
+                "the scanner's position readings look unreliable around the "
+                f"{_ordinal(index + 1)} frame edge you placed (approximately "
+                f"{_approximate_mm(row):.0f} mm into the roll); try refeeding "
+                "the strip and re-scanning the preview"
+            )
+
+    # ---- gate 5: origins strictly increasing at 40..45 units/row ----------
+    picked_origins = [records[row].native_origin for row in final_rows]
+    for index, (row_a, row_b, origin_a, origin_b) in enumerate(
+        zip(final_rows, final_rows[1:], picked_origins, picked_origins[1:]),
+        start=1,
+    ):
+        delta_rows = row_b - row_a
+        delta_origin = origin_b - origin_a
+        implied_scale = delta_origin / delta_rows if delta_rows else 0.0
+        if not (
+            delta_origin > 0
+            and MINIMUM_TRANSPORT_SCALE <= implied_scale <= MAXIMUM_TRANSPORT_SCALE
+        ):
+            raise IndexDecodeError(
+                "the scanner's position readings between the "
+                f"{_ordinal(index)} and {_ordinal(index + 1)} frame edges you "
+                f"placed don't move at a steady rate (about "
+                f"{implied_scale:.1f} position units per row; this driver "
+                "expects roughly 40-45); try refeeding the strip and "
+                "re-scanning the preview"
+            )
+
+    # ---- build the result in the shared roll_index shapes ------------------
+    def boundary_reading(row: int) -> tuple[float, float, float]:
+        if evidence_signal is None:
+            return 0.0, 0.0, 1.0
+        return (
+            float(evidence_signal[row]),
+            float(transmission_signal[row]),  # type: ignore[index]
+            float(nonuniformity_signal[row]),  # type: ignore[index]
+        )
+
+    snapped_indices = {snap.boundary_index for snap in snaps}
+    boundaries: list[GapBoundary] = []
+    for index, row in enumerate(final_rows):
+        ev, tm, nu = boundary_reading(row)
+        reasons = [USER_PICKED_REVIEW_REASON]
+        if index in snapped_indices:
+            reasons.append(SNAP_REVIEW_REASON)
+        boundaries.append(
+            GapBoundary(
+                index=index,
+                output_row=row,
+                fitted_row=float(row),
+                evidence=ev,
+                transmission=tm,
+                nonuniformity=nu,
+                support="user-picked",
+                evidence_run=supporting_runs[index],
+                manual_review=True,
+                review_reasons=tuple(reasons),
+            )
+        )
+
+    intervals: list[FrameInterval] = []
+    for frame_index, (start_boundary, end_boundary) in enumerate(
+        zip(boundaries, boundaries[1:]), start=1
+    ):
+        intervals.append(
+            FrameInterval(
+                frame=frame_index,
+                start_row=start_boundary.output_row,
+                end_row=end_boundary.output_row,
+                height_rows=end_boundary.output_row - start_boundary.output_row,
+                start_boundary=start_boundary.index,
+                end_boundary=end_boundary.index,
+                # Manual mode's whole premise is that the operator's own
+                # visual judgement substitutes for the content heuristic the
+                # automatic detector uses, so both fractions are reported as
+                # fully trusted. coverage_fraction=1.0 is also the honest
+                # value: gate 1 above already proved every boundary lies
+                # inside the captured raster, so no manual frame can ever be
+                # a raster-edge partial the way an automatic detection can.
+                content_fraction=1.0,
+                coverage_fraction=1.0,
+                count_supported=True,
+                count_bridged=False,
+                manual_review=True,
+                review_reasons=(USER_PICKED_REVIEW_REASON,),
+                unclamped_start_row=float(start_boundary.output_row),
+                unclamped_end_row=float(end_boundary.output_row),
+            )
+        )
+
+    origins: list[NativeFrameOrigin] = []
+    for frame_index, start_boundary in enumerate(boundaries[:-1], start=1):
+        record = records[start_boundary.output_row]
+        origins.append(
+            NativeFrameOrigin(
+                frame=frame_index,
+                boundary_index=start_boundary.index,
+                boundary_output_row=start_boundary.output_row,
+                lookup_row=start_boundary.output_row,
+                code=record.code,
+                selector=record.selector,
+                native_origin=record.native_origin,
+                method=MANUAL_ORIGIN_METHOD,
+                automatic=False,
+                manual_review=True,
+                review_reasons=(MANUAL_ORIGIN_REVIEW_REASON,),
+                # Exact same-traversal table read, not an affine-fit
+                # prediction -- there is no fit error to report. Zero here
+                # also keeps worker.py's _addressable_frame_origins residual
+                # filter from ever excluding a manually placed frame; gate 4
+                # above is this module's own, stricter physical check.
+                affine_residual_rows=0.0,
+            )
+        )
+
+    # Diagnostic-only affine summary across every picked boundary (not just
+    # the frame-owning ones) -- purely for TransportMapping.diagnostics();
+    # nothing above derives an origin from this fit.
+    rows_arr = np.asarray([b.output_row for b in boundaries], dtype=np.float64)
+    origin_arr = np.asarray(picked_origins, dtype=np.float64)
+    design = np.column_stack((np.ones(len(rows_arr)), rows_arr))
+    intercept, scale = np.linalg.lstsq(design, origin_arr, rcond=None)[0]
+    if scale:
+        residual_rows = (design @ np.asarray((intercept, scale)) - origin_arr) / scale
+        anchor_mae = float(np.mean(np.abs(residual_rows)))
+        anchor_max = float(np.max(np.abs(residual_rows)))
+    else:  # pragma: no cover - unreachable once gate 5 has passed
+        anchor_mae = 0.0
+        anchor_max = 0.0
+
+    mapping = TransportMapping(
+        record_count=len(records),
+        native_intercept=float(intercept),
+        native_units_per_preview_row=float(scale),
+        anchor_mae_rows=anchor_mae,
+        anchor_max_error_rows=anchor_max,
+        origins=tuple(origins),
+    )
+
+    evidences = [b.evidence for b in boundaries]
+    detection = RollDetection(
+        aperture_columns=aperture if aperture is not None else (0, int(rgb16.shape[1])),
+        nominal_frame_rows=nominal_frame_rows,
+        # No autocorrelation/lattice fit is ever run for a manual placement;
+        # these carry neutral values rather than fabricated ones.
+        autocorrelation_lag=0,
+        autocorrelation_peak=0.0,
+        autocorrelation_best_non_neighbor=0.0,
+        pitch_rows=float(np.mean([end - start for start, end in zip(final_rows, final_rows[1:])])),
+        phase_rows=0.0,
+        lattice_score=0.0,
+        alternative_lattice_score=0.0,
+        lattice_margin_fraction=0.0,
+        mean_boundary_evidence=float(np.mean(evidences)),
+        minimum_boundary_evidence=float(np.min(evidences)),
+        content_level_threshold=0.0,
+        content_range_threshold=0.0,
+        candidate_cell_count=frame_count,
+        bridged_cell_count=0,
+        expected_frame_count=None,
+        expected_frame_count_matches=None,
+        count_confirmation=MANUAL_COUNT_CONFIRMATION,
+        count_confidence=MANUAL_COUNT_CONFIDENCE,
+        content_end_candidates=(),
+        # Never higher than "medium": a human placed these rows, but nothing
+        # here re-derives or double-checks that placement against scene
+        # content or an independent lattice fit the way "high" requires
+        # elsewhere in this package.
+        confidence="medium",
+        warnings=(MANUAL_PLACEMENT_WARNING,),
+        boundaries=tuple(boundaries),
+        intervals=tuple(intervals),
+        manual_review_frames=tuple(range(1, frame_count + 1)),
+    )
+
+    return ManualFrameDetection(
+        detection=detection,
+        mapping=mapping,
+        snaps=tuple(snaps),
+    )
+
+
+__all__ = [
+    "BoundarySnap",
+    "MANUAL_PLACEMENT_WARNING",
+    "ManualFrameDetection",
+    "build_manual_detection",
+]

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
@@ -10,14 +10,39 @@ automatic detector in ``roll_index.py`` produces -- so every downstream
 consumer (``preview_session.py``, the worker's live-scan binding, the app's
 thumbnail/approval UI) keeps working unchanged.
 
-Trust model (binding, from the overnight doc): the human supplies frame
-positions; this module keeps every physical sanity check the scanner can
-still make from its own evidence -- clear-film transmission near the picked
-rows (snap assist only; never a hard requirement) and the same-traversal
-transport table's local physical-motion consistency (a hard requirement).
-A placement that fails any hard check is refused in its entirety: this
-module never returns a result that accepted some picks and silently
-dropped others.
+Trust model (rewritten 2026-08-08 after adversarial review rejected the
+original): the human supplies frame positions; this module keeps every
+physical sanity check the scanner can still make from its own evidence --
+clear-film transmission near the picked rows (snap assist only; never a hard
+requirement) and the same-traversal transport table's local physical-motion
+consistency (a hard requirement).  A placement that fails any hard check is
+refused in its entirety: this module never returns a result that accepted
+some picks and silently dropped others.
+
+The transport-table check used to mean "every single-row step within 3 rows
+of a pick must be 40..45 native units."  Real LS-5000 live READ(0x8e) tables
+never satisfy that: they carry a deterministic ~18-row code lattice (see
+``transport_native_origin`` in roll_index.py) whose per-row steps are mostly
+an exact, steady rate but include a recurring minority of large single-row
+jumps at selector rollovers (roughly +798/-700 native units) and smaller
+jumps at sub-rollovers (the code's high byte advancing alone), averaging
+back out to the steady rate over any run of a dozen-plus rows.  A ±3-row
+window is on the wrong side of that: it is wide enough to *catch* a rollover
+row but too narrow to *outvote* it, so it refused nearly every real capture
+at the very first edge with a message ("try refeeding the strip") that could
+not have been fixed by refeeding, because nothing was wrong with the strip.
+
+The fix is the same class of machinery ``roll_index.derive_transport_mapping``
+already uses for the automatic path: resolve each pick's origin from a local
+affine fit over nearby table records -- robust to that lattice's own minority
+of outlier rows -- rather than trusting one raw row read.  See
+``_resolve_boundary_transport_origin`` for exactly how, and why it mirrors
+two different ``derive_transport_mapping`` conventions depending on whether a
+narrow, specific clear-film run backs the pick.  ``derive_transport_mapping``
+itself is still never called: it requires >=3 "direct"-support boundaries
+classified from automatic detection's own lattice fit, which no user-picked
+boundary ever carries, and it owns the automatic path's exact behavior,
+which nothing in this rework may change.
 """
 
 from __future__ import annotations
@@ -32,10 +57,12 @@ from .roll_index import (
     GapBoundary,
     IncompleteIndexError,
     IndexDecodeError,
+    MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS,
     NativeFrameOrigin,
     RollDetection,
     TransportMapping,
     TransportRecord,
+    TRANSPORT_ORIGIN_CLAMP_REASON,
     _active_aperture,
     _physical_gap_evidence,
     _true_runs,
@@ -52,6 +79,13 @@ MANUAL_PLACEMENT_WARNING = "user-picked-frames"
 USER_PICKED_REVIEW_REASON = "user-picked"
 SNAP_REVIEW_REASON = "snapped-to-clear-film-edge"
 MANUAL_ORIGIN_REVIEW_REASON = "user-picked-origin"
+# Set alongside MANUAL_ORIGIN_REVIEW_REASON when a boundary's origin came
+# from the broad/weak-evidence forward search (_resolve_boundary_transport_
+# origin's "not narrow_run" branch) rather than a specific nearby clear-film
+# trailing edge -- the same string derive_transport_mapping's own
+# affine-guided-local-lookup method appends, kept identical on purpose so a
+# field report grepping for it finds both paths' inferred origins together.
+INFERRED_ORIGIN_REVIEW_REASON = "transport-origin-inferred"
 
 # NativeFrameOrigin.method for every manually placed frame.
 MANUAL_ORIGIN_METHOD = "user-picked-row"
@@ -64,34 +98,139 @@ MANUAL_COUNT_CONFIDENCE = "user-selection-required"
 MINIMUM_MANUAL_BOUNDARY_COUNT = 2
 MAXIMUM_MANUAL_FRAMES = 40
 
-# Physical frame-height gate (Rung 4 point 2): 15-75 mm, deliberately wider
-# than automatic detection's fixed nominal-pitch tolerance band because
-# manual mode exists specifically for film automatic detection does not
-# handle -- half-frame (~19 mm) and panoramic (~65-72 mm). 0.267 mm/row is
-# this driver's documented 97-dpi-preview approximation (matches the ~5.3 mm
-# / 20 rows figure already used for WIDE_GAP_CEILING_ROWS in roll_index.py
-# and the ~0.8 mm / 3 rows figure in the Rung 3 diagnosis spec); it is used
-# only to phrase user-facing sentences in mm. The row bounds below are the
-# actual gate.
+# Physical frame-height floor (Rung 4 point 2, unchanged by the rework):
+# 15 mm (~56 preview rows) is a hard physical floor -- half-frame (~19 mm) is
+# the shortest real film this driver supports manual placement for, and this
+# stays comfortably under it. 0.267 mm/row is this driver's documented
+# 97-dpi-preview approximation (matches the ~5.3 mm / 20 rows figure already
+# used for WIDE_GAP_CEILING_ROWS in roll_index.py and the ~0.8 mm / 3 rows
+# figure in the Rung 3 diagnosis spec); it is used only to phrase
+# user-facing sentences in mm. The row bound below is the actual gate.
 MINIMUM_MANUAL_FRAME_HEIGHT_ROWS = 56
-MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS = 280
 MANUAL_FRAME_HEIGHT_MM_PER_ROW = 0.267
 
-# Snap assist (Rung 4 point 3).
+# Physical frame-height ceiling (F2 rework, replaces the old flat 75 mm / 280
+# row ceiling). The LS-5000 fine scan captures a FIXED-size window starting
+# at a frame's native transport origin -- FINE_NATIVE_HEIGHT in worker.py,
+# 5,959 native units -- and there is no multi-window capture: a manually
+# placed frame taller than that window cannot be captured by one fine scan.
+# Accepting it here anyway (the old ceiling did, up to 75 mm) would deliver
+# a silently truncated frame the first time it was actually scanned, well
+# after the operator believed their placement was fine. worker.py cannot be
+# imported here (worker.py imports THIS module), so this hardware constant
+# is re-stated locally -- the same way it is already independently re-stated
+# in packed.py, density.py, capture/full_negative.py,
+# capture/sane_rgb_geometry.py, and roll/preview_session.py rather than
+# shared from one place.
+#
+# In preview rows that fixed window is FINE_NATIVE_HEIGHT // geometry.pitch;
+# geometry.pitch is fixed at 41 by the scanner's own validated native/preview
+# resolution ratio (4,000 dpi native optical resolution over a ~97.6 dpi
+# preview -- see worker.py's IndexGeometry construction, where "pitch != 41"
+# is itself a hard validation failure), so 5,959 // 41 == 145 rows is a
+# fixed hardware limit, not a per-capture estimate. This module receives
+# nominal_frame_rows as a caller-supplied parameter that existing tests
+# deliberately vary per synthetic scenario (it is otherwise only advisory,
+# carried into RollDetection.nominal_frame_rows), so it cannot stand in for
+# this fixed ceiling here.
+#
+# This kills the old 75 mm / panoramic acceptance: manual mode still exists
+# for film automatic detection cannot handle, but panoramic is no longer
+# one of those cases -- the fine window cannot hold it. Half-frame (short)
+# placements are unaffected; only the ceiling moved.
+FINE_CAPTURE_WINDOW_ROWS = 145
+# Same unfloored ratio expressed in mm, purely for phrasing the refusal
+# sentence -- ~38.8 mm. The row bound above is the actual gate.
+FINE_CAPTURE_WINDOW_MM = (5_959 / 41) * MANUAL_FRAME_HEIGHT_MM_PER_ROW
+
+# Snap assist (Rung 4 point 3, unchanged by the rework).
 SNAP_ASSIST_MAX_DISTANCE_ROWS = 4
 
-# Transport sanity (Rung 4 points 4-5): same 40..45 native-units-per-row
-# scale as roll_index.derive_transport_mapping's own minimum_scale/
-# maximum_scale defaults, and the same per-step local-ramp guard shape as
-# derive_transport_mapping's wide-gap-anchor admission check (grep
-# ramp_is_affine in roll_index.py) -- reimplemented here rather than
-# imported because manual mode's origins are exact same-traversal table
-# reads, never an affine fit prediction, so derive_transport_mapping itself
-# is not called (it requires >=3 "direct"-support boundaries, which no
-# user-picked boundary ever carries).
+# Transport sanity (F1 rework): same 40..45 native-units-per-row scale as
+# roll_index.derive_transport_mapping's own minimum_scale/maximum_scale
+# defaults -- every fit below is gated at this same physical bound.
 MINIMUM_TRANSPORT_SCALE = 40.0
 MAXIMUM_TRANSPORT_SCALE = 45.0
-RAMP_GUARD_RADIUS_ROWS = 3
+
+# Local transport-fit window (F1): how many rows on each side of a pick's
+# anchor row this module is willing to look at when deciding what "a steady
+# rate near this pick" means. 25 rows (a 51-row window) comfortably spans
+# more than two of the table's own ~18-row lattice periods, which matters
+# for the median-based robust start (below) -- it needs the steady rate to
+# be the majority of the window, and a window barely wider than one period
+# leaves too few rows to reliably outvote that period's own 1-2 lattice
+# jumps. Widening far past this stopped helping in practice (measured
+# against 45 archived live captures during this rework: identical results
+# from 40 rows out to 150) and risks pulling in a genuinely different local
+# rate from farther down the roll, so this stays a LOCAL window, never the
+# whole table.
+LOCAL_FIT_WINDOW_RADIUS_ROWS = 25
+# Below this many trusted rows in a window, a fit is not attempted -- there
+# is not enough signal left to tell a steady rate from noise once the
+# lattice's own jumps are set aside.
+LOCAL_FIT_MINIMUM_INLIER_ROWS = 8
+# A window row is trusted ("inlier") when it sits within this many rows of
+# the fitted line; this is also the fit's own final acceptance bound (its
+# worst trusted row can differ from the line by no more than this). Matches
+# MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS, the automatic path's own interior
+# residual bound, imported and reused directly below rather than
+# re-declared, so the two paths cannot silently drift apart.
+LOCAL_FIT_TRIM_RESIDUAL_ROWS = MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS
+# Bounded outlier-trim/refit rounds: the lattice's steady-rate majority and
+# its jump-row minority separate cleanly after one round in every archived
+# capture measured during this rework; a few extra rounds are cheap
+# insurance for a borderline window where a row migrates in or out as the
+# fitted line settles, not evidence more rounds are routinely needed.
+LOCAL_FIT_TRIM_ROUNDS = 4
+
+# A clear-film run up to this many rows wide is "narrow": a specific,
+# physically meaningful gap between two frames, the same class of evidence
+# roll_index.derive_transport_mapping's "direct" method anchors on. Wider
+# than this and a run stops meaning "this one boundary's own gap" -- it is
+# more likely the leader, a broad low-contrast region, or several bridged
+# boundaries sharing one detected run (observed on archived 39-frame-roll
+# captures during this rework: three consecutive automatic boundaries all
+# carrying the SAME ~300-row "cadence-broad" run). Reused conceptually from
+# roll_index.WIDE_GAP_CEILING_ROWS's own narrow/wide split rather than
+# imported, since that constant's own docstring ties it specifically to the
+# wide-gap recovery pass, a different feature this module must not couple
+# to.
+NARROW_EVIDENCE_RUN_MAX_WIDTH_ROWS = 20
+# When a pick has no narrow run to anchor on, how many rows past the pick
+# this module searches for the table's own closest match to the local fit's
+# prediction. Matches derive_transport_mapping's own affine-guided
+# local-lookup search range exactly (see roll_index.py: "the canonical
+# Nikon detector selects roughly 2..5 rows after a physical gap centre").
+CANDIDATE_SEARCH_LOOKAHEAD_ROWS = 8
+
+# A narrow-run anchor whose own table read is untrusted may substitute a
+# neighboring trusted row only within this distance -- the lattice's own
+# selector-rollover displacement is one row, capped at three for margin.
+# Anything farther extrapolates AT the anchor from the local fit instead
+# (re-review 2026-08-08, F-A: the uncapped substitute silently displaced
+# origins by up to 22 rows through gates that all read zero residual).
+SUBSTITUTE_ANCHOR_MAX_DISTANCE_ROWS = 3
+
+# A resolved lookup row farther than this from the operator's pick earns an
+# explicit review reason: the ordinary narrow-gap trailing-edge offset is
+# ~3 rows, and anything beyond it means the resolution moved meaningfully
+# away from what the operator pointed at (re-review 2026-08-08, F-B).
+LOOKUP_FAR_FROM_PICK_ROWS = 4
+LOOKUP_FAR_FROM_PICK_REVIEW_REASON = "transport-anchor-far-from-pick"
+
+# Placement-wide affine-fit residual gate (F4): identical bounds to
+# derive_transport_mapping's own maximum_anchor_mae_rows/
+# maximum_anchor_error_rows defaults. MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS is
+# imported and reused for the max bound; the MAE bound has no equivalent
+# module-level constant in roll_index.py (it is a default parameter value
+# there, not a name), so it is restated here at the same 1.0 value.
+PLACEMENT_ANCHOR_MAE_ROWS_MAX = 1.0
+# A 2-boundary (single-frame) placement's own two points fit a line
+# exactly, always -- MAE and max residual are trivially 0 regardless of
+# whether either point is right, so this whole gate is enforced only from
+# 3 boundaries (2 frames) up. See build_manual_detection's gate 6 comment
+# for what a 2-boundary placement relies on instead.
+PLACEMENT_ANCHOR_GATE_MINIMUM_BOUNDARIES = 3
 
 
 @dataclass(frozen=True)
@@ -113,6 +252,30 @@ class ManualFrameDetection:
     snaps: tuple[BoundarySnap, ...]
 
 
+@dataclass(frozen=True)
+class _ResolvedTransportOrigin:
+    """One boundary's transport-table origin, resolved through a local
+    lattice-aware fit rather than trusted as a single raw row read.
+
+    ``inferred`` and ``substituted`` are mutually informative, not mutually
+    exclusive in meaning: ``inferred`` records which of the two resolution
+    shapes ``_resolve_boundary_transport_origin`` used (narrow-run trailing
+    edge vs broad/weak-evidence forward search); ``substituted`` records
+    whether the row actually read differs from the picked row itself.  The
+    narrow-run shape can still set ``substituted`` (its own trailing-edge
+    row read was untrustworthy, so a nearby trusted row stood in for it);
+    the forward-search shape always sets it (it never reads the picked row
+    itself, by construction -- see its own docstring).
+    """
+
+    lookup_row: int
+    code: int
+    selector: int
+    native_origin: int
+    inferred: bool
+    substituted: bool
+
+
 def _ordinal(n: int) -> str:
     if 10 <= n % 100 <= 20:
         suffix = "th"
@@ -123,6 +286,219 @@ def _ordinal(n: int) -> str:
 
 def _approximate_mm(row: int) -> float:
     return row * MANUAL_FRAME_HEIGHT_MM_PER_ROW
+
+
+def _fit_local_transport_ramp(
+    table_origins: np.ndarray,
+    anchor_row: int,
+    ramp_upper_bound: int,
+) -> tuple[float, float, np.ndarray] | None:
+    """Robustly fit an affine (intercept, scale) line to the transport table
+    in a local window around ``anchor_row``.
+
+    Tolerates the lattice's own recurring selector-rollover / sub-rollover
+    code jumps (see this module's docstring) as a minority of outlier rows,
+    rather than treating any one of them as proof the whole neighborhood is
+    untrustworthy -- the failure mode that made the previous per-step ±3-row
+    guard refuse nearly every real capture.
+
+    Returns ``(intercept, scale, inlier_rows)`` -- ``inlier_rows`` is the
+    absolute row-index array of every window row the final fit trusts -- or
+    ``None`` if this neighborhood cannot support one: too few usable rows,
+    no majority steady rate, or a fitted scale outside the 40..45 physical
+    band even after discounting outliers.
+    """
+
+    window_lo = max(0, anchor_row - LOCAL_FIT_WINDOW_RADIUS_ROWS)
+    window_hi = min(ramp_upper_bound, anchor_row + LOCAL_FIT_WINDOW_RADIUS_ROWS)
+    if window_hi - window_lo + 1 < LOCAL_FIT_MINIMUM_INLIER_ROWS:
+        return None
+
+    rows = np.arange(window_lo, window_hi + 1, dtype=np.float64)
+    origins = table_origins[window_lo : window_hi + 1].astype(np.float64)
+
+    # Robust, leverage-independent starting line: on real LS-5000 tables the
+    # large majority of single-row steps are exactly the scanner's steady
+    # per-row rate, so the MEDIAN step and the MEDIAN per-row intercept
+    # residual both land close to the true line regardless of how far a
+    # minority of lattice-code-boundary rows deviate or where in the window
+    # they sit. An ordinary least-squares fit over the raw window does not
+    # have that property: a single high-leverage row at a window edge (a
+    # leading-anchor-style jump of tens of thousands of native units,
+    # observed on archived captures during this rework) can visibly tilt
+    # it before any outlier has been set aside.
+    step = np.diff(origins) / np.diff(rows)
+    scale = float(np.median(step))
+    if scale == 0:
+        return None
+    intercept = float(np.median(origins - scale * rows))
+    inlier_mask = (
+        np.abs((intercept + scale * rows - origins) / scale)
+        <= LOCAL_FIT_TRIM_RESIDUAL_ROWS
+    )
+
+    # Refit by ordinary least squares on the robust round's inliers only,
+    # then re-trim against THAT fit; repeat a bounded number of times so a
+    # borderline row can migrate in or out as the line settles.
+    for _ in range(LOCAL_FIT_TRIM_ROUNDS):
+        inlier_count = int(inlier_mask.sum())
+        if inlier_count < LOCAL_FIT_MINIMUM_INLIER_ROWS:
+            return None
+        design = np.column_stack((np.ones(inlier_count), rows[inlier_mask]))
+        intercept, scale = np.linalg.lstsq(design, origins[inlier_mask], rcond=None)[0]
+        if scale == 0:
+            return None
+        residual_rows = (intercept + scale * rows - origins) / scale
+        next_mask = np.abs(residual_rows) <= LOCAL_FIT_TRIM_RESIDUAL_ROWS
+        if int(next_mask.sum()) < LOCAL_FIT_MINIMUM_INLIER_ROWS:
+            return None
+        if np.array_equal(next_mask, inlier_mask):
+            inlier_mask = next_mask
+            break
+        inlier_mask = next_mask
+
+    if not MINIMUM_TRANSPORT_SCALE <= scale <= MAXIMUM_TRANSPORT_SCALE:
+        return None
+    final_residuals = (
+        intercept + scale * rows[inlier_mask] - origins[inlier_mask]
+    ) / scale
+    if float(np.max(np.abs(final_residuals))) > LOCAL_FIT_TRIM_RESIDUAL_ROWS:
+        return None
+
+    inlier_rows = np.arange(window_lo, window_hi + 1)[inlier_mask]
+    return float(intercept), float(scale), inlier_rows
+
+
+def _resolve_boundary_transport_origin(
+    records: Sequence[TransportRecord],
+    table_origins: np.ndarray,
+    picked_row: int,
+    evidence_run: tuple[int, int] | None,
+    ramp_upper_bound: int,
+) -> _ResolvedTransportOrigin | None:
+    """Resolve one boundary's native transport origin from a local fit.
+
+    Same class of machinery ``roll_index.derive_transport_mapping`` uses for
+    the automatic path: an affine fit over nearby table records, never a
+    single raw row read trusted on its own.
+
+    The row this reads from is always trusted first as-is: fit the local
+    ramp, and if the anchor row's own raw record already fits it, that
+    record IS the answer, full stop -- an honest pick on a clean table
+    always resolves to the exact row picked, never a neighbor a fixed
+    number of rows away "for consistency" with anything. The anchor itself
+    differs by evidence, though: a narrow (``NARROW_EVIDENCE_RUN_MAX_WIDTH_
+    ROWS``-wide or less) nearby clear-film evidence run is a specific
+    physical reference -- Nikon's own firmware convention places a frame's
+    origin a few rows past such a run's trailing edge, exactly the
+    "direct-gap-trailing-row" reference ``derive_transport_mapping``'s own
+    "direct" method reads -- so when one is available, THAT trailing edge
+    is the anchor, not the picked row itself. Without a narrow run -- a
+    broad/leader-like clear region, a weak or absent evidence signal, or
+    any other picked row with no specific physical trailing edge nearby --
+    there is no such reference, so the picked row itself is the anchor.
+
+    Only when the anchor's own raw record is NOT trustworthy does this fall
+    back to a substitute, and the two anchor kinds fall back differently.
+    A narrow run's trailing edge substitutes its nearest trusted neighbor:
+    it is still a specific physical reference, just misread by this one
+    row. A picked row with no narrow run to anchor on instead searches
+    forward for the table's own closest match to the fit's own prediction,
+    mirroring ``derive_transport_mapping``'s affine-guided-local-lookup --
+    appropriate here because, without a narrow run, there is no single
+    "this one row" already earning trust the way a trailing edge does.
+
+    Returns ``None`` when this neighborhood cannot support a local fit at
+    all; the caller treats that as a refusal of the whole placement, never
+    a silently accepted guess.
+    """
+
+    if not 0 <= picked_row <= ramp_upper_bound:
+        return None
+
+    narrow_run = (
+        evidence_run is not None
+        and evidence_run[1] - evidence_run[0] <= NARROW_EVIDENCE_RUN_MAX_WIDTH_ROWS
+        and evidence_run[1] <= ramp_upper_bound
+    )
+    anchor_row = evidence_run[1] if narrow_run and evidence_run else picked_row
+
+    fit = _fit_local_transport_ramp(table_origins, anchor_row, ramp_upper_bound)
+    if fit is None:
+        return None
+    intercept, scale, inlier_rows = fit
+
+    # The anchor's own raw record is trusted whenever the fit itself trusts
+    # it (whether the anchor is the picked row directly or a narrow run's
+    # trailing edge) -- this is what makes an exact, honest pick on a clean
+    # table resolve to that EXACT row, not a neighbor a fixed number of rows
+    # away. Only once the anchor's own reading is NOT trustworthy does this
+    # fall back to a substitute: a narrow run's trailing edge substitutes
+    # its nearest trusted neighbor (the anchor is still a specific physical
+    # reference, just misread by this one row); a picked row with no narrow
+    # run to anchor on instead searches forward for the table's own closest
+    # match to the fit's prediction, mirroring derive_transport_mapping's
+    # affine-guided-local-lookup -- the same convention Nikon's own firmware
+    # already uses for a broad/interpolated origin, appropriate here because
+    # there is no specific row already earning trust the way a narrow run's
+    # trailing edge does.
+    if anchor_row in inlier_rows:
+        lookup_row = anchor_row
+        substituted = False
+        inferred = False
+    elif narrow_run:
+        nearest = int(inlier_rows[np.argmin(np.abs(inlier_rows - anchor_row))])
+        if abs(nearest - anchor_row) <= SUBSTITUTE_ANCHOR_MAX_DISTANCE_ROWS:
+            lookup_row = nearest
+            substituted = True
+            inferred = False
+        else:
+            # Re-review 2026-08-08, F-A: an uncapped nearest-inlier
+            # substitute silently displaced origins by up to 22 rows on a
+            # table whose symmetric jitter left the median seed standing --
+            # a real physical point, so every downstream residual gate saw
+            # zero error. Beyond the lattice's own ~1-row rollover
+            # displacement (capped at 3 for margin), the anchor's
+            # neighborhood is not trustworthy row-by-row; extrapolate AT
+            # the anchor from the surviving local fit instead -- the same
+            # semantics the automatic path's transport-origin clamp has
+            # always had, which also makes the clamp marker truthful here.
+            lookup_row = anchor_row
+            record = records[anchor_row]
+            return _ResolvedTransportOrigin(
+                lookup_row=anchor_row,
+                code=record.code,
+                selector=record.selector,
+                native_origin=int(round(intercept + scale * anchor_row)),
+                substituted=True,
+                inferred=True,
+            )
+    else:
+        start = max(0, anchor_row + 1)
+        end = min(ramp_upper_bound + 1, anchor_row + CANDIDATE_SEARCH_LOOKAHEAD_ROWS)
+        if start >= end:
+            return None
+        candidates = np.arange(start, end)
+        prediction = intercept + scale * anchor_row
+        lookup_row = int(
+            candidates[
+                np.argmin(
+                    np.abs(table_origins[candidates].astype(np.float64) - prediction)
+                )
+            ]
+        )
+        substituted = True
+        inferred = True
+
+    record = records[lookup_row]
+    return _ResolvedTransportOrigin(
+        lookup_row=lookup_row,
+        code=record.code,
+        selector=record.selector,
+        native_origin=record.native_origin,
+        inferred=inferred,
+        substituted=substituted,
+    )
 
 
 def build_manual_detection(
@@ -136,7 +512,7 @@ def build_manual_detection(
 ) -> ManualFrameDetection:
     """Turn operator-picked boundary rows into a reviewed roll detection.
 
-    ``rgb16``/``known`` are the same decoded whole-roll raster and
+    ``rgb16``/``known`` are the same decoded whole-roll preview raster and
     completeness mask ``detect_roll_frames`` takes; ``records`` is the same
     same-traversal live READ(0x8e) transport table used everywhere else in
     this package. No film moves and no relaxed automatic-detection knobs are
@@ -146,6 +522,20 @@ def build_manual_detection(
     Every gate below fails closed: any failure raises before this function
     returns anything, so a caller can never end up with a placement that
     silently accepted some of the operator's picks and dropped others.
+
+    Idempotent by construction (F3): every check that depends on the exact
+    rows a placement resolves to (the height gates, transport resolution,
+    pairwise and placement-wide fits) runs on ``final_rows`` -- the rows
+    AFTER snap assist, i.e. this function's own output boundary rows -- so
+    feeding a previously accepted placement's own ``detection.boundaries``
+    output rows back in as new ``boundary_rows`` re-derives the identical
+    result rather than re-litigating a pre-snap view of the picks that no
+    longer describes the placement. This matters beyond a nicety: the batch
+    capture wire and the worker's live-scan replay both resupply a session's
+    already-snapped rows as the next call's raw ``boundary_rows``
+    (``Roll.scan_many``, the batch job, and ``worker._derive_live_frame_
+    selection``'s manual branch), so a placement that could not survive its
+    own replay would deadlock an approved session at scan time.
     """
 
     # ---- gate 0: same shape/completeness floor as the automatic detector --
@@ -193,23 +583,7 @@ def build_manual_detection(
             f"{len(rows)} boundary rows would create {frame_count}"
         )
 
-    # ---- gate 2: physical frame-height range, on the operator's own picks -
-    for index, (start, end) in enumerate(zip(rows, rows[1:]), start=1):
-        height_rows = end - start
-        if not (
-            MINIMUM_MANUAL_FRAME_HEIGHT_ROWS
-            <= height_rows
-            <= MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS
-        ):
-            approx_mm = _approximate_mm(height_rows)
-            raise IndexDecodeError(
-                f"the {_ordinal(index)} frame you placed is about "
-                f"{approx_mm:.0f} mm tall (between rows {start} and {end}), "
-                "outside the 15-75 mm range this driver accepts for manual "
-                "placement"
-            )
-
-    # ---- gate 3: snap assist (default on, never a hard requirement) -------
+    # ---- gate 2: snap assist (default on, never a hard requirement) -------
     # Reuses roll_index's own clear-film evidence signal so a "clear film
     # edge" means the exact same physical thing here as it does to the
     # automatic detector and the Rung 3 diagnosis module. If this raster
@@ -285,10 +659,9 @@ def build_manual_detection(
     # Snapping moves each boundary independently by at most
     # SNAP_ASSIST_MAX_DISTANCE_ROWS; re-verify order and raster bounds still
     # hold on the (small number of) final rows before trusting them for
-    # anything downstream. Practically unreachable given the height gate
-    # above already ran on the raw picks, but cheap, correct, and this
-    # module never trusts an unchecked value just because a similar one was
-    # already checked.
+    # anything downstream. Practically unreachable given gate 1 already ran
+    # on the raw picks, but cheap, correct, and this module never trusts an
+    # unchecked value just because a similar one was already checked.
     if any(a >= b for a, b in zip(final_rows, final_rows[1:])):
         raise IndexDecodeError(
             "snap assist moved two placed boundaries out of order; place "
@@ -300,54 +673,141 @@ def build_manual_detection(
             f"(0..{height - 1})"
         )
 
-    # ---- gate 4: per-boundary local transport-ramp guard -------------------
-    # Same guard shape as derive_transport_mapping's wide-gap-anchor
-    # admission check (grep ramp_is_affine in roll_index.py), applied
-    # uniformly to every picked boundary -- manual mode has no separate
-    # "leading anchor" tolerance the way the automatic path does, because
-    # nothing here is inferred from an affine fit; every origin is a direct
-    # table read, and a direct table read next to an untrustworthy ramp is
-    # exactly the case this guard exists to catch.
+    # ---- gate 3: physical frame-height floor and ceiling, on the FINAL ----
+    # ---- (post-snap) rows (F2 + F3) ----------------------------------------
+    # Snap assist (gate 2) can move each boundary independently by up to
+    # SNAP_ASSIST_MAX_DISTANCE_ROWS, which can shrink a frame that was
+    # exactly at the floor below it, or grow one that was exactly at the
+    # ceiling past it (both reachable live: a pick 56 rows from its neighbor
+    # that both snap toward each other lands under the floor; one at the
+    # ceiling that both snap apart lands over it). Checking the RAW picks
+    # here, the way this gate used to, can accept a frame whose real
+    # (post-snap) height violates either bound -- and, because the reviewed
+    # session/batch-wire/worker-replay path always resupplies a prior call's
+    # own final_rows as the next call's raw boundary_rows (see this
+    # function's own docstring), checking raw picks here would also make
+    # this function non-idempotent: a placement it just approved could
+    # refuse when replayed verbatim. A post-snap check does not give up
+    # anything a pre-snap one caught -- snap assist is deterministic and
+    # already re-verified for order/bounds just above -- so there is no
+    # reason to keep both.
+    for index, (start, end) in enumerate(zip(final_rows, final_rows[1:]), start=1):
+        height_rows = end - start
+        if height_rows < MINIMUM_MANUAL_FRAME_HEIGHT_ROWS:
+            approx_mm = _approximate_mm(height_rows)
+            floor_mm = _approximate_mm(MINIMUM_MANUAL_FRAME_HEIGHT_ROWS)
+            raise IndexDecodeError(
+                f"the {_ordinal(index)} frame you placed is about "
+                f"{approx_mm:.0f} mm tall (between rows {start} and {end}), "
+                f"shorter than the {floor_mm:.0f} mm floor this driver "
+                "accepts for manual placement"
+            )
+        if height_rows > FINE_CAPTURE_WINDOW_ROWS:
+            approx_mm = _approximate_mm(height_rows)
+            raise IndexDecodeError(
+                f"the {_ordinal(index)} frame you placed is about "
+                f"{approx_mm:.0f} mm tall (between rows {start} and {end}); "
+                f"the scanner captures about {FINE_CAPTURE_WINDOW_MM:.1f} mm "
+                "per frame in one fine scan and there is no way to capture "
+                "a taller frame in a single pass -- place a boundary "
+                "partway through it instead"
+            )
+
+    # ---- gate 4: per-boundary transport-origin resolution (F1) ------------
+    # Same class of machinery roll_index.derive_transport_mapping uses for
+    # the automatic path: an affine fit over nearby table records, not a
+    # single raw row read trusted on its own. See
+    # _resolve_boundary_transport_origin's own docstring for the two
+    # resolution shapes and why each mirrors a specific
+    # derive_transport_mapping convention. Every failure here still refuses
+    # the WHOLE placement before anything is returned, exactly like every
+    # gate above and below it.
     if len(records) < 1:
         raise IndexDecodeError(
             "manual frame placement requires the same-traversal scanner "
             "position table; none was supplied"
         )
+    for index, row in enumerate(final_rows):
+        if not 0 <= row < len(records):
+            raise IndexDecodeError(
+                f"the {_ordinal(index + 1)} frame edge you placed (row "
+                f"{row}) has no matching entry in the scanner's position "
+                "table; place it on a row the scanner actually recorded a "
+                "position for"
+            )
+
     tail_start = terminal_transport_tail_start(records)
     ramp_upper_bound = (
         len(records) - 1 if tail_start is None else min(len(records) - 1, tail_start - 1)
     )
-    for index, row in enumerate(final_rows):
-        if not 0 <= row < len(records):
-            raise IndexDecodeError(
-                f"the {_ordinal(index + 1)} frame edge you placed (row {row}) "
-                "has no matching entry in the scanner's position table; try "
-                "refeeding the strip and re-scanning the preview"
-            )
-        lo = max(0, row - RAMP_GUARD_RADIUS_ROWS)
-        hi = min(ramp_upper_bound, row + RAMP_GUARD_RADIUS_ROWS)
-        steps_ok = hi > lo and all(
-            MINIMUM_TRANSPORT_SCALE
-            <= records[r + 1].native_origin - records[r].native_origin
-            <= MAXIMUM_TRANSPORT_SCALE
-            for r in range(lo, hi)
-        )
-        if not steps_ok:
-            raise IndexDecodeError(
-                "the scanner's position readings look unreliable around the "
-                f"{_ordinal(index + 1)} frame edge you placed (approximately "
-                f"{_approximate_mm(row):.0f} mm into the roll); try refeeding "
-                "the strip and re-scanning the preview"
-            )
+    table_origins = np.fromiter(
+        (record.native_origin for record in records),
+        dtype=np.int64,
+        count=len(records),
+    )
 
-    # ---- gate 5: origins strictly increasing at 40..45 units/row ----------
-    picked_origins = [records[row].native_origin for row in final_rows]
-    for index, (row_a, row_b, origin_a, origin_b) in enumerate(
-        zip(final_rows, final_rows[1:], picked_origins, picked_origins[1:]),
-        start=1,
-    ):
-        delta_rows = row_b - row_a
-        delta_origin = origin_b - origin_a
+    # The very last picked row is never a frame START -- it is only the
+    # visual END of the final frame (FrameInterval.end_row below), the same
+    # way roll_index.derive_transport_mapping itself only ever resolves
+    # transport origins for boundaries[:frame_count], never the trailing
+    # one. A roll's last frame commonly ends at or after the point the live
+    # 0x8e ramp stops being trustworthy (terminal_transport_tail_start) --
+    # that is an ordinary, healthy end-of-roll shape, not a defect, so
+    # ONLY this one trailing pick is allowed to fail resolution without
+    # refusing the whole placement. Every other pick funds an actual
+    # frame's origin and must resolve or this still refuses in full.
+    trailing_index = len(final_rows) - 1
+    resolved: list[_ResolvedTransportOrigin | None] = []
+    for index, row in enumerate(final_rows):
+        origin = _resolve_boundary_transport_origin(
+            records, table_origins, row, supporting_runs[index], ramp_upper_bound
+        )
+        if origin is None:
+            if index == trailing_index:
+                resolved.append(None)
+                continue
+            raise IndexDecodeError(
+                "the scanner's position table doesn't settle into a steady "
+                f"rate near the {_ordinal(index + 1)} frame edge you "
+                f"placed (row {row}, about {_approximate_mm(row):.0f} mm "
+                "into the roll); try placing the boundary a few rows to "
+                "either side, or re-scan the preview and place the frames "
+                "again"
+            )
+        resolved.append(origin)
+
+    # ---- gate 5: adjacent resolved origins strictly increasing at 40..45 --
+    # Same pairwise sanity as before the rework, now checked against each
+    # boundary's RESOLVED origin (gate 4) instead of one raw row read. This
+    # catches a distinct failure mode from gate 4: gate 4 proves each
+    # boundary's own neighborhood is internally affine; this proves adjacent
+    # boundaries agree with EACH OTHER, which catches a genuine mid-span
+    # table discontinuity between two picks that neither boundary's own
+    # local window ever sees.
+    #
+    # The row side of "position units per row" uses each boundary's
+    # RESOLVED lookup_row, not the visual row the operator placed. A narrow
+    # evidence run's trailing edge and a broad-region forward search each
+    # read the table a few rows away from the exact pick, by design (see
+    # _resolve_boundary_transport_origin); that offset differs between the
+    # two, so two adjacent boundaries resolved through different paths (a
+    # narrow inter-frame gap next to, say, the leader) can have visually
+    # placed rows that imply a fine but genuine steady rate while their
+    # ACTUAL table rows do not, or the other way around. lookup_row is what
+    # was actually read, so it is the only row number this check can hold
+    # to a physical rate without occasionally penalizing a placement for
+    # nothing more than which resolution path two neighbors happened to
+    # take.
+    #
+    # Only the trailing pick (see above) can be None, and only as the very
+    # last element of ``resolved`` -- so the one pair this could affect is
+    # the last one; skip it rather than compare against a resolution that
+    # was never required to exist.
+    for index, (before, after) in enumerate(zip(resolved, resolved[1:]), start=1):
+        if before is None or after is None:
+            continue
+        delta_rows = after.lookup_row - before.lookup_row
+        delta_origin = after.native_origin - before.native_origin
         implied_scale = delta_origin / delta_rows if delta_rows else 0.0
         if not (
             delta_origin > 0
@@ -355,12 +815,96 @@ def build_manual_detection(
         ):
             raise IndexDecodeError(
                 "the scanner's position readings between the "
-                f"{_ordinal(index)} and {_ordinal(index + 1)} frame edges you "
-                f"placed don't move at a steady rate (about "
+                f"{_ordinal(index)} and {_ordinal(index + 1)} frame edges "
+                f"you placed don't move at a steady rate (about "
                 f"{implied_scale:.1f} position units per row; this driver "
-                "expects roughly 40-45); try refeeding the strip and "
-                "re-scanning the preview"
+                "expects roughly 40-45); try placing the boundaries again, "
+                "or re-scan the preview"
             )
+
+    # ---- gate 6: placement-wide affine-fit residuals (F4) -----------------
+    # Same residual contract derive_transport_mapping enforces on the
+    # automatic path (anchor_mae_rows <= PLACEMENT_ANCHOR_MAE_ROWS_MAX,
+    # anchor_max_error_rows <= MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS) -- before
+    # this rework computed here for TransportMapping.diagnostics() but never
+    # enforced, which is exactly how a placement whose picks disagreed with
+    # each other could still get bound downstream: worker.py's
+    # apply_boundary_offset re-checks this same residual at bind time and
+    # either refuses per frame or, if a caller wrongly granted rebase, keeps
+    # a displaced origin (see worker.py's origin_rebase_allowed /
+    # origin_rebase_slots computation for the other half of that fix, which
+    # this rework also closes -- manual placements are no longer eligible
+    # for that rebase).
+    #
+    # A 2-boundary (single-frame) placement's own two points always fit a
+    # line exactly -- MAE and max residual are trivially 0 no matter how
+    # wrong either point is, so this gate cannot add anything for a single
+    # frame. What validates a 2-boundary placement is gate 4 (each pick's
+    # own local neighborhood proves internally affine) and gate 5 (the one
+    # pairwise implied scale between the two picks); there is no third,
+    # independent boundary to cross-check either pick against, so a
+    # systematic table shift confined entirely between the two picks -- one
+    # that neither pick's own local window sees and that still lands inside
+    # the 40..45 pairwise scale band -- is not detectable from two points,
+    # full stop, no matter how this module is written. Documented here
+    # rather than silently pretended away with a gate that would always
+    # pass anyway.
+    #
+    # Fit against each boundary's RESOLVED lookup_row, for the same reason
+    # gate 5 just switched to it: lookup_row is the row this placement's
+    # origins actually came from, so fitting it is a check on whether the
+    # TABLE is one consistent physical ramp across this placement's span --
+    # true regardless of which resolution path (narrow-run trailing edge vs
+    # broad-region forward search) picked each lookup_row. Fitting the
+    # visual pick rows instead would fold each path's own few-row read
+    # offset into the residual alongside genuine table drift, and a
+    # placement that mixes both paths (e.g. a leader-adjacent first
+    # boundary next to ordinary narrow inter-frame gaps -- an entirely
+    # ordinary manual placement) would then show a spurious drift this gate
+    # would wrongly refuse on. NativeFrameOrigin.boundary_output_row is set
+    # to this same lookup_row below (not the visual pick row) precisely so
+    # worker.py's apply_boundary_offset -- the only other reader of that
+    # field, and out of scope for this rework -- re-predicts against the
+    # identical row this fit was trained on.
+    #
+    # Only over the boundaries that actually resolved (see above: the
+    # trailing one may not have).
+    fit_indices = [index for index, item in enumerate(resolved) if item is not None]
+    fit_items = [resolved[index] for index in fit_indices]
+    lookup_rows_arr = np.asarray([item.lookup_row for item in fit_items], dtype=np.float64)
+    origin_arr = np.asarray([item.native_origin for item in fit_items], dtype=np.float64)
+    design = np.column_stack((np.ones(len(lookup_rows_arr)), lookup_rows_arr))
+    placement_intercept, placement_scale = np.linalg.lstsq(design, origin_arr, rcond=None)[0]
+    if placement_scale:
+        fit_residual_rows = (
+            design @ np.asarray((placement_intercept, placement_scale)) - origin_arr
+        ) / placement_scale
+        anchor_mae = float(np.mean(np.abs(fit_residual_rows)))
+        anchor_max = float(np.max(np.abs(fit_residual_rows)))
+    else:  # pragma: no cover - unreachable once gate 5 has passed
+        fit_residual_rows = np.zeros_like(origin_arr)
+        anchor_mae = 0.0
+        anchor_max = 0.0
+    # Full-length (per final_rows position), None only where the trailing
+    # pick has no resolution -- resolved[:-1] (what the origins loop below
+    # actually indexes) never includes that position, so every residual it
+    # reads is always a real float.
+    placement_residual_rows: list[float | None] = [None] * len(resolved)
+    for index, residual in zip(fit_indices, fit_residual_rows):
+        placement_residual_rows[index] = float(residual)
+
+    if len(fit_items) >= PLACEMENT_ANCHOR_GATE_MINIMUM_BOUNDARIES and (
+        anchor_mae > PLACEMENT_ANCHOR_MAE_ROWS_MAX
+        or anchor_max > MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS
+    ):
+        raise IndexDecodeError(
+            "the scanner's position readings across this whole placement "
+            f"don't agree on one steady rate (average drift {anchor_mae:.2f} "
+            f"rows, worst-case drift {anchor_max:.2f} rows against one "
+            "straight line through this placement's own scanner-table "
+            "readings); try placing the boundaries again, or re-scan the "
+            "preview"
+        )
 
     # ---- build the result in the shared roll_index shapes ------------------
     def boundary_reading(row: int) -> tuple[float, float, float]:
@@ -425,49 +969,69 @@ def build_manual_detection(
         )
 
     origins: list[NativeFrameOrigin] = []
-    for frame_index, start_boundary in enumerate(boundaries[:-1], start=1):
-        record = records[start_boundary.output_row]
+    for frame_index, (start_boundary, item, residual) in enumerate(
+        zip(boundaries[:-1], resolved[:-1], placement_residual_rows[:-1]), start=1
+    ):
+        reasons = [MANUAL_ORIGIN_REVIEW_REASON]
+        if item.inferred:
+            reasons.append(INFERRED_ORIGIN_REVIEW_REASON)
+        elif item.substituted:
+            reasons.append(TRANSPORT_ORIGIN_CLAMP_REASON)
+        if (
+            abs(item.lookup_row - start_boundary.output_row)
+            > LOOKUP_FAR_FROM_PICK_ROWS
+        ):
+            # Re-review 2026-08-08, F-B: a false clear-film run inside a
+            # frame (blown-highlight band on slide film) can pull the
+            # trailing-edge anchor well away from what the operator pointed
+            # at with no snap note and no other signal. Beyond the ordinary
+            # ~3-row narrow-gap offset, the divergence gets its own review
+            # reason so the approval UI shows the operator that the scanner
+            # will cut this frame somewhere other than exactly their line.
+            reasons.append(LOOKUP_FAR_FROM_PICK_REVIEW_REASON)
         origins.append(
             NativeFrameOrigin(
                 frame=frame_index,
                 boundary_index=start_boundary.index,
-                boundary_output_row=start_boundary.output_row,
-                lookup_row=start_boundary.output_row,
-                code=record.code,
-                selector=record.selector,
-                native_origin=record.native_origin,
+                # Deliberately the RESOLVED lookup_row, not the visual pick
+                # row (GapBoundary.output_row, used unchanged for thumbnail
+                # cropping in the interval above) -- see gate 6's own
+                # comment for why the placement-wide fit is trained on
+                # lookup_row, and why this field has to match that same row
+                # for worker.py's apply_boundary_offset (this field's only
+                # other reader) to re-predict consistently with it.
+                boundary_output_row=item.lookup_row,
+                lookup_row=item.lookup_row,
+                code=item.code,
+                selector=item.selector,
+                native_origin=item.native_origin,
                 method=MANUAL_ORIGIN_METHOD,
                 automatic=False,
                 manual_review=True,
-                review_reasons=(MANUAL_ORIGIN_REVIEW_REASON,),
-                # Exact same-traversal table read, not an affine-fit
-                # prediction -- there is no fit error to report. Zero here
-                # also keeps worker.py's _addressable_frame_origins residual
-                # filter from ever excluding a manually placed frame; gate 4
-                # above is this module's own, stricter physical check.
-                affine_residual_rows=0.0,
+                review_reasons=tuple(reasons),
+                # The placement-wide fit's own residual (gate 6) for this
+                # boundary, not a per-pick local-window residual: this is
+                # the same quantity worker.py's _addressable_frame_origins
+                # and apply_boundary_offset already gate every AUTOMATIC
+                # origin's affine_residual_rows against
+                # (MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS), so reusing it here
+                # keeps that shared downstream logic meaningful instead of
+                # silently truncating a manual placement's addressable
+                # prefix for a reason nobody surfaced. For a 2-boundary
+                # placement this is exactly 0.0 (a line through two points
+                # has no residual), matching what this field used to be
+                # hardcoded to before the rework.
+                affine_residual_rows=float(residual),
             )
         )
 
     # Diagnostic-only affine summary across every picked boundary (not just
-    # the frame-owning ones) -- purely for TransportMapping.diagnostics();
-    # nothing above derives an origin from this fit.
-    rows_arr = np.asarray([b.output_row for b in boundaries], dtype=np.float64)
-    origin_arr = np.asarray(picked_origins, dtype=np.float64)
-    design = np.column_stack((np.ones(len(rows_arr)), rows_arr))
-    intercept, scale = np.linalg.lstsq(design, origin_arr, rcond=None)[0]
-    if scale:
-        residual_rows = (design @ np.asarray((intercept, scale)) - origin_arr) / scale
-        anchor_mae = float(np.mean(np.abs(residual_rows)))
-        anchor_max = float(np.max(np.abs(residual_rows)))
-    else:  # pragma: no cover - unreachable once gate 5 has passed
-        anchor_mae = 0.0
-        anchor_max = 0.0
-
+    # the frame-owning ones) -- surfaced through TransportMapping.
+    # diagnostics() and now also enforced above (gate 6).
     mapping = TransportMapping(
         record_count=len(records),
-        native_intercept=float(intercept),
-        native_units_per_preview_row=float(scale),
+        native_intercept=float(placement_intercept),
+        native_units_per_preview_row=float(placement_scale),
         anchor_mae_rows=anchor_mae,
         anchor_max_error_rows=anchor_max,
         origins=tuple(origins),

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_diagnosis.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_diagnosis.py
@@ -1,0 +1,406 @@
+"""Read-only probable-cause diagnosis for an LS-5000 roll-index refusal.
+
+Analyzes the same physical evidence signals the frame detector itself
+computes -- illuminated aperture, per-row transmission/uniformity, and the
+resulting clear-film run structure -- to translate *why* a roll failed into
+one plain-English sentence a film hobbyist can act on. This module never
+re-derives or relaxes any detection knob and cannot construct a detection
+result of any kind: its only public function returns a sentence or nothing,
+enforced by a structural test. See FEEDING-UX-LADDER-OVERNIGHT-20260807.md
+("Rung 3") for the design and FEEDING-ROBUSTNESS-20260805.md ("P3") for the
+original rationale this module adapts.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from .roll_index import (
+    WIDE_GAP_CEILING_ROWS,
+    _active_aperture,
+    _physical_gap_evidence,
+    _true_runs,
+)
+
+# One 97 dpi preview row of film, in mm. FEEDING-ROBUSTNESS-20260805.md Sec
+# 1.1: 142.5 measured preview rows per 38.1 mm standard 8-perforation frame.
+MM_PER_PREVIEW_ROW = 0.267
+
+# The detector's own accepted pitch band, as a fraction of nominal_frame_rows
+# (mirrors roll_index.py's own coarse lag_min/lag_max search constants).
+_STANDARD_LAG_LOW_RATIO = 0.85
+_STANDARD_LAG_HIGH_RATIO = 1.15
+
+# Half-frame (18x24) and panoramic/Xpan true pitch, as a fraction of the
+# driver's assumed standard-35mm nominal_frame_rows (~71/145 and ~259/145
+# measured, FEEDING-ROBUSTNESS-20260805.md Sec 3.3).
+_HALF_FRAME_PITCH_RATIO = 0.49
+_PANORAMA_PITCH_RATIO = 1.79
+
+# Search tolerance (+/-) around each alternate-format point estimate above.
+_ALTERNATE_LAG_TOLERANCE = 0.10
+
+# A clear-film run has to stay below this fraction of one whole frame pitch
+# to count as a candidate for the periodicity search below. Without this, a
+# long leading/trailing unexposed leader (legitimately dozens to hundreds of
+# rows, e.g. test_variable_leader_and_trailer_are_visible_without_guessing_
+# roll_count's leader=300/tail=260 case) is one giant, non-periodic block
+# whose own short-lag self-similarity swamps the real inter-frame signal
+# and reads as false alternate-pitch periodicity.
+_ALTERNATE_PITCH_CANDIDATE_SCALE_FRACTION = 0.5
+
+# How much of the standard-window peak an alternate-pitch peak must reach
+# before it is trusted. See _diagnose_alternate_pitch's docstring for why
+# these two differ by an order of magnitude -- it is not an oversight.
+_HALF_FRAME_DOMINANCE_MARGIN = 0.85
+_PANORAMA_DOMINANCE_MARGIN = 2.0
+
+# A panorama candidate whose winning lag sits this close to exactly double
+# the standard-window lag is that roll's own second harmonic, not panorama.
+_HARMONIC_ALIAS_TOLERANCE_ROWS = 4
+
+# Matches the detector's own narrow-run floor (roll_index.py's accepted
+# [3, 12]-row clear-film run window).
+_NARROW_GAP_FLOOR_ROWS = 3
+
+# Distinct too-narrow/too-wide runs required before this check trusts a
+# systematic pattern instead of one noisy outlier run.
+_GAP_GEOMETRY_MIN_RUNS = 3
+
+# A run has to stay below this fraction of one whole frame pitch to still
+# read as "a gap" rather than "an unexposed frame".
+_TOO_WIDE_FRAME_SCALE_FRACTION = 0.5
+
+# The near-miss band just under the detector's own direct-gap gates
+# (roll_index.py's _physical_gap_evidence: transmission >= 0.87,
+# nonuniformity <= 0.18).
+_CONTRAST_FLOOR_LOW = 0.80
+_CONTRAST_FLOOR_HIGH = 0.87
+_CONTRAST_FLOOR_NONUNIFORMITY_CEILING = 0.18
+
+# A near-miss run has to be at least this wide, and there have to be at
+# least this many of them, before low contrast (not noise) is the read.
+_CONTRAST_FLOOR_MIN_RUN_ROWS = 2
+_CONTRAST_FLOOR_MIN_CLUSTERS = 3
+
+# Leading/trailing slice of the aperture width checked against the middle.
+_APERTURE_EDGE_FRACTION = 0.20
+# A side at or below this fraction of the middle's brightness reads as
+# obstructed (measured cliff: 15/96 cols @ 70% transmission fails detection,
+# 10 columns does not -- FEEDING-ROBUSTNESS-20260805.md Sec 3.3).
+_APERTURE_OBSTRUCTION_RATIO = 0.85
+# Below this aperture width, edge/middle columns cannot be split usefully.
+_APERTURE_MIN_WIDTH_FOR_OBSTRUCTION_CHECK = 10
+
+# Mirrors the detector's own row-completeness floor
+# (complete_rows.mean() < 0.995 -- see roll_index.py's single-pass core).
+_MINIMUM_COMPLETE_ROW_FRACTION = 0.995
+
+
+def _autocorrelation_peak(
+    centered: np.ndarray, lag_min: int, lag_max: int
+) -> tuple[float | None, int | None]:
+    """Best centered-signal dot-product correlation in one lag window.
+
+    Same normalized form the detector's own coarse pitch search uses
+    (``np.dot(centered[:-lag], centered[lag:]) / (len(centered) - lag)``) --
+    a single lag-by-lag scan, not a lattice fit, so it stays cheap enough to
+    run on every failure. Returns ``(None, None)`` when the window has no
+    valid lag for this raster's length.
+    """
+
+    lag_min = max(1, int(math.floor(lag_min)))
+    lag_max = min(len(centered) - 3, int(math.ceil(lag_max)))
+    if lag_min > lag_max:
+        return None, None
+    best_value: float | None = None
+    best_lag: int | None = None
+    for lag in range(lag_min, lag_max + 1):
+        value = float(np.dot(centered[:-lag], centered[lag:]) / (len(centered) - lag))
+        if best_value is None or value > best_value:
+            best_value, best_lag = value, lag
+    return best_value, best_lag
+
+
+def _dominates(alternate: float | None, standard: float | None, margin: float) -> bool:
+    """Whether an alternate-pitch peak is confidently the real periodicity.
+
+    ``alternate`` must itself be a genuine positive correlation -- a
+    hypothesis nothing in the raster supports never fires, no matter how
+    weak ``standard`` is. Once that holds, a non-positive ``standard`` peak
+    (no periodicity found at the driver's assumed pitch at all) is beaten
+    automatically; otherwise ``alternate`` must clear ``margin`` times
+    ``standard``.
+    """
+
+    if alternate is None or alternate <= 0:
+        return False
+    if standard is None or standard <= 0:
+        return True
+    return alternate >= margin * standard
+
+
+def _diagnose_alternate_pitch(
+    evidence: np.ndarray, direct: np.ndarray, nominal_frame_rows: int
+) -> str | None:
+    """Half-frame and panoramic film pitch check.
+
+    Half-frame's true pitch sits close to half the driver's assumed
+    nominal; panoramic/Xpan's sits close to 1.79x it. Both are recognized
+    by directly probing an autocorrelation window centered on the
+    alternate pitch instead of the driver's assumed one.
+
+    The signal correlated is ``evidence`` zeroed everywhere except inside
+    clear-film runs narrower than the candidate-scale fraction of one frame
+    pitch (``_ALTERNATE_PITCH_CANDIDATE_SCALE_FRACTION``) -- the same
+    "restrict to run-scale evidence" shape the detector's own
+    ``anchor_signal`` uses, adapted here with a wider, format-agnostic cap
+    instead of the detector's exact [3, 12]-row window, since a half-frame
+    or panoramic roll's own gaps need not fall in that specific band.
+    Without this restriction, a long unexposed leader/trailer (legitimately
+    dozens to hundreds of rows) is one giant non-periodic block whose own
+    short-lag self-similarity reads as false periodicity at short lags --
+    confirmed by direct measurement, not theory: an otherwise-healthy
+    synthetic roll with a 300-row leader produced a spurious "half-frame"
+    reading before this restriction, and none after.
+
+    A margin note, because the obvious "just beat the standard-window
+    peak" comparison does not hold for half-frame: on a clean periodic
+    signal, autocorrelation at any integer multiple of the true period is
+    roughly *equal* to correlation at the true period itself (measured
+    0.87-1.06x across many synthetic half-frame rolls, never close to
+    2x) -- the driver's standard window is finding half-frame film's own
+    second harmonic, not a competing signal. The real tell is sign, not
+    multiple: a genuinely standard roll shows no periodicity at all at the
+    half-frame lag (consistently negative in the same sweep), so
+    ``_HALF_FRAME_DOMINANCE_MARGIN`` only has to rule out noise once the
+    alternate peak is already positive.
+
+    Panorama does not share that ambiguity -- 1.79x is not an integer
+    relationship with the standard pitch -- so the far stricter
+    ``_PANORAMA_DOMINANCE_MARGIN`` applies there instead, matching this
+    check's own "e.g. 2x" starting point. The one confound is the mirror
+    image of the half-frame case: a standard roll's *own* second harmonic
+    (2x its true pitch) can land inside the panorama search window, and
+    there it ties the standard peak the same way half-frame's does.
+    Rejecting any panorama candidate whose winning lag sits within
+    ``_HARMONIC_ALIAS_TOLERANCE_ROWS`` of exactly twice the standard-window
+    lag (the same neighbor-exclusion radius the detector's own
+    ``autocorrelation_best_non_neighbor`` uses) closes that hole.
+    """
+
+    candidate_scale_rows = (
+        _ALTERNATE_PITCH_CANDIDATE_SCALE_FRACTION * nominal_frame_rows
+    )
+    periodic = np.zeros_like(evidence)
+    for start, end in _true_runs(direct):
+        if (end - start) < candidate_scale_rows:
+            periodic[start:end] = evidence[start:end]
+    centered = periodic - float(periodic.mean())
+    standard_peak, standard_lag = _autocorrelation_peak(
+        centered,
+        nominal_frame_rows * _STANDARD_LAG_LOW_RATIO,
+        nominal_frame_rows * _STANDARD_LAG_HIGH_RATIO,
+    )
+    standard_mm = nominal_frame_rows * MM_PER_PREVIEW_ROW
+
+    half_peak, half_lag = _autocorrelation_peak(
+        centered,
+        nominal_frame_rows * _HALF_FRAME_PITCH_RATIO * (1 - _ALTERNATE_LAG_TOLERANCE),
+        nominal_frame_rows * _HALF_FRAME_PITCH_RATIO * (1 + _ALTERNATE_LAG_TOLERANCE),
+    )
+    if _dominates(half_peak, standard_peak, _HALF_FRAME_DOMINANCE_MARGIN):
+        half_mm = half_lag * MM_PER_PREVIEW_ROW
+        return (
+            f"this looks like half-frame film (a frame about every {half_mm:.0f} mm); "
+            f"this driver expects standard 35 mm spacing (about {standard_mm:.0f} mm "
+            "between frame starts)"
+        )
+
+    panorama_peak, panorama_lag = _autocorrelation_peak(
+        centered,
+        nominal_frame_rows * _PANORAMA_PITCH_RATIO * (1 - _ALTERNATE_LAG_TOLERANCE),
+        nominal_frame_rows * _PANORAMA_PITCH_RATIO * (1 + _ALTERNATE_LAG_TOLERANCE),
+    )
+    aliases_standard_second_harmonic = (
+        standard_peak is not None
+        and standard_peak > 0
+        and standard_lag is not None
+        and panorama_lag is not None
+        and abs(panorama_lag - 2 * standard_lag) <= _HARMONIC_ALIAS_TOLERANCE_ROWS
+    )
+    if not aliases_standard_second_harmonic and _dominates(
+        panorama_peak, standard_peak, _PANORAMA_DOMINANCE_MARGIN
+    ):
+        panorama_mm = panorama_lag * MM_PER_PREVIEW_ROW
+        return (
+            f"this looks like panoramic film (a frame about every {panorama_mm:.0f} mm); "
+            f"this driver expects standard 35 mm spacing (about {standard_mm:.0f} mm "
+            "between frame starts)"
+        )
+    return None
+
+
+def _diagnose_gap_geometry(direct: np.ndarray, nominal_frame_rows: int) -> str | None:
+    """Clear-film run-width histogram: systematically too-narrow or too-wide gaps.
+
+    Only fires when *every* found run shares the same problem -- a mix of
+    narrow and wide runs is a messier picture this check should not guess
+    at, and ``_GAP_GEOMETRY_MIN_RUNS`` keeps one stray run from deciding
+    the sentence on its own.
+    """
+
+    runs = _true_runs(direct)
+    if len(runs) < _GAP_GEOMETRY_MIN_RUNS:
+        return None
+    widths = [end - start for start, end in runs]
+
+    if all(width < _NARROW_GAP_FLOOR_ROWS for width in widths):
+        measured_mm = float(np.median(widths)) * MM_PER_PREVIEW_ROW
+        floor_mm = _NARROW_GAP_FLOOR_ROWS * MM_PER_PREVIEW_ROW
+        return (
+            f"the blank strips between your frames measure about {measured_mm:.1f} mm; "
+            f"that is under the {floor_mm:.1f} mm this detector needs to recognize a gap"
+        )
+
+    frame_scale_rows = _TOO_WIDE_FRAME_SCALE_FRACTION * nominal_frame_rows
+    too_wide = [
+        width for width in widths if WIDE_GAP_CEILING_ROWS < width < frame_scale_rows
+    ]
+    if too_wide and len(too_wide) == len(widths):
+        measured_mm = float(np.median(too_wide)) * MM_PER_PREVIEW_ROW
+        return (
+            f"a blank region measures about {measured_mm:.1f} mm; that is wider than "
+            "anything the detector accepts as a between-frame gap"
+        )
+    return None
+
+
+def _diagnose_contrast_floor(
+    transmission: np.ndarray, nonuniformity: np.ndarray, direct: np.ndarray
+) -> str | None:
+    """Rows that fail only the transmission half of the direct gap gate.
+
+    ``nonuniformity`` is held to the same ceiling the detector's own direct
+    gate uses, so this isolates rows that are flat (not scene content) but
+    simply too dim -- fog or a dense film base, not noise.
+    """
+
+    near_miss = (
+        ~direct
+        & (nonuniformity <= _CONTRAST_FLOOR_NONUNIFORMITY_CEILING)
+        & (transmission >= _CONTRAST_FLOOR_LOW)
+        & (transmission < _CONTRAST_FLOOR_HIGH)
+    )
+    runs = _true_runs(near_miss)
+    clusters = [
+        (start, end)
+        for start, end in runs
+        if end - start >= _CONTRAST_FLOOR_MIN_RUN_ROWS
+    ]
+    if len(clusters) < _CONTRAST_FLOOR_MIN_CLUSTERS:
+        return None
+    measured = float(
+        np.median(np.concatenate([transmission[start:end] for start, end in clusters]))
+    )
+    return (
+        "the blank film between frames is only slightly clearer than the frames "
+        f"themselves (relative brightness about {measured:.2f}, against the "
+        f"{_CONTRAST_FLOOR_HIGH:.2f} the detector needs); this could be fog or a "
+        "dense film base"
+    )
+
+
+def _diagnose_aperture_obstruction(
+    rgb16: np.ndarray, aperture: tuple[int, int]
+) -> str | None:
+    """Column-wise brightness profile: one aperture edge depressed against the middle.
+
+    Uses every row, not just clear-film rows: a real physical obstruction
+    -- carrier mask edge, curl shadow, tape, heavy edge fog -- depresses a
+    fixed band of columns whether that row is a gap or a photographed
+    frame, so the median over all rows is the more reliable read (a
+    genuine obstruction can push transmission on affected rows below the
+    direct gate everywhere, leaving too few clear-film rows to trust on
+    their own).
+    """
+
+    lo, hi = aperture
+    width = hi - lo
+    if width < _APERTURE_MIN_WIDTH_FOR_OBSTRUCTION_CHECK:
+        return None
+    column_level = np.median(rgb16[:, lo:hi].astype(np.float64).mean(axis=2), axis=0)
+    edge = max(1, round(width * _APERTURE_EDGE_FRACTION))
+    if width - 2 * edge < edge:
+        return None
+    middle = float(np.median(column_level[edge:-edge]))
+    if middle <= 0:
+        return None
+    leading_ratio = float(np.median(column_level[:edge])) / middle
+    trailing_ratio = float(np.median(column_level[-edge:])) / middle
+    if leading_ratio <= _APERTURE_OBSTRUCTION_RATIO:
+        side = "leading"
+    elif trailing_ratio <= _APERTURE_OBSTRUCTION_RATIO:
+        side = "trailing"
+    else:
+        return None
+    return (
+        f"one edge of the film window looks partly blocked (the {side} side reads "
+        "darker than the middle); check the film holder seating and film curl"
+    )
+
+
+def diagnose_roll_refusal(
+    rgb16: np.ndarray,
+    known: np.ndarray,
+    *,
+    nominal_frame_rows: int,
+) -> str | None:
+    """One plain-English probable cause for a roll refusal, or ``None``.
+
+    Pure read-only analysis over the same evidence signals the frame
+    detector itself computes -- aperture, per-row transmission/uniformity,
+    and the resulting clear-film run structure. It never re-runs detection
+    with relaxed knobs and cannot produce frames, boundaries, or a
+    detection result of any kind: the only thing it can hand back is one
+    sentence or nothing. Checks run in a fixed priority order and the
+    first one confident enough to speak wins; if none clear their margin
+    this returns ``None``, on the belief that no sentence beats a wrong
+    one.
+    """
+
+    try:
+        if rgb16.shape != known.shape or nominal_frame_rows < 16:
+            return None
+        complete_rows = np.asarray(known, dtype=bool).all(axis=(1, 2))
+        if complete_rows.mean() < _MINIMUM_COMPLETE_ROW_FRACTION:
+            return None
+        aperture = _active_aperture(rgb16)
+        evidence, transmission, nonuniformity, direct = _physical_gap_evidence(
+            rgb16, aperture
+        )
+    except Exception:
+        # Every check below assumes a well-formed raster with a real
+        # aperture; anything that breaks those preconditions leaves
+        # nothing trustworthy left to diagnose.
+        return None
+
+    checks = (
+        lambda: _diagnose_alternate_pitch(evidence, direct, nominal_frame_rows),
+        lambda: _diagnose_gap_geometry(direct, nominal_frame_rows),
+        lambda: _diagnose_contrast_floor(transmission, nonuniformity, direct),
+        lambda: _diagnose_aperture_obstruction(rgb16, aperture),
+    )
+    for check in checks:
+        try:
+            sentence = check()
+        except Exception:
+            # One check's own bug must not block the others, and must
+            # never surface here as anything but "this check found
+            # nothing".
+            continue
+        if sentence is not None:
+            return sentence
+    return None

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_diagnosis.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_diagnosis.py
@@ -91,6 +91,36 @@ _APERTURE_EDGE_FRACTION = 0.20
 # obstructed (measured cliff: 15/96 cols @ 70% transmission fails detection,
 # 10 columns does not -- FEEDING-ROBUSTNESS-20260805.md Sec 3.3).
 _APERTURE_OBSTRUCTION_RATIO = 0.85
+# The fog/dense-base sentence requires both aperture edges within this
+# fraction of the middle: below it, the transmission depression is
+# one-sided (an obstruction-shaped signal, whatever its depth), and the
+# contrast check stays silent rather than blaming the film stock.
+_CONTRAST_FLOOR_SYMMETRY_FLOOR = 0.90
+# The obstruction profile is judged over clear-film candidate rows: rows
+# whose middle-column level reaches this fraction of the raster's own
+# clear-base reference (p99 of row middles -- the same self-normalising
+# shape the detector's clear_base uses). A fixed top-percentile cut is
+# wrong here: on a full roll only ~6% of rows are clear film, so any
+# percentile wide enough to be robust also admits bright FRAME rows,
+# whose scene content carries per-column structure that median-stacks
+# into a false one-sided depression (caught by the healthy-roll
+# regression, 2026-08-08). A minimum count of candidate rows is still
+# required before the check may speak at all.
+_OBSTRUCTION_CLEAR_LEVEL_FRACTION = 0.75
+_OBSTRUCTION_MIN_BRIGHT_ROWS = 6
+# ...and the p99 reference itself must stand clearly apart from the typical
+# row before those candidates are believed to be clear film at all: on a
+# roll with NO clear rows (dense/gapless refusals -- exactly when diagnosis
+# runs), p99 lands on bright FRAME rows whose one-sided scene content then
+# resurrects the phantom-obstruction sentence (re-review 2026-08-08, F-C).
+# Real clear film reads several times brighter than frame content; a p99
+# within this ratio of the median row means there is no clear-film
+# population to judge from, and the check stays silent. 1.8 sits between
+# frame texture's own p99/median spread (~1.5-1.6 measured on the synthetic
+# fixtures) and real clear film's ~3x separation; dense film whose clear
+# rows barely clear its frames loses obstruction diagnosis rather than
+# risking a wrong sentence.
+_OBSTRUCTION_CLEAR_SEPARATION_RATIO = 1.8
 # Below this aperture width, edge/middle columns cannot be split usefully.
 _APERTURE_MIN_WIDTH_FOR_OBSTRUCTION_CHECK = 10
 
@@ -279,14 +309,42 @@ def _diagnose_gap_geometry(direct: np.ndarray, nominal_frame_rows: int) -> str |
 
 
 def _diagnose_contrast_floor(
-    transmission: np.ndarray, nonuniformity: np.ndarray, direct: np.ndarray
+    transmission: np.ndarray,
+    nonuniformity: np.ndarray,
+    direct: np.ndarray,
+    rgb16: np.ndarray,
+    aperture: tuple[int, int],
 ) -> str | None:
     """Rows that fail only the transmission half of the direct gap gate.
 
     ``nonuniformity`` is held to the same ceiling the detector's own direct
     gate uses, so this isolates rows that are flat (not scene content) but
     simply too dim -- fog or a dense film base, not noise.
+
+    Fog and a dense base are whole-film properties, so the depression must
+    be roughly column-symmetric before this speaks (adversarial review
+    2026-08-08, F5): a one-sided aperture band can drag gap rows into the
+    same 0.80-0.87 near-miss window while sitting just above the
+    obstruction check's own ratio, and the fog sentence would then send
+    the reporter chasing their film stock when the real problem is holder
+    seating. An asymmetric profile stays silent -- no sentence beats a
+    wrong one.
     """
+
+    lo, hi = aperture
+    width = hi - lo
+    if width >= _APERTURE_MIN_WIDTH_FOR_OBSTRUCTION_CHECK:
+        column_level = np.median(
+            rgb16[:, lo:hi].astype(np.float64).mean(axis=2), axis=0
+        )
+        edge = max(1, round(width * _APERTURE_EDGE_FRACTION))
+        if width - 2 * edge >= edge:
+            middle = float(np.median(column_level[edge:-edge]))
+            if middle > 0:
+                leading = float(np.median(column_level[:edge])) / middle
+                trailing = float(np.median(column_level[-edge:])) / middle
+                if min(leading, trailing) < _CONTRAST_FLOOR_SYMMETRY_FLOOR:
+                    return None
 
     near_miss = (
         ~direct
@@ -318,23 +376,38 @@ def _diagnose_aperture_obstruction(
 ) -> str | None:
     """Column-wise brightness profile: one aperture edge depressed against the middle.
 
-    Uses every row, not just clear-film rows: a real physical obstruction
-    -- carrier mask edge, curl shadow, tape, heavy edge fog -- depresses a
-    fixed band of columns whether that row is a gap or a photographed
-    frame, so the median over all rows is the more reliable read (a
-    genuine obstruction can push transmission on affected rows below the
-    direct gate everywhere, leaving too few clear-film rows to trust on
-    their own).
+    Measured over the raster's BRIGHTEST rows by middle-column level -- the
+    clear-film candidates. A real physical obstruction -- carrier mask
+    edge, curl shadow, tape, heavy edge fog -- depresses a fixed band of
+    columns on every row including the clear ones, while a roll whose
+    photographs simply carry dark content along one side (2026-08-08
+    review, S9) depresses that side only where there is picture. Judging
+    on bright rows keeps the first and drops the second: an obstruction
+    still shows there (its columns stay dark even when the film is clear),
+    but composition cannot (a bright/clear row has no dark subject edge).
     """
 
     lo, hi = aperture
     width = hi - lo
     if width < _APERTURE_MIN_WIDTH_FOR_OBSTRUCTION_CHECK:
         return None
-    column_level = np.median(rgb16[:, lo:hi].astype(np.float64).mean(axis=2), axis=0)
+    levels = rgb16[:, lo:hi].astype(np.float64).mean(axis=2)
     edge = max(1, round(width * _APERTURE_EDGE_FRACTION))
     if width - 2 * edge < edge:
         return None
+    row_middle = np.median(levels[:, edge:-edge], axis=1)
+    clear_reference = float(np.percentile(row_middle, 99.0))
+    if clear_reference <= 0:
+        return None
+    typical_row = float(np.median(row_middle))
+    if typical_row > 0 and clear_reference < (
+        _OBSTRUCTION_CLEAR_SEPARATION_RATIO * typical_row
+    ):
+        return None
+    bright_rows = row_middle >= _OBSTRUCTION_CLEAR_LEVEL_FRACTION * clear_reference
+    if int(bright_rows.sum()) < _OBSTRUCTION_MIN_BRIGHT_ROWS:
+        return None
+    column_level = np.median(levels[bright_rows], axis=0)
     middle = float(np.median(column_level[edge:-edge]))
     if middle <= 0:
         return None
@@ -387,11 +460,19 @@ def diagnose_roll_refusal(
         # nothing trustworthy left to diagnose.
         return None
 
+    # Obstruction runs BEFORE the contrast floor (adversarial review
+    # 2026-08-08, F5): a one-sided aperture band dims gap rows into the
+    # contrast check's 0.80-0.87 near-miss window, and the fog/dense-base
+    # sentence would then send the reporter chasing their film stock when
+    # the physically correct advice is to reseat the holder. The
+    # obstruction check is the more specific signal, so it speaks first.
     checks = (
         lambda: _diagnose_alternate_pitch(evidence, direct, nominal_frame_rows),
         lambda: _diagnose_gap_geometry(direct, nominal_frame_rows),
-        lambda: _diagnose_contrast_floor(transmission, nonuniformity, direct),
         lambda: _diagnose_aperture_obstruction(rgb16, aperture),
+        lambda: _diagnose_contrast_floor(
+            transmission, nonuniformity, direct, rgb16, aperture
+        ),
     )
     for check in checks:
         try:

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -931,6 +931,28 @@ def _gap_lattice_diagnostics(
     }
 
 
+def _diagnose_refusal_safely(
+    rgb16: np.ndarray, known: np.ndarray, nominal_frame_rows: int
+) -> str | None:
+    """Best-effort probable-cause sentence for a refusal about to be raised.
+
+    Deferred import breaks the two-module cycle -- roll_diagnosis.py imports
+    this module's own private evidence helpers -- and only needs to resolve
+    once a raise is already underway. The broad except is deliberate: a bug
+    in diagnosis must never replace or hide the real IndexDecodeError being
+    raised, so any failure in here is silently treated as "no diagnosis".
+    """
+
+    try:
+        from .roll_diagnosis import diagnose_roll_refusal
+
+        return diagnose_roll_refusal(
+            rgb16, known, nominal_frame_rows=nominal_frame_rows
+        )
+    except Exception:
+        return None
+
+
 def detect_roll_frames(
     rgb16: np.ndarray,
     known: np.ndarray,
@@ -947,6 +969,12 @@ def detect_roll_frames(
     as gap anchors. If recovery also fails, the *original* pass-1 error
     is re-raised with a recovery note appended to its diagnostics so
     field reports stay comparable across versions.
+
+    Both re-raise paths below also attach a best-effort plain-English
+    ``diagnostics["probable_cause"]`` sentence (roll_diagnosis.py) whenever
+    one fires with enough confidence to speak. This only ever adds that one
+    key: the error id, message prefix, and every other diagnostics key are
+    unchanged from today's behavior.
     """
 
     try:
@@ -960,7 +988,16 @@ def detect_roll_frames(
         raise
     except IndexDecodeError as primary:
         if primary.error_id not in _WIDE_GAP_RECOVERY_ERROR_IDS:
-            raise
+            cause = _diagnose_refusal_safely(rgb16, known, nominal_frame_rows)
+            if cause is None:
+                raise
+            diagnostics = dict(primary.diagnostics or {})
+            diagnostics["probable_cause"] = cause
+            raise IndexDecodeError(
+                str(primary).split(" [")[0],
+                error_id=primary.error_id,
+                diagnostics=diagnostics,
+            ) from None
         try:
             return _detect_roll_frames_single(
                 rgb16,
@@ -974,6 +1011,9 @@ def detect_roll_frames(
             diagnostics["wide_gap_recovery"] = (
                 f"attempted and failed: {recovery}"
             )
+            cause = _diagnose_refusal_safely(rgb16, known, nominal_frame_rows)
+            if cause is not None:
+                diagnostics["probable_cause"] = cause
             raise IndexDecodeError(
                 str(primary).split(" [")[0],
                 error_id=primary.error_id,

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -988,6 +988,16 @@ def detect_roll_frames(
         raise
     except IndexDecodeError as primary:
         if primary.error_id not in _WIDE_GAP_RECOVERY_ERROR_IDS:
+            # Reconstructing to attach the sentence is only safe for the
+            # exact base class: subclasses (e.g. a vendored tree's
+            # LeadingFrameClippedError) carry their own constructor
+            # signatures, structured fields, and dedicated downstream
+            # handling that a plain IndexDecodeError rebuild would silently
+            # erase. Those re-raise untouched -- their messages are already
+            # specific -- and only a bare IndexDecodeError gains the
+            # probable-cause key.
+            if type(primary) is not IndexDecodeError:
+                raise
             cause = _diagnose_refusal_safely(rgb16, known, nominal_frame_rows)
             if cause is None:
                 raise

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -42,6 +42,26 @@ GAP_COUNT_FLOOR_ERROR_ID = "gap-count-floor"
 GAP_LATTICE_ANCHOR_ERROR_ID = "gap-lattice-anchor-floor"
 GAP_DIRECT_SUPPORT_ERROR_ID = "gap-direct-support-floor"
 
+# Wide-gap recovery (FEEDING-DETECTOR-ROUND-20260807): a clear-film run
+# wider than the 12-row narrow ceiling but no wider than this is treated
+# as a candidate *wide* inter-frame gap during the recovery pass only.
+# 20 preview rows is ~5.3 mm of film: comfortably above the widest field-
+# reported gap (14 rows, ScanStudio #23/#24) and comfortably below
+# leader/trailer runs (38 rows observed) and any blank-frame-scale run
+# (~130 rows). Recovery can never produce an automatic, unattended, or
+# high-confidence result: slots anchored on wide runs are always manual
+# review and detection confidence is capped at medium.
+WIDE_GAP_CEILING_ROWS = 20
+WIDE_GAP_RECOVERY_WARNING = "wide-gap-recovery"
+WIDE_GAP_ANCHOR_REVIEW_REASON = "wide-gap-anchor"
+_WIDE_GAP_RECOVERY_ERROR_IDS = frozenset(
+    {
+        GAP_COUNT_FLOOR_ERROR_ID,
+        GAP_LATTICE_ANCHOR_ERROR_ID,
+        GAP_DIRECT_SUPPORT_ERROR_ID,
+    }
+)
+
 
 class IndexDecodeError(ValueError):
     """Input is not a self-consistent LS-5000 roll-index capture.
@@ -918,6 +938,57 @@ def detect_roll_frames(
     nominal_frame_rows: int,
     expected_frame_count: int | None = None,
 ) -> RollDetection:
+    """Two-pass wrapper: stock detection first, wide-gap recovery second.
+
+    Pass 1 is the unmodified stock detector; any raster it resolves is
+    returned bit-identically. Only when it raises one of the three
+    physical-gap floor errors is a single recovery pass attempted with
+    wide clear-film runs (12 < width <= WIDE_GAP_CEILING_ROWS) admitted
+    as gap anchors. If recovery also fails, the *original* pass-1 error
+    is re-raised with a recovery note appended to its diagnostics so
+    field reports stay comparable across versions.
+    """
+
+    try:
+        return _detect_roll_frames_single(
+            rgb16,
+            known,
+            nominal_frame_rows=nominal_frame_rows,
+            expected_frame_count=expected_frame_count,
+        )
+    except IncompleteIndexError:
+        raise
+    except IndexDecodeError as primary:
+        if primary.error_id not in _WIDE_GAP_RECOVERY_ERROR_IDS:
+            raise
+        try:
+            return _detect_roll_frames_single(
+                rgb16,
+                known,
+                nominal_frame_rows=nominal_frame_rows,
+                expected_frame_count=expected_frame_count,
+                wide_gap_ceiling=WIDE_GAP_CEILING_ROWS,
+            )
+        except IndexDecodeError as recovery:
+            diagnostics = dict(primary.diagnostics or {})
+            diagnostics["wide_gap_recovery"] = (
+                f"attempted and failed: {recovery}"
+            )
+            raise IndexDecodeError(
+                str(primary).split(" [")[0],
+                error_id=primary.error_id,
+                diagnostics=diagnostics,
+            ) from None
+
+
+def _detect_roll_frames_single(
+    rgb16: np.ndarray,
+    known: np.ndarray,
+    *,
+    nominal_frame_rows: int,
+    expected_frame_count: int | None = None,
+    wide_gap_ceiling: int | None = None,
+) -> RollDetection:
     """Detect arbitrary roll frames from physical clear-film gap evidence.
 
     The result contains N+1 lattice boundaries and N candidate slots.  The
@@ -948,7 +1019,16 @@ def detect_roll_frames(
     narrow_runs = [
         (start, end) for start, end in evidence_runs if 3 <= end - start <= 12
     ]
-    if len(narrow_runs) < 3:
+    wide_runs = (
+        [
+            (start, end)
+            for start, end in evidence_runs
+            if 12 < end - start <= wide_gap_ceiling
+        ]
+        if wide_gap_ceiling is not None
+        else []
+    )
+    if len(narrow_runs) + len(wide_runs) < 3:
         raise IndexDecodeError(
             "roll detector found too few distinct physical gaps",
             error_id=GAP_COUNT_FLOOR_ERROR_ID,
@@ -964,7 +1044,7 @@ def detect_roll_frames(
         )
     anchor_signal = np.zeros_like(evidence)
     anchor_centers = []
-    for start, end in narrow_runs:
+    for start, end in narrow_runs + wide_runs:
         anchor_signal[start:end] = evidence[start:end]
         anchor_centers.append((start + end - 1) / 2.0)
 
@@ -1104,6 +1184,13 @@ def detect_roll_frames(
             if 3 <= width <= 12:
                 support = "direct"
                 output_row = int(math.floor((run[0] + run[1] - 1) / 2.0 + 0.5))
+            elif (
+                wide_gap_ceiling is not None
+                and 12 < width <= wide_gap_ceiling
+            ):
+                support = "direct-wide"
+                output_row = int(math.floor((run[0] + run[1] - 1) / 2.0 + 0.5))
+                reasons.append(WIDE_GAP_ANCHOR_REVIEW_REASON)
             elif width > 12:
                 support = "cadence-broad"
                 reasons.append("broad-clear-region")
@@ -1128,7 +1215,7 @@ def detect_roll_frames(
 
     def boundary_is_supported(boundary: GapBoundary) -> bool:
         return bool(
-            boundary.support in {"direct", "cadence-broad"}
+            boundary.support in {"direct", "direct-wide", "cadence-broad"}
             and boundary.evidence >= 0.40
             and boundary.transmission >= 0.82
             and boundary.nonuniformity <= 0.22
@@ -1297,7 +1384,8 @@ def detect_roll_frames(
     alignment_boundary_count = alignment_end - cell_start + 1
     alignment_boundaries = boundaries[:alignment_boundary_count]
     direct_support_count = sum(
-        item.support == "direct" for item in alignment_boundaries
+        item.support in {"direct", "direct-wide"}
+        for item in alignment_boundaries
     )
     if direct_support_count < 3:
         raise IndexDecodeError(
@@ -1363,8 +1451,10 @@ def detect_roll_frames(
         [item.evidence for item in supported_alignment_boundaries], dtype=np.float64
     )
     direct_fraction = sum(
-        item.support == "direct" for item in alignment_boundaries[:-1]
+        item.support in {"direct", "direct-wide"}
+        for item in alignment_boundaries[:-1]
     ) / max(1, len(alignment_boundaries) - 1)
+    recovered_wide_gap = wide_gap_ceiling is not None
     if (
         lattice_score >= 0.65
         and lattice_margin >= 0.08
@@ -1376,9 +1466,13 @@ def detect_roll_frames(
         confidence = "medium"
     else:
         confidence = "low"
+    if recovered_wide_gap and confidence == "high":
+        confidence = "medium"
 
     expected_frame_count_matches: bool | None = None
     warnings: list[str] = []
+    if recovered_wide_gap:
+        warnings.append(WIDE_GAP_RECOVERY_WARNING)
     if expected_frame_count is not None:
         expected_frame_count_matches = expected_frame_count in content_end_candidates
         if expected_frame_count_matches:
@@ -1561,18 +1655,87 @@ def derive_transport_mapping(
         if leading_anchor is not None and len(fit_candidates) > 4
         else fit_candidates
     )
-    if len(fit_direct) < 3:
+    # Wide-gap recovery: a strip anchored on wide clear-film runs can
+    # carry fewer than three narrow direct gaps. Only in that case --
+    # never to perturb a fit that already has its three narrow anchors --
+    # admit direct-wide boundaries as additional fit anchors. A wide
+    # run's center is not offset from its trailing edge the way a narrow
+    # run's is, so its anchor x is its trailing edge translated into the
+    # narrow anchors' center space by their own measured center-to-
+    # trailing offset (3 rows on 90% of 1,272 archived direct anchors;
+    # per-capture median used here). Wide anchors never become
+    # automatic and every fit gate below is unchanged.
+    narrow_offsets = [
+        float(item.evidence_run[1] - item.output_row)
+        for item, _record in fit_direct
+        if item.evidence_run is not None
+    ]
+    # 3 rows on 1,146 of 1,272 archived direct anchors (min 2, max 6).
+    # The constant fallback is unreachable in practice -- every path to
+    # the affine fit carries at least one narrow anchor with an evidence
+    # run -- and exists as belt-and-braces only.
+    narrow_anchor_offset = (
+        float(np.median(narrow_offsets)) if narrow_offsets else 3.0
+    )
+    wide_fit: list[tuple[GapBoundary, TransportRecord, float]] = []
+    if len(fit_direct) < 3 and narrow_offsets:
+        for boundary in frame_boundaries:
+            if boundary.support != "direct-wide":
+                continue
+            if boundary.evidence_run is None:
+                continue
+            if (
+                boundary.evidence < 0.40
+                or boundary.transmission < 0.82
+                or boundary.nonuniformity > 0.22
+            ):
+                continue
+            lookup_row = boundary.evidence_run[1]
+            if not 0 <= lookup_row < len(records):
+                continue
+            record = records[lookup_row]
+            if tail_start is not None and record.row >= tail_start:
+                continue
+            # The last interior gap of a short strip can sit right
+            # where the live 0x8e ramp degrades (observed on the
+            # phoenix capture: clean 42/row through the gap's leading
+            # side, then -70/+154/-714 jitter immediately after,
+            # well before terminal_transport_tail_start). A wide
+            # anchor is admitted only when every single-row step of
+            # the table across its trailing edge is affine at the
+            # transport scale -- an endpoint chord would pass the
+            # observed single-record spikes (F2, adversarial review
+            # 2026-08-07). Otherwise the anchor is unusable and the
+            # mapping refuses rather than fitting to noise.
+            lo = max(0, lookup_row - 3)
+            hi = min(len(records) - 1, lookup_row + 3)
+            if hi <= lo:
+                continue
+            ramp_is_affine = all(
+                minimum_scale
+                <= records[r + 1].native_origin - records[r].native_origin
+                <= maximum_scale
+                for r in range(lo, hi)
+            )
+            if not ramp_is_affine:
+                continue
+            wide_fit.append(
+                (boundary, record, lookup_row - narrow_anchor_offset)
+            )
+    if len(fit_direct) + len(wide_fit) < 3:
         raise IndexDecodeError(
             "transport mapping requires at least three direct physical gaps "
             "before the terminal transport tail"
         )
 
     x = np.asarray(
-        [item.output_row for item, _record in fit_direct],
+        [item.output_row for item, _record in fit_direct]
+        + [anchor_x for _b, _r, anchor_x in wide_fit],
         dtype=np.float64,
     )
     y = np.asarray(
-        [record.native_origin for _item, record in fit_direct],
+        [record.native_origin for _item, record in fit_direct]
+        + [record.native_origin for _b, record, _x in wide_fit],
         dtype=np.float64,
     )
     design = np.column_stack((np.ones(len(x)), x))
@@ -1605,21 +1768,48 @@ def derive_transport_mapping(
         leading_anchor_requires_review = leading_error > maximum_anchor_error_rows
 
     direct_by_index = {item.index: record for item, record in direct}
+    wide_by_index = {
+        boundary.index: (record, anchor_x)
+        for boundary, record, anchor_x in wide_fit
+    }
     origins: list[NativeFrameOrigin] = []
     terminal_boundary_index: int | None = None
     for frame, boundary in enumerate(frame_boundaries, start=1):
         prediction = float(intercept + scale * boundary.output_row)
         record = direct_by_index.get(boundary.index)
+        wide_record = wide_by_index.get(boundary.index)
         if record is not None:
             method = "direct-gap-trailing-row"
             reasons = list(boundary.review_reasons)
             automatic = not boundary.manual_review
+        elif wide_record is not None:
+            record, wide_anchor_x = wide_record
+            # A wide gap's output_row is its run center, which sits
+            # farther from the frame's true start than the narrow-run
+            # convention the affine intercept absorbed. Predict (and, if
+            # the clamp fires, extrapolate) at the same translated
+            # trailing-edge x this anchor used in the fit, so the origin
+            # lands on the frame's actual leading edge.
+            prediction = float(intercept + scale * wide_anchor_x)
+            method = "wide-gap-trailing-row"
+            reasons = list(boundary.review_reasons)
+            automatic = False
         else:
             # The canonical Nikon detector selects roughly 2..5 rows after a
             # physical gap centre.  Restrict the search to that local trailing
             # neighborhood, then use the direct-anchor line only to choose a
             # record already supplied by this capture's transport table.
             centre = int(math.floor(boundary.fitted_row + 0.5))
+            if (
+                boundary.support == "direct-wide"
+                and boundary.evidence_run is not None
+            ):
+                centre = int(boundary.evidence_run[1]) - 1
+                prediction = float(
+                    intercept
+                    + scale
+                    * (boundary.evidence_run[1] - narrow_anchor_offset)
+                )
             start = max(0, centre + 1)
             end = min(len(records), centre + 8)
             if start >= end:

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
@@ -519,6 +519,12 @@ class LiveBatchJob:
     continuation_plan_sha256: str
     job_sha256: str
     exposure_override_10ns: tuple[int, int, int] | None = None
+    # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): see
+    # capture_process.CaptureBatchRequest.manual_boundary_rows -- the exact
+    # same value, carried through load_validated_batch_job's own parse of
+    # this untrusted job JSON, for _derive_live_batch_selections to replay
+    # fresh against this call's own live re-read bytes.
+    manual_boundary_rows: tuple[int, ...] | None = None
 
     @property
     def selected_slots(self) -> tuple[int, ...]:
@@ -1863,6 +1869,7 @@ def load_validated_batch_job(
         "expected_usb_bus",
         "exposure_override_10ns",
         "frames",
+        "manual_boundary_rows",
         "reviewed_roll_fingerprint",
         "session_id",
     }
@@ -1902,6 +1909,27 @@ def load_validated_batch_job(
                 )
             parsed_ticks.append(raw)
         exposure_override_10ns = (parsed_ticks[0], parsed_ticks[1], parsed_ticks[2])
+    # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): same
+    # defense-in-depth stance as exposure_override_10ns above -- the worker
+    # subprocess trusts nothing it reads from this job file, even though
+    # Roll/CaptureBatchRequest already only ever emit rows a manual session
+    # itself produced.
+    raw_manual_boundary_rows = payload.get("manual_boundary_rows")
+    manual_boundary_rows: tuple[int, ...] | None = None
+    if raw_manual_boundary_rows is not None:
+        if not isinstance(raw_manual_boundary_rows, list) or not raw_manual_boundary_rows:
+            raise ProtocolError(
+                "batch job manual_boundary_rows must be a nonempty array of "
+                "integer preview rows"
+            )
+        parsed_rows: list[int] = []
+        for row in raw_manual_boundary_rows:
+            if isinstance(row, bool) or not isinstance(row, int):
+                raise ProtocolError(
+                    "batch job manual_boundary_rows entries must be integers"
+                )
+            parsed_rows.append(row)
+        manual_boundary_rows = tuple(parsed_rows)
     session_id = payload.get("session_id")
     if (
         not isinstance(session_id, str)
@@ -2015,6 +2043,7 @@ def load_validated_batch_job(
         continuation_plan_sha256=expected_continuation_sha256,
         job_sha256=actual_job_sha256,
         exposure_override_10ns=exposure_override_10ns,
+        manual_boundary_rows=manual_boundary_rows,
     )
 
 
@@ -6051,6 +6080,7 @@ def run_live_capture(
                                 live_sub_8e_table,
                                 batch_job.frames,
                                 reviewed_fingerprint=(batch_job.reviewed_fingerprint),
+                                manual_boundary_rows=batch_job.manual_boundary_rows,
                             )
                             live_selection = batch_selections[0]
                             journal["batch_prevalidated_frame_selections"] = [
@@ -6803,6 +6833,7 @@ def run_live_capture(
                     live_sub_8e_table,
                     batch_job.frames,
                     reviewed_fingerprint=batch_job.reviewed_fingerprint,
+                    manual_boundary_rows=batch_job.manual_boundary_rows,
                 )
                 session_journal.update(
                     {

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
@@ -57,6 +57,10 @@ from .capture_process import (
     compare_reviewed_roll_fingerprints,
     compare_selected_roll_fingerprint,
 )
+from .manual_frames import (
+    MANUAL_PLACEMENT_WARNING,
+    build_manual_detection,
+)
 from .meter import (
     DEFAULT_EXPOSURES,
     EXPOSURE_MAX,
@@ -1369,35 +1373,125 @@ def _derive_live_frame_selection(
     manual_review_approved: bool = False,
     reviewed_as_automatic: bool = False,
     reviewed_leading_residual_rows: float | None = None,
+    manual_boundary_rows: tuple[int, ...] | None = None,
 ) -> LiveFrameSelection:
-    """Resolve one automatic frame origin from same-traversal live data."""
+    """Resolve one frame origin from same-traversal live data.
+
+    Automatic (default, ``manual_boundary_rows`` omitted): resolves via
+    ``detect_roll_frames``/``derive_transport_mapping`` exactly as this
+    function has always worked. See the gate comment below for the one new
+    path manual placement adds to this function's confidence gate.
+
+    Manual (Rung 4, FEEDING-UX-LADDER-OVERNIGHT-20260807.md):
+    ``manual_boundary_rows`` is never trusted as a serialized detection
+    blob. It is the small list of row numbers a human picked while
+    reviewing this same physical traversal's preview, replayed here through
+    the exact same pure ``manual_frames.build_manual_detection`` call the
+    review session used -- fresh, against THIS call's own freshly-decoded
+    ``rgb16``/``known``/``records``, exactly the way the automatic branch
+    below always re-derives ``detect_roll_frames`` from scratch rather than
+    trusting anything cached. If the bytes changed since the operator
+    reviewed them, this recompute reflects that change (it may now refuse,
+    or resolve to different origins); the reviewed_fingerprint comparison
+    further below independently proves the bytes still match what a human
+    actually reviewed before anything can bind.
+    """
 
     geometry = _derive_index_geometry(plan)
     validated_table, usable_rows = validate_live_0x8e_bytes(table_data, geometry.height)
     rgb16, known, decode_report = decode_full_index_bytes(
         preview_data, geometry, usable_rows=usable_rows
     )
-    detection = detect_roll_frames(
-        rgb16,
-        known,
-        nominal_frame_rows=FINE_NATIVE_HEIGHT // geometry.pitch,
-        expected_frame_count=expected_frame_count,
+
+    if manual_boundary_rows is not None:
+        records = parse_live_transport_records_bytes(
+            validated_table, maximum_rows=geometry.height
+        )
+        manual_result = build_manual_detection(
+            rgb16,
+            known,
+            manual_boundary_rows,
+            nominal_frame_rows=FINE_NATIVE_HEIGHT // geometry.pitch,
+            records=records,
+        )
+        detection = manual_result.detection
+        mapping = manual_result.mapping
+        scanner_frame_count = len(mapping.origins)
+        scanner_intervals = detection.intervals[:scanner_frame_count]
+    else:
+        detection = detect_roll_frames(
+            rgb16,
+            known,
+            nominal_frame_rows=FINE_NATIVE_HEIGHT // geometry.pitch,
+            expected_frame_count=expected_frame_count,
+        )
+        # Deferred to the "records is None" branch below, exactly where
+        # they were computed before this change, so a non-manual call never
+        # does this work when the gate is about to refuse anyway.
+        records = None
+        mapping = None
+        scanner_frame_count = None
+        scanner_intervals = None
+
+    # ------------------------------------------------------------------
+    # THE GATE (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, Rung 4 worker gate
+    # change -- deliberate, in scope by owner instruction. Adversarial
+    # review must attack this specifically).
+    #
+    # Unattended behavior for every NON-manual detection is byte-for-byte
+    # unchanged: any confidence below "high" refuses here, exactly as this
+    # function has always refused, full stop. The one new path this change
+    # adds: a detection carrying manual_frames' explicit
+    # MANUAL_PLACEMENT_WARNING marker -- which only build_manual_detection
+    # above can ever attach to a RollDetection.warnings tuple, never
+    # detect_roll_frames -- may bind at "medium" (build_manual_detection
+    # never emits anything higher; see manual_frames.py), but only when
+    # BOTH:
+    #   (a) this call actually took the manual branch above
+    #       (manual_boundary_rows is not None), and
+    #   (b) this call's caller also passes manual_review_approved=True: an
+    #       operator-approval receipt the caller must already hold (e.g.
+    #       from RollPreviewSession.approve_manual_origin on every
+    #       manual_review slot -- see BatchFrameSpec.manual_review_approval
+    #       and how _derive_live_batch_selections derives this flag).
+    # A caller cannot forge condition (a) by simply passing
+    # manual_review_approved=True against an automatic (wide-gap-recovery or
+    # any other) medium/low-confidence detection: MANUAL_PLACEMENT_WARNING
+    # is never present unless build_manual_detection itself ran and
+    # produced it, so the pre-existing refusal is intact for every
+    # non-manual detection no matter what approval flags a caller passes.
+    #
+    # Binding here is not the same as looking automatic: every manually
+    # placed origin already carries automatic=False, manual_review=True
+    # (build_manual_detection), so the per-origin manual-review handling
+    # later in this function -- and apply_batch_boundary_offsets's own
+    # approved_manual_slots gate, for the batch caller -- still applies to
+    # every one of these frames independently. This gate only decides
+    # whether the ROLL-level confidence check may be attempted at all; it
+    # grants no exemption from any other check in this function.
+    manual_placement = (
+        manual_boundary_rows is not None
+        and MANUAL_PLACEMENT_WARNING in detection.warnings
     )
-    if detection.confidence != "high":
+    if detection.confidence != "high" and not (
+        manual_placement and manual_review_approved
+    ):
         raise ProtocolError(
             f"roll boundary lattice confidence is {detection.confidence!r}; "
             "unattended frame binding requires 'high'"
         )
-    records = parse_live_transport_records_bytes(
-        validated_table, maximum_rows=geometry.height
-    )
-    scanner_frame_count = scanner_addressable_interval_count(detection.intervals)
-    scanner_intervals = detection.intervals[:scanner_frame_count]
-    mapping = derive_transport_mapping(
-        detection.boundaries,
-        scanner_frame_count,
-        records,
-    )
+
+    if records is None:
+        records = parse_live_transport_records_bytes(
+            validated_table, maximum_rows=geometry.height
+        )
+        scanner_frame_count = scanner_addressable_interval_count(detection.intervals)
+        scanner_intervals = detection.intervals[:scanner_frame_count]
+        mapping = derive_transport_mapping(
+            detection.boundaries,
+            scanner_frame_count,
+            records,
+        )
     fresh_fingerprint: ReviewedRollFingerprint | None = None
     fingerprint_comparison: RollFingerprintComparison | None = None
     if reviewed_fingerprint is not None:
@@ -1524,8 +1618,21 @@ def _derive_live_batch_selections(
     frames: Sequence[BatchFrameSpec],
     *,
     reviewed_fingerprint: ReviewedRollFingerprint,
+    manual_boundary_rows: tuple[int, ...] | None = None,
 ) -> tuple[LiveFrameSelection, ...]:
-    """Pre-bind every batch frame to one same-traversal transport table."""
+    """Pre-bind every batch frame to one same-traversal transport table.
+
+    ``manual_boundary_rows`` (Rung 4, FEEDING-UX-LADDER-OVERNIGHT-20260807.md):
+    the batch caller's one hook into the same manual-placement gate
+    ``_derive_live_frame_selection`` implements -- passed straight through to
+    the single context-establishing call below. Every other line in this
+    function is unchanged: the per-frame manual-review gate a manual batch
+    still has to pass lives in ``apply_batch_boundary_offsets``'s existing
+    ``approved_manual_slots`` check (every manually placed origin carries
+    ``automatic=False, manual_review=True``, so every frame in a manual
+    batch already has to appear in ``approved_manual_slots`` or that
+    pre-existing, unmodified check refuses it).
+    """
 
     if not frames:
         raise ProtocolError("live batch has no selected frames")
@@ -1555,6 +1662,7 @@ def _derive_live_batch_selections(
         reviewed_fingerprint=reviewed_fingerprint,
         manual_review_approved=frames[0].manual_review_approval is not None,
         reviewed_as_automatic=frames[0].slot in reviewed_automatic_slots,
+        manual_boundary_rows=manual_boundary_rows,
     )
     if context.fresh_fingerprint is None:
         raise ProtocolError("fresh batch roll fingerprint was not retained")

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
@@ -1571,11 +1571,24 @@ def _derive_live_frame_selection(
                 f"frame {frame} transport origin requires manual review; "
                 "refusing an unattended fine scan"
             )
+    # F4 rework: a manual placement is never eligible for the leading-anchor
+    # rebase, no matter how well its fingerprints match. Rebase exists for
+    # ONE narrow, physically-understood case -- Nikon's own leading-record
+    # wobble, bounded and reviewed elsewhere -- and it works by keeping the
+    # ALREADY-DERIVED origin even when a fresh table read disagrees with it
+    # (see apply_boundary_offset's own docstring/rebase_info handling). A
+    # manual origin's own resolution (manual_frames._resolve_boundary_
+    # transport_origin, F1) already re-derives from THIS traversal's live
+    # table every time it runs; a fresh disagreement there is not leading-
+    # anchor wobble, it is this specific placement failing to reproduce
+    # itself, and rebasing would launder that into a silently accepted,
+    # possibly displaced origin instead of the refusal it should be.
     origin_rebase_allowed = (
         fingerprint_comparison is not None
         and fingerprint_comparison.matches
         and selected_fingerprint_comparison is not None
         and selected_fingerprint_comparison.matches
+        and not manual_placement
     )
     mapping, selected, origin_rebase_info = apply_boundary_offset(
         mapping,
@@ -1701,10 +1714,55 @@ def _derive_live_batch_selections(
     # apply_boundary_offset can rebase a frame-1 leading offset onto the fresh
     # traversal's own detected origin when the resolved record lands outside
     # the two-row affine bound but inside the five-row leading-anchor bound.
+    #
+    # F4 rework: never for a manual placement, no matter how well its
+    # fingerprints match -- same reasoning as _derive_live_frame_selection's
+    # own origin_rebase_allowed (single-frame path); see that comment. Every
+    # frame in a manual batch shares the one manual_boundary_rows this
+    # function received, so this is a single placement-wide flag, not a
+    # per-slot one.
+    manual_placement = (
+        manual_boundary_rows is not None
+        and MANUAL_PLACEMENT_WARNING in context.detection.warnings
+    )
+    # S6 hardening (FEEDING-UX-LADDER-OVERNIGHT-20260807.md F1 rework):
+    # load_validated_batch_job already checked each approval's own
+    # self-digest, slot, offset, reviewed-fingerprint digest, and (as of
+    # this same hardening) manual_boundary_rows_sha256 -- all proving the
+    # receipt is internally consistent and was signed for THIS placement.
+    # None of that proves the receipt's own CLAIMED per-slot values
+    # (reviewed_lookup_row, reviewed_native_origin, review_reasons) are
+    # what this exact traversal's fresh resolution actually produces for
+    # that slot -- context.mapping, built above from manual_boundary_rows
+    # by this rework's own lattice-aware resolution
+    # (manual_frames._resolve_boundary_transport_origin), is the only
+    # thing that can prove that, and only once it exists. thumbnail_sha256
+    # is deliberately not re-verified here: it is not derivable from the
+    # mapping alone (it needs the raster plus the app's own cropping
+    # logic, a layer this protocol worker does not have), so re-checking
+    # it belongs at the layer that already recomputes it, not here.
+    if manual_placement:
+        for spec in frames:
+            approval = spec.manual_review_approval
+            if approval is None:
+                continue
+            if not 1 <= spec.slot <= len(context.mapping.origins):
+                continue  # refused elsewhere (addressable-count checks)
+            fresh_origin = context.mapping.origins[spec.slot - 1]
+            if (
+                approval.reviewed_lookup_row != fresh_origin.lookup_row
+                or approval.reviewed_native_origin != fresh_origin.native_origin
+                or not set(fresh_origin.review_reasons) <= set(approval.review_reasons)
+            ):
+                raise ProtocolError(
+                    f"frame {spec.slot} manual review approval does not match "
+                    "this traversal's freshly resolved origin"
+                )
     origin_rebase_slots = frozenset(
         spec.slot
         for spec in frames
-        if context.fingerprint_comparison is not None
+        if not manual_placement
+        and context.fingerprint_comparison is not None
         and context.fingerprint_comparison.matches
         and selected_fingerprint_comparisons.get(spec.slot) is not None
         and selected_fingerprint_comparisons[spec.slot].matches
@@ -2009,6 +2067,24 @@ def load_validated_batch_job(
             ):
                 raise ProtocolError(
                     f"batch frame {index} manual review approval belongs to another preview"
+                )
+            # S6 hardening (FEEDING-UX-LADDER-OVERNIGHT-20260807.md F1
+            # rework): same defense-in-depth shape as the checks just
+            # above, cheap and available before any scanner/table access.
+            # reviewed_fingerprint_sha256 alone is not enough: fingerprint
+            # comparison has deliberate tolerance for a legitimate re-read
+            # (compare_reviewed_roll_fingerprints), so two DIFFERENT
+            # placements of the same physical roll could still compare as
+            # matching. This job's own manual_boundary_rows (parsed above)
+            # is the exact placement this attempt is about to bind against;
+            # the receipt must have been signed for that exact placement,
+            # not merely "a" placement whose fingerprint happens to match.
+            if approval.manual_boundary_rows_sha256 != ManualFrameApproval.digest_manual_boundary_rows(
+                manual_boundary_rows
+            ):
+                raise ProtocolError(
+                    f"batch frame {index} manual review approval belongs to a "
+                    "different set of placed boundaries"
                 )
         expected_directory = f"frame-{slot:03d}"
         expected_paths = {

--- a/coolscanpy/src/coolscanpy/roll/preview_session.py
+++ b/coolscanpy/src/coolscanpy/roll/preview_session.py
@@ -14,7 +14,7 @@ import stat
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Iterable, Literal, Mapping, cast
+from typing import Any, Iterable, Literal, Mapping, Sequence, cast
 
 import numpy as np
 
@@ -34,6 +34,10 @@ from coolscanpy.protocol.ls5000_single_pass.density import (
     NikonDensityExposureBinding,
     NikonDensitySourceBinding,
     density_source_geometry_for_startup_records,
+)
+from coolscanpy.protocol.ls5000_single_pass.manual_frames import (
+    MANUAL_PLACEMENT_WARNING,
+    build_manual_detection,
 )
 from coolscanpy.protocol.ls5000_single_pass.plan import (
     CANONICAL_PLAN_SHA256,
@@ -451,6 +455,18 @@ class RollPreviewSession:
             "material": self.material.value,
             "selected_slots": list(self.selected_slots),
             "boundary_offsets": [item.boundary_offset_rows for item in self.slots],
+            # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): additive-only
+            # provenance. None for an ordinary automatically-detected
+            # session; the exact final (post-snap-assist) boundary rows a
+            # human placed for a manual one. See
+            # _restore_roll_preview_session for why restoring a manual
+            # session from this JSON is deliberately refused rather than
+            # silently re-run through automatic detection.
+            "manual_boundary_rows": (
+                [boundary.output_row for boundary in self.detection.boundaries]
+                if MANUAL_PLACEMENT_WARNING in self.detection.warnings
+                else None
+            ),
         }
         return json.dumps(
             payload,
@@ -1282,6 +1298,120 @@ def build_roll_preview_session(
     )
 
 
+def build_manual_roll_preview_session(
+    preview: ValidatedRollPreview,
+    boundary_rows: Sequence[int],
+    *,
+    material: ScanMaterial = ScanMaterial.COLOR_NEGATIVE,
+    selected_slots: Iterable[int] = (),
+    snap_assist: bool = True,
+) -> RollPreviewSession:
+    """Build a reviewed roll session from operator-placed frame boundaries.
+
+    Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md). ``preview`` is a
+    ``ValidatedRollPreview`` already produced by an earlier preview attempt
+    on this same physical traversal -- typically one whose automatic
+    ``detect_roll_frames`` pass failed or scored low confidence, which is
+    exactly when manual placement applies. No film moves here, and the
+    persisted preview raster/table are not re-read or re-validated: this
+    function only re-slices the same already-decoded raster ``preview``
+    holds, at the rows a human picked, through ``manual_frames.
+    build_manual_detection``.
+
+    Everything downstream of frame geometry -- thumbnails, boundary-offset
+    re-cropping, manual-origin approval, JSON serialization -- reuses the
+    exact same ``RollPreviewSession``/``RollPreviewSlot`` machinery
+    ``build_roll_preview_session`` produces, unchanged.
+
+    ``known`` is not part of ``ValidatedRollPreview`` (its own
+    ``__post_init__`` already only accepts a fully decoded raster), so this
+    passes an all-True completeness mask -- exactly the value
+    ``decode_full_index_bytes`` itself always produces
+    (``known = np.ones(rgb16.shape, dtype=bool)``, unconditionally, in
+    roll_index.py), not an approximation of it.
+    """
+
+    if not isinstance(preview, ValidatedRollPreview):
+        raise TypeError("preview must be a ValidatedRollPreview")
+    if not isinstance(material, ScanMaterial):
+        raise TypeError("material must be a ScanMaterial")
+
+    result = build_manual_detection(
+        preview.rgb,
+        np.ones(preview.rgb.shape, dtype=bool),
+        tuple(boundary_rows),
+        nominal_frame_rows=LS5000_FINE_NATIVE_HEIGHT // preview.geometry.pitch,
+        records=preview.transport_records,
+        snap_assist=snap_assist,
+    )
+    detection = result.detection
+    mapping = result.mapping
+
+    scanner_frame_count = scanner_addressable_interval_count(detection.intervals)
+    slot_count = min(
+        SA30_ADAPTER_FRAME_CAPACITY,
+        scanner_frame_count,
+        len(mapping.origins),
+    )
+    if slot_count < 1:
+        raise RollSessionError(
+            "manual frame placement produced no scanner-addressable slots: "
+            + _roll_session_diagnostics(detection)
+        )
+
+    slots = []
+    for interval, origin in zip(
+        detection.intervals[:slot_count],
+        mapping.origins[:slot_count],
+    ):
+        warnings = _slot_warnings(interval.frame, interval, origin, detection)
+        # Same partial-frame computation build_roll_preview_session uses
+        # (#19/Lane C D2). manual_frames.build_manual_detection always sets
+        # unclamped_start_row/unclamped_end_row equal to the (raster-
+        # in-bounds, gate-checked) start_row/end_row, so this always
+        # resolves "full" for a manual slot -- written out in full anyway so
+        # a future change to either builder cannot silently diverge.
+        coverage_start = (
+            interval.unclamped_start_row
+            if interval.unclamped_start_row is not None
+            else interval.start_row
+        )
+        coverage_end = (
+            interval.unclamped_end_row
+            if interval.unclamped_end_row is not None
+            else interval.end_row
+        )
+        state = _crop_state(coverage_start, coverage_end, len(preview.rgb))
+        slots.append(
+            RollPreviewSlot(
+                slot_id=interval.frame,
+                start_boundary_row=interval.start_row,
+                end_boundary_row=interval.end_row,
+                base_origin=origin,
+                thumbnail=_thumbnail(
+                    preview.rgb, interval.start_row, interval.end_row
+                ),
+                warnings=warnings,
+                manual_review=bool(
+                    interval.manual_review or origin.manual_review or warnings
+                ),
+                partial=(True if state == "partial" else None),
+            )
+        )
+    selected = _validate_selected_slots(selected_slots, len(slots))
+    return RollPreviewSession(
+        preview=preview,
+        geometry=preview.geometry,
+        detection=detection,
+        mapping=mapping,
+        slots=tuple(slots),
+        material=material,
+        recipe=recipe_for_material(material),
+        selected_slots=selected,
+        warnings=tuple(detection.warnings),
+    )
+
+
 def _restore_roll_preview_session(payload: str) -> RollPreviewSession:
     if type(payload) is not str:
         raise TypeError("roll session JSON must be a string")
@@ -1304,9 +1434,31 @@ def _restore_roll_preview_session(payload: str) -> RollPreviewSession:
         "material",
         "selected_slots",
         "boundary_offsets",
+        "manual_boundary_rows",
     }
     if set(state) != expected_keys or state.get("version") != SESSION_VERSION:
         raise RollSessionIntegrityError("roll session JSON has an unsupported schema")
+    manual_boundary_rows_value = state.get("manual_boundary_rows")
+    if manual_boundary_rows_value is not None and (
+        not isinstance(manual_boundary_rows_value, list)
+        or any(type(item) is not int for item in manual_boundary_rows_value)
+    ):
+        raise RollSessionIntegrityError(
+            "roll session manual boundary rows are malformed"
+        )
+    if manual_boundary_rows_value is not None:
+        # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): to_json() persists
+        # a manual session's picked boundary rows as pure provenance --
+        # restoring one is deliberately NOT implemented yet. Everything below
+        # this point always replays through build_roll_preview_session's
+        # algorithmic detector, never build_manual_roll_preview_session's
+        # operator picks, so silently continuing here would hand back a
+        # session whose frame lattice does not match what a human actually
+        # reviewed. Refuse loudly instead of guessing.
+        raise RollSessionIntegrityError(
+            "roll session was built from manual frame placement; restoring "
+            "a manual session from JSON is not yet supported"
+        )
     journal_identity = state.get("journal")
     if type(journal_identity) is not dict or set(journal_identity) != {
         "path",
@@ -1417,6 +1569,7 @@ __all__ = [
     "RollSessionError",
     "RollSessionIntegrityError",
     "ValidatedRollPreview",
+    "build_manual_roll_preview_session",
     "build_roll_preview_session",
     "reload_thumbnail",
     "recipe_for_material",

--- a/coolscanpy/src/coolscanpy/roll/preview_session.py
+++ b/coolscanpy/src/coolscanpy/roll/preview_session.py
@@ -340,6 +340,21 @@ class RollPreviewSession:
             source_table_sha256=self.preview.table_artifact.sha256,
         )
 
+    @property
+    def manual_boundary_rows(self) -> tuple[int, ...] | None:
+        """This session's exact picked boundary rows, or None if automatic.
+
+        Single source of truth for "what did the operator pick" -- to_json
+        (persisted provenance) and approve_manual_origin (S6 hardening:
+        ManualFrameApproval.manual_boundary_rows_sha256) both read this
+        instead of each re-deriving it from self.detection, so the two can
+        never independently drift on what counts as "this session's rows".
+        """
+
+        if MANUAL_PLACEMENT_WARNING not in self.detection.warnings:
+            return None
+        return tuple(boundary.output_row for boundary in self.detection.boundaries)
+
     def approve_manual_origin(
         self,
         slot_id: int,
@@ -373,6 +388,12 @@ class RollPreviewSession:
             reviewed_lookup_row=origin.lookup_row,
             reviewed_native_origin=origin.native_origin,
             review_reasons=reasons,
+            # S6 hardening: ties this receipt to the exact placement this
+            # whole session reviewed, not just this one slot's own
+            # resolved position -- see ManualFrameApproval's own docstring.
+            manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+                self.manual_boundary_rows
+            ),
         )
 
     def validate_manual_approval(
@@ -463,8 +484,8 @@ class RollPreviewSession:
             # session from this JSON is deliberately refused rather than
             # silently re-run through automatic detection.
             "manual_boundary_rows": (
-                [boundary.output_row for boundary in self.detection.boundaries]
-                if MANUAL_PLACEMENT_WARNING in self.detection.warnings
+                list(self.manual_boundary_rows)
+                if self.manual_boundary_rows is not None
                 else None
             ),
         }
@@ -1436,7 +1457,21 @@ def _restore_roll_preview_session(payload: str) -> RollPreviewSession:
         "boundary_offsets",
         "manual_boundary_rows",
     }
-    if set(state) != expected_keys or state.get("version") != SESSION_VERSION:
+    # F7 rework (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): to_json() always
+    # emits "manual_boundary_rows" now, but every session saved before this
+    # key existed has neither it nor anything to migrate -- manual
+    # placement did not exist yet, so an absent key means exactly the same
+    # thing an explicit null does below (state.get returns None either
+    # way). SESSION_VERSION stays 1: nothing about any OTHER field's
+    # meaning changed, so a pre-rework session still restores byte-for-byte
+    # the way it always did. Only an unsupported schema in some OTHER way
+    # -- missing/extra keys beyond this one additive field, or a value for
+    # this key that is neither absent, null, nor a row list -- still
+    # refuses exactly as before.
+    if (
+        set(state) not in (expected_keys, expected_keys - {"manual_boundary_rows"})
+        or state.get("version") != SESSION_VERSION
+    ):
         raise RollSessionIntegrityError("roll session JSON has an unsupported schema")
     manual_boundary_rows_value = state.get("manual_boundary_rows")
     if manual_boundary_rows_value is not None and (

--- a/coolscanpy/tests/capture/test_ls5000_single_pass_workflow.py
+++ b/coolscanpy/tests/capture/test_ls5000_single_pass_workflow.py
@@ -64,6 +64,9 @@ def _journal(
         reviewed_lookup_row=2_580 + boundary_offset_rows,
         reviewed_native_origin=origin,
         review_reasons=("transport-origin-inferred",),
+        manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+            None
+        ),
     ).to_payload()
     roll_comparison = RollFingerprintComparison(
         matches=True,

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
@@ -931,6 +931,7 @@ def test_prepare_batch_frames_every_selected_slot_as_one_future_child_session(
         "expected_usb_address": 2,
         "expected_usb_bus": 1,
         "exposure_override_10ns": None,
+        "manual_boundary_rows": None,
         "frames": [
             {
                 "ack": "frame-017/parent-ack.json",
@@ -998,6 +999,37 @@ def test_prepare_batch_session_threads_exposure_override_into_the_batch_job(
     job = json.loads(prepared.paths.job.read_text(encoding="utf-8"))
 
     assert job["exposure_override_10ns"] == [97_482, 195_597, 180_705]
+
+
+def test_prepare_batch_session_threads_manual_boundary_rows_into_the_batch_job(
+    tmp_path: Path,
+    binding: Binding,
+) -> None:
+    """Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): same choke point as
+    exposure_override_10ns above, for the operator-picked rows a manual
+    placement session hands Roll.scan_many() -- must reach the published
+    batch-job.json unchanged (as a plain array; JSON has no tuple type)."""
+
+    runner = FakeRunner(binding.worker_sha256)
+    adapter = _adapter(tmp_path, binding, runner)
+    request = capture.CaptureBatchRequest(
+        frames=(
+            capture.CaptureRequest(
+                mode=capture.CaptureMode.FULL,
+                selected_slot=1,
+                boundary_offset_rows=0,
+            ),
+        ),
+        reviewed_fingerprint=_reviewed_fingerprint(),
+        expected_usb_bus=1,
+        expected_usb_address=2,
+        manual_boundary_rows=(128, 271, 414),
+    )
+
+    prepared = adapter.prepare_batch_session(request)
+    job = json.loads(prepared.paths.job.read_text(encoding="utf-8"))
+
+    assert job["manual_boundary_rows"] == [128, 271, 414]
 
 
 @pytest.mark.parametrize(

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
@@ -452,6 +452,7 @@ def _manual_approval(
     *,
     slot: int,
     offset: int,
+    manual_boundary_rows: tuple[int, ...] | None = None,
 ) -> capture.ManualFrameApproval:
     return capture.ManualFrameApproval(
         reviewed_fingerprint_sha256=fingerprint.binding_sha256,
@@ -461,6 +462,9 @@ def _manual_approval(
         reviewed_lookup_row=2_400,
         reviewed_native_origin=100_000,
         review_reasons=("transport-origin-inferred",),
+        manual_boundary_rows_sha256=capture.ManualFrameApproval.digest_manual_boundary_rows(
+            manual_boundary_rows
+        ),
     )
 
 

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_manual_frames.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_manual_frames.py
@@ -1,0 +1,394 @@
+"""Regression contracts for Rung 4 manual frame placement.
+
+FEEDING-UX-LADDER-OVERNIGHT-20260807.md: the human supplies frame boundary
+rows on an already-captured preview raster; this module keeps the physical
+sanity checks. These tests exercise every validation gate plus the happy
+path's exact result shape, independent of and never calling
+detect_roll_frames/derive_transport_mapping.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from coolscanpy.protocol.ls5000_single_pass import manual_frames
+from coolscanpy.protocol.ls5000_single_pass.roll_index import (
+    IndexDecodeError,
+    TransportRecord,
+)
+
+
+def _synthetic_roll(
+    frame_count: int,
+    *,
+    pitch: int = 143,
+    leader: int = 24,
+    tail: int = 24,
+) -> tuple[np.ndarray, list[int]]:
+    """Same construction as test_roll_index.py's own helper: textured cells
+    separated by physical clear-film gaps six preview rows wide, centered on
+    each boundary row.
+    """
+
+    boundaries = [leader + index * pitch for index in range(frame_count + 1)]
+    height = boundaries[-1] + tail
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[:, :, channel] = base + texture * (3 - channel) // 2
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    clear_noise = ((x * 19 + y * 13) % 301 - 150)[:, :, None]
+    aperture[: boundaries[0]] = clear_base + clear_noise[: boundaries[0]]
+    aperture[boundaries[-1] :] = clear_base + clear_noise[boundaries[-1] :]
+    for boundary in boundaries:
+        start = max(0, boundary - 3)
+        end = min(height, boundary + 3)
+        aperture[start:end] = clear_base + clear_noise[start:end]
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16), boundaries
+
+
+def _clean_records(count: int) -> tuple[TransportRecord, ...]:
+    """Same-traversal transport table stepping at exactly 42 native units/row.
+
+    ``code=6*(row%18), selector=row//18`` is the standard synthetic-records
+    convention used throughout this package's tests (test_worker.py,
+    test_ls5000_roll_session.py); it decodes to ``native_origin = 42 * row``
+    exactly.
+    """
+
+    return tuple(
+        TransportRecord(
+            row=row,
+            code=6 * (row % 18),
+            selector=row // 18,
+            native_origin=42 * row,
+        )
+        for row in range(count)
+    )
+
+
+def _known(rgb: np.ndarray) -> np.ndarray:
+    return np.ones_like(rgb, dtype=bool)
+
+
+def _spike(
+    records: tuple[TransportRecord, ...], row: int, delta: int
+) -> tuple[TransportRecord, ...]:
+    patched = list(records)
+    victim = patched[row]
+    patched[row] = TransportRecord(
+        row=victim.row,
+        code=victim.code,
+        selector=victim.selector,
+        native_origin=victim.native_origin + delta,
+    )
+    return tuple(patched)
+
+
+# --------------------------------------------------------------------------
+# Happy path
+# --------------------------------------------------------------------------
+
+
+def test_exact_picks_produce_the_real_boundaries_with_no_snaps() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb,
+        _known(rgb),
+        boundaries,
+        nominal_frame_rows=143,
+        records=records,
+    )
+
+    assert result.snaps == ()
+    detection = result.detection
+    mapping = result.mapping
+
+    assert detection.confidence == "medium"
+    assert manual_frames.MANUAL_PLACEMENT_WARNING in detection.warnings
+    assert detection.nominal_frame_rows == 143
+    assert detection.candidate_cell_count == 6
+    assert detection.manual_review_frames == (1, 2, 3, 4, 5, 6)
+    assert len(detection.intervals) == 6
+    assert len(detection.boundaries) == 7
+    assert len(mapping.origins) == 6
+
+    for interval in detection.intervals:
+        assert interval.manual_review is True
+        assert "user-picked" in interval.review_reasons
+
+    for boundary in detection.boundaries:
+        assert boundary.support == "user-picked"
+        assert boundary.manual_review is True
+        assert "user-picked" in boundary.review_reasons
+
+    for frame, (origin, boundary_row) in enumerate(
+        zip(mapping.origins, boundaries), start=1
+    ):
+        assert origin.frame == frame
+        assert origin.native_origin == 42 * boundary_row
+        assert origin.method == "user-picked-row"
+        assert origin.automatic is False
+        assert origin.manual_review is True
+
+
+def test_picks_off_run_edges_snap_and_are_noted() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+    picks = list(boundaries)
+    # The evidence run at boundaries[2] is (boundary-3, boundary+3); picking
+    # 2 rows short of its leading edge should snap onto that edge.
+    picks[2] = boundaries[2] - 3 - 2
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), picks, nominal_frame_rows=143, records=records
+    )
+
+    assert len(result.snaps) == 1
+    snap = result.snaps[0]
+    assert snap.boundary_index == 2
+    assert snap.requested_row == picks[2]
+    assert snap.snapped_row == boundaries[2] - 3
+    assert result.detection.boundaries[2].output_row == boundaries[2] - 3
+    assert "snapped-to-clear-film-edge" in result.detection.boundaries[2].review_reasons
+
+
+def test_snap_assist_disabled_keeps_the_operators_exact_picks() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+    picks = list(boundaries)
+    picks[2] = boundaries[2] - 3 - 2
+
+    result = manual_frames.build_manual_detection(
+        rgb,
+        _known(rgb),
+        picks,
+        nominal_frame_rows=143,
+        records=records,
+        snap_assist=False,
+    )
+
+    assert result.snaps == ()
+    assert result.detection.boundaries[2].output_row == picks[2]
+
+
+def test_single_frame_minimum_two_boundaries_is_accepted() -> None:
+    rgb, boundaries = _synthetic_roll(1, pitch=143)
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=records
+    )
+
+    assert len(result.detection.intervals) == 1
+    assert len(result.mapping.origins) == 1
+
+
+# --------------------------------------------------------------------------
+# Structural gates
+# --------------------------------------------------------------------------
+
+
+def test_refuses_fewer_than_two_boundaries() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+
+    with pytest.raises(IndexDecodeError, match="at least 2 boundary rows"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), [boundaries[0]], nominal_frame_rows=143, records=records
+        )
+
+
+def test_refuses_non_monotonic_boundaries() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+
+    with pytest.raises(IndexDecodeError, match="strictly increasing order"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), [10, 5, 200], nominal_frame_rows=143, records=records
+        )
+
+
+def test_refuses_boundary_outside_the_raster() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+
+    with pytest.raises(IndexDecodeError, match="inside the captured preview"):
+        manual_frames.build_manual_detection(
+            rgb,
+            _known(rgb),
+            [10, len(rgb) + 5],
+            nominal_frame_rows=143,
+            records=records,
+        )
+
+
+def test_refuses_more_than_forty_frames() -> None:
+    height = 3_000
+    rgb = np.zeros((height, 96, 3), dtype=np.uint16)
+    records = _clean_records(height)
+    boundaries = list(range(10, 10 + 42 * 60, 60))  # 42 boundaries -> 41 frames
+
+    with pytest.raises(IndexDecodeError, match="at most 40 frames"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), boundaries, nominal_frame_rows=60, records=records
+        )
+
+
+def test_exactly_forty_frames_is_accepted() -> None:
+    height = 3_000
+    rgb = np.zeros((height, 96, 3), dtype=np.uint16)
+    records = _clean_records(height)
+    boundaries = list(range(10, 10 + 41 * 60, 60))  # 41 boundaries -> 40 frames
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=60, records=records
+    )
+
+    assert len(result.detection.intervals) == 40
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        (100, 110),  # ~3 mm, below the 15 mm floor
+        (100, 500),  # ~107 mm, above the 75 mm ceiling
+    ],
+)
+def test_refuses_absurd_frame_heights(start: int, end: int) -> None:
+    height = 3_000
+    rgb = np.zeros((height, 96, 3), dtype=np.uint16)
+    records = _clean_records(height)
+
+    with pytest.raises(IndexDecodeError, match="outside the 15-75 mm range"):
+        manual_frames.build_manual_detection(
+            rgb,
+            _known(rgb),
+            [start, end, end + 200],
+            nominal_frame_rows=143,
+            records=records,
+        )
+
+
+def test_half_frame_heights_are_accepted() -> None:
+    rgb, boundaries = _synthetic_roll(4, pitch=71, leader=20, tail=20)
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=71, records=records
+    )
+
+    assert len(result.detection.intervals) == 4
+    for interval in result.detection.intervals:
+        assert interval.height_rows == 71
+
+
+def test_panoramic_heights_are_accepted() -> None:
+    rgb, boundaries = _synthetic_roll(3, pitch=250, leader=30, tail=30)
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=250, records=records
+    )
+
+    assert len(result.detection.intervals) == 3
+    for interval in result.detection.intervals:
+        assert interval.height_rows == 250
+
+
+# --------------------------------------------------------------------------
+# Transport table gates
+# --------------------------------------------------------------------------
+
+
+def test_single_record_spike_near_a_boundary_refuses_the_whole_placement() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    spiked = _spike(_clean_records(len(rgb)), boundaries[2] + 1, 5_000)
+
+    with pytest.raises(IndexDecodeError, match="position readings look unreliable"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=spiked
+        )
+
+
+def test_spike_message_names_the_ordinal_edge_and_no_frames_are_returned() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    spiked = _spike(_clean_records(len(rgb)), boundaries[2] + 1, 5_000)
+
+    with pytest.raises(IndexDecodeError, match="3rd frame edge"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=spiked
+        )
+
+
+def test_non_affine_implied_scale_between_boundaries_refuses() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = list(_clean_records(len(rgb)))
+    # A jump well clear of every boundary's own +-3 row ramp-guard window
+    # (boundaries[2]=310, next boundary 453; the jump sits at 380) still
+    # skews the aggregate origins-vs-rows relationship between those two
+    # picked boundaries -- a distinct failure mode from the local guard.
+    jump_row = boundaries[2] + 70
+    for row in range(jump_row, len(records)):
+        victim = records[row]
+        records[row] = TransportRecord(
+            row=victim.row,
+            code=victim.code,
+            selector=victim.selector,
+            native_origin=victim.native_origin + 3_000,
+        )
+
+    with pytest.raises(IndexDecodeError, match="don't move at a steady rate"):
+        manual_frames.build_manual_detection(
+            rgb,
+            _known(rgb),
+            boundaries,
+            nominal_frame_rows=143,
+            records=tuple(records),
+        )
+
+
+def test_refuses_when_no_transport_records_are_supplied() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+
+    with pytest.raises(IndexDecodeError, match="scanner position table"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=()
+        )
+
+
+# --------------------------------------------------------------------------
+# Shape/completeness gates
+# --------------------------------------------------------------------------
+
+
+def test_refuses_mismatched_raster_and_completeness_shapes() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+    wrong_known = np.ones((len(rgb) - 1, 96, 3), dtype=bool)
+
+    with pytest.raises(IndexDecodeError, match="shapes differ"):
+        manual_frames.build_manual_detection(
+            rgb, wrong_known, boundaries, nominal_frame_rows=143, records=records
+        )
+
+
+def test_refuses_an_incomplete_preview() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+    known = _known(rgb)
+    known[:200] = False
+
+    with pytest.raises(manual_frames.IncompleteIndexError, match="row coverage"):
+        manual_frames.build_manual_detection(
+            rgb, known, boundaries, nominal_frame_rows=143, records=records
+        )

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_manual_frames.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_manual_frames.py
@@ -5,6 +5,18 @@ rows on an already-captured preview raster; this module keeps the physical
 sanity checks. These tests exercise every validation gate plus the happy
 path's exact result shape, independent of and never calling
 detect_roll_frames/derive_transport_mapping.
+
+Rewritten 2026-08-08 after adversarial review rejected the original: gate 4
+used to require every single-row transport-table step within 3 rows of a
+pick to be 40..45 native units, which real LS-5000 tables never satisfy (see
+manual_frames.py's own module docstring for the measured lattice structure).
+``_lattice_records`` below builds a synthetic table with that same
+structure -- deterministic ~18-row-period selector-rollover and
+sub-rollover jumps, computed through the real ``transport_native_origin``
+identity, not approximated deltas -- so these tests, and the ones in this
+file that exercise the transport-table gates specifically, can never again
+diverge from hardware reality the way the plain 42-units/row ``_clean_
+records`` table did.
 """
 
 from __future__ import annotations
@@ -15,7 +27,9 @@ import pytest
 from coolscanpy.protocol.ls5000_single_pass import manual_frames
 from coolscanpy.protocol.ls5000_single_pass.roll_index import (
     IndexDecodeError,
+    TRANSPORT_ORIGIN_CLAMP_REASON,
     TransportRecord,
+    transport_native_origin,
 )
 
 
@@ -25,10 +39,14 @@ def _synthetic_roll(
     pitch: int = 143,
     leader: int = 24,
     tail: int = 24,
+    gap_half: int = 3,
 ) -> tuple[np.ndarray, list[int]]:
     """Same construction as test_roll_index.py's own helper: textured cells
-    separated by physical clear-film gaps six preview rows wide, centered on
-    each boundary row.
+    separated by physical clear-film gaps ``2 * gap_half`` preview rows
+    wide, centered on each boundary row. The leader and tail themselves are
+    one wide clear-film run each (``leader``/``tail`` rows), never a
+    ``gap_half``-narrow one -- this matters for tests that care whether a
+    boundary's evidence run classifies as narrow.
     """
 
     boundaries = [leader + index * pitch for index in range(frame_count + 1)]
@@ -44,8 +62,8 @@ def _synthetic_roll(
     aperture[: boundaries[0]] = clear_base + clear_noise[: boundaries[0]]
     aperture[boundaries[-1] :] = clear_base + clear_noise[boundaries[-1] :]
     for boundary in boundaries:
-        start = max(0, boundary - 3)
-        end = min(height, boundary + 3)
+        start = max(0, boundary - gap_half)
+        end = min(height, boundary + gap_half)
         aperture[start:end] = clear_base + clear_noise[start:end]
     rgb = np.empty((height, 96, 3), dtype=np.int64)
     rgb[:, 2:92] = aperture
@@ -54,13 +72,33 @@ def _synthetic_roll(
     return rgb.clip(0, 65_535).astype(np.uint16), boundaries
 
 
+def _blank_roll(height: int) -> np.ndarray:
+    """A raster with NO clear-film runs anywhere, so snap assist finds no
+    evidence and every pick resolves through the no-narrow-run path."""
+
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[:, :, channel] = base + texture * (3 - channel) // 2
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16)
+
+
 def _clean_records(count: int) -> tuple[TransportRecord, ...]:
     """Same-traversal transport table stepping at exactly 42 native units/row.
 
     ``code=6*(row%18), selector=row//18`` is the standard synthetic-records
     convention used throughout this package's tests (test_worker.py,
     test_ls5000_roll_session.py); it decodes to ``native_origin = 42 * row``
-    exactly.
+    exactly. A perfectly smooth ramp -- useful for gates that have nothing
+    to do with the transport table's own lattice structure, but never used
+    below for a test that is specifically about that structure; see
+    ``_lattice_records`` for those.
     """
 
     return tuple(
@@ -72,6 +110,65 @@ def _clean_records(count: int) -> tuple[TransportRecord, ...]:
         )
         for row in range(count)
     )
+
+
+# One ~18-row lattice period's ordinary (non-rollover) code progression,
+# transcribed from the archived 20260719-phoenix live capture inspected
+# during this rework (rows 1-16 of its first full period): the code's low
+# byte advances by 6 almost every row, with the high byte periodically
+# absorbing part of that advance (the "sub-rollover" jumps -- +28, +84
+# native units here, matching the task's own measured "-56/+98/+98/+0"
+# class of jump; the exact sub-rollover magnitudes are a hardware
+# implementation detail this generator does not need to reproduce exactly
+# to be a faithful stress test of "mostly steady, occasionally not").
+_LATTICE_CYCLE_CODES = (
+    0x0006, 0x000C, 0x0012, 0x0018, 0x001E, 0x0024, 0x002A,
+    0x0202, 0x0208, 0x020E, 0x0214, 0x021A, 0x0220, 0x0226,
+    0x0406, 0x040C,
+)
+
+
+def _lattice_records(count: int) -> tuple[TransportRecord, ...]:
+    """Same-traversal transport table with the REAL LS-5000 code lattice.
+
+    Real live READ(0x8e) tables are not a smooth ramp: every ~18 rows, the
+    selector rolls over, and the row at that rollover reports the NEXT
+    selector's own low code one row early -- a jump of roughly +798 native
+    units -- corrected the very next row by roughly -700 (measured on
+    archived captures during this rework; see manual_frames.py's module
+    docstring). Built from ``transport_native_origin`` itself rather than
+    hand-picked deltas, so every record this returns decodes losslessly the
+    same way a real table does, and the average rate across any complete
+    18-row cycle is exactly 42 native units/row (756 native units -- one
+    selector step -- over 18 rows), matching this driver's accepted
+    40..45 physical band.
+    """
+
+    cycle_len = len(_LATTICE_CYCLE_CODES)
+    period = cycle_len + 2
+    records = []
+    for row in range(count):
+        position = row % period
+        selector = row // period
+        if position < cycle_len:
+            code = _LATTICE_CYCLE_CODES[position]
+        elif position == cycle_len:
+            # Selector-rollover lookahead.
+            code = 0x0412
+            selector += 1
+        else:
+            # Selector-rollover correction.
+            code = 0x0004
+            selector += 1
+        records.append(
+            TransportRecord(
+                row=row,
+                code=code,
+                selector=selector,
+                native_origin=transport_native_origin(code, selector),
+            )
+        )
+    return tuple(records)
 
 
 def _known(rgb: np.ndarray) -> np.ndarray:
@@ -89,6 +186,34 @@ def _spike(
         selector=victim.selector,
         native_origin=victim.native_origin + delta,
     )
+    return tuple(patched)
+
+
+def _corrupt_span(
+    records: tuple[TransportRecord, ...], start: int, end: int, magnitude: int
+) -> tuple[TransportRecord, ...]:
+    """Displace every record in [start, end) by an independent random value
+    in [-magnitude, magnitude] -- a widespread, genuinely noisy corruption
+    with no steady rate left inside it, unlike ``_spike`` (one row) or a
+    uniform/alternating shift (either of which is really just a second
+    internally-consistent trend a robust fit can still lock onto -- a
+    uniform shift is caught by gate 5 instead, see
+    test_non_affine_implied_scale_between_boundaries_refuses; a fixed
+    alternation is, structurally, two interleaved uniform shifts, which a
+    median-based fit can still separate).  A seeded RNG keeps this
+    deterministic across runs."""
+
+    rng = np.random.default_rng(20260808)
+    patched = list(records)
+    for row in range(start, end):
+        victim = patched[row]
+        signed_delta = int(rng.integers(-magnitude, magnitude + 1))
+        patched[row] = TransportRecord(
+            row=victim.row,
+            code=victim.code,
+            selector=victim.selector,
+            native_origin=victim.native_origin + signed_delta,
+        )
     return tuple(patched)
 
 
@@ -130,19 +255,36 @@ def test_exact_picks_produce_the_real_boundaries_with_no_snaps() -> None:
         assert boundary.support == "user-picked"
         assert boundary.manual_review is True
         assert "user-picked" in boundary.review_reasons
+        # The VISUAL boundary position is always the exact row the operator
+        # placed, regardless of how its transport origin resolved.
+    assert [b.output_row for b in detection.boundaries] == boundaries
 
-    for frame, (origin, boundary_row) in enumerate(
-        zip(mapping.origins, boundaries), start=1
+    # Origins: boundary 0 sits in the wide (24-row) leader run, which is
+    # NOT a narrow inter-frame gap, so it resolves at the picked row
+    # itself. Boundaries 1-5 each sit at the center of an ordinary 6-row
+    # inter-frame gap -- a narrow run -- so each resolves at that run's
+    # OWN trailing edge (boundary + gap_half), mirroring
+    # derive_transport_mapping's "direct-gap-trailing-row" convention on
+    # the automatic path (see manual_frames.py's own docstring for why).
+    gap_half = 3
+    expected_lookup_rows = [boundaries[0]] + [b + gap_half for b in boundaries[1:6]]
+    for frame, (origin, lookup_row) in enumerate(
+        zip(mapping.origins, expected_lookup_rows), start=1
     ):
         assert origin.frame == frame
-        assert origin.native_origin == 42 * boundary_row
+        assert origin.lookup_row == lookup_row
+        assert origin.native_origin == 42 * lookup_row
         assert origin.method == "user-picked-row"
         assert origin.automatic is False
         assert origin.manual_review is True
+        assert manual_frames.MANUAL_ORIGIN_REVIEW_REASON in origin.review_reasons
 
 
 def test_picks_off_run_edges_snap_and_are_noted() -> None:
-    rgb, boundaries = _synthetic_roll(6)
+    # A shorter pitch than the happy-path test above so a boundary shifted
+    # a few rows by snap assist cannot itself brush the fine-capture-window
+    # ceiling (F2) -- this test is about snap mechanics, not that gate.
+    rgb, boundaries = _synthetic_roll(6, pitch=100, leader=20, tail=20)
     records = _clean_records(len(rgb))
     picks = list(boundaries)
     # The evidence run at boundaries[2] is (boundary-3, boundary+3); picking
@@ -150,7 +292,7 @@ def test_picks_off_run_edges_snap_and_are_noted() -> None:
     picks[2] = boundaries[2] - 3 - 2
 
     result = manual_frames.build_manual_detection(
-        rgb, _known(rgb), picks, nominal_frame_rows=143, records=records
+        rgb, _known(rgb), picks, nominal_frame_rows=100, records=records
     )
 
     assert len(result.snaps) == 1
@@ -163,7 +305,7 @@ def test_picks_off_run_edges_snap_and_are_noted() -> None:
 
 
 def test_snap_assist_disabled_keeps_the_operators_exact_picks() -> None:
-    rgb, boundaries = _synthetic_roll(6)
+    rgb, boundaries = _synthetic_roll(6, pitch=100, leader=20, tail=20)
     records = _clean_records(len(rgb))
     picks = list(boundaries)
     picks[2] = boundaries[2] - 3 - 2
@@ -172,7 +314,7 @@ def test_snap_assist_disabled_keeps_the_operators_exact_picks() -> None:
         rgb,
         _known(rgb),
         picks,
-        nominal_frame_rows=143,
+        nominal_frame_rows=100,
         records=records,
         snap_assist=False,
     )
@@ -257,26 +399,63 @@ def test_exactly_forty_frames_is_accepted() -> None:
     assert len(result.detection.intervals) == 40
 
 
-@pytest.mark.parametrize(
-    ("start", "end"),
-    [
-        (100, 110),  # ~3 mm, below the 15 mm floor
-        (100, 500),  # ~107 mm, above the 75 mm ceiling
-    ],
-)
-def test_refuses_absurd_frame_heights(start: int, end: int) -> None:
+# --------------------------------------------------------------------------
+# Physical frame-height gates (F2 + F3): 15 mm floor, fine-capture-window
+# ceiling, both enforced on the POST-SNAP rows.
+# --------------------------------------------------------------------------
+
+
+def test_refuses_a_frame_shorter_than_the_floor() -> None:
     height = 3_000
     rgb = np.zeros((height, 96, 3), dtype=np.uint16)
     records = _clean_records(height)
 
-    with pytest.raises(IndexDecodeError, match="outside the 15-75 mm range"):
+    with pytest.raises(IndexDecodeError, match=r"shorter than the 15 mm floor"):
         manual_frames.build_manual_detection(
             rgb,
             _known(rgb),
-            [start, end, end + 200],
+            [100, 110, 400],  # 10 rows, ~3 mm
             nominal_frame_rows=143,
             records=records,
         )
+
+
+def test_refuses_a_frame_taller_than_the_fine_capture_window() -> None:
+    """F2: the fine scan captures a fixed window; there is no multi-window
+    capture. A frame taller than that window must refuse honestly instead
+    of silently delivering a truncated capture."""
+
+    height = 3_000
+    rgb = np.zeros((height, 96, 3), dtype=np.uint16)
+    records = _clean_records(height)
+
+    with pytest.raises(
+        IndexDecodeError,
+        match=r"the scanner captures about 38\.8 mm per frame in one fine scan",
+    ):
+        manual_frames.build_manual_detection(
+            rgb,
+            _known(rgb),
+            [100, 100 + manual_frames.FINE_CAPTURE_WINDOW_ROWS + 1, 2_900],
+            nominal_frame_rows=143,
+            records=records,
+        )
+
+
+def test_frame_exactly_at_the_ceiling_is_accepted() -> None:
+    height = 3_000
+    rgb = np.zeros((height, 96, 3), dtype=np.uint16)
+    records = _clean_records(height)
+
+    result = manual_frames.build_manual_detection(
+        rgb,
+        _known(rgb),
+        [100, 100 + manual_frames.FINE_CAPTURE_WINDOW_ROWS],
+        nominal_frame_rows=143,
+        records=records,
+    )
+
+    assert len(result.detection.intervals) == 1
 
 
 def test_half_frame_heights_are_accepted() -> None:
@@ -292,51 +471,114 @@ def test_half_frame_heights_are_accepted() -> None:
         assert interval.height_rows == 71
 
 
-def test_panoramic_heights_are_accepted() -> None:
+def test_panoramic_heights_are_now_refused() -> None:
+    """F2 rework: panoramic acceptance is deliberately removed. The fine
+    scan cannot capture a ~66 mm frame in one pass, so this must refuse
+    rather than silently truncate -- manual mode still exists for film
+    automatic detection cannot handle, but panoramic is no longer one of
+    those cases."""
+
     rgb, boundaries = _synthetic_roll(3, pitch=250, leader=30, tail=30)
     records = _clean_records(len(rgb))
 
-    result = manual_frames.build_manual_detection(
-        rgb, _known(rgb), boundaries, nominal_frame_rows=250, records=records
-    )
-
-    assert len(result.detection.intervals) == 3
-    for interval in result.detection.intervals:
-        assert interval.height_rows == 250
-
-
-# --------------------------------------------------------------------------
-# Transport table gates
-# --------------------------------------------------------------------------
-
-
-def test_single_record_spike_near_a_boundary_refuses_the_whole_placement() -> None:
-    rgb, boundaries = _synthetic_roll(6)
-    spiked = _spike(_clean_records(len(rgb)), boundaries[2] + 1, 5_000)
-
-    with pytest.raises(IndexDecodeError, match="position readings look unreliable"):
+    with pytest.raises(
+        IndexDecodeError, match="there is no way to capture a taller frame"
+    ):
         manual_frames.build_manual_detection(
-            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=spiked
+            rgb, _known(rgb), boundaries, nominal_frame_rows=250, records=records
         )
 
 
-def test_spike_message_names_the_ordinal_edge_and_no_frames_are_returned() -> None:
+@pytest.mark.parametrize(
+    ("picks", "clear_runs", "expected_match"),
+    [
+        # P1 (adversarial review probe): a raw pick pair exactly at the 56-
+        # row floor, crafted so snap assist pulls them TOWARD each other,
+        # eroding the post-snap height to 48 rows (~12.8 mm). Must refuse.
+        ([100, 156], [(104, 110), (146, 153)], r"shorter than the 15 mm floor"),
+        # P1b: a raw pick pair exactly at the (old) 280-row ceiling,
+        # crafted so snap assist pushes them APART; under the new
+        # fine-window ceiling this is refused even more decisively.
+        ([100, 380], [(90, 97), (384, 390)], "there is no way to capture"),
+    ],
+)
+def test_height_gate_runs_on_post_snap_rows(
+    picks: list[int], clear_runs: list[tuple[int, int]], expected_match: str
+) -> None:
+    height = 700
+    rgb = _blank_roll(height)
+    clear = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    rgb_i = rgb.astype(np.int64)
+    for start, end in clear_runs:
+        rgb_i[start:end, 2:92] = clear
+    rgb = rgb_i.clip(0, 65_535).astype(np.uint16)
+    records = _clean_records(height)
+
+    with pytest.raises(IndexDecodeError, match=expected_match):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), picks, nominal_frame_rows=143, records=records
+        )
+
+
+# --------------------------------------------------------------------------
+# Transport table gates (F1 + F4 rework)
+# --------------------------------------------------------------------------
+
+
+def test_isolated_table_row_anomaly_near_a_boundary_is_tolerated() -> None:
+    """F1: a single-row transport-table anomaly -- exactly the shape a real
+    lattice rollover takes -- near a boundary no longer refuses the whole
+    placement. The local fit robustly resolves around it, the same way it
+    resolves around the real lattice's own rollover rows.
+    """
+
     rgb, boundaries = _synthetic_roll(6)
     spiked = _spike(_clean_records(len(rgb)), boundaries[2] + 1, 5_000)
 
-    with pytest.raises(IndexDecodeError, match="3rd frame edge"):
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=spiked
+    )
+
+    # Frame 3 (0-indexed origin 2) anchors on boundaries[2]'s own narrow-run
+    # trailing edge (boundaries[2] + 3), untouched by the spike at
+    # boundaries[2] + 1, so it resolves exactly as if the spike were absent.
+    assert result.mapping.origins[2].native_origin == 42 * (boundaries[2] + 3)
+
+
+def test_widespread_table_corruption_near_a_boundary_still_refuses() -> None:
+    """The tolerance F1 adds has a limit: when a boundary's ENTIRE local
+    neighborhood is corrupted (not one isolated row), there is no steady
+    rate left to find, and this must still refuse -- naming that specific
+    edge, not blaming the physical strip for a table-reading problem."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    # Wide enough to blank out this boundary's ENTIRE local-fit window
+    # (LOCAL_FIT_WINDOW_RADIUS_ROWS on each side) with alternating noise,
+    # leaving no steady-rate majority anywhere nearby to find.
+    radius = manual_frames.LOCAL_FIT_WINDOW_RADIUS_ROWS
+    corrupted = _corrupt_span(
+        _clean_records(len(rgb)),
+        boundaries[2] - radius - 5,
+        boundaries[2] + radius + 5,
+        30_000,
+    )
+
+    with pytest.raises(
+        IndexDecodeError, match=r"doesn't settle into a steady rate"
+    ):
         manual_frames.build_manual_detection(
-            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=spiked
+            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=corrupted
         )
 
 
 def test_non_affine_implied_scale_between_boundaries_refuses() -> None:
     rgb, boundaries = _synthetic_roll(6)
     records = list(_clean_records(len(rgb)))
-    # A jump well clear of every boundary's own +-3 row ramp-guard window
-    # (boundaries[2]=310, next boundary 453; the jump sits at 380) still
-    # skews the aggregate origins-vs-rows relationship between those two
-    # picked boundaries -- a distinct failure mode from the local guard.
+    # A jump well clear of every boundary's own local-fit window (radius
+    # LOCAL_FIT_WINDOW_RADIUS_ROWS; boundaries[2]=310, next boundary 453,
+    # the jump sits at 380) still skews the relationship between those two
+    # picks' own resolved origins -- a distinct failure mode from gate 4's
+    # per-boundary local check.
     jump_row = boundaries[2] + 70
     for row in range(jump_row, len(records)):
         victim = records[row]
@@ -366,6 +608,200 @@ def test_refuses_when_no_transport_records_are_supplied() -> None:
         )
 
 
+def test_lattice_table_boundaries_resolve_despite_rollover_neighbors() -> None:
+    """F1's core regression: a REAL lattice table (see _lattice_records)
+    carries a selector-rollover jump pair roughly every 18 rows -- so a
+    typical local-fit window around any boundary contains at least one.
+    Every boundary here must still be accepted, and every resolved origin
+    must land on the true clean-ramp value (42 * lookup_row) despite that
+    neighbor, the same way real archived captures do (see this rework's
+    51-table regression in test_roll_index.py).
+    """
+
+    rgb, boundaries = _synthetic_roll(6)
+    records = _lattice_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=records
+    )
+
+    assert len(result.mapping.origins) == 6
+    for origin in result.mapping.origins:
+        expected = transport_native_origin(
+            records[origin.lookup_row].code, records[origin.lookup_row].selector
+        )
+        assert origin.native_origin == expected
+        # Every resolved origin must itself be an exact, real table read --
+        # never a value that does not correspond to any row in the table.
+        assert origin.native_origin == records[origin.lookup_row].native_origin
+
+
+def test_lattice_table_pick_exactly_on_a_rollover_row_is_tolerated() -> None:
+    """The narrowest version of F1's fix: the operator's own pick (not just
+    a nearby row) lands exactly on one of the lattice's rollover rows. No
+    narrow evidence run is nearby (a blank roll), so the pick row itself is
+    the anchor -- and it is NOT trustworthy on its own. Resolution must
+    still succeed, via the no-narrow-run forward search (the same
+    resolution shape a broad/weak-evidence pick always uses -- see
+    _resolve_boundary_transport_origin's own docstring), landing on a
+    nearby row the local fit does trust.
+    """
+
+    height = 900
+    rgb = _blank_roll(height)
+    records = _lattice_records(height)
+    period = len(_LATTICE_CYCLE_CODES) + 2
+
+    # A rollover-lookahead row (see _lattice_records) comfortably inside
+    # the table, far from either raster edge or the terminal-tail concept
+    # (records here have none).
+    rollover_row = next(
+        row for row in range(300, 340) if row % period == len(_LATTICE_CYCLE_CODES)
+    )
+    picks = [rollover_row - 100, rollover_row, rollover_row + 100]
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), picks, nominal_frame_rows=143, records=records
+    )
+
+    origin = result.mapping.origins[1]  # frame 2 starts at the rollover pick
+    assert origin.lookup_row != rollover_row
+    assert abs(origin.lookup_row - rollover_row) <= manual_frames.CANDIDATE_SEARCH_LOOKAHEAD_ROWS
+    assert manual_frames.INFERRED_ORIGIN_REVIEW_REASON in origin.review_reasons
+    assert origin.native_origin == records[origin.lookup_row].native_origin
+
+
+# --------------------------------------------------------------------------
+# Placement-wide affine-fit gate (F4)
+# --------------------------------------------------------------------------
+
+
+def test_placement_wide_drift_too_small_for_any_single_pair_still_refuses() -> None:
+    """A gentle, CONTINUOUS bow across the whole table -- a mild quadratic
+    offset, applied to every row, never a step -- curves too slowly to
+    disturb any one boundary's own local-fit window (gate 4) or any one
+    adjacent pair's implied scale (gate 5: a quadratic's local slope near
+    either end of an 8-frame placement is still well inside the 40..45
+    band), but a single straight line cannot fit a bow across the WHOLE
+    placement, and that is exactly the worst-case residual only the
+    placement-wide fit (>=3 boundaries) checks. (A step offset, tried
+    first while writing this test, is a much blunter tool: any discrete
+    jump has to sit inside SOME boundary's own window, so it trips gate 4
+    or gate 5 instead of demonstrating gate 6 specifically -- a bow is the
+    shape that is invisible to both of those and visible only in
+    aggregate.) The k=0.0015 coefficient below was chosen empirically
+    against this exact scenario: comfortably clear of gate 4 (which first
+    breaks around k=0.003) with about a 1.5-row aggregate drift, comfortably
+    past the gate 6 bounds (MAE 1.0, max 2.0 rows).
+    """
+
+    rgb, boundaries = _synthetic_roll(8, pitch=90, leader=30, tail=30)
+    records = list(_clean_records(len(rgb)))
+    center = len(records) / 2
+    curvature = 0.0015
+    for row in range(len(records)):
+        victim = records[row]
+        offset = int(round(curvature * (row - center) ** 2))
+        records[row] = TransportRecord(
+            row=victim.row,
+            code=victim.code,
+            selector=victim.selector,
+            native_origin=victim.native_origin + offset,
+        )
+    records_tuple = tuple(records)
+
+    with pytest.raises(
+        IndexDecodeError, match="don't agree on one steady rate"
+    ):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), boundaries, nominal_frame_rows=90, records=records_tuple
+        )
+
+
+def test_two_boundary_placement_skips_the_placement_wide_gate() -> None:
+    """Documented limitation (F4): two points always fit a line exactly, so
+    the placement-wide MAE/max gate is vacuous for a single-frame
+    placement and is not enforced -- gate 4 (each pick's own local
+    neighborhood) and gate 5 (the one pairwise implied scale) are what
+    validate a 2-boundary placement instead."""
+
+    rgb, boundaries = _synthetic_roll(1, pitch=143)
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=records
+    )
+
+    # A 2x2 least-squares solve through exactly 2 points is analytically
+    # exact but not always bit-exact in floating point.
+    assert result.mapping.anchor_mae_rows == pytest.approx(0.0, abs=1e-6)
+    assert result.mapping.anchor_max_error_rows == pytest.approx(0.0, abs=1e-6)
+
+
+# --------------------------------------------------------------------------
+# Idempotency (F3): build_manual_detection(final_rows) must accept its own
+# output rows unchanged -- the batch capture wire and the worker's live-scan
+# replay both resupply a prior call's own boundary output rows as the next
+# call's raw picks.
+# --------------------------------------------------------------------------
+
+
+def test_build_manual_detection_is_idempotent_on_its_own_output() -> None:
+    # Shorter pitch than the default 143: this test shifts a pick by 5 rows
+    # before snapping, and the resulting frame must stay comfortably clear
+    # of the fine-capture-window ceiling (F2) -- a different gate than the
+    # one this test exercises.
+    rgb, boundaries = _synthetic_roll(6, pitch=100, leader=20, tail=20)
+    records = _lattice_records(len(rgb))
+    picks = list(boundaries)
+    picks[2] = boundaries[2] - 5  # off the run edge, exercises a real snap
+
+    first = manual_frames.build_manual_detection(
+        rgb, _known(rgb), picks, nominal_frame_rows=100, records=records
+    )
+    replay_rows = tuple(b.output_row for b in first.detection.boundaries)
+
+    second = manual_frames.build_manual_detection(
+        rgb, _known(rgb), replay_rows, nominal_frame_rows=100, records=records
+    )
+
+    assert second.snaps == ()
+    assert [b.output_row for b in second.detection.boundaries] == list(replay_rows)
+    assert [o.native_origin for o in second.mapping.origins] == [
+        o.native_origin for o in first.mapping.origins
+    ]
+    assert [o.lookup_row for o in second.mapping.origins] == [
+        o.lookup_row for o in first.mapping.origins
+    ]
+
+
+def test_idempotency_holds_after_a_gate_3_snap_erosion_scenario() -> None:
+    """The exact P1 probe scenario (adversarial review), but confirming the
+    NEW behavior end to end: gate 3 now refuses the eroded placement
+    directly (test_height_gate_runs_on_post_snap_rows above), so there is
+    no approved-then-unreplayable placement left to deadlock on -- replay
+    of a placement that WAS accepted (picks safely clear of the floor)
+    still round-trips cleanly."""
+
+    height = 700
+    rgb = _blank_roll(height)
+    clear = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    rgb_i = rgb.astype(np.int64)
+    rgb_i[104:110, 2:92] = clear
+    rgb_i[146:153, 2:92] = clear
+    rgb = rgb_i.clip(0, 65_535).astype(np.uint16)
+    records = _clean_records(height)
+    # Snaps to (104, 152): 48 rows, short of the 56-row floor on purpose --
+    # must refuse identically on first call and replay.
+    picks = [100, 156]
+
+    for _ in range(2):
+        with pytest.raises(IndexDecodeError, match="shorter than the 15 mm floor"):
+            manual_frames.build_manual_detection(
+                rgb, _known(rgb), picks, nominal_frame_rows=143, records=records
+            )
+
+
 # --------------------------------------------------------------------------
 # Shape/completeness gates
 # --------------------------------------------------------------------------
@@ -392,3 +828,74 @@ def test_refuses_an_incomplete_preview() -> None:
         manual_frames.build_manual_detection(
             rgb, known, boundaries, nominal_frame_rows=143, records=records
         )
+
+
+def test_far_substitute_extrapolates_at_the_anchor_instead_of_drifting() -> None:
+    """Re-review 2026-08-08, F-A: symmetric corruption around a narrow run's
+    trailing edge left the local fit's median seed standing while pushing the
+    nearest trusted row far from the anchor. The uncapped nearest-inlier
+    substitute then silently displaced the origin by up to 22 rows through
+    gates that all read zero residual. Beyond the 3-row cap the origin must
+    now extrapolate AT the anchor from the surviving fit -- landing within
+    one step of the true line -- and carry the clamp reason truthfully."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    records = list(_clean_records(len(rgb)))
+    target = boundaries[3]
+    run_end = target + 3
+    for offset in range(-12, 13):
+        row = run_end + offset
+        if not 0 <= row < len(records):
+            continue
+        if abs(offset) <= 8:
+            spoiled = records[row]
+            records[row] = TransportRecord(
+                row=spoiled.row,
+                code=spoiled.code,
+                selector=spoiled.selector,
+                native_origin=spoiled.native_origin
+                + (30_000 if offset % 2 else -30_000),
+            )
+
+    result = manual_frames.build_manual_detection(
+        rgb,
+        np.ones_like(rgb, dtype=bool),
+        list(boundaries),
+        nominal_frame_rows=145,
+        records=records,
+    )
+
+    frame4 = result.mapping.origins[3]
+    assert abs(frame4.native_origin - 42 * run_end) <= 84
+    assert TRANSPORT_ORIGIN_CLAMP_REASON in frame4.review_reasons or (
+        manual_frames.INFERRED_ORIGIN_REVIEW_REASON in frame4.review_reasons
+    )
+
+
+def test_lookup_far_from_pick_earns_its_own_review_reason() -> None:
+    """Re-review 2026-08-08, F-B: an 18-row clear band inside a frame pulls
+    the trailing-edge anchor well away from the operator's line with no
+    other signal; the divergence now carries an explicit review reason."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    clear_row = rgb[boundaries[2]].copy()
+    # Extend boundary 2's natural clear run (rows b-3..b+3) to a 20-row
+    # band b-3..b+17 -- still narrow (<= 20), so the trailing-edge anchor
+    # lands at b+17 while the operator's line stays at b: a 17-row
+    # divergence with no snap and no other signal.
+    rgb[boundaries[2] + 3 : boundaries[2] + 17] = clear_row
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb,
+        np.ones_like(rgb, dtype=bool),
+        list(boundaries),
+        nominal_frame_rows=145,
+        records=records,
+    )
+
+    frame3 = result.mapping.origins[2]
+    assert abs(frame3.lookup_row - result.detection.boundaries[2].output_row) > 4
+    assert (
+        manual_frames.LOOKUP_FAR_FROM_PICK_REVIEW_REASON in frame3.review_reasons
+    )

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_diagnosis.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_diagnosis.py
@@ -1,0 +1,389 @@
+"""Contracts for the read-only roll-refusal diagnosis pass.
+
+Reuses the synthetic raster builders from test_roll_index.py (the one
+cross-file test dependency documented in tests/conftest.py) instead of
+duplicating them, so a change to the builders' conventions cannot silently
+drift the two test files apart.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from coolscanpy.protocol.ls5000_single_pass import roll_diagnosis as diagnosis
+from coolscanpy.protocol.ls5000_single_pass import roll_index as roll
+from tests.protocol.ls5000_single_pass.test_roll_index import (
+    _synthetic_roll,
+    _synthetic_roll_with_gap_rows,
+)
+
+NOMINAL_FRAME_ROWS = 145
+
+
+def _low_contrast_roll() -> np.ndarray:
+    """A healthy roll whose interior inter-frame gaps read ~0.83-0.86 relative
+    transmission instead of the usual ~0.95+.
+
+    Scaling only the *interior* gap bands (never the leader/tail) keeps the
+    clear-film p99 reference anchored to unscaled film, so the scaled gaps
+    genuinely read as dim rather than silently re-normalizing away (the
+    detector's own clear-film reference is the raster's own p99 -- scaling
+    every clear-film row uniformly, leader and tail included, changes
+    nothing, per FEEDING-ROBUSTNESS-20260805.md Sec 0 finding 3).
+    """
+
+    rgb, boundaries = _synthetic_roll(8, leader=60, tail=60, pitch=143)
+    scaled = rgb.astype(np.float64)
+    for boundary in boundaries[1:-1]:
+        lo, hi = max(0, boundary - 3), min(len(rgb), boundary + 3)
+        scaled[lo:hi, 2:92] *= 0.85
+    return np.clip(scaled, 0, 65_535).astype(np.uint16)
+
+
+def _obstructed_roll() -> np.ndarray:
+    """A healthy roll with its leading ~18 aperture columns dimmed to 70%.
+
+    70% clears the measured obstruction cliff (15/96 columns @ 70% fails
+    detection with string A per FEEDING-ROBUSTNESS-20260805.md Sec 3.3) with
+    a wide margin, exactly like the field mechanism it stands in for: a
+    carrier mask edge or curl shadow depressing one side of the window.
+    """
+
+    rgb, _boundaries = _synthetic_roll(10, leader=30, tail=30)
+    dimmed = rgb.astype(np.float64)
+    dimmed[:, 2:20] *= 0.70
+    return np.clip(dimmed, 0, 65_535).astype(np.uint16)
+
+
+def _known(rgb: np.ndarray) -> np.ndarray:
+    return np.ones_like(rgb, dtype=bool)
+
+
+# ---------------------------------------------------------------------------
+# Structural guarantee: str | None, always -- never RollDetection/GapBoundary/
+# a raised exception, no matter what the input looks like.
+
+
+def _structural_scenarios() -> list[tuple[str, np.ndarray, np.ndarray, int]]:
+    healthy_rgb, _ = _synthetic_roll(24, leader=17, tail=21)
+    half_frame_rgb, _ = _synthetic_roll(20, pitch=71, leader=30, tail=30)
+    panorama_rgb, _ = _synthetic_roll(8, pitch=259, leader=30, tail=30)
+    narrow_boundary_rows = [200 + index * 143 for index in range(6)]
+    narrow_rgb = _synthetic_roll_with_gap_rows(
+        narrow_boundary_rows, height=6 * 145 + 200, band_halfwidth=1
+    )
+    wide_rgb = _synthetic_roll_with_gap_rows(
+        narrow_boundary_rows, height=6 * 145 + 200, band_halfwidth=13
+    )
+    low_contrast_rgb = _low_contrast_roll()
+    obstructed_rgb = _obstructed_roll()
+    too_short_rgb, _ = _synthetic_roll(2, leader=5, tail=5)
+    garbage_rgb = np.zeros((10, 96, 3), dtype=np.uint16)
+
+    return [
+        ("healthy", healthy_rgb, _known(healthy_rgb), NOMINAL_FRAME_ROWS),
+        ("half_frame", half_frame_rgb, _known(half_frame_rgb), NOMINAL_FRAME_ROWS),
+        ("panorama", panorama_rgb, _known(panorama_rgb), NOMINAL_FRAME_ROWS),
+        ("narrow_gaps", narrow_rgb, _known(narrow_rgb), NOMINAL_FRAME_ROWS),
+        ("wide_gaps", wide_rgb, _known(wide_rgb), NOMINAL_FRAME_ROWS),
+        (
+            "low_contrast",
+            low_contrast_rgb,
+            _known(low_contrast_rgb),
+            NOMINAL_FRAME_ROWS,
+        ),
+        ("obstructed", obstructed_rgb, _known(obstructed_rgb), NOMINAL_FRAME_ROWS),
+        (
+            "too_short_for_pitch_detection",
+            too_short_rgb,
+            _known(too_short_rgb),
+            NOMINAL_FRAME_ROWS,
+        ),
+        ("all_zero_garbage", garbage_rgb, _known(garbage_rgb), NOMINAL_FRAME_ROWS),
+        (
+            "mismatched_known_shape",
+            garbage_rgb,
+            np.ones((5, 96, 3), dtype=bool),
+            NOMINAL_FRAME_ROWS,
+        ),
+        (
+            "all_incomplete_known",
+            healthy_rgb,
+            np.zeros_like(healthy_rgb, dtype=bool),
+            NOMINAL_FRAME_ROWS,
+        ),
+        ("nominal_below_floor", healthy_rgb, _known(healthy_rgb), 5),
+        ("nominal_zero", healthy_rgb, _known(healthy_rgb), 0),
+        (
+            "one_dimensional_raster",
+            np.zeros(10, dtype=np.uint16),
+            np.ones(10, dtype=bool),
+            NOMINAL_FRAME_ROWS,
+        ),
+    ]
+
+
+_SCENARIOS = _structural_scenarios()
+
+
+@pytest.mark.parametrize(
+    ("label", "rgb16", "known", "nominal_frame_rows"),
+    _SCENARIOS,
+    ids=[scenario[0] for scenario in _SCENARIOS],
+)
+def test_diagnose_roll_refusal_always_returns_str_or_none(
+    label: str,
+    rgb16: np.ndarray,
+    known: np.ndarray,
+    nominal_frame_rows: int,
+) -> None:
+    result = diagnosis.diagnose_roll_refusal(
+        rgb16, known, nominal_frame_rows=nominal_frame_rows
+    )
+    assert result is None or isinstance(result, str)
+
+
+def test_module_never_references_detection_result_types_or_the_wrapper() -> None:
+    """Grep-level guarantee: this module cannot construct or even name a
+    detection result. Source-text check, not an import-time property, so a
+    future ``from .roll_index import RollDetection`` (even if unused) still
+    fails this the same way a real violation would.
+    """
+
+    source = Path(diagnosis.__file__).read_text()
+    for forbidden in ("RollDetection", "GapBoundary", "detect_roll_frames"):
+        assert forbidden not in source, (
+            f"{forbidden!r} must never appear in roll_diagnosis.py"
+        )
+
+
+# ---------------------------------------------------------------------------
+# One test per diagnosis class (priority order 1-4; half-frame and panorama
+# are both the alternate-pitch check, class 1).
+
+
+def test_half_frame_pitch_is_recognized() -> None:
+    rgb = _synthetic_roll(20, pitch=71, leader=30, tail=30)[0]
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "half-frame film" in sentence
+    assert "19 mm" in sentence
+    assert "standard 35 mm spacing" in sentence
+
+
+def test_panoramic_pitch_is_recognized() -> None:
+    rgb = _synthetic_roll(8, pitch=259, leader=30, tail=30)[0]
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "panoramic film" in sentence
+    assert "69 mm" in sentence
+    assert "standard 35 mm spacing" in sentence
+
+
+def test_narrow_gaps_are_recognized() -> None:
+    boundary_rows = [200 + index * 143 for index in range(6)]
+    rgb = _synthetic_roll_with_gap_rows(
+        boundary_rows, height=6 * 145 + 200, band_halfwidth=1
+    )
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "blank strips between your frames" in sentence
+    assert "0.5 mm" in sentence
+    assert "0.8 mm" in sentence
+
+
+def test_wide_gaps_are_recognized() -> None:
+    boundary_rows = [200 + index * 143 for index in range(6)]
+    rgb = _synthetic_roll_with_gap_rows(
+        boundary_rows, height=6 * 145 + 200, band_halfwidth=13
+    )
+    # Confirm the fixture actually exceeds the recovery ceiling, so this
+    # test is exercising "too wide", not some other accepted width.
+    aperture = roll._active_aperture(rgb)
+    _evidence, _transmission, _nonuniformity, direct = roll._physical_gap_evidence(
+        rgb, aperture
+    )
+    widths = [end - start for start, end in roll._true_runs(direct)]
+    assert all(width > roll.WIDE_GAP_CEILING_ROWS for width in widths)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "a blank region measures" in sentence
+    assert "wider than anything the detector accepts" in sentence
+
+
+def test_low_contrast_gaps_are_recognized() -> None:
+    rgb = _low_contrast_roll()
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "only slightly clearer than the frames themselves" in sentence
+    assert "fog or a dense film base" in sentence
+
+
+def test_aperture_obstruction_is_recognized() -> None:
+    rgb = _obstructed_roll()
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "partly blocked" in sentence
+    assert "leading side" in sentence
+    assert "film holder seating and film curl" in sentence
+
+
+# ---------------------------------------------------------------------------
+# Wiring: detect_roll_frames's failure paths attach diagnostics["probable_
+# cause"] when (and only when) a diagnosis fires, without touching the
+# error id, message prefix, or any pre-existing diagnostics key.
+
+
+def test_wiring_attaches_probable_cause_without_changing_error_id_or_existing_keys() -> (
+    None
+):
+    boundary_rows = [200 + index * 143 for index in range(6)]
+    rgb = _synthetic_roll_with_gap_rows(
+        boundary_rows, height=6 * 145 + 200, band_halfwidth=1
+    )
+    known = _known(rgb)
+
+    # The undecorated pass-1 error -- exactly what today's behavior is
+    # without any diagnosis wired in.
+    with pytest.raises(roll.IndexDecodeError) as baseline_excinfo:
+        roll._detect_roll_frames_single(
+            rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS
+        )
+    baseline = baseline_excinfo.value
+
+    with pytest.raises(roll.IndexDecodeError) as wired_excinfo:
+        roll.detect_roll_frames(rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS)
+    wired = wired_excinfo.value
+
+    assert wired.error_id == baseline.error_id == roll.GAP_COUNT_FLOOR_ERROR_ID
+    assert str(wired).split(" [")[0] == str(baseline).split(" [")[0]
+    for key, value in (baseline.diagnostics or {}).items():
+        assert wired.diagnostics[key] == value
+    assert set(wired.diagnostics) - set(baseline.diagnostics or {}) == {
+        "wide_gap_recovery",
+        "probable_cause",
+    }
+
+    expected_sentence = diagnosis.diagnose_roll_refusal(
+        rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert expected_sentence is not None
+    assert wired.diagnostics["probable_cause"] == expected_sentence
+
+
+def test_wiring_adds_no_probable_cause_key_when_no_check_fires() -> None:
+    """A raster whose actual failure mode (one gap 30 rows off-lattice) does
+    not match any of the four diagnosis classes must raise exactly today's
+    error -- diagnosis returning ``None`` must never add the key.
+    """
+
+    # Matches test_roll_index.py's own off-lattice-gap fixture: three narrow
+    # gaps clear the count floor, but the third is 30 rows off the pitch the
+    # other two establish.
+    boundary_rows = [200, 345, 520]
+    rgb = _synthetic_roll_with_gap_rows(boundary_rows, height=6 * 145, band_halfwidth=3)
+    known = _known(rgb)
+
+    assert (
+        diagnosis.diagnose_roll_refusal(
+            rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS
+        )
+        is None
+    )
+
+    with pytest.raises(roll.IndexDecodeError) as excinfo:
+        roll.detect_roll_frames(rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS)
+    error = excinfo.value
+    assert error.error_id == roll.GAP_LATTICE_ANCHOR_ERROR_ID
+    assert "probable_cause" not in error.diagnostics
+
+
+def test_incomplete_index_error_never_carries_probable_cause() -> None:
+    """IncompleteIndexError re-raises untouched (task boundary: this is not
+    a roll-geometry refusal the diagnosis pass has any business commenting
+    on -- the raster is simply missing rows).
+    """
+
+    rgb, _boundaries = _synthetic_roll(5)
+    known = _known(rgb)
+    known[: rgb.shape[0] // 10] = False
+
+    with pytest.raises(roll.IncompleteIndexError) as excinfo:
+        roll.detect_roll_frames(rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS)
+    error = excinfo.value
+    assert error.diagnostics is None
+    assert "probable_cause" not in str(error)
+
+
+# ---------------------------------------------------------------------------
+# No false positives: healthy film must never receive an invented cause.
+# Belt-and-braces -- diagnose_roll_refusal never runs on healthy film in
+# production (it is only ever called from a failure path), but the
+# structural contract holds regardless of what a caller hands it.
+
+
+@pytest.mark.parametrize(
+    ("frame_count", "pitch", "leader", "tail"),
+    [
+        (24, 143, 17, 21),
+        (8, 143, 91, 47),
+        (36, 143, 300, 21),
+        (6, 143, 0, 3),
+        (10, 143, 300, 260),
+        (4, 123, 30, 30),
+        (4, 167, 30, 30),
+        (20, 145, 30, 30),
+    ],
+    ids=[
+        "typical_leader_trailer",
+        "short_leader_long_trailer",
+        "long_leader_short_trailer",
+        "no_leader_minimal_trailer",
+        "very_long_leader_and_trailer",
+        "pitch_at_low_edge_of_standard_band",
+        "pitch_at_high_edge_of_standard_band",
+        "pitch_equals_nominal",
+    ],
+)
+def test_healthy_roll_never_invents_a_cause(
+    frame_count: int, pitch: int, leader: int, tail: int
+) -> None:
+    rgb, _boundaries = _synthetic_roll(
+        frame_count, pitch=pitch, leader=leader, tail=tail
+    )
+    assert (
+        diagnosis.diagnose_roll_refusal(
+            rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+        )
+        is None
+    )
+
+
+def test_healthy_roll_succeeds_normally_through_the_wrapper_with_no_probable_cause() -> (
+    None
+):
+    """End-to-end sanity: wiring diagnosis into the failure paths must not
+    perturb the success path at all."""
+
+    rgb, _boundaries = _synthetic_roll(24, leader=17, tail=21)
+    known = _known(rgb)
+    detection = roll.detect_roll_frames(
+        rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert detection.confidence == "high"

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_diagnosis.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_diagnosis.py
@@ -387,3 +387,127 @@ def test_healthy_roll_succeeds_normally_through_the_wrapper_with_no_probable_cau
         rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS
     )
     assert detection.confidence == "high"
+
+
+def test_one_sided_band_never_reads_as_fog(synthetic_roll_factory=None) -> None:
+    """Adversarial review 2026-08-08, F5: a mild one-sided aperture band
+    (84% brightness, sitting just above the obstruction check's own ratio)
+    dragged gap rows into the contrast near-miss window and fired the
+    fog/dense-base sentence -- physically wrong advice. The contrast check
+    now requires column symmetry, so this construction yields either the
+    obstruction sentence or silence, never fog."""
+
+    rgb, _boundaries = _synthetic_roll(6)
+    banded = rgb.astype(np.float64)
+    banded[:, 2:16] *= 0.84
+    banded = banded.astype(rgb.dtype)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        banded, np.ones_like(banded, dtype=bool), nominal_frame_rows=145
+    )
+
+    assert sentence is None or "partly blocked" in sentence
+    assert sentence is None or "fog" not in sentence
+
+
+def test_uniform_dimming_still_reads_as_fog_when_clustered() -> None:
+    """The symmetry guard must not silence the genuine fog case: a
+    column-uniform near-miss depression keeps its sentence."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    dimmed = rgb.astype(np.float64)
+    for boundary in boundaries:
+        lo = max(0, boundary - 3)
+        hi = min(len(dimmed), boundary + 3)
+        dimmed[lo:hi] *= 0.86
+    dimmed = dimmed.astype(rgb.dtype)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        dimmed, np.ones_like(dimmed, dtype=bool), nominal_frame_rows=145
+    )
+
+    assert sentence is not None and "fog" in sentence
+
+
+def test_subclassed_refusals_pass_through_unreconstructed(monkeypatch) -> None:
+    """Adversarial review 2026-08-08, F6: attaching a probable-cause
+    sentence must never rebuild an IndexDecodeError SUBCLASS into the bare
+    base class -- subclasses carry their own constructor signatures,
+    structured fields, and dedicated downstream handling."""
+
+    class StructuredRefusal(roll.IndexDecodeError):
+        def __init__(self) -> None:
+            super().__init__("structured refusal with its own contract")
+            self.structured_field = 42
+
+    def raise_structured(*args, **kwargs):
+        raise StructuredRefusal()
+
+    monkeypatch.setattr(roll, "_detect_roll_frames_single", raise_structured)
+    rgb, _boundaries = _synthetic_roll(4)
+
+    with pytest.raises(StructuredRefusal) as excinfo:
+        roll.detect_roll_frames(
+            rgb,
+            np.ones_like(rgb, dtype=bool),
+            nominal_frame_rows=145,
+            expected_frame_count=None,
+        )
+    assert excinfo.value.structured_field == 42
+    assert "probable_cause" not in str(excinfo.value)
+
+
+def test_dark_image_composition_along_one_side_is_not_an_obstruction() -> None:
+    """Adversarial review 2026-08-08, S9: a roll whose photographs carry
+    dark content along one side must not read as a blocked film window --
+    the depression exists only where there is picture, so the brightest
+    (clear-film) rows show no one-sided dip and the check stays silent."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    composed = rgb.astype(np.float64)
+    for start, end in zip(boundaries, boundaries[1:]):
+        frame_lo = start + 5
+        frame_hi = end - 5
+        composed[frame_lo:frame_hi, 2:20] *= 0.55  # dark subject edge, frames only
+    composed = composed.astype(rgb.dtype)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        composed, np.ones_like(composed, dtype=bool), nominal_frame_rows=145
+    )
+
+    assert sentence is None or "partly blocked" not in sentence
+
+
+def test_true_obstruction_on_clear_rows_still_reads_as_blocked() -> None:
+    """The bright-row restriction must not silence a genuine obstruction:
+    a fixed 70% band across every row (gaps included) keeps its sentence."""
+
+    rgb, _boundaries = _synthetic_roll(6)
+    blocked = rgb.astype(np.float64)
+    blocked[:, 2:20] *= 0.70
+    blocked = blocked.astype(rgb.dtype)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        blocked, np.ones_like(blocked, dtype=bool), nominal_frame_rows=145
+    )
+
+    assert sentence is not None and "partly blocked" in sentence
+
+
+def test_gapless_roll_never_reads_as_obstruction() -> None:
+    """Re-review 2026-08-08, F-C: on a roll with NO clear rows at all, the
+    p99 'clear' reference lands on bright frame rows, and one-sided scene
+    content resurrected the phantom blocked-window sentence. With the
+    separation floor, a raster whose brightest rows are not clearly apart
+    from typical rows stays silent on obstruction."""
+
+    gapless_rgb = _synthetic_roll_with_gap_rows([], height=6 * 145)
+    gapless = gapless_rgb.astype(np.float64)
+    gapless[:, 2:20] *= 0.55  # one-sided dark composition
+    gapless = gapless.astype(gapless_rgb.dtype)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        gapless, np.ones_like(gapless, dtype=bool), nominal_frame_rows=145
+    )
+
+    assert sentence is None or "partly blocked" not in sentence

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -1,5 +1,6 @@
 """Regression contracts for whole-roll index decoding and dynamic frame origins."""
 
+import hashlib
 import json
 import math
 import os
@@ -9,6 +10,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from coolscanpy.protocol.ls5000_single_pass import manual_frames
 from coolscanpy.protocol.ls5000_single_pass import roll_index as roll
 
 
@@ -36,6 +38,20 @@ LIVE_PREVIEW = (
     LIVE_PREVIEW_ATTEMPT / "capture-preview.bin" if LIVE_PREVIEW_ATTEMPT else None
 )
 LIVE_TABLE = LIVE_PREVIEW_ATTEMPT / "capture-008e.bin" if LIVE_PREVIEW_ATTEMPT else None
+
+# Manual-placement rework (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, F1/F4):
+# the 51-table regression. Every capture-preview.bin/capture-008e.bin pair
+# anywhere under this root is a real archived LS-5000 traversal from this
+# project's own reverse-engineering and live-validation work -- exactly the
+# corpus the adversarial review used to prove the pre-rework gate 4 refused
+# 51 of 51 real captures at the first frame edge. Defaults to this
+# developer machine's own copy (present for this project's own contributor;
+# absent everywhere else, including CI), and skips cleanly either way,
+# following the same convention as COOLSCANPY_SINGLE_PASS_WIRE_DIR and
+# COOLSCANPY_LIVE_PREVIEW_ATTEMPT_DIR above.
+_ARCHIVE_ROOT_ENV = "COOLSCANPY_ARCHIVE_ROOT"
+_default_archive_root = "/Users/rohan/Downloads/digital-ice-2026"
+ARCHIVE_ROOT = Path(os.environ.get(_ARCHIVE_ROOT_ENV, _default_archive_root))
 
 
 def _encode_index(rgb16: np.ndarray) -> bytes:
@@ -1507,3 +1523,197 @@ def test_all_wide_no_narrow_anchors_refuses_mapping() -> None:
 
     with pytest.raises(roll.IndexDecodeError, match="three direct physical gaps"):
         roll.derive_transport_mapping(boundaries, 3, records)
+
+
+# ---------------------------------------------------------------------------
+# Manual placement rework (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, F1/F4):
+# the 51-table archive regression.
+# ---------------------------------------------------------------------------
+
+
+def _archive_capture_pairs(root: Path) -> list[tuple[Path, Path]]:
+    """Every (preview, table) pair under root, deduped by preview SHA-256."""
+
+    if not root.is_dir():
+        return []
+    seen: set[str] = set()
+    pairs: list[tuple[Path, Path]] = []
+    for preview_path in sorted(root.rglob("capture-preview.bin")):
+        table_path = preview_path.with_name("capture-008e.bin")
+        if not table_path.is_file():
+            continue
+        digest = hashlib.sha256(preview_path.read_bytes()).hexdigest()
+        if digest in seen:
+            continue
+        seen.add(digest)
+        pairs.append((preview_path, table_path))
+    return pairs
+
+
+_ARCHIVE_PAIRS = _archive_capture_pairs(ARCHIVE_ROOT)
+
+
+@pytest.mark.skipif(
+    not _ARCHIVE_PAIRS,
+    reason=(
+        "no archived capture-preview.bin/capture-008e.bin pairs found; set "
+        f"{_ARCHIVE_ROOT_ENV} to a directory tree containing them to run "
+        "this regression"
+    ),
+)
+def test_manual_placement_accepts_every_archived_automatic_boundary_set() -> None:
+    """F1/F4 acceptance gate: feed every real archived capture's own
+    AUTOMATIC boundary rows into build_manual_detection, using the exact
+    same same-traversal transport table. The placement must be accepted --
+    this is the specific defect the pre-rework gate 4 had: adversarial
+    review measured it refusing 51 of 51 real captures at the first frame
+    edge, because a real live 0x8e table's deterministic ~18-row code
+    lattice (selector-rollover jumps of roughly +798/-700 native units,
+    smaller sub-rollover jumps within each cycle -- see manual_frames.py's
+    own module docstring) fails a per-step "every row within 3 of a pick
+    must be 40..45 units" guard almost everywhere.
+
+    Every resolved origin must also land close to derive_transport_
+    mapping's own origin for the same boundary. Origins derive_transport_
+    mapping itself marks "automatic" (a clean, directly-read narrow gap --
+    the overwhelming majority in this corpus) must match within 2.0
+    preview rows (~85 native units), the same interior-anchor bound the
+    automatic path enforces on itself. Origins it marks manual_review (a
+    broad or weak-evidence region even automatic could not read directly --
+    a small minority) are held to a looser, still-bounded 5.0 rows, the
+    same wobble allowance this codebase already grants its own
+    leading-anchor divergence (MAXIMUM_LEADING_ANCHOR_ERROR_ROWS in this
+    module) -- comparing two independent estimates of an already-uncertain
+    position is not the same claim as comparing against a proven direct
+    read, and this test does not pretend otherwise.
+    """
+
+    accepted = 0
+    expected_ceiling_refusals = 0
+    trusted_deltas: list[float] = []
+    inferred_deltas: list[float] = []
+
+    for preview_path, table_path in _ARCHIVE_PAIRS:
+        preview_bytes = preview_path.read_bytes()
+        table_bytes = table_path.read_bytes()
+        # IndexGeometry derived purely from the preview file's own byte
+        # length (decode_full_index_bytes needs nothing more than height,
+        # width, block_bytes, and their product) -- this corpus spans many
+        # independent capture campaigns with different allocated preview
+        # heights, and native_height is not needed by anything this test
+        # calls (it matters to worker.py's own fine-window-overflow check,
+        # out of scope here).
+        height = len(preview_bytes) // (roll.INDEX_ROW_WORDS * 2)
+        geometry = roll.IndexGeometry(
+            requested_resolution=97,
+            native_resolution=4_000,
+            pitch=41,
+            native_width=3_946,
+            native_height=height * 41,
+            width=96,
+            height=height,
+            block_bytes=2_048,
+            expected_stream_bytes=height * roll.INDEX_ROW_WORDS * 2,
+        )
+        table, usable_rows = roll.validate_live_0x8e_bytes(table_bytes, geometry.height)
+        rgb, known, _report = roll.decode_full_index_bytes(
+            preview_bytes, geometry, usable_rows=usable_rows
+        )
+        try:
+            detection = roll.detect_roll_frames(
+                rgb, known, nominal_frame_rows=5_959 // geometry.pitch
+            )
+        except roll.IndexDecodeError:
+            # Automatic detection itself refused this capture (e.g. the
+            # vendored tree's leading-frame-clip gate on a strip whose
+            # first frame starts before the raster) -- out of this gate's
+            # scope exactly like a below-high confidence result.
+            continue
+        if detection.confidence != "high":
+            continue  # automatic did not succeed; out of this gate's scope
+        records = roll.parse_live_transport_records_bytes(
+            table, maximum_rows=geometry.height
+        )
+        scanner_frame_count = roll.scanner_addressable_interval_count(detection.intervals)
+        try:
+            auto_mapping = roll.derive_transport_mapping(
+                detection.boundaries, scanner_frame_count, records
+            )
+        except roll.IndexDecodeError:
+            continue  # automatic itself did not succeed; out of scope
+
+        boundary_rows = [
+            b.output_row for b in detection.boundaries[: scanner_frame_count + 1]
+        ]
+        try:
+            manual_result = manual_frames.build_manual_detection(
+                rgb,
+                known,
+                boundary_rows,
+                nominal_frame_rows=5_959 // geometry.pitch,
+                records=records,
+            )
+        except roll.IndexDecodeError as error:
+            # F2 (this same rework) is a deliberate NEW restriction: a
+            # frame taller than the fine capture window now refuses rather
+            # than silently truncating. If automatic's own high-confidence
+            # lattice fit happened to place two boundaries far enough apart
+            # to trip that new ceiling, refusing here is correct, not a
+            # regression -- count it, but do not let it slip past as an
+            # unnoticed acceptance failure either.
+            if "there is no way to capture a taller frame" in str(error):
+                expected_ceiling_refusals += 1
+                continue
+            pytest.fail(
+                f"{preview_path}: manual placement refused automatic's own "
+                f"boundary rows: {error}"
+            )
+
+        accepted += 1
+        scale = auto_mapping.native_units_per_preview_row
+        for auto_origin, manual_origin in zip(
+            auto_mapping.origins, manual_result.mapping.origins
+        ):
+            delta_rows = (manual_origin.native_origin - auto_origin.native_origin) / scale
+            if auto_origin.automatic:
+                trusted_deltas.append(delta_rows)
+            else:
+                inferred_deltas.append(delta_rows)
+
+    total_eligible = accepted + expected_ceiling_refusals
+    print(
+        f"\ngate A: {len(_ARCHIVE_PAIRS)} unique archived captures; "
+        f"{total_eligible} automatic-high-confidence and eligible; "
+        f"{accepted} accepted, {expected_ceiling_refusals} correctly refused "
+        "(F2 fine-capture-window ceiling)"
+    )
+    assert accepted > 0, "no eligible archived captures were accepted -- check ARCHIVE_ROOT"
+
+    trusted = np.abs(np.asarray(trusted_deltas, dtype=np.float64))
+    inferred = np.abs(np.asarray(inferred_deltas, dtype=np.float64))
+    if len(trusted):
+        print(
+            f"origin deltas vs automatic, preview rows -- trusted: n={len(trusted)} "
+            f"mean={trusted.mean():.4f} p95={np.percentile(trusted, 95):.4f} "
+            f"max={trusted.max():.4f}"
+        )
+    if len(inferred):
+        print(
+            f"origin deltas vs automatic, preview rows -- inferred: n={len(inferred)} "
+            f"mean={inferred.mean():.4f} median={np.median(inferred):.4f} "
+            f"max={inferred.max():.4f}"
+        )
+
+    if len(trusted):
+        assert trusted.max() <= 2.0, (
+            f"an automatic-trusted origin diverged {trusted.max():.3f} rows "
+            "from derive_transport_mapping's own answer for the same "
+            "boundary -- expected <= 2.0"
+        )
+    if len(inferred):
+        assert inferred.max() <= 5.0, (
+            f"an automatic-inferred origin diverged {inferred.max():.3f} "
+            "rows from derive_transport_mapping's own answer for the same "
+            "boundary -- expected <= 5.0 (this codebase's own leading-"
+            "anchor wobble allowance)"
+        )

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -526,13 +526,14 @@ def _synthetic_roll_with_gap_rows(
 
 
 def test_wide_gaps_raise_gap_count_floor_with_numeric_diagnostics() -> None:
-    """P1, site :810.  Six gaps widened to 20 rows (>12, discarded as "wide")
-    leaves zero narrow runs -- confirms the id and every field the predicate
-    actually evaluated.
+    """P1, site :810.  Six gaps widened to 26 rows -- past even the recovery
+    ceiling (FEEDING-DETECTOR-ROUND-20260807) -- leaves zero anchorable runs
+    in both passes: confirms the id, every field the predicate evaluated,
+    and the recovery note the failed second pass appends.
     """
     boundary_rows = [200 + index * 143 for index in range(6)]
     rgb = _synthetic_roll_with_gap_rows(
-        boundary_rows, height=6 * 145 + 200, band_halfwidth=10
+        boundary_rows, height=6 * 145 + 200, band_halfwidth=13
     )
 
     with pytest.raises(roll.IndexDecodeError) as excinfo:
@@ -545,10 +546,11 @@ def test_wide_gaps_raise_gap_count_floor_with_numeric_diagnostics() -> None:
     assert diagnostics["narrow_run_count"] == 0
     assert diagnostics["narrow_run_count_required"] == 3
     assert diagnostics["evidence_run_count"] == 6
-    assert diagnostics["discarded_wide_widths"] == [20] * 6
+    assert diagnostics["discarded_wide_widths"] == [26] * 6
     assert diagnostics["discarded_narrow_widths"] == []
     assert diagnostics["raster_rows"] == rgb.shape[0]
     assert diagnostics["aperture_width"] == 90
+    assert "wide_gap_recovery" in diagnostics
     assert json.dumps(diagnostics, sort_keys=True) in str(error)
 
 
@@ -1258,3 +1260,250 @@ def test_persisted_gold36_expected_count_and_frame18_origin() -> None:
     )
     assert mismatched.frame_starts == detection.frame_starts
     assert not mismatched.expected_frame_count_matches
+
+
+# ---------------------------------------------------------------------------
+# Wide-gap recovery (FEEDING-DETECTOR-ROUND-20260807): pass 1 is the stock
+# detector, byte-identical; a single recovery pass runs only when pass 1
+# raises one of the three physical-gap floors, admits wide clear-film runs
+# (12 < width <= WIDE_GAP_CEILING_ROWS) as gap anchors, and can never
+# produce an automatic, unattended, or high-confidence result.
+
+
+def _synthetic_roll_with_mixed_gap_rows(
+    gaps: list[tuple[int, int]],
+    *,
+    height: int,
+) -> np.ndarray:
+    """Like ``_synthetic_roll_with_gap_rows`` but with a per-gap half-width,
+    so one raster can carry narrow, wide, and sliver clear-film runs at once
+    (the webmogul1 beta.3 field signature, ScanStudio #23/#24)."""
+
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[:, :, channel] = base + texture * (3 - channel) // 2
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    clear_noise = ((x * 19 + y * 13) % 301 - 150)[:, :, None]
+    for boundary, half_width in gaps:
+        lo = max(0, boundary - half_width)
+        hi = min(height, boundary + half_width)
+        aperture[lo:hi] = clear_base + clear_noise[lo:hi]
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16)
+
+
+def test_wide_gap_recovery_rescues_two_narrow_plus_one_wide_gap() -> None:
+    """The field signature: two narrow gaps plus one wide (14-row) gap on a
+    short strip. Pass 1 refuses at the count floor; the recovery pass
+    resolves it -- capped at medium, wide slot under manual review, recovery
+    warning present, and the wide boundary carries the distinct support
+    class instead of ``cadence-broad``."""
+
+    gaps = [(200, 2), (343, 3), (486, 7)]  # widths 4, 6, 14
+    rgb = _synthetic_roll_with_mixed_gap_rows(gaps, height=4 * 145 + 200)
+
+    detection = _detect(rgb)
+
+    assert detection.confidence == "medium"
+    assert "wide-gap-recovery" in detection.warnings
+    supports = [boundary.support for boundary in detection.boundaries]
+    assert supports.count("direct-wide") == 1
+    wide = next(b for b in detection.boundaries if b.support == "direct-wide")
+    assert wide.manual_review
+    assert "wide-gap-anchor" in wide.review_reasons
+    assert wide.evidence_run is not None
+    assert wide.evidence_run[1] - wide.evidence_run[0] == 14
+
+
+def test_pass_one_success_never_enters_recovery_even_with_a_wide_gap() -> None:
+    """Strict superset: a roll pass 1 already resolves -- plenty of narrow
+    gaps, one broad clear region -- must return the stock single-pass result
+    exactly, bit-identical: no recovery warning, no direct-wide support, no
+    confidence cap."""
+
+    rgb, boundaries = _synthetic_roll(8)
+    lo, hi = boundaries[4] - 8, boundaries[4] + 8  # broaden one gap to 16 rows
+    clear = rgb[boundaries[4]].copy()
+    rgb[lo:hi] = clear
+
+    detection = _detect(rgb)
+    stock = roll._detect_roll_frames_single(
+        rgb,
+        np.ones_like(rgb, dtype=bool),
+        nominal_frame_rows=145,
+        expected_frame_count=None,
+    )
+
+    assert detection == stock
+    assert "wide-gap-recovery" not in detection.warnings
+    supports = {boundary.support for boundary in detection.boundaries}
+    assert "direct-wide" not in supports
+    assert "cadence-broad" in supports
+
+
+def test_recovery_slivers_never_anchor_and_failure_keeps_the_original_error() -> None:
+    """F1 (adversarial review 2026-08-07): 1-2-row slivers are not wide gaps.
+    Two narrow gaps plus slivers must still refuse -- with the pass-1 error
+    id and the recovery note -- rather than letting slivers vote. And a gap
+    past the recovery ceiling (26 rows) must refuse identically."""
+
+    for extra in [(486, 1), (486, 13)]:  # width-2 sliver / width-26 run
+        gaps = [(200, 2), (343, 3), extra]
+        rgb = _synthetic_roll_with_mixed_gap_rows(gaps, height=4 * 145 + 200)
+        with pytest.raises(roll.IndexDecodeError) as excinfo:
+            _detect(rgb)
+        error = excinfo.value
+        assert error.error_id == roll.GAP_COUNT_FLOOR_ERROR_ID
+        assert "wide_gap_recovery" in error.diagnostics
+        assert error.diagnostics["narrow_run_count"] == 2
+
+
+def test_recovery_confidence_cap_is_keyed_to_the_mode() -> None:
+    """F3b (adversarial review 2026-08-07): the medium cap and the warning
+    come from running in recovery mode, not from whether a direct-wide
+    boundary survived to the output."""
+
+    gaps = [(200, 2), (343, 3), (486, 7)]
+    rgb = _synthetic_roll_with_mixed_gap_rows(gaps, height=4 * 145 + 200)
+
+    detection = _detect(rgb)
+
+    assert detection.confidence != "high"
+    assert "wide-gap-recovery" in detection.warnings
+
+
+def test_incomplete_index_never_triggers_recovery() -> None:
+    """IncompleteIndexError is a subclass of IndexDecodeError; it must pass
+    through the two-pass wrapper untouched, with no recovery note."""
+
+    rgb, _boundaries = _synthetic_roll(5)
+    known = np.ones_like(rgb, dtype=bool)
+    known[: rgb.shape[0] // 10] = False
+
+    with pytest.raises(roll.IncompleteIndexError) as excinfo:
+        roll.detect_roll_frames(
+            rgb, known, nominal_frame_rows=145, expected_frame_count=None
+        )
+    assert "wide_gap_recovery" not in str(excinfo.value)
+
+
+def _wide_boundary(index: int, row: int, run: tuple[int, int]) -> roll.GapBoundary:
+    return roll.GapBoundary(
+        index=index,
+        output_row=row,
+        fitted_row=float(row),
+        evidence=0.9,
+        transmission=0.95,
+        nonuniformity=0.08,
+        support="direct-wide",
+        evidence_run=run,
+        manual_review=True,
+        review_reasons=("wide-gap-anchor",),
+    )
+
+
+def _clean_records(count: int) -> list[roll.TransportRecord]:
+    return [
+        roll.TransportRecord(
+            row=row,
+            code=6 * (row % 18),
+            selector=row // 18,
+            native_origin=42 * row,
+        )
+        for row in range(count)
+    ]
+
+
+def test_wide_anchor_joins_the_fit_by_trailing_edge_when_narrow_count_is_two() -> None:
+    """With only two narrow direct anchors the stock fit refuses; a healthy
+    direct-wide boundary supplies the third anchor at its trailing edge
+    translated into the narrow anchors' centre space. The wide slot resolves
+    through its own trailing-edge record, never automatic; narrow slots stay
+    automatic; the fit gates are unchanged."""
+
+    records = _clean_records(900)
+    boundaries = [
+        _boundary(0, 20),
+        _boundary(1, 163),
+        _wide_boundary(2, 306, (299, 313)),
+        _boundary(3, 449, support="cadence-broad", evidence_run=(429, 469)),
+    ]
+
+    mapping = roll.derive_transport_mapping(boundaries, 4, records)
+
+    assert mapping.native_units_per_preview_row == pytest.approx(42.0)
+    wide_origin = mapping.origins[2]
+    assert wide_origin.method == "wide-gap-trailing-row"
+    assert wide_origin.native_origin == 42 * 313
+    assert not wide_origin.automatic
+    assert wide_origin.manual_review
+    assert mapping.origins[0].automatic
+    assert mapping.origins[1].automatic
+
+
+def test_wide_anchor_is_refused_when_the_local_ramp_is_spiked() -> None:
+    """F2 (adversarial review 2026-08-07): a single-record spike at the wide
+    anchor's trailing edge -- endpoints clean -- must reject the anchor
+    (per-step ramp check), leaving the fit under three anchors and the
+    mapping refused, instead of fitting to noise."""
+
+    records = _clean_records(900)
+    spiked = records[313]
+    records[313] = roll.TransportRecord(
+        row=spiked.row,
+        code=spiked.code,
+        selector=spiked.selector,
+        native_origin=spiked.native_origin + 150,
+    )
+    boundaries = [
+        _boundary(0, 20),
+        _boundary(1, 163),
+        _wide_boundary(2, 306, (299, 313)),
+        _boundary(3, 449, support="cadence-broad", evidence_run=(429, 469)),
+    ]
+
+    with pytest.raises(roll.IndexDecodeError, match="three direct physical gaps"):
+        roll.derive_transport_mapping(boundaries, 4, records)
+
+
+def test_fit_satisfied_by_narrow_anchors_resolves_wide_slot_at_trailing_edge() -> None:
+    """F4 (adversarial review 2026-08-07): when the fit already has its three
+    narrow anchors, a direct-wide slot outside the fit must still resolve at
+    its trailing edge -- the stock centre-keyed window lands ~half a gap
+    early and cannot contain the true record for wide runs."""
+
+    records = _clean_records(900)
+    boundaries = [
+        _boundary(0, 20),
+        _boundary(1, 163),
+        _boundary(2, 306),
+        _wide_boundary(3, 449, (442, 456)),
+    ]
+
+    mapping = roll.derive_transport_mapping(boundaries, 4, records)
+
+    wide_origin = mapping.origins[3]
+    assert wide_origin.native_origin == 42 * 456
+    assert not wide_origin.automatic
+    assert wide_origin.manual_review
+
+
+def test_all_wide_no_narrow_anchors_refuses_mapping() -> None:
+    """Zero narrow anchors means no measured centre-to-trailing offset; wide
+    anchors alone must not fabricate one -- the mapping refuses."""
+
+    records = _clean_records(900)
+    boundaries = [
+        _wide_boundary(0, 20, (13, 27)),
+        _wide_boundary(1, 163, (156, 170)),
+        _wide_boundary(2, 306, (299, 313)),
+    ]
+
+    with pytest.raises(roll.IndexDecodeError, match="three direct physical gaps"):
+        roll.derive_transport_mapping(boundaries, 3, records)

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -44,14 +44,15 @@ LIVE_TABLE = LIVE_PREVIEW_ATTEMPT / "capture-008e.bin" if LIVE_PREVIEW_ATTEMPT e
 # anywhere under this root is a real archived LS-5000 traversal from this
 # project's own reverse-engineering and live-validation work -- exactly the
 # corpus the adversarial review used to prove the pre-rework gate 4 refused
-# 51 of 51 real captures at the first frame edge. Defaults to this
-# developer machine's own copy (present for this project's own contributor;
-# absent everywhere else, including CI), and skips cleanly either way,
-# following the same convention as COOLSCANPY_SINGLE_PASS_WIRE_DIR and
+# 51 of 51 real captures at the first frame edge. Env-only, no baked-in
+# default: the packaged-bridge self-containment check rightly refuses any
+# bundle retaining a private source path, so the archive location lives
+# solely in the contributor's environment. Unset skips cleanly, following
+# the same convention as COOLSCANPY_SINGLE_PASS_WIRE_DIR and
 # COOLSCANPY_LIVE_PREVIEW_ATTEMPT_DIR above.
 _ARCHIVE_ROOT_ENV = "COOLSCANPY_ARCHIVE_ROOT"
-_default_archive_root = "/Users/rohan/Downloads/digital-ice-2026"
-ARCHIVE_ROOT = Path(os.environ.get(_ARCHIVE_ROOT_ENV, _default_archive_root))
+_archive_root_value = os.environ.get(_ARCHIVE_ROOT_ENV)
+ARCHIVE_ROOT = Path(_archive_root_value) if _archive_root_value else None
 
 
 def _encode_index(rgb16: np.ndarray) -> bytes:
@@ -1531,10 +1532,10 @@ def test_all_wide_no_narrow_anchors_refuses_mapping() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _archive_capture_pairs(root: Path) -> list[tuple[Path, Path]]:
+def _archive_capture_pairs(root: Path | None) -> list[tuple[Path, Path]]:
     """Every (preview, table) pair under root, deduped by preview SHA-256."""
 
-    if not root.is_dir():
+    if root is None or not root.is_dir():
         return []
     seen: set[str] = set()
     pairs: list[tuple[Path, Path]] = []

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
@@ -1467,6 +1467,11 @@ def test_batch_job_loader_binds_ordered_frame_paths_and_parent_ack_contract(
         reviewed_lookup_row=2_400,
         reviewed_native_origin=100_000,
         review_reasons=("transport-origin-inferred",),
+        # Matches this job payload's own "manual_boundary_rows": None below
+        # -- load_validated_batch_job cross-checks the two (S6 hardening).
+        manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+            None
+        ),
     )
     job_path = tmp_path / "batch-job.json"
     job_path.write_text(
@@ -1608,6 +1613,56 @@ def test_batch_job_loader_parses_valid_manual_boundary_rows(tmp_path: Path) -> N
     )
 
     assert job.manual_boundary_rows == (128, 271, 414)
+
+
+def test_batch_job_loader_refuses_a_receipt_bound_to_different_boundary_rows(
+    tmp_path: Path,
+) -> None:
+    """S6 hardening (FEEDING-UX-LADDER-OVERNIGHT-20260807.md F1 rework): a
+    manual approval receipt is only valid for the EXACT set of boundary
+    rows it was signed for. reviewed_fingerprint_sha256 alone is not
+    enough -- fingerprint comparison has deliberate tolerance for a
+    legitimate re-read (compare_reviewed_roll_fingerprints), so two
+    DIFFERENT placements of the same physical roll could still compare as
+    matching. Here the receipt was signed for [128, 271, 414] (matching
+    test_batch_job_loader_parses_valid_manual_boundary_rows's own honest
+    case) but the job claims a different placement, [128, 271, 500] --
+    same slot, same offset, same reviewed_fingerprint_sha256, everything
+    the pre-hardening checks looked at unchanged, only the actual placed
+    rows different.
+    """
+
+    fingerprint = _reviewed_fingerprint()
+    approval = ManualFrameApproval(
+        reviewed_fingerprint_sha256=fingerprint.binding_sha256,
+        slot=1,
+        boundary_offset_rows=0,
+        thumbnail_sha256="5" * 64,
+        reviewed_lookup_row=2_400,
+        reviewed_native_origin=100_000,
+        review_reasons=("user-picked-origin",),
+        manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+            (128, 271, 414)
+        ),
+    )
+    payload = _one_frame_job_payload(
+        fingerprint,
+        exposure_override_10ns=None,
+        manual_boundary_rows=[128, 271, 500],
+    )
+    payload["frames"][0]["manual_review_approval"] = approval.to_payload()
+    job_path = tmp_path / "batch-job.json"
+    job_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        ProtocolError, match="different set of placed boundaries"
+    ):
+        load_validated_batch_job(
+            job_path,
+            expected_job_sha256=hashlib.sha256(job_path.read_bytes()).hexdigest(),
+            expected_plan_sha256="a" * 64,
+            expected_continuation_sha256="b" * 64,
+        )
 
 
 def test_batch_job_loader_refuses_malformed_manual_boundary_rows(
@@ -3392,6 +3447,101 @@ def test_manual_selection_still_refuses_on_fingerprint_mismatch(
         )
 
 
+def test_manual_selection_never_qualifies_for_origin_rebase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F4 rework, single-frame path: a manual placement must not be
+    granted the leading-anchor rebase, no matter how well its fingerprints
+    match. Frame 1's live record is displaced by ~3.5 rows (inside the
+    2..5-row band that WOULD rebase for an automatic origin with matching
+    fingerprints) while every other condition for rebase is satisfied
+    (operator approval given, whole-roll and selected-slot fingerprints
+    both matching this exact displaced table); only origin_rebase_allowed
+    excluding this manual placement stands between that and a silently
+    displaced bound origin. See test_manual_batch_selection_never_
+    qualifies_for_origin_rebase for the batch-path equivalent.
+    """
+
+    # Textured, not all-zero: the reviewed fingerprint's visual signature
+    # needs real dynamic range in the signed frame region (rows 0..99) or
+    # the comparison below reports "visual-signature-indeterminate" rather
+    # than matching -- and this test needs it to match, on purpose, so
+    # origin_rebase_allowed is the only thing left to decide the outcome.
+    y = np.arange(500, dtype=np.int64)[:, None]
+    x = np.arange(96, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    rgb = np.stack([texture, texture // 2, texture // 3], axis=2).astype(np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+
+    # Frame 1's OWN live record (lookup_row=10, see _manual_gate_mapping)
+    # displaced by +147 native units (~3.5 rows). A different, still
+    # internally-consistent code (147 = 7 * 21, a reachable subposition
+    # step) keeps transport_native_origin's own identity check satisfied,
+    # the same way test_manual_batch_selection_never_qualifies_for_origin_
+    # rebase's displacement does.
+    base_records = _manual_gate_records()
+    victim = base_records[10]
+    displaced_code = victim.code + 21
+    displaced_records = (
+        base_records[:10]
+        + (
+            TransportRecord(
+                row=victim.row,
+                code=displaced_code,
+                selector=victim.selector,
+                native_origin=worker_module.transport_native_origin(
+                    displaced_code, victim.selector
+                ),
+            ),
+        )
+        + base_records[11:]
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "parse_live_transport_records_bytes",
+        lambda *_a, **_k: displaced_records,
+    )
+
+    mapping = _manual_gate_mapping()
+    detection = _manual_gate_detection(confidence="medium", user_picked=True)
+    monkeypatch.setattr(
+        worker_module,
+        "build_manual_detection",
+        lambda *_a, **_k: SimpleNamespace(
+            detection=detection, mapping=mapping, snaps=()
+        ),
+    )
+
+    # A reviewed fingerprint built from exactly the same inputs
+    # _derive_live_frame_selection will freshly recompute (mapping.origins
+    # is unchanged -- only the raw records table was displaced above, the
+    # same way a real reviewed session's own signed origin would not move
+    # just because a LATER traversal's table read differently) --
+    # constructed to match on purpose, so origin_rebase_allowed is the
+    # only thing left to decide whether this binds.
+    reviewed = build_reviewed_roll_fingerprint(
+        rgb,
+        frame_intervals=((0, 100),),
+        frame_native_origins=(420,),
+        source_preview_sha256=hashlib.sha256(b"fresh-preview").hexdigest(),
+        source_table_sha256=hashlib.sha256(b"fresh-table").hexdigest(),
+    )
+
+    with pytest.raises(
+        ProtocolError,
+        match=r"frame 1 boundary offset resolves to a transport origin",
+    ):
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            reviewed_fingerprint=reviewed,
+            manual_review_approved=True,
+            manual_boundary_rows=(10, 200),
+        )
+
+
 def test_live8_frame_table_is_the_exact_firmware_accepted_payload() -> None:
     payload = build_live_frame_table_payload(_mapping(LIVE8_TRANSPORT_FIELDS))
     send = next(entry for entry in load_canonical_plan() if entry["seq"] == 174)
@@ -4273,6 +4423,231 @@ def test_batch_selections_accept_one_addressable_sliver_beyond_reviewed(
 
     assert [selection.frame for selection in selections] == [1]
     assert bound_frames == [1]
+
+
+def test_manual_batch_selection_never_qualifies_for_origin_rebase(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F4 rework: a manual placement must not be granted the leading-anchor
+    rebase, no matter how well its fingerprints match. Frame 1's live
+    record is displaced by ~3.6 rows (inside the 2..5-row band that WOULD
+    rebase for an automatic origin -- see
+    test_leading_anchor_divergence_narrowly_auto_accepted_when_reviewed_
+    automatic for that accepted case); with every other condition for
+    rebase satisfied, only origin_rebase_slots excluding this manual
+    placement stands between that and a silently displaced bound origin.
+    """
+
+    mapping, records = _short_strip_mapping(6)
+    # Every origin manual: automatic=False, manual_review=True, exactly
+    # build_manual_detection's own shape for every frame it places.
+    mapping = replace(
+        mapping,
+        origins=tuple(
+            replace(
+                origin,
+                automatic=False,
+                manual_review=True,
+                method="user-picked-row",
+            )
+            for origin in mapping.origins
+        ),
+    )
+    # Frame 1's OWN live record (lookup_row=100, see _short_strip_mapping)
+    # displaced by +147 native units (~3.5 rows) -- apply_boundary_offset
+    # re-reads this fresh, it does not trust the origin's own stored value.
+    # A different, still internally-consistent code (147 = 7 * 21, so this
+    # stays a reachable subposition) keeps transport_native_origin's own
+    # identity check satisfied -- a real live record could not desync from
+    # that identity, and this displacement should look exactly like one.
+    records = list(records)
+    victim = records[100]
+    displaced_code = victim.code + 21
+    records[100] = TransportRecord(
+        row=victim.row,
+        code=displaced_code,
+        selector=victim.selector,
+        native_origin=worker_module.transport_native_origin(
+            displaced_code, victim.selector
+        ),
+    )
+    records = tuple(records)
+
+    reviewed = _reviewed_fingerprint_with_count(6)
+    context = _batch_selection_context(mapping, records, reviewed)
+    context.detection = SimpleNamespace(
+        warnings=(manual_frames.MANUAL_PLACEMENT_WARNING,)
+    )
+    frame_root = tmp_path / "manual-rebase-attempt"
+    # A genuine (self-consistent) receipt whose claimed values match the
+    # MAPPING's own (undisplaced) origin -- exactly what an honest approval
+    # would have recorded, since the operator reviewed this before the
+    # live table above was displaced. This is what lets the scenario reach
+    # the rebase decision this test is actually about, rather than
+    # tripping the S6 fresh-recomputation cross-check first.
+    approval = ManualFrameApproval(
+        reviewed_fingerprint_sha256=reviewed.binding_sha256,
+        slot=1,
+        boundary_offset_rows=0,
+        thumbnail_sha256="4" * 64,
+        reviewed_lookup_row=mapping.origins[0].lookup_row,
+        reviewed_native_origin=mapping.origins[0].native_origin,
+        review_reasons=("user-picked-origin",),
+        manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+            (10, 200)
+        ),
+    )
+    frames = (
+        worker_module.BatchFrameSpec(
+            slot=1,
+            boundary_offset_rows=0,
+            manual_review_approval=approval,
+            output=frame_root / "frame-001" / "capture.bin",
+            journal=frame_root / "frame-001" / "journal.json",
+            ack=frame_root / "frame-001" / "parent-ack.json",
+        ),
+    )
+
+    monkeypatch.setattr(
+        worker_module, "_derive_live_frame_selection", lambda *_a, **_k: context
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "compare_selected_roll_fingerprint",
+        lambda *_a, **_k: SimpleNamespace(matches=True, reason="matched"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "validate_live_0x8e_bytes",
+        lambda table, _height: (table, len(records)),
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "parse_live_transport_records_bytes",
+        lambda *_a, **_k: records,
+    )
+
+    with pytest.raises(
+        ProtocolError,
+        match=r"frame 1 boundary offset resolves to a transport origin",
+    ):
+        worker_module._derive_live_batch_selections(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frames,
+            reviewed_fingerprint=reviewed,
+            # Required for the manual_placement check itself (worker.py
+            # cannot infer "this batch is manual" from context.detection
+            # alone -- see the comment at that computation site): without
+            # this, the fix under test would not even engage, and the old,
+            # buggy rebase-eligible path would silently pass instead.
+            manual_boundary_rows=(10, 200),
+        )
+
+
+def test_manual_batch_selection_refuses_when_approval_disagrees_with_fresh_origin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S6 hardening: load_validated_batch_job proves a receipt is
+    internally consistent and was signed for this exact placement's
+    boundary rows (see test_batch_job_loader_refuses_a_receipt_bound_to_
+    different_boundary_rows), but proves nothing about whether its
+    CLAIMED per-slot values (reviewed_lookup_row, reviewed_native_origin,
+    review_reasons) match what this traversal's fresh manual resolution
+    actually produced for that slot -- only context.mapping, built from
+    this rework's own lattice-aware resolution
+    (manual_frames._resolve_boundary_transport_origin), can prove that.
+    Here the receipt claims frame 1's reviewed_native_origin is 4200 + 147
+    -- disagreeing with the mapping's own (undisplaced, correctly
+    resolved) native_origin of 4200 -- with every job-file-level check
+    otherwise satisfied (matching fingerprint, matching manual_boundary_
+    rows digest, matching slot/offset). A malformed trusted-parent job
+    fabricating this field is exactly the attack this closes.
+    """
+
+    mapping, records = _short_strip_mapping(6)
+    mapping = replace(
+        mapping,
+        origins=tuple(
+            replace(
+                origin,
+                automatic=False,
+                manual_review=True,
+                method="user-picked-row",
+            )
+            for origin in mapping.origins
+        ),
+    )
+    reviewed = _reviewed_fingerprint_with_count(6)
+    context = _batch_selection_context(mapping, records, reviewed)
+    context.detection = SimpleNamespace(
+        warnings=(manual_frames.MANUAL_PLACEMENT_WARNING,)
+    )
+    frame_root = tmp_path / "manual-fresh-mismatch"
+    fresh_origin = mapping.origins[0]
+    approval = ManualFrameApproval(
+        reviewed_fingerprint_sha256=reviewed.binding_sha256,
+        slot=1,
+        boundary_offset_rows=0,
+        thumbnail_sha256="6" * 64,
+        # Disagrees with fresh_origin.native_origin (4_200) by 147 native
+        # units (~3.5 rows) -- everything else about this receipt is
+        # genuine and self-consistent.
+        reviewed_lookup_row=fresh_origin.lookup_row,
+        reviewed_native_origin=fresh_origin.native_origin + 147,
+        review_reasons=("user-picked-origin",),
+        manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+            (10, 200)
+        ),
+    )
+    frames = (
+        worker_module.BatchFrameSpec(
+            slot=1,
+            boundary_offset_rows=0,
+            manual_review_approval=approval,
+            output=frame_root / "frame-001" / "capture.bin",
+            journal=frame_root / "frame-001" / "journal.json",
+            ack=frame_root / "frame-001" / "parent-ack.json",
+        ),
+    )
+
+    monkeypatch.setattr(
+        worker_module, "_derive_live_frame_selection", lambda *_a, **_k: context
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "compare_selected_roll_fingerprint",
+        lambda *_a, **_k: SimpleNamespace(matches=True, reason="matched"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "validate_live_0x8e_bytes",
+        lambda table, _height: (table, len(records)),
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "parse_live_transport_records_bytes",
+        lambda *_a, **_k: records,
+    )
+
+    with pytest.raises(
+        ProtocolError,
+        match=r"frame 1 manual review approval does not match this traversal's "
+        r"freshly resolved origin",
+    ):
+        worker_module._derive_live_batch_selections(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frames,
+            reviewed_fingerprint=reviewed,
+            manual_boundary_rows=(10, 200),
+        )
 
 
 def test_batch_selections_accept_a_live_count_several_frames_below_reviewed(

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest
 
 from coolscanpy.protocol.ls5000_single_pass import worker as worker_module
+from coolscanpy.protocol.ls5000_single_pass import manual_frames
 from coolscanpy.protocol.ls5000_single_pass.capture_process import (
     AttemptPaths,
     CaptureAttemptResult,
@@ -3128,6 +3129,211 @@ def test_derive_live_frame_selection_still_refuses_on_fingerprint_mismatch(
             manual_review_approved=False,
             reviewed_as_automatic=True,
             reviewed_leading_residual_rows=-1.525,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): the manual-placement
+# worker gate. build_manual_detection is monkeypatched to a canned result --
+# manual_frames.py's own gates are exercised in test_manual_frames.py; these
+# tests attack _derive_live_frame_selection's gate wiring specifically.
+# ---------------------------------------------------------------------------
+
+
+def _manual_gate_records() -> tuple[TransportRecord, ...]:
+    return tuple(
+        TransportRecord(
+            row=row,
+            code=6 * (row % 18),
+            selector=row // 18,
+            native_origin=42 * row,
+        )
+        for row in range(500)
+    )
+
+
+def _manual_gate_mapping() -> TransportMapping:
+    origin = NativeFrameOrigin(
+        frame=1,
+        boundary_index=0,
+        boundary_output_row=10,
+        lookup_row=10,
+        code=6 * (10 % 18),
+        selector=10 // 18,
+        native_origin=420,
+        method="user-picked-row",
+        automatic=False,
+        manual_review=True,
+        review_reasons=("user-picked-origin",),
+        affine_residual_rows=0.0,
+    )
+    return TransportMapping(
+        record_count=500,
+        native_intercept=0.0,
+        native_units_per_preview_row=42.0,
+        anchor_mae_rows=0.0,
+        anchor_max_error_rows=0.0,
+        origins=(origin,),
+    )
+
+
+def _manual_gate_detection(*, confidence: str, user_picked: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        confidence=confidence,
+        warnings=(
+            (manual_frames.MANUAL_PLACEMENT_WARNING,)
+            if user_picked
+            else ("wide-gap-recovery",)
+        ),
+        boundaries=(),
+        intervals=(SimpleNamespace(start_row=0, end_row=100),),
+    )
+
+
+def _wire_manual_gate_common(
+    monkeypatch: pytest.MonkeyPatch, rgb: np.ndarray
+) -> None:
+    geometry = SimpleNamespace(height=500, pitch=41, native_height=250_278)
+    monkeypatch.setattr(worker_module, "_derive_index_geometry", lambda _plan: geometry)
+    monkeypatch.setattr(
+        worker_module,
+        "validate_live_0x8e_bytes",
+        lambda table, _height: (table, len(rgb)),
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "decode_full_index_bytes",
+        lambda *_a, **_k: (rgb, np.ones(rgb.shape, dtype=bool), {}),
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "parse_live_transport_records_bytes",
+        lambda *_a, **_k: _manual_gate_records(),
+    )
+
+
+def test_manual_selection_with_approval_binds_at_medium_confidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rgb = np.zeros((500, 96, 3), dtype=np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+    mapping = _manual_gate_mapping()
+    detection = _manual_gate_detection(confidence="medium", user_picked=True)
+    monkeypatch.setattr(
+        worker_module,
+        "build_manual_detection",
+        lambda *_a, **_k: SimpleNamespace(
+            detection=detection, mapping=mapping, snaps=()
+        ),
+    )
+
+    selection = worker_module._derive_live_frame_selection(
+        [],
+        b"fresh-preview",
+        b"fresh-table",
+        frame=1,
+        manual_review_approved=True,
+        manual_boundary_rows=(10, 200),
+    )
+
+    assert selection.detection.confidence == "medium"
+    assert selection.selected.native_origin == 420
+    assert selection.selected.manual_review is True
+    assert selection.selected.automatic is False
+
+
+def test_manual_selection_without_approval_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rgb = np.zeros((500, 96, 3), dtype=np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+    mapping = _manual_gate_mapping()
+    detection = _manual_gate_detection(confidence="medium", user_picked=True)
+    monkeypatch.setattr(
+        worker_module,
+        "build_manual_detection",
+        lambda *_a, **_k: SimpleNamespace(
+            detection=detection, mapping=mapping, snaps=()
+        ),
+    )
+
+    with pytest.raises(
+        ProtocolError, match="unattended frame binding requires 'high'"
+    ):
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            manual_review_approved=False,
+            manual_boundary_rows=(10, 200),
+        )
+
+
+def test_non_manual_medium_detection_still_refuses_even_with_approval_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pre-existing gate is untouched: passing manual_review_approved=True
+    on a NON-manual (e.g. wide-gap-recovery) medium-confidence detection must
+    still refuse -- MANUAL_PLACEMENT_WARNING can only ever come from
+    build_manual_detection, which this call never even reaches.
+    """
+
+    rgb = np.zeros((500, 96, 3), dtype=np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+    detection = _manual_gate_detection(confidence="medium", user_picked=False)
+    monkeypatch.setattr(worker_module, "detect_roll_frames", lambda *_a, **_k: detection)
+
+    with pytest.raises(
+        ProtocolError, match="unattended frame binding requires 'high'"
+    ):
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            manual_review_approved=True,
+            # manual_boundary_rows intentionally omitted: the automatic path.
+        )
+
+
+def test_manual_selection_still_refuses_on_fingerprint_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rgb = np.zeros((500, 96, 3), dtype=np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+    mapping = _manual_gate_mapping()
+    detection = _manual_gate_detection(confidence="medium", user_picked=True)
+    monkeypatch.setattr(
+        worker_module,
+        "build_manual_detection",
+        lambda *_a, **_k: SimpleNamespace(
+            detection=detection, mapping=mapping, snaps=()
+        ),
+    )
+    # A different preview width is an immediate, deterministic mismatch
+    # (compare_reviewed_roll_fingerprints's first check), independent of any
+    # visual-hash heuristics.
+    mismatched_rgb = np.zeros((500, 80, 3), dtype=np.uint16)
+    reviewed = build_reviewed_roll_fingerprint(
+        mismatched_rgb,
+        frame_intervals=((0, 100),),
+        frame_native_origins=(420,),
+        source_preview_sha256="a" * 64,
+        source_table_sha256="b" * 64,
+    )
+
+    with pytest.raises(
+        ProtocolError, match="does not match the reviewed roll fingerprint"
+    ):
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            reviewed_fingerprint=reviewed,
+            manual_review_approved=True,
+            manual_boundary_rows=(10, 200),
         )
 
 

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
@@ -1478,6 +1478,7 @@ def test_batch_job_loader_binds_ordered_frame_paths_and_parent_ack_contract(
                 "expected_usb_address": 2,
                 "expected_usb_bus": 1,
                 "exposure_override_10ns": None,
+                "manual_boundary_rows": None,
                 "frames": [
                     {
                         "ack": "frame-017/parent-ack.json",
@@ -1531,6 +1532,7 @@ def _one_frame_job_payload(
     fingerprint: ReviewedRollFingerprint,
     *,
     exposure_override_10ns: object,
+    manual_boundary_rows: object = None,
 ) -> dict[str, object]:
     return {
         "apply_all_boundary_offsets_before_first_frame": True,
@@ -1539,6 +1541,7 @@ def _one_frame_job_payload(
         "expected_usb_bus": 1,
         "expected_usb_address": 2,
         "exposure_override_10ns": exposure_override_10ns,
+        "manual_boundary_rows": manual_boundary_rows,
         "frames": [
             {
                 "ack": "frame-001/parent-ack.json",
@@ -1578,6 +1581,57 @@ def test_batch_job_loader_parses_a_valid_exposure_override(tmp_path: Path) -> No
     )
 
     assert job.exposure_override_10ns == (97_482, 195_597, 180_705)
+
+
+def test_batch_job_loader_parses_valid_manual_boundary_rows(tmp_path: Path) -> None:
+    """Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): same choke point as
+    exposure_override_10ns above -- the operator-picked rows a manual
+    placement session hands Roll.scan_many() must survive the batch-job.json
+    round trip so _derive_live_batch_selections can replay them fresh."""
+    job_path = tmp_path / "batch-job.json"
+    job_path.write_text(
+        json.dumps(
+            _one_frame_job_payload(
+                _reviewed_fingerprint(),
+                exposure_override_10ns=None,
+                manual_boundary_rows=[128, 271, 414],
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    job = load_validated_batch_job(
+        job_path,
+        expected_job_sha256=hashlib.sha256(job_path.read_bytes()).hexdigest(),
+        expected_plan_sha256="a" * 64,
+        expected_continuation_sha256="b" * 64,
+    )
+
+    assert job.manual_boundary_rows == (128, 271, 414)
+
+
+def test_batch_job_loader_refuses_malformed_manual_boundary_rows(
+    tmp_path: Path,
+) -> None:
+    job_path = tmp_path / "batch-job.json"
+    job_path.write_text(
+        json.dumps(
+            _one_frame_job_payload(
+                _reviewed_fingerprint(),
+                exposure_override_10ns=None,
+                manual_boundary_rows=[128, "271"],
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ProtocolError, match="manual_boundary_rows"):
+        load_validated_batch_job(
+            job_path,
+            expected_job_sha256=hashlib.sha256(job_path.read_bytes()).hexdigest(),
+            expected_plan_sha256="a" * 64,
+            expected_continuation_sha256="b" * 64,
+        )
 
 
 @pytest.mark.parametrize(
@@ -2246,6 +2300,7 @@ def test_batch_cli_dry_run_validates_one_session_without_single_frame_flags(
                 "expected_usb_address": 2,
                 "expected_usb_bus": 1,
                 "exposure_override_10ns": None,
+                "manual_boundary_rows": None,
                 "frames": [
                     {
                         "ack": "frame-017/parent-ack.json",
@@ -5141,6 +5196,7 @@ def test_live_two_frame_batch_uses_one_combined_table_and_one_release(
         frames: tuple[worker_module.BatchFrameSpec, ...],
         *,
         reviewed_fingerprint: ReviewedRollFingerprint,
+        manual_boundary_rows: tuple[int, ...] | None = None,
     ) -> tuple[SimpleNamespace, ...]:
         nonlocal prevalidated
         assert len(preview) == len(worker_module.PREVIEW_READ_SEQUENCES)
@@ -5807,6 +5863,7 @@ def test_preview_and_hold_two_rounds_share_one_reservation_then_eject_after(
             "expected_usb_bus": 1,
             "expected_usb_address": 2,
             "exposure_override_10ns": None,
+            "manual_boundary_rows": None,
             "frames": [
                 {
                     "ack": f"frame-{frame.slot:03d}/parent-ack.json",
@@ -5856,6 +5913,7 @@ def test_preview_and_hold_two_rounds_share_one_reservation_then_eject_after(
         frames: tuple,
         *,
         reviewed_fingerprint: ReviewedRollFingerprint,
+        manual_boundary_rows: tuple[int, ...] | None = None,
     ) -> tuple:
         assert len(preview) == len(worker_module.PREVIEW_READ_SEQUENCES)
         assert table == header_8e
@@ -6332,6 +6390,7 @@ def test_preview_and_hold_resume_binds_density_ownership_to_calibration_identity
             "expected_usb_bus": 1,
             "expected_usb_address": 2,
             "exposure_override_10ns": None,
+            "manual_boundary_rows": None,
             "frames": [
                 {
                     "ack": f"frame-{frame.slot:03d}/parent-ack.json",
@@ -6381,6 +6440,7 @@ def test_preview_and_hold_resume_binds_density_ownership_to_calibration_identity
         frames: tuple,
         *,
         reviewed_fingerprint: ReviewedRollFingerprint,
+        manual_boundary_rows: tuple[int, ...] | None = None,
     ) -> tuple:
         assert len(preview) == len(worker_module.PREVIEW_READ_SEQUENCES)
         assert table == header_8e

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_worker_streaming_integration.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_worker_streaming_integration.py
@@ -666,7 +666,9 @@ def _drive_two_frame_batch(
         def dispose_resources(_device):
             pass
 
-    def derive_batch(_plan, preview, table, frames, *, reviewed_fingerprint):
+    def derive_batch(
+        _plan, preview, table, frames, *, reviewed_fingerprint, manual_boundary_rows=None
+    ):
         state["prevalidated"] = True
         return selections
 

--- a/coolscanpy/tests/roll/test_ls5000_roll_session.py
+++ b/coolscanpy/tests/roll/test_ls5000_roll_session.py
@@ -972,13 +972,22 @@ def test_manual_session_yields_slots_with_boundary_offset_still_working() -> Non
     assert len(session.slots) == 6
     assert session.detection.confidence == "medium"
     assert all(slot.manual_review for slot in session.slots)
-    for frame, (slot, boundary_row) in enumerate(
-        zip(session.slots, boundaries), start=1
+    # Boundary 0 sits in the wide (128-row) leader run -- not a narrow
+    # inter-frame gap -- so it resolves at the picked row itself. The rest
+    # each sit at the center of an ordinary 6-row inter-frame gap, so each
+    # resolves at that run's OWN trailing edge (boundary + 3), mirroring
+    # derive_transport_mapping's "direct-gap-trailing-row" convention (see
+    # manual_frames.py's own docstring for why manual placement's F1
+    # rework does the same).
+    expected_lookup_rows = [boundaries[0]] + [b + 3 for b in boundaries[1:6]]
+    for frame, (slot, lookup_row) in enumerate(
+        zip(session.slots, expected_lookup_rows), start=1
     ):
-        assert slot.base_origin.native_origin == 42 * boundary_row
+        assert slot.base_origin.lookup_row == lookup_row
+        assert slot.base_origin.native_origin == 42 * lookup_row
         assert slot.base_origin.method == "user-picked-row"
 
-    picked_slot = session.slots[1]  # frame 2, base lookup row = boundaries[1]
+    picked_slot = session.slots[1]  # frame 2, base lookup row = boundaries[1] + 3
     adjusted = session.with_boundary_offset(2, -10)
 
     assert adjusted.slots[1].boundary_offset_rows == -10
@@ -1022,6 +1031,42 @@ def test_automatic_session_json_has_no_manual_provenance(tmp_path: Path) -> None
     # now that the schema carries this additive key.
     restored = type(session).from_json(session.to_json())
     assert restored.preview.preview_artifact == session.preview.preview_artifact
+
+
+def test_pre_rework_session_json_without_manual_boundary_rows_key_still_restores(
+    tmp_path: Path,
+) -> None:
+    """F7 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): to_json() started always
+    emitting "manual_boundary_rows" the same night manual placement shipped.
+    A session persisted by the PREVIOUS build never had that key at all --
+    simulated here by deleting it from an otherwise-real payload -- and must
+    restore exactly as it always did, not refuse on an unsupported schema.
+    """
+
+    session = build_roll_preview_session(_preview_fixture(tmp_path).result)
+    payload = json.loads(session.to_json())
+    assert "manual_boundary_rows" in payload
+    del payload["manual_boundary_rows"]
+    pre_rework_json = json.dumps(payload)
+
+    restored = type(session).from_json(pre_rework_json)
+
+    assert restored.preview.preview_artifact == session.preview.preview_artifact
+    assert restored.selected_slots == session.selected_slots
+
+
+def test_session_json_with_an_unrelated_missing_key_still_refuses(
+    tmp_path: Path,
+) -> None:
+    """The tolerance above is scoped to exactly one additive key -- any
+    OTHER missing key is still an unsupported schema."""
+
+    session = build_roll_preview_session(_preview_fixture(tmp_path).result)
+    payload = json.loads(session.to_json())
+    del payload["slot_count"]
+
+    with pytest.raises(RollSessionIntegrityError, match="unsupported schema"):
+        type(session).from_json(json.dumps(payload))
 
 
 def test_session_json_round_trip_revalidates_sources_and_restores_operator_state(

--- a/coolscanpy/tests/roll/test_ls5000_roll_session.py
+++ b/coolscanpy/tests/roll/test_ls5000_roll_session.py
@@ -27,11 +27,14 @@ from coolscanpy.protocol.ls5000_single_pass.density import (
 )
 from coolscanpy.roll.preview_session import (
     PARTIAL_FRAME_MIN_COVERAGE,
+    ArtifactIdentity,
     CaptureRoute,
     RollSessionIntegrityError,
+    ValidatedRollPreview,
     _crop_coverage,
     _crop_state,
     _preview_binding_contract,
+    build_manual_roll_preview_session,
     build_roll_preview_session,
     reload_thumbnail,
 )
@@ -895,6 +898,130 @@ def test_boundary_offset_reloads_only_that_slot_and_resolves_exact_table_record(
         adjusted.slots[17].thumbnail,
         reload_thumbnail(session.preview, base, -21),
     )
+
+
+def _clean_transport_records(count: int) -> tuple[roll_index.TransportRecord, ...]:
+    """Same-traversal table stepping at exactly 42 native units/row (matches
+    test_manual_frames.py's convention: ``code=6*(row%18), selector=row//18``
+    decodes to ``native_origin = 42 * row`` exactly).
+    """
+
+    return tuple(
+        roll_index.TransportRecord(
+            row=row,
+            code=6 * (row % 18),
+            selector=row // 18,
+            native_origin=42 * row,
+        )
+        for row in range(count)
+    )
+
+
+def _synthetic_validated_preview(
+    *, frame_count: int = 6, leader: int = 128
+) -> tuple[ValidatedRollPreview, list[int]]:
+    """A directly-constructed ValidatedRollPreview, bypassing the full
+    attempt-journal simulation _preview_fixture uses -- Rung 4 manual
+    placement's whole premise is that this object already exists (from an
+    earlier, possibly failed, preview attempt) by the time a human places
+    boundaries, so tests exercise build_manual_roll_preview_session against
+    it directly.
+    """
+
+    pitch = 143
+    boundaries = [leader + index * pitch for index in range(frame_count + 1)]
+    height = boundaries[-1] + 24
+    rgb = _synthetic_index(height=height, frame_count=frame_count, leader=leader)
+    records = _clean_transport_records(height)
+    geometry = roll_index.IndexGeometry(
+        requested_resolution=97,
+        native_resolution=4_000,
+        pitch=41,
+        native_width=3_946,
+        native_height=height * 41,
+        width=96,
+        height=height,
+        block_bytes=2_048,
+        expected_stream_bytes=height * roll_index.INDEX_ROW_WORDS * 2,
+    )
+    preview = ValidatedRollPreview(
+        preview_artifact=ArtifactIdentity(
+            path=Path("/fake/capture-preview.bin"), byte_length=0, sha256="a" * 64
+        ),
+        table_artifact=ArtifactIdentity(
+            path=Path("/fake/capture-008e.bin"), byte_length=0, sha256="b" * 64
+        ),
+        journal_artifact=ArtifactIdentity(
+            path=Path("/fake/journal.json"), byte_length=0, sha256="c" * 64
+        ),
+        usb_topology=(1, 2),
+        geometry=geometry,
+        usable_rows=height,
+        rgb=rgb,
+        transport_records=records,
+        decode_report={},
+    )
+    return preview, boundaries
+
+
+def test_manual_session_yields_slots_with_boundary_offset_still_working() -> None:
+    preview, boundaries = _synthetic_validated_preview()
+
+    session = build_manual_roll_preview_session(preview, boundaries)
+
+    assert len(session.slots) == 6
+    assert session.detection.confidence == "medium"
+    assert all(slot.manual_review for slot in session.slots)
+    for frame, (slot, boundary_row) in enumerate(
+        zip(session.slots, boundaries), start=1
+    ):
+        assert slot.base_origin.native_origin == 42 * boundary_row
+        assert slot.base_origin.method == "user-picked-row"
+
+    picked_slot = session.slots[1]  # frame 2, base lookup row = boundaries[1]
+    adjusted = session.with_boundary_offset(2, -10)
+
+    assert adjusted.slots[1].boundary_offset_rows == -10
+    resolved = adjusted.resolve_origin(2, -10)
+    assert resolved.lookup_row == picked_slot.base_origin.lookup_row - 10
+    assert resolved.native_origin == 42 * resolved.lookup_row
+    np.testing.assert_array_equal(
+        adjusted.slots[1].thumbnail,
+        reload_thumbnail(session.preview, picked_slot, -10),
+    )
+    # The unmodified session and its other slots are untouched (RollPreviewSession
+    # is immutable, same contract build_roll_preview_session's own sessions have).
+    assert session.slots[1].boundary_offset_rows == 0
+    assert adjusted.slots[0] is session.slots[0]
+
+
+def test_manual_session_provenance_round_trips_through_to_json_only() -> None:
+    """to_json persists the picked boundary rows (additive field); from_json
+    deliberately refuses to restore a manual session rather than silently
+    re-running automatic detection against it.
+    """
+
+    preview, boundaries = _synthetic_validated_preview()
+    session = build_manual_roll_preview_session(preview, boundaries)
+
+    payload = json.loads(session.to_json())
+
+    assert payload["manual_boundary_rows"] == boundaries
+
+    with pytest.raises(RollSessionIntegrityError, match="manual frame placement"):
+        type(session).from_json(session.to_json())
+
+
+def test_automatic_session_json_has_no_manual_provenance(tmp_path: Path) -> None:
+    session = build_roll_preview_session(_preview_fixture(tmp_path).result)
+
+    payload = json.loads(session.to_json())
+
+    assert payload["manual_boundary_rows"] is None
+    # And the ordinary round trip (already covered above) still restores fine
+    # now that the schema carries this additive key.
+    restored = type(session).from_json(session.to_json())
+    assert restored.preview.preview_artifact == session.preview.preview_artifact
 
 
 def test_session_json_round_trip_revalidates_sources_and_restores_operator_state(

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/_roll.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/_roll.py
@@ -86,6 +86,9 @@ from coolscanpy.protocol.ls5000_single_pass.density import (
     NikonExactBuilderEvidence,
     build_nikon_exact_builder_evidence,
 )
+from coolscanpy.protocol.ls5000_single_pass.manual_frames import (
+    MANUAL_PLACEMENT_WARNING,
+)
 from coolscanpy.protocol.ls5000_single_pass.meter import (
     EXPOSURE_MAX,
     EXPOSURE_MIN,
@@ -954,6 +957,21 @@ class Roll:
                 expected_usb_bus=topology[0],
                 expected_usb_address=topology[1],
                 exposure_override_10ns=exposure_override_10ns,
+                # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): the same
+                # computation RollPreviewSession.to_json() already uses to
+                # decide whether ITS OWN provenance is a manual session's
+                # (preview_session.py) -- MANUAL_PLACEMENT_WARNING is only
+                # ever attached by manual_frames.build_manual_detection,
+                # never by the automatic detector, so this is None for
+                # every ordinary session, unchanged from before this batch
+                # gained the field.
+                manual_boundary_rows=(
+                    tuple(
+                        boundary.output_row for boundary in session.detection.boundaries
+                    )
+                    if MANUAL_PLACEMENT_WARNING in session.detection.warnings
+                    else None
+                ),
             )
             # A held session is single-use *per call*: whether this batch
             # resumes it successfully, fails, is stopped, or is ended by

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/_roll.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/_roll.py
@@ -746,6 +746,68 @@ class Roll:
                 if wanted is None or slot.slot_id in wanted
             ]
 
+    def install_manual_session(self, session: RollPreviewSession) -> None:
+        """Install an already-built, already-validated manual-placement
+        preview session as this Roll's current review state (Rung 4 of the
+        feeding UX ladder; 2026-08-08 adversarial review, S1/S5).
+
+        No film moves and no evidence is read from disk here: the caller
+        (``coolscanpy_transport.manual_frames()``) has already produced
+        ``session`` from a validated, decoded ``ValidatedRollPreview`` via
+        :func:`coolscanpy.roll.preview_session.build_manual_roll_preview_session`.
+        This method's whole job is the same locked, atomic state transition
+        every other in-place mutator on this class already performs --
+        :meth:`preview`'s own success tail, :meth:`restore_preview_session`,
+        :meth:`set_spacing_offset`, :meth:`approve` -- so a manual-placement
+        caller never has to reach into ``_session``/``_approvals`` directly
+        (previously the only way to arm a manual session at all, since
+        neither of those two existing methods accepts one: ``preview()``
+        always re-reads the transport, and ``restore_preview_session()``
+        explicitly refuses a session serialized from manual placement).
+
+        Checks run in this order, all under one lock, before anything is
+        mutated:
+
+        1. This Roll must not be closing, mid-preview, or hold an active
+           batch -- the same "review state is frozen" contract
+           ``_require_mutable_review_locked`` enforces for every other
+           mutator here.
+        2. ``session``'s material must match this Roll's own material.
+        3. ``session.preview.usb_topology`` -- the USB bus/address recorded
+           when the underlying evidence was originally captured, which may
+           be considerably older than this exact call -- must match this
+           Roll's CURRENT device topology, verified fresh here the same way
+           a live :meth:`preview` or :meth:`restore_preview_session` call
+           already does. Never trusted bare: a manual session built from a
+           stale attempt must not silently bind to whatever scanner happens
+           to be attached now.
+
+        Raises ``TypeError`` if ``session`` is not a ``RollPreviewSession``,
+        ``DeviceBusy`` if check 1 fails, or ``RollMismatch`` if check 2 or 3
+        fails. Every check runs before any mutation, and a raise leaves the
+        existing session and approvals (if any) exactly as they were --
+        this method never partially installs a session.
+        """
+
+        if not isinstance(session, RollPreviewSession):
+            raise TypeError("session must be a RollPreviewSession")
+        with self._state_condition:
+            self._require_mutable_review_locked()
+            if session.material is not self._material:
+                raise RollMismatch(
+                    "manual placement session material does not match this "
+                    "Roll's material"
+                )
+            topology = self._preview_topology_locked()
+            if session.preview.usb_topology != topology:
+                raise RollMismatch(
+                    "manual placement evidence belongs to a different USB "
+                    "topology than this Roll"
+                )
+            self._session = session
+            self._session_usb_topology = topology
+            self._approvals.clear()
+
     # -- spacing offset ----------------------------------------------------
 
     def spacing_offset(self, slot: int) -> int:

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -28,8 +28,8 @@ CANONICAL_MANIFEST_FILENAME = "replay-first-rgbi4-manifest.json"
 # density-source cap-0x10d/f03 exposures, the proven 97-dpi reservation-preview
 # evidence, runtime arithmetic gate, and exact per-frame ownership receipt.
 CAPTURE_BUNDLE_COMPONENT_SHA256 = {
-    "capture_process.py": "db84ea56a9cfa687a4db6835d226c78d52bdf38d50ac26f88de6a8f52fcb41e0",
-    "worker.py": "6a74f83a938eb8f97c7d09f1639f110b486ae766395ad4660dd623e59e767d09",
+    "capture_process.py": "8df668809b15493ff4b0ac4da23133c848120daf6f3266198a91a30a225a5d44",
+    "worker.py": "b371517b6980bd238c343c952840fd4df676b02da4b583d54dfa9ebec73484f8",
     "manual_frames.py": "729fee63adcd597bf0e4d6594b9a31a723ca80755d6d8b3c333854497c0b45af",
     "usb_backend.py": "77499a606dc48049521d2fd0359a0405cb55525242843d61165b642c78841208",
     "density.py": "be7e1e11635edcc70e150fd7454625a478effbb2446017b2cb56676dcb5ebed9",

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -28,16 +28,16 @@ CANONICAL_MANIFEST_FILENAME = "replay-first-rgbi4-manifest.json"
 # density-source cap-0x10d/f03 exposures, the proven 97-dpi reservation-preview
 # evidence, runtime arithmetic gate, and exact per-frame ownership receipt.
 CAPTURE_BUNDLE_COMPONENT_SHA256 = {
-    "capture_process.py": "8df668809b15493ff4b0ac4da23133c848120daf6f3266198a91a30a225a5d44",
-    "worker.py": "b371517b6980bd238c343c952840fd4df676b02da4b583d54dfa9ebec73484f8",
-    "manual_frames.py": "729fee63adcd597bf0e4d6594b9a31a723ca80755d6d8b3c333854497c0b45af",
+    "capture_process.py": "31485687011afad5dcf3470d72da26bc090ec43398518c7c9b85c42841fc97ef",
+    "worker.py": "f625057c5619c9ddf94d7e233c6ac9d2a86e300c1a8b1bd8d7f5f03d0eac8c24",
+    "manual_frames.py": "f30f0003e081c3a98610d5700d7e6b6ee4d182b9d5228932f3304f1307d4815f",
     "usb_backend.py": "77499a606dc48049521d2fd0359a0405cb55525242843d61165b642c78841208",
     "density.py": "be7e1e11635edcc70e150fd7454625a478effbb2446017b2cb56676dcb5ebed9",
     "packed.py": "856315714e4f7e81f42e1ca93917e4cc0feb03b24915c2ad604302bfdca46f87",
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "d13c1850f1400d2a89c8594b65330fd82a4074b82dfafd75c954c4218c71fad1",
+    "roll_index.py": "ee4320ac7f71f42db57d6a7a8c1c103226635f1214fb9f4a6271c8ef2ff0d812",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -29,14 +29,15 @@ CANONICAL_MANIFEST_FILENAME = "replay-first-rgbi4-manifest.json"
 # evidence, runtime arithmetic gate, and exact per-frame ownership receipt.
 CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "capture_process.py": "db84ea56a9cfa687a4db6835d226c78d52bdf38d50ac26f88de6a8f52fcb41e0",
-    "worker.py": "5cb678bc32c24fb0931ea1cde5a49fedc659003e94955d136b37baa07037fd4f",
+    "worker.py": "6a74f83a938eb8f97c7d09f1639f110b486ae766395ad4660dd623e59e767d09",
+    "manual_frames.py": "729fee63adcd597bf0e4d6594b9a31a723ca80755d6d8b3c333854497c0b45af",
     "usb_backend.py": "77499a606dc48049521d2fd0359a0405cb55525242843d61165b642c78841208",
     "density.py": "be7e1e11635edcc70e150fd7454625a478effbb2446017b2cb56676dcb5ebed9",
     "packed.py": "856315714e4f7e81f42e1ca93917e4cc0feb03b24915c2ad604302bfdca46f87",
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "fdddefe3be30bc9025e32343c4ab656262e171f828844f3afba546380fee3d98",
+    "roll_index.py": "d13c1850f1400d2a89c8594b65330fd82a4074b82dfafd75c954c4218c71fad1",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -36,7 +36,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "46147850ff5e7e42b83a7ca04eb0d262eb9028858e444beb4818c4f217426d7a",
+    "roll_index.py": "fdddefe3be30bc9025e32343c4ab656262e171f828844f3afba546380fee3d98",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
@@ -1095,6 +1095,16 @@ class CaptureBatchRequest:
     expected_usb_bus: int
     expected_usb_address: int
     exposure_override_10ns: tuple[int, int, int] | None = None
+    # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): the exact operator-
+    # picked boundary rows from a manual-placement preview session, carried
+    # across the process boundary so the batch child can replay
+    # manual_frames.build_manual_detection fresh against its own live re-read
+    # bytes -- never trusted as a serialized detection result (see worker.py's
+    # _derive_live_frame_selection docstring). None for an ordinary,
+    # automatically-detected session -- see Roll.scan_many, which derives
+    # this from its own reviewed session rather than accepting it from a
+    # caller.
+    manual_boundary_rows: tuple[int, ...] | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.frames, tuple):
@@ -3506,6 +3516,14 @@ class CaptureProcessAdapter:
                 else list(request.exposure_override_10ns)
             ),
             "frames": frames,
+            # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): same optional,
+            # always-present, nullable-array shape as exposure_override_10ns
+            # above -- see CaptureBatchRequest.manual_boundary_rows.
+            "manual_boundary_rows": (
+                None
+                if request.manual_boundary_rows is None
+                else list(request.manual_boundary_rows)
+            ),
             "parent_ack_required_after_every_frame": True,
             "release_once_after_last_frame": True,
             "reviewed_roll_fingerprint": request.reviewed_fingerprint.to_payload(),

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
@@ -80,7 +80,19 @@ WORKER_BOOTSTRAP_SCHEMA_VERSION = 1
 WORKER_BOOTSTRAP_FAILED = "failed-before-ready"
 WORKER_BOOTSTRAP_STATUS_FILENAME = "worker-bootstrap.json"
 REVIEWED_ROLL_FINGERPRINT_VERSION = 2
-MANUAL_FRAME_APPROVAL_VERSION = 1
+# Bumped 2 (S6 hardening, FEEDING-UX-LADDER-OVERNIGHT-20260807.md F1
+# rework): adds manual_boundary_rows_sha256, a required field, so this is a
+# breaking schema change on purpose. A genuine version-1 payload is refused
+# by from_payload's exact key-set check first (its key set no longer
+# matches); only a fabricated payload carrying version 1 WITH version-2
+# keys reaches __post_init__'s schema_version check. Both paths refuse --
+# the ordering is recorded here so nobody expects the version check to be
+# the gate that ordinary stale receipts hit (re-review 2026-08-08). Approval
+# receipts are ephemeral (created and consumed within one reviewed-session
+# -> scan-time flow, never persisted the way RollPreviewSession.to_json()
+# is), so there is no backward-compatibility case to preserve here the way
+# F7 preserved one for session JSON.
+MANUAL_FRAME_APPROVAL_VERSION = 2
 MAX_VISUAL_MEDIAN_HAMMING = 24
 MAX_VISUAL_P90_HAMMING = 48
 MAX_SELECTED_VISUAL_HAMMING = 48
@@ -596,7 +608,22 @@ class ReviewedRollFingerprint:
 
 @dataclass(frozen=True)
 class ManualFrameApproval:
-    """Operator approval bound to one reviewed thumbnail and transport choice."""
+    """Operator approval bound to one reviewed thumbnail and transport choice.
+
+    ``manual_boundary_rows_sha256`` (S6 hardening, FEEDING-UX-LADDER-
+    OVERNIGHT-20260807.md F1 rework): binds this approval to the EXACT set
+    of boundary rows the operator's whole session reviewed, not just this
+    one slot's own resolved position. Without it, a receipt legitimately
+    signed for slot N of one placement carries nothing that distinguishes
+    it from a receipt for slot N of a DIFFERENT placement of the same
+    physical roll whose fingerprint happens to still compare as matching
+    (fingerprint comparison has deliberate tolerance for legitimate re-
+    reads; see compare_reviewed_roll_fingerprints) -- this digest has none.
+    Use ``digest_manual_boundary_rows`` to compute it, both when creating a
+    receipt (RollPreviewSession.approve_manual_origin) and when verifying
+    one against a batch job's own manual_boundary_rows (worker.py), so the
+    two sides can never independently drift on how it is derived.
+    """
 
     reviewed_fingerprint_sha256: str
     slot: int
@@ -605,7 +632,23 @@ class ManualFrameApproval:
     reviewed_lookup_row: int
     reviewed_native_origin: int
     review_reasons: tuple[str, ...]
+    manual_boundary_rows_sha256: str
     schema_version: int = MANUAL_FRAME_APPROVAL_VERSION
+
+    @staticmethod
+    def digest_manual_boundary_rows(rows: Sequence[int] | None) -> str:
+        """Canonical digest of a placement's manual boundary rows.
+
+        ``rows`` is ``None`` for an automatic (non-manual) reviewed slot --
+        still given a fixed, well-defined digest rather than an empty
+        string, so this field is never optional/absent on the receipt
+        itself and a caller cannot bypass the check by omitting it.
+        """
+
+        payload = {
+            "manual_boundary_rows": list(rows) if rows is not None else None
+        }
+        return _canonical_json_sha256(payload)
 
     def __post_init__(self) -> None:
         if self.schema_version != MANUAL_FRAME_APPROVAL_VERSION:
@@ -630,6 +673,10 @@ class ManualFrameApproval:
             or self.reviewed_native_origin < 0
         ):
             raise ValueError("manual frame approval native origin is invalid")
+        if not _lower_sha256(self.manual_boundary_rows_sha256):
+            raise ValueError(
+                "manual frame approval manual-boundary-rows identity is invalid"
+            )
         if (
             not isinstance(self.review_reasons, tuple)
             or not self.review_reasons
@@ -640,6 +687,7 @@ class ManualFrameApproval:
     def binding_payload(self) -> dict[str, Any]:
         return {
             "boundary_offset_rows": self.boundary_offset_rows,
+            "manual_boundary_rows_sha256": self.manual_boundary_rows_sha256,
             "review_reasons": list(self.review_reasons),
             "reviewed_fingerprint_sha256": self.reviewed_fingerprint_sha256,
             "reviewed_lookup_row": self.reviewed_lookup_row,
@@ -664,6 +712,7 @@ class ManualFrameApproval:
         if not isinstance(payload, dict) or set(payload) != {
             "binding_sha256",
             "boundary_offset_rows",
+            "manual_boundary_rows_sha256",
             "review_reasons",
             "reviewed_fingerprint_sha256",
             "reviewed_lookup_row",
@@ -684,6 +733,7 @@ class ManualFrameApproval:
             reviewed_lookup_row=payload.get("reviewed_lookup_row"),  # type: ignore[arg-type]
             reviewed_native_origin=payload.get("reviewed_native_origin"),  # type: ignore[arg-type]
             review_reasons=tuple(reasons),
+            manual_boundary_rows_sha256=payload.get("manual_boundary_rows_sha256"),  # type: ignore[arg-type]
             schema_version=payload.get("schema_version"),  # type: ignore[arg-type]
         )
         if payload.get("binding_sha256") != value.binding_sha256:

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
@@ -1,0 +1,524 @@
+"""Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): driver-side manual frame
+placement for the LS-5000 whole-roll pipeline.
+
+This module never runs film movement and never re-derives detection with
+relaxed knobs.  It accepts an already-decoded whole-roll preview raster (from
+a preview attempt that has already completed and released the device) plus
+the boundary rows a human picked by looking at that raster, and turns those
+picks into the same ``RollDetection``/``TransportMapping`` shape the
+automatic detector in ``roll_index.py`` produces -- so every downstream
+consumer (``preview_session.py``, the worker's live-scan binding, the app's
+thumbnail/approval UI) keeps working unchanged.
+
+Trust model (binding, from the overnight doc): the human supplies frame
+positions; this module keeps every physical sanity check the scanner can
+still make from its own evidence -- clear-film transmission near the picked
+rows (snap assist only; never a hard requirement) and the same-traversal
+transport table's local physical-motion consistency (a hard requirement).
+A placement that fails any hard check is refused in its entirety: this
+module never returns a result that accepted some picks and silently
+dropped others.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from .roll_index import (
+    FrameInterval,
+    GapBoundary,
+    IncompleteIndexError,
+    IndexDecodeError,
+    NativeFrameOrigin,
+    RollDetection,
+    TransportMapping,
+    TransportRecord,
+    _active_aperture,
+    _physical_gap_evidence,
+    _true_runs,
+    terminal_transport_tail_start,
+)
+
+# RollDetection.warnings marker: the one thing worker.py's live-scan gate
+# checks to recognize a manually-placed roll. Only this module ever sets it;
+# the automatic detector in roll_index.py never does. See worker.py's
+# _derive_live_frame_selection for the one gate path this marker unlocks.
+MANUAL_PLACEMENT_WARNING = "user-picked-frames"
+
+# review_reasons markers.
+USER_PICKED_REVIEW_REASON = "user-picked"
+SNAP_REVIEW_REASON = "snapped-to-clear-film-edge"
+MANUAL_ORIGIN_REVIEW_REASON = "user-picked-origin"
+
+# NativeFrameOrigin.method for every manually placed frame.
+MANUAL_ORIGIN_METHOD = "user-picked-row"
+
+# RollDetection.count_confirmation / count_confidence for manual placements.
+MANUAL_COUNT_CONFIRMATION = "user-picked-boundaries"
+MANUAL_COUNT_CONFIDENCE = "user-selection-required"
+
+# Structural limits (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, Rung 4 point 1).
+MINIMUM_MANUAL_BOUNDARY_COUNT = 2
+MAXIMUM_MANUAL_FRAMES = 40
+
+# Physical frame-height gate (Rung 4 point 2): 15-75 mm, deliberately wider
+# than automatic detection's fixed nominal-pitch tolerance band because
+# manual mode exists specifically for film automatic detection does not
+# handle -- half-frame (~19 mm) and panoramic (~65-72 mm). 0.267 mm/row is
+# this driver's documented 97-dpi-preview approximation (matches the ~5.3 mm
+# / 20 rows figure already used for WIDE_GAP_CEILING_ROWS in roll_index.py
+# and the ~0.8 mm / 3 rows figure in the Rung 3 diagnosis spec); it is used
+# only to phrase user-facing sentences in mm. The row bounds below are the
+# actual gate.
+MINIMUM_MANUAL_FRAME_HEIGHT_ROWS = 56
+MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS = 280
+MANUAL_FRAME_HEIGHT_MM_PER_ROW = 0.267
+
+# Snap assist (Rung 4 point 3).
+SNAP_ASSIST_MAX_DISTANCE_ROWS = 4
+
+# Transport sanity (Rung 4 points 4-5): same 40..45 native-units-per-row
+# scale as roll_index.derive_transport_mapping's own minimum_scale/
+# maximum_scale defaults, and the same per-step local-ramp guard shape as
+# derive_transport_mapping's wide-gap-anchor admission check (grep
+# ramp_is_affine in roll_index.py) -- reimplemented here rather than
+# imported because manual mode's origins are exact same-traversal table
+# reads, never an affine fit prediction, so derive_transport_mapping itself
+# is not called (it requires >=3 "direct"-support boundaries, which no
+# user-picked boundary ever carries).
+MINIMUM_TRANSPORT_SCALE = 40.0
+MAXIMUM_TRANSPORT_SCALE = 45.0
+RAMP_GUARD_RADIUS_ROWS = 3
+
+
+@dataclass(frozen=True)
+class BoundarySnap:
+    """One snap-assist adjustment applied to a user-picked boundary row."""
+
+    boundary_index: int
+    requested_row: int
+    snapped_row: int
+    evidence_run: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class ManualFrameDetection:
+    """A manual placement's detection, transport mapping, and snap notes."""
+
+    detection: RollDetection
+    mapping: TransportMapping
+    snaps: tuple[BoundarySnap, ...]
+
+
+def _ordinal(n: int) -> str:
+    if 10 <= n % 100 <= 20:
+        suffix = "th"
+    else:
+        suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+    return f"{n}{suffix}"
+
+
+def _approximate_mm(row: int) -> float:
+    return row * MANUAL_FRAME_HEIGHT_MM_PER_ROW
+
+
+def build_manual_detection(
+    rgb16: np.ndarray,
+    known: np.ndarray,
+    boundary_rows: Sequence[int],
+    *,
+    nominal_frame_rows: int,
+    records: Sequence[TransportRecord],
+    snap_assist: bool = True,
+) -> ManualFrameDetection:
+    """Turn operator-picked boundary rows into a reviewed roll detection.
+
+    ``rgb16``/``known`` are the same decoded whole-roll raster and
+    completeness mask ``detect_roll_frames`` takes; ``records`` is the same
+    same-traversal live READ(0x8e) transport table used everywhere else in
+    this package. No film moves and no relaxed automatic-detection knobs are
+    tried here -- this is a completely separate code path from
+    ``detect_roll_frames``/``derive_transport_mapping``.
+
+    Every gate below fails closed: any failure raises before this function
+    returns anything, so a caller can never end up with a placement that
+    silently accepted some of the operator's picks and dropped others.
+    """
+
+    # ---- gate 0: same shape/completeness floor as the automatic detector --
+    if rgb16.ndim != 3 or rgb16.shape[2] != 3:
+        raise IndexDecodeError("manual frame placement requires an HxWx3 RGB raster")
+    if rgb16.shape != known.shape:
+        raise IndexDecodeError("RGB raster and completeness mask shapes differ")
+    complete_rows = known.all(axis=(1, 2))
+    if complete_rows.mean() < 0.995:
+        raise IncompleteIndexError(
+            "manual frame placement requires a persisted complete preview; "
+            f"row coverage is {complete_rows.mean():.1%}"
+        )
+    if (
+        type(nominal_frame_rows) is not int
+        or isinstance(nominal_frame_rows, bool)
+        or nominal_frame_rows < 1
+    ):
+        raise IndexDecodeError("nominal frame rows must be a positive integer")
+
+    # ---- gate 1: structure -- count, type, order, in-raster ---------------
+    height = int(rgb16.shape[0])
+    rows = list(boundary_rows)
+    if len(rows) < MINIMUM_MANUAL_BOUNDARY_COUNT:
+        raise IndexDecodeError(
+            "manual frame placement needs at least 2 boundary rows (1 frame); "
+            f"only {len(rows)} were given"
+        )
+    if any(type(row) is not int or isinstance(row, bool) for row in rows):
+        raise IndexDecodeError("manual frame boundary rows must be plain integers")
+    if any(a >= b for a, b in zip(rows, rows[1:])):
+        raise IndexDecodeError(
+            "frame boundary rows must be placed in strictly increasing order, "
+            "top to bottom of the preview"
+        )
+    if any(not 0 <= row < height for row in rows):
+        raise IndexDecodeError(
+            "every boundary row must lie inside the captured preview "
+            f"(0..{height - 1}); a boundary was placed outside it"
+        )
+    frame_count = len(rows) - 1
+    if frame_count > MAXIMUM_MANUAL_FRAMES:
+        raise IndexDecodeError(
+            f"manual placement supports at most {MAXIMUM_MANUAL_FRAMES} frames; "
+            f"{len(rows)} boundary rows would create {frame_count}"
+        )
+
+    # ---- gate 2: physical frame-height range, on the operator's own picks -
+    for index, (start, end) in enumerate(zip(rows, rows[1:]), start=1):
+        height_rows = end - start
+        if not (
+            MINIMUM_MANUAL_FRAME_HEIGHT_ROWS
+            <= height_rows
+            <= MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS
+        ):
+            approx_mm = _approximate_mm(height_rows)
+            raise IndexDecodeError(
+                f"the {_ordinal(index)} frame you placed is about "
+                f"{approx_mm:.0f} mm tall (between rows {start} and {end}), "
+                "outside the 15-75 mm range this driver accepts for manual "
+                "placement"
+            )
+
+    # ---- gate 3: snap assist (default on, never a hard requirement) -------
+    # Reuses roll_index's own clear-film evidence signal so a "clear film
+    # edge" means the exact same physical thing here as it does to the
+    # automatic detector and the Rung 3 diagnosis module. If this raster
+    # defeats that heuristic (e.g. an aperture shape automatic detection
+    # itself would have refused), snap assist degrades to a no-op instead of
+    # refusing the placement -- unlike every gate above and below, snapping
+    # is a nicety layered on top of the operator's own judgement, not a
+    # physical sanity check, and manual mode exists precisely for rasters
+    # this heuristic cannot always read.
+    evidence_signal: np.ndarray | None = None
+    transmission_signal: np.ndarray | None = None
+    nonuniformity_signal: np.ndarray | None = None
+    aperture: tuple[int, int] | None = None
+    evidence_runs: list[tuple[int, int]] = []
+    try:
+        aperture = _active_aperture(rgb16)
+        evidence_signal, transmission_signal, nonuniformity_signal, direct = (
+            _physical_gap_evidence(rgb16, aperture)
+        )
+        evidence_runs = _true_runs(direct)
+    except IndexDecodeError:
+        aperture = None
+        evidence_signal = None
+        transmission_signal = None
+        nonuniformity_signal = None
+        evidence_runs = []
+
+    final_rows: list[int] = []
+    supporting_runs: list[tuple[int, int] | None] = []
+    snaps: list[BoundarySnap] = []
+    for index, row in enumerate(rows):
+        nearest_edge: int | None = None
+        nearest_run: tuple[int, int] | None = None
+        nearest_distance = SNAP_ASSIST_MAX_DISTANCE_ROWS + 1
+        if snap_assist:
+            # Same reference points as roll_index._nearest_evidence_run: a
+            # row already inside a run is a perfect (zero-distance) match --
+            # it needs no snap, and in particular a pick already centered on
+            # a clear-film run must NOT get pulled to that run's start/end
+            # sides just because they happen to be the closer numbers.
+            # Outside a run, distance is to the nearer of the run's own
+            # first/last clear-film row (never past it).
+            for start, end in evidence_runs:
+                if start <= row < end:
+                    distance, edge = 0, row
+                else:
+                    distance_to_start = abs(row - start)
+                    distance_to_last = abs(row - (end - 1))
+                    if distance_to_start <= distance_to_last:
+                        distance, edge = distance_to_start, start
+                    else:
+                        distance, edge = distance_to_last, end - 1
+                if distance < nearest_distance:
+                    nearest_distance = distance
+                    nearest_edge = edge
+                    nearest_run = (start, end)
+        if nearest_run is not None and nearest_distance <= SNAP_ASSIST_MAX_DISTANCE_ROWS:
+            supporting_runs.append(nearest_run)
+            final_rows.append(nearest_edge)  # type: ignore[arg-type]
+            if nearest_edge != row:
+                snaps.append(
+                    BoundarySnap(
+                        boundary_index=index,
+                        requested_row=row,
+                        snapped_row=nearest_edge,  # type: ignore[arg-type]
+                        evidence_run=nearest_run,
+                    )
+                )
+        else:
+            supporting_runs.append(None)
+            final_rows.append(row)
+
+    # Snapping moves each boundary independently by at most
+    # SNAP_ASSIST_MAX_DISTANCE_ROWS; re-verify order and raster bounds still
+    # hold on the (small number of) final rows before trusting them for
+    # anything downstream. Practically unreachable given the height gate
+    # above already ran on the raw picks, but cheap, correct, and this
+    # module never trusts an unchecked value just because a similar one was
+    # already checked.
+    if any(a >= b for a, b in zip(final_rows, final_rows[1:])):
+        raise IndexDecodeError(
+            "snap assist moved two placed boundaries out of order; place "
+            "them farther apart, or place them by hand with snap assist off"
+        )
+    if any(not 0 <= row < height for row in final_rows):
+        raise IndexDecodeError(
+            "snap assist moved a boundary outside the captured preview "
+            f"(0..{height - 1})"
+        )
+
+    # ---- gate 4: per-boundary local transport-ramp guard -------------------
+    # Same guard shape as derive_transport_mapping's wide-gap-anchor
+    # admission check (grep ramp_is_affine in roll_index.py), applied
+    # uniformly to every picked boundary -- manual mode has no separate
+    # "leading anchor" tolerance the way the automatic path does, because
+    # nothing here is inferred from an affine fit; every origin is a direct
+    # table read, and a direct table read next to an untrustworthy ramp is
+    # exactly the case this guard exists to catch.
+    if len(records) < 1:
+        raise IndexDecodeError(
+            "manual frame placement requires the same-traversal scanner "
+            "position table; none was supplied"
+        )
+    tail_start = terminal_transport_tail_start(records)
+    ramp_upper_bound = (
+        len(records) - 1 if tail_start is None else min(len(records) - 1, tail_start - 1)
+    )
+    for index, row in enumerate(final_rows):
+        if not 0 <= row < len(records):
+            raise IndexDecodeError(
+                f"the {_ordinal(index + 1)} frame edge you placed (row {row}) "
+                "has no matching entry in the scanner's position table; try "
+                "refeeding the strip and re-scanning the preview"
+            )
+        lo = max(0, row - RAMP_GUARD_RADIUS_ROWS)
+        hi = min(ramp_upper_bound, row + RAMP_GUARD_RADIUS_ROWS)
+        steps_ok = hi > lo and all(
+            MINIMUM_TRANSPORT_SCALE
+            <= records[r + 1].native_origin - records[r].native_origin
+            <= MAXIMUM_TRANSPORT_SCALE
+            for r in range(lo, hi)
+        )
+        if not steps_ok:
+            raise IndexDecodeError(
+                "the scanner's position readings look unreliable around the "
+                f"{_ordinal(index + 1)} frame edge you placed (approximately "
+                f"{_approximate_mm(row):.0f} mm into the roll); try refeeding "
+                "the strip and re-scanning the preview"
+            )
+
+    # ---- gate 5: origins strictly increasing at 40..45 units/row ----------
+    picked_origins = [records[row].native_origin for row in final_rows]
+    for index, (row_a, row_b, origin_a, origin_b) in enumerate(
+        zip(final_rows, final_rows[1:], picked_origins, picked_origins[1:]),
+        start=1,
+    ):
+        delta_rows = row_b - row_a
+        delta_origin = origin_b - origin_a
+        implied_scale = delta_origin / delta_rows if delta_rows else 0.0
+        if not (
+            delta_origin > 0
+            and MINIMUM_TRANSPORT_SCALE <= implied_scale <= MAXIMUM_TRANSPORT_SCALE
+        ):
+            raise IndexDecodeError(
+                "the scanner's position readings between the "
+                f"{_ordinal(index)} and {_ordinal(index + 1)} frame edges you "
+                f"placed don't move at a steady rate (about "
+                f"{implied_scale:.1f} position units per row; this driver "
+                "expects roughly 40-45); try refeeding the strip and "
+                "re-scanning the preview"
+            )
+
+    # ---- build the result in the shared roll_index shapes ------------------
+    def boundary_reading(row: int) -> tuple[float, float, float]:
+        if evidence_signal is None:
+            return 0.0, 0.0, 1.0
+        return (
+            float(evidence_signal[row]),
+            float(transmission_signal[row]),  # type: ignore[index]
+            float(nonuniformity_signal[row]),  # type: ignore[index]
+        )
+
+    snapped_indices = {snap.boundary_index for snap in snaps}
+    boundaries: list[GapBoundary] = []
+    for index, row in enumerate(final_rows):
+        ev, tm, nu = boundary_reading(row)
+        reasons = [USER_PICKED_REVIEW_REASON]
+        if index in snapped_indices:
+            reasons.append(SNAP_REVIEW_REASON)
+        boundaries.append(
+            GapBoundary(
+                index=index,
+                output_row=row,
+                fitted_row=float(row),
+                evidence=ev,
+                transmission=tm,
+                nonuniformity=nu,
+                support="user-picked",
+                evidence_run=supporting_runs[index],
+                manual_review=True,
+                review_reasons=tuple(reasons),
+            )
+        )
+
+    intervals: list[FrameInterval] = []
+    for frame_index, (start_boundary, end_boundary) in enumerate(
+        zip(boundaries, boundaries[1:]), start=1
+    ):
+        intervals.append(
+            FrameInterval(
+                frame=frame_index,
+                start_row=start_boundary.output_row,
+                end_row=end_boundary.output_row,
+                height_rows=end_boundary.output_row - start_boundary.output_row,
+                start_boundary=start_boundary.index,
+                end_boundary=end_boundary.index,
+                # Manual mode's whole premise is that the operator's own
+                # visual judgement substitutes for the content heuristic the
+                # automatic detector uses, so both fractions are reported as
+                # fully trusted. coverage_fraction=1.0 is also the honest
+                # value: gate 1 above already proved every boundary lies
+                # inside the captured raster, so no manual frame can ever be
+                # a raster-edge partial the way an automatic detection can.
+                content_fraction=1.0,
+                coverage_fraction=1.0,
+                count_supported=True,
+                count_bridged=False,
+                manual_review=True,
+                review_reasons=(USER_PICKED_REVIEW_REASON,),
+                unclamped_start_row=float(start_boundary.output_row),
+                unclamped_end_row=float(end_boundary.output_row),
+            )
+        )
+
+    origins: list[NativeFrameOrigin] = []
+    for frame_index, start_boundary in enumerate(boundaries[:-1], start=1):
+        record = records[start_boundary.output_row]
+        origins.append(
+            NativeFrameOrigin(
+                frame=frame_index,
+                boundary_index=start_boundary.index,
+                boundary_output_row=start_boundary.output_row,
+                lookup_row=start_boundary.output_row,
+                code=record.code,
+                selector=record.selector,
+                native_origin=record.native_origin,
+                method=MANUAL_ORIGIN_METHOD,
+                automatic=False,
+                manual_review=True,
+                review_reasons=(MANUAL_ORIGIN_REVIEW_REASON,),
+                # Exact same-traversal table read, not an affine-fit
+                # prediction -- there is no fit error to report. Zero here
+                # also keeps worker.py's _addressable_frame_origins residual
+                # filter from ever excluding a manually placed frame; gate 4
+                # above is this module's own, stricter physical check.
+                affine_residual_rows=0.0,
+            )
+        )
+
+    # Diagnostic-only affine summary across every picked boundary (not just
+    # the frame-owning ones) -- purely for TransportMapping.diagnostics();
+    # nothing above derives an origin from this fit.
+    rows_arr = np.asarray([b.output_row for b in boundaries], dtype=np.float64)
+    origin_arr = np.asarray(picked_origins, dtype=np.float64)
+    design = np.column_stack((np.ones(len(rows_arr)), rows_arr))
+    intercept, scale = np.linalg.lstsq(design, origin_arr, rcond=None)[0]
+    if scale:
+        residual_rows = (design @ np.asarray((intercept, scale)) - origin_arr) / scale
+        anchor_mae = float(np.mean(np.abs(residual_rows)))
+        anchor_max = float(np.max(np.abs(residual_rows)))
+    else:  # pragma: no cover - unreachable once gate 5 has passed
+        anchor_mae = 0.0
+        anchor_max = 0.0
+
+    mapping = TransportMapping(
+        record_count=len(records),
+        native_intercept=float(intercept),
+        native_units_per_preview_row=float(scale),
+        anchor_mae_rows=anchor_mae,
+        anchor_max_error_rows=anchor_max,
+        origins=tuple(origins),
+    )
+
+    evidences = [b.evidence for b in boundaries]
+    detection = RollDetection(
+        aperture_columns=aperture if aperture is not None else (0, int(rgb16.shape[1])),
+        nominal_frame_rows=nominal_frame_rows,
+        # No autocorrelation/lattice fit is ever run for a manual placement;
+        # these carry neutral values rather than fabricated ones.
+        autocorrelation_lag=0,
+        autocorrelation_peak=0.0,
+        autocorrelation_best_non_neighbor=0.0,
+        pitch_rows=float(np.mean([end - start for start, end in zip(final_rows, final_rows[1:])])),
+        phase_rows=0.0,
+        lattice_score=0.0,
+        alternative_lattice_score=0.0,
+        lattice_margin_fraction=0.0,
+        mean_boundary_evidence=float(np.mean(evidences)),
+        minimum_boundary_evidence=float(np.min(evidences)),
+        content_level_threshold=0.0,
+        content_range_threshold=0.0,
+        candidate_cell_count=frame_count,
+        bridged_cell_count=0,
+        expected_frame_count=None,
+        expected_frame_count_matches=None,
+        count_confirmation=MANUAL_COUNT_CONFIRMATION,
+        count_confidence=MANUAL_COUNT_CONFIDENCE,
+        content_end_candidates=(),
+        # Never higher than "medium": a human placed these rows, but nothing
+        # here re-derives or double-checks that placement against scene
+        # content or an independent lattice fit the way "high" requires
+        # elsewhere in this package.
+        confidence="medium",
+        warnings=(MANUAL_PLACEMENT_WARNING,),
+        boundaries=tuple(boundaries),
+        intervals=tuple(intervals),
+        manual_review_frames=tuple(range(1, frame_count + 1)),
+    )
+
+    return ManualFrameDetection(
+        detection=detection,
+        mapping=mapping,
+        snaps=tuple(snaps),
+    )
+
+
+__all__ = [
+    "BoundarySnap",
+    "MANUAL_PLACEMENT_WARNING",
+    "ManualFrameDetection",
+    "build_manual_detection",
+]

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
@@ -10,14 +10,39 @@ automatic detector in ``roll_index.py`` produces -- so every downstream
 consumer (``preview_session.py``, the worker's live-scan binding, the app's
 thumbnail/approval UI) keeps working unchanged.
 
-Trust model (binding, from the overnight doc): the human supplies frame
-positions; this module keeps every physical sanity check the scanner can
-still make from its own evidence -- clear-film transmission near the picked
-rows (snap assist only; never a hard requirement) and the same-traversal
-transport table's local physical-motion consistency (a hard requirement).
-A placement that fails any hard check is refused in its entirety: this
-module never returns a result that accepted some picks and silently
-dropped others.
+Trust model (rewritten 2026-08-08 after adversarial review rejected the
+original): the human supplies frame positions; this module keeps every
+physical sanity check the scanner can still make from its own evidence --
+clear-film transmission near the picked rows (snap assist only; never a hard
+requirement) and the same-traversal transport table's local physical-motion
+consistency (a hard requirement).  A placement that fails any hard check is
+refused in its entirety: this module never returns a result that accepted
+some picks and silently dropped others.
+
+The transport-table check used to mean "every single-row step within 3 rows
+of a pick must be 40..45 native units."  Real LS-5000 live READ(0x8e) tables
+never satisfy that: they carry a deterministic ~18-row code lattice (see
+``transport_native_origin`` in roll_index.py) whose per-row steps are mostly
+an exact, steady rate but include a recurring minority of large single-row
+jumps at selector rollovers (roughly +798/-700 native units) and smaller
+jumps at sub-rollovers (the code's high byte advancing alone), averaging
+back out to the steady rate over any run of a dozen-plus rows.  A ±3-row
+window is on the wrong side of that: it is wide enough to *catch* a rollover
+row but too narrow to *outvote* it, so it refused nearly every real capture
+at the very first edge with a message ("try refeeding the strip") that could
+not have been fixed by refeeding, because nothing was wrong with the strip.
+
+The fix is the same class of machinery ``roll_index.derive_transport_mapping``
+already uses for the automatic path: resolve each pick's origin from a local
+affine fit over nearby table records -- robust to that lattice's own minority
+of outlier rows -- rather than trusting one raw row read.  See
+``_resolve_boundary_transport_origin`` for exactly how, and why it mirrors
+two different ``derive_transport_mapping`` conventions depending on whether a
+narrow, specific clear-film run backs the pick.  ``derive_transport_mapping``
+itself is still never called: it requires >=3 "direct"-support boundaries
+classified from automatic detection's own lattice fit, which no user-picked
+boundary ever carries, and it owns the automatic path's exact behavior,
+which nothing in this rework may change.
 """
 
 from __future__ import annotations
@@ -32,10 +57,12 @@ from .roll_index import (
     GapBoundary,
     IncompleteIndexError,
     IndexDecodeError,
+    MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS,
     NativeFrameOrigin,
     RollDetection,
     TransportMapping,
     TransportRecord,
+    TRANSPORT_ORIGIN_CLAMP_REASON,
     _active_aperture,
     _physical_gap_evidence,
     _true_runs,
@@ -52,6 +79,13 @@ MANUAL_PLACEMENT_WARNING = "user-picked-frames"
 USER_PICKED_REVIEW_REASON = "user-picked"
 SNAP_REVIEW_REASON = "snapped-to-clear-film-edge"
 MANUAL_ORIGIN_REVIEW_REASON = "user-picked-origin"
+# Set alongside MANUAL_ORIGIN_REVIEW_REASON when a boundary's origin came
+# from the broad/weak-evidence forward search (_resolve_boundary_transport_
+# origin's "not narrow_run" branch) rather than a specific nearby clear-film
+# trailing edge -- the same string derive_transport_mapping's own
+# affine-guided-local-lookup method appends, kept identical on purpose so a
+# field report grepping for it finds both paths' inferred origins together.
+INFERRED_ORIGIN_REVIEW_REASON = "transport-origin-inferred"
 
 # NativeFrameOrigin.method for every manually placed frame.
 MANUAL_ORIGIN_METHOD = "user-picked-row"
@@ -64,34 +98,139 @@ MANUAL_COUNT_CONFIDENCE = "user-selection-required"
 MINIMUM_MANUAL_BOUNDARY_COUNT = 2
 MAXIMUM_MANUAL_FRAMES = 40
 
-# Physical frame-height gate (Rung 4 point 2): 15-75 mm, deliberately wider
-# than automatic detection's fixed nominal-pitch tolerance band because
-# manual mode exists specifically for film automatic detection does not
-# handle -- half-frame (~19 mm) and panoramic (~65-72 mm). 0.267 mm/row is
-# this driver's documented 97-dpi-preview approximation (matches the ~5.3 mm
-# / 20 rows figure already used for WIDE_GAP_CEILING_ROWS in roll_index.py
-# and the ~0.8 mm / 3 rows figure in the Rung 3 diagnosis spec); it is used
-# only to phrase user-facing sentences in mm. The row bounds below are the
-# actual gate.
+# Physical frame-height floor (Rung 4 point 2, unchanged by the rework):
+# 15 mm (~56 preview rows) is a hard physical floor -- half-frame (~19 mm) is
+# the shortest real film this driver supports manual placement for, and this
+# stays comfortably under it. 0.267 mm/row is this driver's documented
+# 97-dpi-preview approximation (matches the ~5.3 mm / 20 rows figure already
+# used for WIDE_GAP_CEILING_ROWS in roll_index.py and the ~0.8 mm / 3 rows
+# figure in the Rung 3 diagnosis spec); it is used only to phrase
+# user-facing sentences in mm. The row bound below is the actual gate.
 MINIMUM_MANUAL_FRAME_HEIGHT_ROWS = 56
-MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS = 280
 MANUAL_FRAME_HEIGHT_MM_PER_ROW = 0.267
 
-# Snap assist (Rung 4 point 3).
+# Physical frame-height ceiling (F2 rework, replaces the old flat 75 mm / 280
+# row ceiling). The LS-5000 fine scan captures a FIXED-size window starting
+# at a frame's native transport origin -- FINE_NATIVE_HEIGHT in worker.py,
+# 5,959 native units -- and there is no multi-window capture: a manually
+# placed frame taller than that window cannot be captured by one fine scan.
+# Accepting it here anyway (the old ceiling did, up to 75 mm) would deliver
+# a silently truncated frame the first time it was actually scanned, well
+# after the operator believed their placement was fine. worker.py cannot be
+# imported here (worker.py imports THIS module), so this hardware constant
+# is re-stated locally -- the same way it is already independently re-stated
+# in packed.py, density.py, capture/full_negative.py,
+# capture/sane_rgb_geometry.py, and roll/preview_session.py rather than
+# shared from one place.
+#
+# In preview rows that fixed window is FINE_NATIVE_HEIGHT // geometry.pitch;
+# geometry.pitch is fixed at 41 by the scanner's own validated native/preview
+# resolution ratio (4,000 dpi native optical resolution over a ~97.6 dpi
+# preview -- see worker.py's IndexGeometry construction, where "pitch != 41"
+# is itself a hard validation failure), so 5,959 // 41 == 145 rows is a
+# fixed hardware limit, not a per-capture estimate. This module receives
+# nominal_frame_rows as a caller-supplied parameter that existing tests
+# deliberately vary per synthetic scenario (it is otherwise only advisory,
+# carried into RollDetection.nominal_frame_rows), so it cannot stand in for
+# this fixed ceiling here.
+#
+# This kills the old 75 mm / panoramic acceptance: manual mode still exists
+# for film automatic detection cannot handle, but panoramic is no longer
+# one of those cases -- the fine window cannot hold it. Half-frame (short)
+# placements are unaffected; only the ceiling moved.
+FINE_CAPTURE_WINDOW_ROWS = 145
+# Same unfloored ratio expressed in mm, purely for phrasing the refusal
+# sentence -- ~38.8 mm. The row bound above is the actual gate.
+FINE_CAPTURE_WINDOW_MM = (5_959 / 41) * MANUAL_FRAME_HEIGHT_MM_PER_ROW
+
+# Snap assist (Rung 4 point 3, unchanged by the rework).
 SNAP_ASSIST_MAX_DISTANCE_ROWS = 4
 
-# Transport sanity (Rung 4 points 4-5): same 40..45 native-units-per-row
-# scale as roll_index.derive_transport_mapping's own minimum_scale/
-# maximum_scale defaults, and the same per-step local-ramp guard shape as
-# derive_transport_mapping's wide-gap-anchor admission check (grep
-# ramp_is_affine in roll_index.py) -- reimplemented here rather than
-# imported because manual mode's origins are exact same-traversal table
-# reads, never an affine fit prediction, so derive_transport_mapping itself
-# is not called (it requires >=3 "direct"-support boundaries, which no
-# user-picked boundary ever carries).
+# Transport sanity (F1 rework): same 40..45 native-units-per-row scale as
+# roll_index.derive_transport_mapping's own minimum_scale/maximum_scale
+# defaults -- every fit below is gated at this same physical bound.
 MINIMUM_TRANSPORT_SCALE = 40.0
 MAXIMUM_TRANSPORT_SCALE = 45.0
-RAMP_GUARD_RADIUS_ROWS = 3
+
+# Local transport-fit window (F1): how many rows on each side of a pick's
+# anchor row this module is willing to look at when deciding what "a steady
+# rate near this pick" means. 25 rows (a 51-row window) comfortably spans
+# more than two of the table's own ~18-row lattice periods, which matters
+# for the median-based robust start (below) -- it needs the steady rate to
+# be the majority of the window, and a window barely wider than one period
+# leaves too few rows to reliably outvote that period's own 1-2 lattice
+# jumps. Widening far past this stopped helping in practice (measured
+# against 45 archived live captures during this rework: identical results
+# from 40 rows out to 150) and risks pulling in a genuinely different local
+# rate from farther down the roll, so this stays a LOCAL window, never the
+# whole table.
+LOCAL_FIT_WINDOW_RADIUS_ROWS = 25
+# Below this many trusted rows in a window, a fit is not attempted -- there
+# is not enough signal left to tell a steady rate from noise once the
+# lattice's own jumps are set aside.
+LOCAL_FIT_MINIMUM_INLIER_ROWS = 8
+# A window row is trusted ("inlier") when it sits within this many rows of
+# the fitted line; this is also the fit's own final acceptance bound (its
+# worst trusted row can differ from the line by no more than this). Matches
+# MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS, the automatic path's own interior
+# residual bound, imported and reused directly below rather than
+# re-declared, so the two paths cannot silently drift apart.
+LOCAL_FIT_TRIM_RESIDUAL_ROWS = MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS
+# Bounded outlier-trim/refit rounds: the lattice's steady-rate majority and
+# its jump-row minority separate cleanly after one round in every archived
+# capture measured during this rework; a few extra rounds are cheap
+# insurance for a borderline window where a row migrates in or out as the
+# fitted line settles, not evidence more rounds are routinely needed.
+LOCAL_FIT_TRIM_ROUNDS = 4
+
+# A clear-film run up to this many rows wide is "narrow": a specific,
+# physically meaningful gap between two frames, the same class of evidence
+# roll_index.derive_transport_mapping's "direct" method anchors on. Wider
+# than this and a run stops meaning "this one boundary's own gap" -- it is
+# more likely the leader, a broad low-contrast region, or several bridged
+# boundaries sharing one detected run (observed on archived 39-frame-roll
+# captures during this rework: three consecutive automatic boundaries all
+# carrying the SAME ~300-row "cadence-broad" run). Reused conceptually from
+# roll_index.WIDE_GAP_CEILING_ROWS's own narrow/wide split rather than
+# imported, since that constant's own docstring ties it specifically to the
+# wide-gap recovery pass, a different feature this module must not couple
+# to.
+NARROW_EVIDENCE_RUN_MAX_WIDTH_ROWS = 20
+# When a pick has no narrow run to anchor on, how many rows past the pick
+# this module searches for the table's own closest match to the local fit's
+# prediction. Matches derive_transport_mapping's own affine-guided
+# local-lookup search range exactly (see roll_index.py: "the canonical
+# Nikon detector selects roughly 2..5 rows after a physical gap centre").
+CANDIDATE_SEARCH_LOOKAHEAD_ROWS = 8
+
+# A narrow-run anchor whose own table read is untrusted may substitute a
+# neighboring trusted row only within this distance -- the lattice's own
+# selector-rollover displacement is one row, capped at three for margin.
+# Anything farther extrapolates AT the anchor from the local fit instead
+# (re-review 2026-08-08, F-A: the uncapped substitute silently displaced
+# origins by up to 22 rows through gates that all read zero residual).
+SUBSTITUTE_ANCHOR_MAX_DISTANCE_ROWS = 3
+
+# A resolved lookup row farther than this from the operator's pick earns an
+# explicit review reason: the ordinary narrow-gap trailing-edge offset is
+# ~3 rows, and anything beyond it means the resolution moved meaningfully
+# away from what the operator pointed at (re-review 2026-08-08, F-B).
+LOOKUP_FAR_FROM_PICK_ROWS = 4
+LOOKUP_FAR_FROM_PICK_REVIEW_REASON = "transport-anchor-far-from-pick"
+
+# Placement-wide affine-fit residual gate (F4): identical bounds to
+# derive_transport_mapping's own maximum_anchor_mae_rows/
+# maximum_anchor_error_rows defaults. MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS is
+# imported and reused for the max bound; the MAE bound has no equivalent
+# module-level constant in roll_index.py (it is a default parameter value
+# there, not a name), so it is restated here at the same 1.0 value.
+PLACEMENT_ANCHOR_MAE_ROWS_MAX = 1.0
+# A 2-boundary (single-frame) placement's own two points fit a line
+# exactly, always -- MAE and max residual are trivially 0 regardless of
+# whether either point is right, so this whole gate is enforced only from
+# 3 boundaries (2 frames) up. See build_manual_detection's gate 6 comment
+# for what a 2-boundary placement relies on instead.
+PLACEMENT_ANCHOR_GATE_MINIMUM_BOUNDARIES = 3
 
 
 @dataclass(frozen=True)
@@ -113,6 +252,30 @@ class ManualFrameDetection:
     snaps: tuple[BoundarySnap, ...]
 
 
+@dataclass(frozen=True)
+class _ResolvedTransportOrigin:
+    """One boundary's transport-table origin, resolved through a local
+    lattice-aware fit rather than trusted as a single raw row read.
+
+    ``inferred`` and ``substituted`` are mutually informative, not mutually
+    exclusive in meaning: ``inferred`` records which of the two resolution
+    shapes ``_resolve_boundary_transport_origin`` used (narrow-run trailing
+    edge vs broad/weak-evidence forward search); ``substituted`` records
+    whether the row actually read differs from the picked row itself.  The
+    narrow-run shape can still set ``substituted`` (its own trailing-edge
+    row read was untrustworthy, so a nearby trusted row stood in for it);
+    the forward-search shape always sets it (it never reads the picked row
+    itself, by construction -- see its own docstring).
+    """
+
+    lookup_row: int
+    code: int
+    selector: int
+    native_origin: int
+    inferred: bool
+    substituted: bool
+
+
 def _ordinal(n: int) -> str:
     if 10 <= n % 100 <= 20:
         suffix = "th"
@@ -123,6 +286,219 @@ def _ordinal(n: int) -> str:
 
 def _approximate_mm(row: int) -> float:
     return row * MANUAL_FRAME_HEIGHT_MM_PER_ROW
+
+
+def _fit_local_transport_ramp(
+    table_origins: np.ndarray,
+    anchor_row: int,
+    ramp_upper_bound: int,
+) -> tuple[float, float, np.ndarray] | None:
+    """Robustly fit an affine (intercept, scale) line to the transport table
+    in a local window around ``anchor_row``.
+
+    Tolerates the lattice's own recurring selector-rollover / sub-rollover
+    code jumps (see this module's docstring) as a minority of outlier rows,
+    rather than treating any one of them as proof the whole neighborhood is
+    untrustworthy -- the failure mode that made the previous per-step ±3-row
+    guard refuse nearly every real capture.
+
+    Returns ``(intercept, scale, inlier_rows)`` -- ``inlier_rows`` is the
+    absolute row-index array of every window row the final fit trusts -- or
+    ``None`` if this neighborhood cannot support one: too few usable rows,
+    no majority steady rate, or a fitted scale outside the 40..45 physical
+    band even after discounting outliers.
+    """
+
+    window_lo = max(0, anchor_row - LOCAL_FIT_WINDOW_RADIUS_ROWS)
+    window_hi = min(ramp_upper_bound, anchor_row + LOCAL_FIT_WINDOW_RADIUS_ROWS)
+    if window_hi - window_lo + 1 < LOCAL_FIT_MINIMUM_INLIER_ROWS:
+        return None
+
+    rows = np.arange(window_lo, window_hi + 1, dtype=np.float64)
+    origins = table_origins[window_lo : window_hi + 1].astype(np.float64)
+
+    # Robust, leverage-independent starting line: on real LS-5000 tables the
+    # large majority of single-row steps are exactly the scanner's steady
+    # per-row rate, so the MEDIAN step and the MEDIAN per-row intercept
+    # residual both land close to the true line regardless of how far a
+    # minority of lattice-code-boundary rows deviate or where in the window
+    # they sit. An ordinary least-squares fit over the raw window does not
+    # have that property: a single high-leverage row at a window edge (a
+    # leading-anchor-style jump of tens of thousands of native units,
+    # observed on archived captures during this rework) can visibly tilt
+    # it before any outlier has been set aside.
+    step = np.diff(origins) / np.diff(rows)
+    scale = float(np.median(step))
+    if scale == 0:
+        return None
+    intercept = float(np.median(origins - scale * rows))
+    inlier_mask = (
+        np.abs((intercept + scale * rows - origins) / scale)
+        <= LOCAL_FIT_TRIM_RESIDUAL_ROWS
+    )
+
+    # Refit by ordinary least squares on the robust round's inliers only,
+    # then re-trim against THAT fit; repeat a bounded number of times so a
+    # borderline row can migrate in or out as the line settles.
+    for _ in range(LOCAL_FIT_TRIM_ROUNDS):
+        inlier_count = int(inlier_mask.sum())
+        if inlier_count < LOCAL_FIT_MINIMUM_INLIER_ROWS:
+            return None
+        design = np.column_stack((np.ones(inlier_count), rows[inlier_mask]))
+        intercept, scale = np.linalg.lstsq(design, origins[inlier_mask], rcond=None)[0]
+        if scale == 0:
+            return None
+        residual_rows = (intercept + scale * rows - origins) / scale
+        next_mask = np.abs(residual_rows) <= LOCAL_FIT_TRIM_RESIDUAL_ROWS
+        if int(next_mask.sum()) < LOCAL_FIT_MINIMUM_INLIER_ROWS:
+            return None
+        if np.array_equal(next_mask, inlier_mask):
+            inlier_mask = next_mask
+            break
+        inlier_mask = next_mask
+
+    if not MINIMUM_TRANSPORT_SCALE <= scale <= MAXIMUM_TRANSPORT_SCALE:
+        return None
+    final_residuals = (
+        intercept + scale * rows[inlier_mask] - origins[inlier_mask]
+    ) / scale
+    if float(np.max(np.abs(final_residuals))) > LOCAL_FIT_TRIM_RESIDUAL_ROWS:
+        return None
+
+    inlier_rows = np.arange(window_lo, window_hi + 1)[inlier_mask]
+    return float(intercept), float(scale), inlier_rows
+
+
+def _resolve_boundary_transport_origin(
+    records: Sequence[TransportRecord],
+    table_origins: np.ndarray,
+    picked_row: int,
+    evidence_run: tuple[int, int] | None,
+    ramp_upper_bound: int,
+) -> _ResolvedTransportOrigin | None:
+    """Resolve one boundary's native transport origin from a local fit.
+
+    Same class of machinery ``roll_index.derive_transport_mapping`` uses for
+    the automatic path: an affine fit over nearby table records, never a
+    single raw row read trusted on its own.
+
+    The row this reads from is always trusted first as-is: fit the local
+    ramp, and if the anchor row's own raw record already fits it, that
+    record IS the answer, full stop -- an honest pick on a clean table
+    always resolves to the exact row picked, never a neighbor a fixed
+    number of rows away "for consistency" with anything. The anchor itself
+    differs by evidence, though: a narrow (``NARROW_EVIDENCE_RUN_MAX_WIDTH_
+    ROWS``-wide or less) nearby clear-film evidence run is a specific
+    physical reference -- Nikon's own firmware convention places a frame's
+    origin a few rows past such a run's trailing edge, exactly the
+    "direct-gap-trailing-row" reference ``derive_transport_mapping``'s own
+    "direct" method reads -- so when one is available, THAT trailing edge
+    is the anchor, not the picked row itself. Without a narrow run -- a
+    broad/leader-like clear region, a weak or absent evidence signal, or
+    any other picked row with no specific physical trailing edge nearby --
+    there is no such reference, so the picked row itself is the anchor.
+
+    Only when the anchor's own raw record is NOT trustworthy does this fall
+    back to a substitute, and the two anchor kinds fall back differently.
+    A narrow run's trailing edge substitutes its nearest trusted neighbor:
+    it is still a specific physical reference, just misread by this one
+    row. A picked row with no narrow run to anchor on instead searches
+    forward for the table's own closest match to the fit's own prediction,
+    mirroring ``derive_transport_mapping``'s affine-guided-local-lookup --
+    appropriate here because, without a narrow run, there is no single
+    "this one row" already earning trust the way a trailing edge does.
+
+    Returns ``None`` when this neighborhood cannot support a local fit at
+    all; the caller treats that as a refusal of the whole placement, never
+    a silently accepted guess.
+    """
+
+    if not 0 <= picked_row <= ramp_upper_bound:
+        return None
+
+    narrow_run = (
+        evidence_run is not None
+        and evidence_run[1] - evidence_run[0] <= NARROW_EVIDENCE_RUN_MAX_WIDTH_ROWS
+        and evidence_run[1] <= ramp_upper_bound
+    )
+    anchor_row = evidence_run[1] if narrow_run and evidence_run else picked_row
+
+    fit = _fit_local_transport_ramp(table_origins, anchor_row, ramp_upper_bound)
+    if fit is None:
+        return None
+    intercept, scale, inlier_rows = fit
+
+    # The anchor's own raw record is trusted whenever the fit itself trusts
+    # it (whether the anchor is the picked row directly or a narrow run's
+    # trailing edge) -- this is what makes an exact, honest pick on a clean
+    # table resolve to that EXACT row, not a neighbor a fixed number of rows
+    # away. Only once the anchor's own reading is NOT trustworthy does this
+    # fall back to a substitute: a narrow run's trailing edge substitutes
+    # its nearest trusted neighbor (the anchor is still a specific physical
+    # reference, just misread by this one row); a picked row with no narrow
+    # run to anchor on instead searches forward for the table's own closest
+    # match to the fit's prediction, mirroring derive_transport_mapping's
+    # affine-guided-local-lookup -- the same convention Nikon's own firmware
+    # already uses for a broad/interpolated origin, appropriate here because
+    # there is no specific row already earning trust the way a narrow run's
+    # trailing edge does.
+    if anchor_row in inlier_rows:
+        lookup_row = anchor_row
+        substituted = False
+        inferred = False
+    elif narrow_run:
+        nearest = int(inlier_rows[np.argmin(np.abs(inlier_rows - anchor_row))])
+        if abs(nearest - anchor_row) <= SUBSTITUTE_ANCHOR_MAX_DISTANCE_ROWS:
+            lookup_row = nearest
+            substituted = True
+            inferred = False
+        else:
+            # Re-review 2026-08-08, F-A: an uncapped nearest-inlier
+            # substitute silently displaced origins by up to 22 rows on a
+            # table whose symmetric jitter left the median seed standing --
+            # a real physical point, so every downstream residual gate saw
+            # zero error. Beyond the lattice's own ~1-row rollover
+            # displacement (capped at 3 for margin), the anchor's
+            # neighborhood is not trustworthy row-by-row; extrapolate AT
+            # the anchor from the surviving local fit instead -- the same
+            # semantics the automatic path's transport-origin clamp has
+            # always had, which also makes the clamp marker truthful here.
+            lookup_row = anchor_row
+            record = records[anchor_row]
+            return _ResolvedTransportOrigin(
+                lookup_row=anchor_row,
+                code=record.code,
+                selector=record.selector,
+                native_origin=int(round(intercept + scale * anchor_row)),
+                substituted=True,
+                inferred=True,
+            )
+    else:
+        start = max(0, anchor_row + 1)
+        end = min(ramp_upper_bound + 1, anchor_row + CANDIDATE_SEARCH_LOOKAHEAD_ROWS)
+        if start >= end:
+            return None
+        candidates = np.arange(start, end)
+        prediction = intercept + scale * anchor_row
+        lookup_row = int(
+            candidates[
+                np.argmin(
+                    np.abs(table_origins[candidates].astype(np.float64) - prediction)
+                )
+            ]
+        )
+        substituted = True
+        inferred = True
+
+    record = records[lookup_row]
+    return _ResolvedTransportOrigin(
+        lookup_row=lookup_row,
+        code=record.code,
+        selector=record.selector,
+        native_origin=record.native_origin,
+        inferred=inferred,
+        substituted=substituted,
+    )
 
 
 def build_manual_detection(
@@ -136,7 +512,7 @@ def build_manual_detection(
 ) -> ManualFrameDetection:
     """Turn operator-picked boundary rows into a reviewed roll detection.
 
-    ``rgb16``/``known`` are the same decoded whole-roll raster and
+    ``rgb16``/``known`` are the same decoded whole-roll preview raster and
     completeness mask ``detect_roll_frames`` takes; ``records`` is the same
     same-traversal live READ(0x8e) transport table used everywhere else in
     this package. No film moves and no relaxed automatic-detection knobs are
@@ -146,6 +522,20 @@ def build_manual_detection(
     Every gate below fails closed: any failure raises before this function
     returns anything, so a caller can never end up with a placement that
     silently accepted some of the operator's picks and dropped others.
+
+    Idempotent by construction (F3): every check that depends on the exact
+    rows a placement resolves to (the height gates, transport resolution,
+    pairwise and placement-wide fits) runs on ``final_rows`` -- the rows
+    AFTER snap assist, i.e. this function's own output boundary rows -- so
+    feeding a previously accepted placement's own ``detection.boundaries``
+    output rows back in as new ``boundary_rows`` re-derives the identical
+    result rather than re-litigating a pre-snap view of the picks that no
+    longer describes the placement. This matters beyond a nicety: the batch
+    capture wire and the worker's live-scan replay both resupply a session's
+    already-snapped rows as the next call's raw ``boundary_rows``
+    (``Roll.scan_many``, the batch job, and ``worker._derive_live_frame_
+    selection``'s manual branch), so a placement that could not survive its
+    own replay would deadlock an approved session at scan time.
     """
 
     # ---- gate 0: same shape/completeness floor as the automatic detector --
@@ -193,23 +583,7 @@ def build_manual_detection(
             f"{len(rows)} boundary rows would create {frame_count}"
         )
 
-    # ---- gate 2: physical frame-height range, on the operator's own picks -
-    for index, (start, end) in enumerate(zip(rows, rows[1:]), start=1):
-        height_rows = end - start
-        if not (
-            MINIMUM_MANUAL_FRAME_HEIGHT_ROWS
-            <= height_rows
-            <= MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS
-        ):
-            approx_mm = _approximate_mm(height_rows)
-            raise IndexDecodeError(
-                f"the {_ordinal(index)} frame you placed is about "
-                f"{approx_mm:.0f} mm tall (between rows {start} and {end}), "
-                "outside the 15-75 mm range this driver accepts for manual "
-                "placement"
-            )
-
-    # ---- gate 3: snap assist (default on, never a hard requirement) -------
+    # ---- gate 2: snap assist (default on, never a hard requirement) -------
     # Reuses roll_index's own clear-film evidence signal so a "clear film
     # edge" means the exact same physical thing here as it does to the
     # automatic detector and the Rung 3 diagnosis module. If this raster
@@ -285,10 +659,9 @@ def build_manual_detection(
     # Snapping moves each boundary independently by at most
     # SNAP_ASSIST_MAX_DISTANCE_ROWS; re-verify order and raster bounds still
     # hold on the (small number of) final rows before trusting them for
-    # anything downstream. Practically unreachable given the height gate
-    # above already ran on the raw picks, but cheap, correct, and this
-    # module never trusts an unchecked value just because a similar one was
-    # already checked.
+    # anything downstream. Practically unreachable given gate 1 already ran
+    # on the raw picks, but cheap, correct, and this module never trusts an
+    # unchecked value just because a similar one was already checked.
     if any(a >= b for a, b in zip(final_rows, final_rows[1:])):
         raise IndexDecodeError(
             "snap assist moved two placed boundaries out of order; place "
@@ -300,54 +673,141 @@ def build_manual_detection(
             f"(0..{height - 1})"
         )
 
-    # ---- gate 4: per-boundary local transport-ramp guard -------------------
-    # Same guard shape as derive_transport_mapping's wide-gap-anchor
-    # admission check (grep ramp_is_affine in roll_index.py), applied
-    # uniformly to every picked boundary -- manual mode has no separate
-    # "leading anchor" tolerance the way the automatic path does, because
-    # nothing here is inferred from an affine fit; every origin is a direct
-    # table read, and a direct table read next to an untrustworthy ramp is
-    # exactly the case this guard exists to catch.
+    # ---- gate 3: physical frame-height floor and ceiling, on the FINAL ----
+    # ---- (post-snap) rows (F2 + F3) ----------------------------------------
+    # Snap assist (gate 2) can move each boundary independently by up to
+    # SNAP_ASSIST_MAX_DISTANCE_ROWS, which can shrink a frame that was
+    # exactly at the floor below it, or grow one that was exactly at the
+    # ceiling past it (both reachable live: a pick 56 rows from its neighbor
+    # that both snap toward each other lands under the floor; one at the
+    # ceiling that both snap apart lands over it). Checking the RAW picks
+    # here, the way this gate used to, can accept a frame whose real
+    # (post-snap) height violates either bound -- and, because the reviewed
+    # session/batch-wire/worker-replay path always resupplies a prior call's
+    # own final_rows as the next call's raw boundary_rows (see this
+    # function's own docstring), checking raw picks here would also make
+    # this function non-idempotent: a placement it just approved could
+    # refuse when replayed verbatim. A post-snap check does not give up
+    # anything a pre-snap one caught -- snap assist is deterministic and
+    # already re-verified for order/bounds just above -- so there is no
+    # reason to keep both.
+    for index, (start, end) in enumerate(zip(final_rows, final_rows[1:]), start=1):
+        height_rows = end - start
+        if height_rows < MINIMUM_MANUAL_FRAME_HEIGHT_ROWS:
+            approx_mm = _approximate_mm(height_rows)
+            floor_mm = _approximate_mm(MINIMUM_MANUAL_FRAME_HEIGHT_ROWS)
+            raise IndexDecodeError(
+                f"the {_ordinal(index)} frame you placed is about "
+                f"{approx_mm:.0f} mm tall (between rows {start} and {end}), "
+                f"shorter than the {floor_mm:.0f} mm floor this driver "
+                "accepts for manual placement"
+            )
+        if height_rows > FINE_CAPTURE_WINDOW_ROWS:
+            approx_mm = _approximate_mm(height_rows)
+            raise IndexDecodeError(
+                f"the {_ordinal(index)} frame you placed is about "
+                f"{approx_mm:.0f} mm tall (between rows {start} and {end}); "
+                f"the scanner captures about {FINE_CAPTURE_WINDOW_MM:.1f} mm "
+                "per frame in one fine scan and there is no way to capture "
+                "a taller frame in a single pass -- place a boundary "
+                "partway through it instead"
+            )
+
+    # ---- gate 4: per-boundary transport-origin resolution (F1) ------------
+    # Same class of machinery roll_index.derive_transport_mapping uses for
+    # the automatic path: an affine fit over nearby table records, not a
+    # single raw row read trusted on its own. See
+    # _resolve_boundary_transport_origin's own docstring for the two
+    # resolution shapes and why each mirrors a specific
+    # derive_transport_mapping convention. Every failure here still refuses
+    # the WHOLE placement before anything is returned, exactly like every
+    # gate above and below it.
     if len(records) < 1:
         raise IndexDecodeError(
             "manual frame placement requires the same-traversal scanner "
             "position table; none was supplied"
         )
+    for index, row in enumerate(final_rows):
+        if not 0 <= row < len(records):
+            raise IndexDecodeError(
+                f"the {_ordinal(index + 1)} frame edge you placed (row "
+                f"{row}) has no matching entry in the scanner's position "
+                "table; place it on a row the scanner actually recorded a "
+                "position for"
+            )
+
     tail_start = terminal_transport_tail_start(records)
     ramp_upper_bound = (
         len(records) - 1 if tail_start is None else min(len(records) - 1, tail_start - 1)
     )
-    for index, row in enumerate(final_rows):
-        if not 0 <= row < len(records):
-            raise IndexDecodeError(
-                f"the {_ordinal(index + 1)} frame edge you placed (row {row}) "
-                "has no matching entry in the scanner's position table; try "
-                "refeeding the strip and re-scanning the preview"
-            )
-        lo = max(0, row - RAMP_GUARD_RADIUS_ROWS)
-        hi = min(ramp_upper_bound, row + RAMP_GUARD_RADIUS_ROWS)
-        steps_ok = hi > lo and all(
-            MINIMUM_TRANSPORT_SCALE
-            <= records[r + 1].native_origin - records[r].native_origin
-            <= MAXIMUM_TRANSPORT_SCALE
-            for r in range(lo, hi)
-        )
-        if not steps_ok:
-            raise IndexDecodeError(
-                "the scanner's position readings look unreliable around the "
-                f"{_ordinal(index + 1)} frame edge you placed (approximately "
-                f"{_approximate_mm(row):.0f} mm into the roll); try refeeding "
-                "the strip and re-scanning the preview"
-            )
+    table_origins = np.fromiter(
+        (record.native_origin for record in records),
+        dtype=np.int64,
+        count=len(records),
+    )
 
-    # ---- gate 5: origins strictly increasing at 40..45 units/row ----------
-    picked_origins = [records[row].native_origin for row in final_rows]
-    for index, (row_a, row_b, origin_a, origin_b) in enumerate(
-        zip(final_rows, final_rows[1:], picked_origins, picked_origins[1:]),
-        start=1,
-    ):
-        delta_rows = row_b - row_a
-        delta_origin = origin_b - origin_a
+    # The very last picked row is never a frame START -- it is only the
+    # visual END of the final frame (FrameInterval.end_row below), the same
+    # way roll_index.derive_transport_mapping itself only ever resolves
+    # transport origins for boundaries[:frame_count], never the trailing
+    # one. A roll's last frame commonly ends at or after the point the live
+    # 0x8e ramp stops being trustworthy (terminal_transport_tail_start) --
+    # that is an ordinary, healthy end-of-roll shape, not a defect, so
+    # ONLY this one trailing pick is allowed to fail resolution without
+    # refusing the whole placement. Every other pick funds an actual
+    # frame's origin and must resolve or this still refuses in full.
+    trailing_index = len(final_rows) - 1
+    resolved: list[_ResolvedTransportOrigin | None] = []
+    for index, row in enumerate(final_rows):
+        origin = _resolve_boundary_transport_origin(
+            records, table_origins, row, supporting_runs[index], ramp_upper_bound
+        )
+        if origin is None:
+            if index == trailing_index:
+                resolved.append(None)
+                continue
+            raise IndexDecodeError(
+                "the scanner's position table doesn't settle into a steady "
+                f"rate near the {_ordinal(index + 1)} frame edge you "
+                f"placed (row {row}, about {_approximate_mm(row):.0f} mm "
+                "into the roll); try placing the boundary a few rows to "
+                "either side, or re-scan the preview and place the frames "
+                "again"
+            )
+        resolved.append(origin)
+
+    # ---- gate 5: adjacent resolved origins strictly increasing at 40..45 --
+    # Same pairwise sanity as before the rework, now checked against each
+    # boundary's RESOLVED origin (gate 4) instead of one raw row read. This
+    # catches a distinct failure mode from gate 4: gate 4 proves each
+    # boundary's own neighborhood is internally affine; this proves adjacent
+    # boundaries agree with EACH OTHER, which catches a genuine mid-span
+    # table discontinuity between two picks that neither boundary's own
+    # local window ever sees.
+    #
+    # The row side of "position units per row" uses each boundary's
+    # RESOLVED lookup_row, not the visual row the operator placed. A narrow
+    # evidence run's trailing edge and a broad-region forward search each
+    # read the table a few rows away from the exact pick, by design (see
+    # _resolve_boundary_transport_origin); that offset differs between the
+    # two, so two adjacent boundaries resolved through different paths (a
+    # narrow inter-frame gap next to, say, the leader) can have visually
+    # placed rows that imply a fine but genuine steady rate while their
+    # ACTUAL table rows do not, or the other way around. lookup_row is what
+    # was actually read, so it is the only row number this check can hold
+    # to a physical rate without occasionally penalizing a placement for
+    # nothing more than which resolution path two neighbors happened to
+    # take.
+    #
+    # Only the trailing pick (see above) can be None, and only as the very
+    # last element of ``resolved`` -- so the one pair this could affect is
+    # the last one; skip it rather than compare against a resolution that
+    # was never required to exist.
+    for index, (before, after) in enumerate(zip(resolved, resolved[1:]), start=1):
+        if before is None or after is None:
+            continue
+        delta_rows = after.lookup_row - before.lookup_row
+        delta_origin = after.native_origin - before.native_origin
         implied_scale = delta_origin / delta_rows if delta_rows else 0.0
         if not (
             delta_origin > 0
@@ -355,12 +815,96 @@ def build_manual_detection(
         ):
             raise IndexDecodeError(
                 "the scanner's position readings between the "
-                f"{_ordinal(index)} and {_ordinal(index + 1)} frame edges you "
-                f"placed don't move at a steady rate (about "
+                f"{_ordinal(index)} and {_ordinal(index + 1)} frame edges "
+                f"you placed don't move at a steady rate (about "
                 f"{implied_scale:.1f} position units per row; this driver "
-                "expects roughly 40-45); try refeeding the strip and "
-                "re-scanning the preview"
+                "expects roughly 40-45); try placing the boundaries again, "
+                "or re-scan the preview"
             )
+
+    # ---- gate 6: placement-wide affine-fit residuals (F4) -----------------
+    # Same residual contract derive_transport_mapping enforces on the
+    # automatic path (anchor_mae_rows <= PLACEMENT_ANCHOR_MAE_ROWS_MAX,
+    # anchor_max_error_rows <= MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS) -- before
+    # this rework computed here for TransportMapping.diagnostics() but never
+    # enforced, which is exactly how a placement whose picks disagreed with
+    # each other could still get bound downstream: worker.py's
+    # apply_boundary_offset re-checks this same residual at bind time and
+    # either refuses per frame or, if a caller wrongly granted rebase, keeps
+    # a displaced origin (see worker.py's origin_rebase_allowed /
+    # origin_rebase_slots computation for the other half of that fix, which
+    # this rework also closes -- manual placements are no longer eligible
+    # for that rebase).
+    #
+    # A 2-boundary (single-frame) placement's own two points always fit a
+    # line exactly -- MAE and max residual are trivially 0 no matter how
+    # wrong either point is, so this gate cannot add anything for a single
+    # frame. What validates a 2-boundary placement is gate 4 (each pick's
+    # own local neighborhood proves internally affine) and gate 5 (the one
+    # pairwise implied scale between the two picks); there is no third,
+    # independent boundary to cross-check either pick against, so a
+    # systematic table shift confined entirely between the two picks -- one
+    # that neither pick's own local window sees and that still lands inside
+    # the 40..45 pairwise scale band -- is not detectable from two points,
+    # full stop, no matter how this module is written. Documented here
+    # rather than silently pretended away with a gate that would always
+    # pass anyway.
+    #
+    # Fit against each boundary's RESOLVED lookup_row, for the same reason
+    # gate 5 just switched to it: lookup_row is the row this placement's
+    # origins actually came from, so fitting it is a check on whether the
+    # TABLE is one consistent physical ramp across this placement's span --
+    # true regardless of which resolution path (narrow-run trailing edge vs
+    # broad-region forward search) picked each lookup_row. Fitting the
+    # visual pick rows instead would fold each path's own few-row read
+    # offset into the residual alongside genuine table drift, and a
+    # placement that mixes both paths (e.g. a leader-adjacent first
+    # boundary next to ordinary narrow inter-frame gaps -- an entirely
+    # ordinary manual placement) would then show a spurious drift this gate
+    # would wrongly refuse on. NativeFrameOrigin.boundary_output_row is set
+    # to this same lookup_row below (not the visual pick row) precisely so
+    # worker.py's apply_boundary_offset -- the only other reader of that
+    # field, and out of scope for this rework -- re-predicts against the
+    # identical row this fit was trained on.
+    #
+    # Only over the boundaries that actually resolved (see above: the
+    # trailing one may not have).
+    fit_indices = [index for index, item in enumerate(resolved) if item is not None]
+    fit_items = [resolved[index] for index in fit_indices]
+    lookup_rows_arr = np.asarray([item.lookup_row for item in fit_items], dtype=np.float64)
+    origin_arr = np.asarray([item.native_origin for item in fit_items], dtype=np.float64)
+    design = np.column_stack((np.ones(len(lookup_rows_arr)), lookup_rows_arr))
+    placement_intercept, placement_scale = np.linalg.lstsq(design, origin_arr, rcond=None)[0]
+    if placement_scale:
+        fit_residual_rows = (
+            design @ np.asarray((placement_intercept, placement_scale)) - origin_arr
+        ) / placement_scale
+        anchor_mae = float(np.mean(np.abs(fit_residual_rows)))
+        anchor_max = float(np.max(np.abs(fit_residual_rows)))
+    else:  # pragma: no cover - unreachable once gate 5 has passed
+        fit_residual_rows = np.zeros_like(origin_arr)
+        anchor_mae = 0.0
+        anchor_max = 0.0
+    # Full-length (per final_rows position), None only where the trailing
+    # pick has no resolution -- resolved[:-1] (what the origins loop below
+    # actually indexes) never includes that position, so every residual it
+    # reads is always a real float.
+    placement_residual_rows: list[float | None] = [None] * len(resolved)
+    for index, residual in zip(fit_indices, fit_residual_rows):
+        placement_residual_rows[index] = float(residual)
+
+    if len(fit_items) >= PLACEMENT_ANCHOR_GATE_MINIMUM_BOUNDARIES and (
+        anchor_mae > PLACEMENT_ANCHOR_MAE_ROWS_MAX
+        or anchor_max > MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS
+    ):
+        raise IndexDecodeError(
+            "the scanner's position readings across this whole placement "
+            f"don't agree on one steady rate (average drift {anchor_mae:.2f} "
+            f"rows, worst-case drift {anchor_max:.2f} rows against one "
+            "straight line through this placement's own scanner-table "
+            "readings); try placing the boundaries again, or re-scan the "
+            "preview"
+        )
 
     # ---- build the result in the shared roll_index shapes ------------------
     def boundary_reading(row: int) -> tuple[float, float, float]:
@@ -425,49 +969,69 @@ def build_manual_detection(
         )
 
     origins: list[NativeFrameOrigin] = []
-    for frame_index, start_boundary in enumerate(boundaries[:-1], start=1):
-        record = records[start_boundary.output_row]
+    for frame_index, (start_boundary, item, residual) in enumerate(
+        zip(boundaries[:-1], resolved[:-1], placement_residual_rows[:-1]), start=1
+    ):
+        reasons = [MANUAL_ORIGIN_REVIEW_REASON]
+        if item.inferred:
+            reasons.append(INFERRED_ORIGIN_REVIEW_REASON)
+        elif item.substituted:
+            reasons.append(TRANSPORT_ORIGIN_CLAMP_REASON)
+        if (
+            abs(item.lookup_row - start_boundary.output_row)
+            > LOOKUP_FAR_FROM_PICK_ROWS
+        ):
+            # Re-review 2026-08-08, F-B: a false clear-film run inside a
+            # frame (blown-highlight band on slide film) can pull the
+            # trailing-edge anchor well away from what the operator pointed
+            # at with no snap note and no other signal. Beyond the ordinary
+            # ~3-row narrow-gap offset, the divergence gets its own review
+            # reason so the approval UI shows the operator that the scanner
+            # will cut this frame somewhere other than exactly their line.
+            reasons.append(LOOKUP_FAR_FROM_PICK_REVIEW_REASON)
         origins.append(
             NativeFrameOrigin(
                 frame=frame_index,
                 boundary_index=start_boundary.index,
-                boundary_output_row=start_boundary.output_row,
-                lookup_row=start_boundary.output_row,
-                code=record.code,
-                selector=record.selector,
-                native_origin=record.native_origin,
+                # Deliberately the RESOLVED lookup_row, not the visual pick
+                # row (GapBoundary.output_row, used unchanged for thumbnail
+                # cropping in the interval above) -- see gate 6's own
+                # comment for why the placement-wide fit is trained on
+                # lookup_row, and why this field has to match that same row
+                # for worker.py's apply_boundary_offset (this field's only
+                # other reader) to re-predict consistently with it.
+                boundary_output_row=item.lookup_row,
+                lookup_row=item.lookup_row,
+                code=item.code,
+                selector=item.selector,
+                native_origin=item.native_origin,
                 method=MANUAL_ORIGIN_METHOD,
                 automatic=False,
                 manual_review=True,
-                review_reasons=(MANUAL_ORIGIN_REVIEW_REASON,),
-                # Exact same-traversal table read, not an affine-fit
-                # prediction -- there is no fit error to report. Zero here
-                # also keeps worker.py's _addressable_frame_origins residual
-                # filter from ever excluding a manually placed frame; gate 4
-                # above is this module's own, stricter physical check.
-                affine_residual_rows=0.0,
+                review_reasons=tuple(reasons),
+                # The placement-wide fit's own residual (gate 6) for this
+                # boundary, not a per-pick local-window residual: this is
+                # the same quantity worker.py's _addressable_frame_origins
+                # and apply_boundary_offset already gate every AUTOMATIC
+                # origin's affine_residual_rows against
+                # (MAXIMUM_INTERIOR_ANCHOR_ERROR_ROWS), so reusing it here
+                # keeps that shared downstream logic meaningful instead of
+                # silently truncating a manual placement's addressable
+                # prefix for a reason nobody surfaced. For a 2-boundary
+                # placement this is exactly 0.0 (a line through two points
+                # has no residual), matching what this field used to be
+                # hardcoded to before the rework.
+                affine_residual_rows=float(residual),
             )
         )
 
     # Diagnostic-only affine summary across every picked boundary (not just
-    # the frame-owning ones) -- purely for TransportMapping.diagnostics();
-    # nothing above derives an origin from this fit.
-    rows_arr = np.asarray([b.output_row for b in boundaries], dtype=np.float64)
-    origin_arr = np.asarray(picked_origins, dtype=np.float64)
-    design = np.column_stack((np.ones(len(rows_arr)), rows_arr))
-    intercept, scale = np.linalg.lstsq(design, origin_arr, rcond=None)[0]
-    if scale:
-        residual_rows = (design @ np.asarray((intercept, scale)) - origin_arr) / scale
-        anchor_mae = float(np.mean(np.abs(residual_rows)))
-        anchor_max = float(np.max(np.abs(residual_rows)))
-    else:  # pragma: no cover - unreachable once gate 5 has passed
-        anchor_mae = 0.0
-        anchor_max = 0.0
-
+    # the frame-owning ones) -- surfaced through TransportMapping.
+    # diagnostics() and now also enforced above (gate 6).
     mapping = TransportMapping(
         record_count=len(records),
-        native_intercept=float(intercept),
-        native_units_per_preview_row=float(scale),
+        native_intercept=float(placement_intercept),
+        native_units_per_preview_row=float(placement_scale),
         anchor_mae_rows=anchor_mae,
         anchor_max_error_rows=anchor_max,
         origins=tuple(origins),

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_diagnosis.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_diagnosis.py
@@ -1,0 +1,406 @@
+"""Read-only probable-cause diagnosis for an LS-5000 roll-index refusal.
+
+Analyzes the same physical evidence signals the frame detector itself
+computes -- illuminated aperture, per-row transmission/uniformity, and the
+resulting clear-film run structure -- to translate *why* a roll failed into
+one plain-English sentence a film hobbyist can act on. This module never
+re-derives or relaxes any detection knob and cannot construct a detection
+result of any kind: its only public function returns a sentence or nothing,
+enforced by a structural test. See FEEDING-UX-LADDER-OVERNIGHT-20260807.md
+("Rung 3") for the design and FEEDING-ROBUSTNESS-20260805.md ("P3") for the
+original rationale this module adapts.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from .roll_index import (
+    WIDE_GAP_CEILING_ROWS,
+    _active_aperture,
+    _physical_gap_evidence,
+    _true_runs,
+)
+
+# One 97 dpi preview row of film, in mm. FEEDING-ROBUSTNESS-20260805.md Sec
+# 1.1: 142.5 measured preview rows per 38.1 mm standard 8-perforation frame.
+MM_PER_PREVIEW_ROW = 0.267
+
+# The detector's own accepted pitch band, as a fraction of nominal_frame_rows
+# (mirrors roll_index.py's own coarse lag_min/lag_max search constants).
+_STANDARD_LAG_LOW_RATIO = 0.85
+_STANDARD_LAG_HIGH_RATIO = 1.15
+
+# Half-frame (18x24) and panoramic/Xpan true pitch, as a fraction of the
+# driver's assumed standard-35mm nominal_frame_rows (~71/145 and ~259/145
+# measured, FEEDING-ROBUSTNESS-20260805.md Sec 3.3).
+_HALF_FRAME_PITCH_RATIO = 0.49
+_PANORAMA_PITCH_RATIO = 1.79
+
+# Search tolerance (+/-) around each alternate-format point estimate above.
+_ALTERNATE_LAG_TOLERANCE = 0.10
+
+# A clear-film run has to stay below this fraction of one whole frame pitch
+# to count as a candidate for the periodicity search below. Without this, a
+# long leading/trailing unexposed leader (legitimately dozens to hundreds of
+# rows, e.g. test_variable_leader_and_trailer_are_visible_without_guessing_
+# roll_count's leader=300/tail=260 case) is one giant, non-periodic block
+# whose own short-lag self-similarity swamps the real inter-frame signal
+# and reads as false alternate-pitch periodicity.
+_ALTERNATE_PITCH_CANDIDATE_SCALE_FRACTION = 0.5
+
+# How much of the standard-window peak an alternate-pitch peak must reach
+# before it is trusted. See _diagnose_alternate_pitch's docstring for why
+# these two differ by an order of magnitude -- it is not an oversight.
+_HALF_FRAME_DOMINANCE_MARGIN = 0.85
+_PANORAMA_DOMINANCE_MARGIN = 2.0
+
+# A panorama candidate whose winning lag sits this close to exactly double
+# the standard-window lag is that roll's own second harmonic, not panorama.
+_HARMONIC_ALIAS_TOLERANCE_ROWS = 4
+
+# Matches the detector's own narrow-run floor (roll_index.py's accepted
+# [3, 12]-row clear-film run window).
+_NARROW_GAP_FLOOR_ROWS = 3
+
+# Distinct too-narrow/too-wide runs required before this check trusts a
+# systematic pattern instead of one noisy outlier run.
+_GAP_GEOMETRY_MIN_RUNS = 3
+
+# A run has to stay below this fraction of one whole frame pitch to still
+# read as "a gap" rather than "an unexposed frame".
+_TOO_WIDE_FRAME_SCALE_FRACTION = 0.5
+
+# The near-miss band just under the detector's own direct-gap gates
+# (roll_index.py's _physical_gap_evidence: transmission >= 0.87,
+# nonuniformity <= 0.18).
+_CONTRAST_FLOOR_LOW = 0.80
+_CONTRAST_FLOOR_HIGH = 0.87
+_CONTRAST_FLOOR_NONUNIFORMITY_CEILING = 0.18
+
+# A near-miss run has to be at least this wide, and there have to be at
+# least this many of them, before low contrast (not noise) is the read.
+_CONTRAST_FLOOR_MIN_RUN_ROWS = 2
+_CONTRAST_FLOOR_MIN_CLUSTERS = 3
+
+# Leading/trailing slice of the aperture width checked against the middle.
+_APERTURE_EDGE_FRACTION = 0.20
+# A side at or below this fraction of the middle's brightness reads as
+# obstructed (measured cliff: 15/96 cols @ 70% transmission fails detection,
+# 10 columns does not -- FEEDING-ROBUSTNESS-20260805.md Sec 3.3).
+_APERTURE_OBSTRUCTION_RATIO = 0.85
+# Below this aperture width, edge/middle columns cannot be split usefully.
+_APERTURE_MIN_WIDTH_FOR_OBSTRUCTION_CHECK = 10
+
+# Mirrors the detector's own row-completeness floor
+# (complete_rows.mean() < 0.995 -- see roll_index.py's single-pass core).
+_MINIMUM_COMPLETE_ROW_FRACTION = 0.995
+
+
+def _autocorrelation_peak(
+    centered: np.ndarray, lag_min: int, lag_max: int
+) -> tuple[float | None, int | None]:
+    """Best centered-signal dot-product correlation in one lag window.
+
+    Same normalized form the detector's own coarse pitch search uses
+    (``np.dot(centered[:-lag], centered[lag:]) / (len(centered) - lag)``) --
+    a single lag-by-lag scan, not a lattice fit, so it stays cheap enough to
+    run on every failure. Returns ``(None, None)`` when the window has no
+    valid lag for this raster's length.
+    """
+
+    lag_min = max(1, int(math.floor(lag_min)))
+    lag_max = min(len(centered) - 3, int(math.ceil(lag_max)))
+    if lag_min > lag_max:
+        return None, None
+    best_value: float | None = None
+    best_lag: int | None = None
+    for lag in range(lag_min, lag_max + 1):
+        value = float(np.dot(centered[:-lag], centered[lag:]) / (len(centered) - lag))
+        if best_value is None or value > best_value:
+            best_value, best_lag = value, lag
+    return best_value, best_lag
+
+
+def _dominates(alternate: float | None, standard: float | None, margin: float) -> bool:
+    """Whether an alternate-pitch peak is confidently the real periodicity.
+
+    ``alternate`` must itself be a genuine positive correlation -- a
+    hypothesis nothing in the raster supports never fires, no matter how
+    weak ``standard`` is. Once that holds, a non-positive ``standard`` peak
+    (no periodicity found at the driver's assumed pitch at all) is beaten
+    automatically; otherwise ``alternate`` must clear ``margin`` times
+    ``standard``.
+    """
+
+    if alternate is None or alternate <= 0:
+        return False
+    if standard is None or standard <= 0:
+        return True
+    return alternate >= margin * standard
+
+
+def _diagnose_alternate_pitch(
+    evidence: np.ndarray, direct: np.ndarray, nominal_frame_rows: int
+) -> str | None:
+    """Half-frame and panoramic film pitch check.
+
+    Half-frame's true pitch sits close to half the driver's assumed
+    nominal; panoramic/Xpan's sits close to 1.79x it. Both are recognized
+    by directly probing an autocorrelation window centered on the
+    alternate pitch instead of the driver's assumed one.
+
+    The signal correlated is ``evidence`` zeroed everywhere except inside
+    clear-film runs narrower than the candidate-scale fraction of one frame
+    pitch (``_ALTERNATE_PITCH_CANDIDATE_SCALE_FRACTION``) -- the same
+    "restrict to run-scale evidence" shape the detector's own
+    ``anchor_signal`` uses, adapted here with a wider, format-agnostic cap
+    instead of the detector's exact [3, 12]-row window, since a half-frame
+    or panoramic roll's own gaps need not fall in that specific band.
+    Without this restriction, a long unexposed leader/trailer (legitimately
+    dozens to hundreds of rows) is one giant non-periodic block whose own
+    short-lag self-similarity reads as false periodicity at short lags --
+    confirmed by direct measurement, not theory: an otherwise-healthy
+    synthetic roll with a 300-row leader produced a spurious "half-frame"
+    reading before this restriction, and none after.
+
+    A margin note, because the obvious "just beat the standard-window
+    peak" comparison does not hold for half-frame: on a clean periodic
+    signal, autocorrelation at any integer multiple of the true period is
+    roughly *equal* to correlation at the true period itself (measured
+    0.87-1.06x across many synthetic half-frame rolls, never close to
+    2x) -- the driver's standard window is finding half-frame film's own
+    second harmonic, not a competing signal. The real tell is sign, not
+    multiple: a genuinely standard roll shows no periodicity at all at the
+    half-frame lag (consistently negative in the same sweep), so
+    ``_HALF_FRAME_DOMINANCE_MARGIN`` only has to rule out noise once the
+    alternate peak is already positive.
+
+    Panorama does not share that ambiguity -- 1.79x is not an integer
+    relationship with the standard pitch -- so the far stricter
+    ``_PANORAMA_DOMINANCE_MARGIN`` applies there instead, matching this
+    check's own "e.g. 2x" starting point. The one confound is the mirror
+    image of the half-frame case: a standard roll's *own* second harmonic
+    (2x its true pitch) can land inside the panorama search window, and
+    there it ties the standard peak the same way half-frame's does.
+    Rejecting any panorama candidate whose winning lag sits within
+    ``_HARMONIC_ALIAS_TOLERANCE_ROWS`` of exactly twice the standard-window
+    lag (the same neighbor-exclusion radius the detector's own
+    ``autocorrelation_best_non_neighbor`` uses) closes that hole.
+    """
+
+    candidate_scale_rows = (
+        _ALTERNATE_PITCH_CANDIDATE_SCALE_FRACTION * nominal_frame_rows
+    )
+    periodic = np.zeros_like(evidence)
+    for start, end in _true_runs(direct):
+        if (end - start) < candidate_scale_rows:
+            periodic[start:end] = evidence[start:end]
+    centered = periodic - float(periodic.mean())
+    standard_peak, standard_lag = _autocorrelation_peak(
+        centered,
+        nominal_frame_rows * _STANDARD_LAG_LOW_RATIO,
+        nominal_frame_rows * _STANDARD_LAG_HIGH_RATIO,
+    )
+    standard_mm = nominal_frame_rows * MM_PER_PREVIEW_ROW
+
+    half_peak, half_lag = _autocorrelation_peak(
+        centered,
+        nominal_frame_rows * _HALF_FRAME_PITCH_RATIO * (1 - _ALTERNATE_LAG_TOLERANCE),
+        nominal_frame_rows * _HALF_FRAME_PITCH_RATIO * (1 + _ALTERNATE_LAG_TOLERANCE),
+    )
+    if _dominates(half_peak, standard_peak, _HALF_FRAME_DOMINANCE_MARGIN):
+        half_mm = half_lag * MM_PER_PREVIEW_ROW
+        return (
+            f"this looks like half-frame film (a frame about every {half_mm:.0f} mm); "
+            f"this driver expects standard 35 mm spacing (about {standard_mm:.0f} mm "
+            "between frame starts)"
+        )
+
+    panorama_peak, panorama_lag = _autocorrelation_peak(
+        centered,
+        nominal_frame_rows * _PANORAMA_PITCH_RATIO * (1 - _ALTERNATE_LAG_TOLERANCE),
+        nominal_frame_rows * _PANORAMA_PITCH_RATIO * (1 + _ALTERNATE_LAG_TOLERANCE),
+    )
+    aliases_standard_second_harmonic = (
+        standard_peak is not None
+        and standard_peak > 0
+        and standard_lag is not None
+        and panorama_lag is not None
+        and abs(panorama_lag - 2 * standard_lag) <= _HARMONIC_ALIAS_TOLERANCE_ROWS
+    )
+    if not aliases_standard_second_harmonic and _dominates(
+        panorama_peak, standard_peak, _PANORAMA_DOMINANCE_MARGIN
+    ):
+        panorama_mm = panorama_lag * MM_PER_PREVIEW_ROW
+        return (
+            f"this looks like panoramic film (a frame about every {panorama_mm:.0f} mm); "
+            f"this driver expects standard 35 mm spacing (about {standard_mm:.0f} mm "
+            "between frame starts)"
+        )
+    return None
+
+
+def _diagnose_gap_geometry(direct: np.ndarray, nominal_frame_rows: int) -> str | None:
+    """Clear-film run-width histogram: systematically too-narrow or too-wide gaps.
+
+    Only fires when *every* found run shares the same problem -- a mix of
+    narrow and wide runs is a messier picture this check should not guess
+    at, and ``_GAP_GEOMETRY_MIN_RUNS`` keeps one stray run from deciding
+    the sentence on its own.
+    """
+
+    runs = _true_runs(direct)
+    if len(runs) < _GAP_GEOMETRY_MIN_RUNS:
+        return None
+    widths = [end - start for start, end in runs]
+
+    if all(width < _NARROW_GAP_FLOOR_ROWS for width in widths):
+        measured_mm = float(np.median(widths)) * MM_PER_PREVIEW_ROW
+        floor_mm = _NARROW_GAP_FLOOR_ROWS * MM_PER_PREVIEW_ROW
+        return (
+            f"the blank strips between your frames measure about {measured_mm:.1f} mm; "
+            f"that is under the {floor_mm:.1f} mm this detector needs to recognize a gap"
+        )
+
+    frame_scale_rows = _TOO_WIDE_FRAME_SCALE_FRACTION * nominal_frame_rows
+    too_wide = [
+        width for width in widths if WIDE_GAP_CEILING_ROWS < width < frame_scale_rows
+    ]
+    if too_wide and len(too_wide) == len(widths):
+        measured_mm = float(np.median(too_wide)) * MM_PER_PREVIEW_ROW
+        return (
+            f"a blank region measures about {measured_mm:.1f} mm; that is wider than "
+            "anything the detector accepts as a between-frame gap"
+        )
+    return None
+
+
+def _diagnose_contrast_floor(
+    transmission: np.ndarray, nonuniformity: np.ndarray, direct: np.ndarray
+) -> str | None:
+    """Rows that fail only the transmission half of the direct gap gate.
+
+    ``nonuniformity`` is held to the same ceiling the detector's own direct
+    gate uses, so this isolates rows that are flat (not scene content) but
+    simply too dim -- fog or a dense film base, not noise.
+    """
+
+    near_miss = (
+        ~direct
+        & (nonuniformity <= _CONTRAST_FLOOR_NONUNIFORMITY_CEILING)
+        & (transmission >= _CONTRAST_FLOOR_LOW)
+        & (transmission < _CONTRAST_FLOOR_HIGH)
+    )
+    runs = _true_runs(near_miss)
+    clusters = [
+        (start, end)
+        for start, end in runs
+        if end - start >= _CONTRAST_FLOOR_MIN_RUN_ROWS
+    ]
+    if len(clusters) < _CONTRAST_FLOOR_MIN_CLUSTERS:
+        return None
+    measured = float(
+        np.median(np.concatenate([transmission[start:end] for start, end in clusters]))
+    )
+    return (
+        "the blank film between frames is only slightly clearer than the frames "
+        f"themselves (relative brightness about {measured:.2f}, against the "
+        f"{_CONTRAST_FLOOR_HIGH:.2f} the detector needs); this could be fog or a "
+        "dense film base"
+    )
+
+
+def _diagnose_aperture_obstruction(
+    rgb16: np.ndarray, aperture: tuple[int, int]
+) -> str | None:
+    """Column-wise brightness profile: one aperture edge depressed against the middle.
+
+    Uses every row, not just clear-film rows: a real physical obstruction
+    -- carrier mask edge, curl shadow, tape, heavy edge fog -- depresses a
+    fixed band of columns whether that row is a gap or a photographed
+    frame, so the median over all rows is the more reliable read (a
+    genuine obstruction can push transmission on affected rows below the
+    direct gate everywhere, leaving too few clear-film rows to trust on
+    their own).
+    """
+
+    lo, hi = aperture
+    width = hi - lo
+    if width < _APERTURE_MIN_WIDTH_FOR_OBSTRUCTION_CHECK:
+        return None
+    column_level = np.median(rgb16[:, lo:hi].astype(np.float64).mean(axis=2), axis=0)
+    edge = max(1, round(width * _APERTURE_EDGE_FRACTION))
+    if width - 2 * edge < edge:
+        return None
+    middle = float(np.median(column_level[edge:-edge]))
+    if middle <= 0:
+        return None
+    leading_ratio = float(np.median(column_level[:edge])) / middle
+    trailing_ratio = float(np.median(column_level[-edge:])) / middle
+    if leading_ratio <= _APERTURE_OBSTRUCTION_RATIO:
+        side = "leading"
+    elif trailing_ratio <= _APERTURE_OBSTRUCTION_RATIO:
+        side = "trailing"
+    else:
+        return None
+    return (
+        f"one edge of the film window looks partly blocked (the {side} side reads "
+        "darker than the middle); check the film holder seating and film curl"
+    )
+
+
+def diagnose_roll_refusal(
+    rgb16: np.ndarray,
+    known: np.ndarray,
+    *,
+    nominal_frame_rows: int,
+) -> str | None:
+    """One plain-English probable cause for a roll refusal, or ``None``.
+
+    Pure read-only analysis over the same evidence signals the frame
+    detector itself computes -- aperture, per-row transmission/uniformity,
+    and the resulting clear-film run structure. It never re-runs detection
+    with relaxed knobs and cannot produce frames, boundaries, or a
+    detection result of any kind: the only thing it can hand back is one
+    sentence or nothing. Checks run in a fixed priority order and the
+    first one confident enough to speak wins; if none clear their margin
+    this returns ``None``, on the belief that no sentence beats a wrong
+    one.
+    """
+
+    try:
+        if rgb16.shape != known.shape or nominal_frame_rows < 16:
+            return None
+        complete_rows = np.asarray(known, dtype=bool).all(axis=(1, 2))
+        if complete_rows.mean() < _MINIMUM_COMPLETE_ROW_FRACTION:
+            return None
+        aperture = _active_aperture(rgb16)
+        evidence, transmission, nonuniformity, direct = _physical_gap_evidence(
+            rgb16, aperture
+        )
+    except Exception:
+        # Every check below assumes a well-formed raster with a real
+        # aperture; anything that breaks those preconditions leaves
+        # nothing trustworthy left to diagnose.
+        return None
+
+    checks = (
+        lambda: _diagnose_alternate_pitch(evidence, direct, nominal_frame_rows),
+        lambda: _diagnose_gap_geometry(direct, nominal_frame_rows),
+        lambda: _diagnose_contrast_floor(transmission, nonuniformity, direct),
+        lambda: _diagnose_aperture_obstruction(rgb16, aperture),
+    )
+    for check in checks:
+        try:
+            sentence = check()
+        except Exception:
+            # One check's own bug must not block the others, and must
+            # never surface here as anything but "this check found
+            # nothing".
+            continue
+        if sentence is not None:
+            return sentence
+    return None

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_diagnosis.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_diagnosis.py
@@ -91,6 +91,36 @@ _APERTURE_EDGE_FRACTION = 0.20
 # obstructed (measured cliff: 15/96 cols @ 70% transmission fails detection,
 # 10 columns does not -- FEEDING-ROBUSTNESS-20260805.md Sec 3.3).
 _APERTURE_OBSTRUCTION_RATIO = 0.85
+# The fog/dense-base sentence requires both aperture edges within this
+# fraction of the middle: below it, the transmission depression is
+# one-sided (an obstruction-shaped signal, whatever its depth), and the
+# contrast check stays silent rather than blaming the film stock.
+_CONTRAST_FLOOR_SYMMETRY_FLOOR = 0.90
+# The obstruction profile is judged over clear-film candidate rows: rows
+# whose middle-column level reaches this fraction of the raster's own
+# clear-base reference (p99 of row middles -- the same self-normalising
+# shape the detector's clear_base uses). A fixed top-percentile cut is
+# wrong here: on a full roll only ~6% of rows are clear film, so any
+# percentile wide enough to be robust also admits bright FRAME rows,
+# whose scene content carries per-column structure that median-stacks
+# into a false one-sided depression (caught by the healthy-roll
+# regression, 2026-08-08). A minimum count of candidate rows is still
+# required before the check may speak at all.
+_OBSTRUCTION_CLEAR_LEVEL_FRACTION = 0.75
+_OBSTRUCTION_MIN_BRIGHT_ROWS = 6
+# ...and the p99 reference itself must stand clearly apart from the typical
+# row before those candidates are believed to be clear film at all: on a
+# roll with NO clear rows (dense/gapless refusals -- exactly when diagnosis
+# runs), p99 lands on bright FRAME rows whose one-sided scene content then
+# resurrects the phantom-obstruction sentence (re-review 2026-08-08, F-C).
+# Real clear film reads several times brighter than frame content; a p99
+# within this ratio of the median row means there is no clear-film
+# population to judge from, and the check stays silent. 1.8 sits between
+# frame texture's own p99/median spread (~1.5-1.6 measured on the synthetic
+# fixtures) and real clear film's ~3x separation; dense film whose clear
+# rows barely clear its frames loses obstruction diagnosis rather than
+# risking a wrong sentence.
+_OBSTRUCTION_CLEAR_SEPARATION_RATIO = 1.8
 # Below this aperture width, edge/middle columns cannot be split usefully.
 _APERTURE_MIN_WIDTH_FOR_OBSTRUCTION_CHECK = 10
 
@@ -279,14 +309,42 @@ def _diagnose_gap_geometry(direct: np.ndarray, nominal_frame_rows: int) -> str |
 
 
 def _diagnose_contrast_floor(
-    transmission: np.ndarray, nonuniformity: np.ndarray, direct: np.ndarray
+    transmission: np.ndarray,
+    nonuniformity: np.ndarray,
+    direct: np.ndarray,
+    rgb16: np.ndarray,
+    aperture: tuple[int, int],
 ) -> str | None:
     """Rows that fail only the transmission half of the direct gap gate.
 
     ``nonuniformity`` is held to the same ceiling the detector's own direct
     gate uses, so this isolates rows that are flat (not scene content) but
     simply too dim -- fog or a dense film base, not noise.
+
+    Fog and a dense base are whole-film properties, so the depression must
+    be roughly column-symmetric before this speaks (adversarial review
+    2026-08-08, F5): a one-sided aperture band can drag gap rows into the
+    same 0.80-0.87 near-miss window while sitting just above the
+    obstruction check's own ratio, and the fog sentence would then send
+    the reporter chasing their film stock when the real problem is holder
+    seating. An asymmetric profile stays silent -- no sentence beats a
+    wrong one.
     """
+
+    lo, hi = aperture
+    width = hi - lo
+    if width >= _APERTURE_MIN_WIDTH_FOR_OBSTRUCTION_CHECK:
+        column_level = np.median(
+            rgb16[:, lo:hi].astype(np.float64).mean(axis=2), axis=0
+        )
+        edge = max(1, round(width * _APERTURE_EDGE_FRACTION))
+        if width - 2 * edge >= edge:
+            middle = float(np.median(column_level[edge:-edge]))
+            if middle > 0:
+                leading = float(np.median(column_level[:edge])) / middle
+                trailing = float(np.median(column_level[-edge:])) / middle
+                if min(leading, trailing) < _CONTRAST_FLOOR_SYMMETRY_FLOOR:
+                    return None
 
     near_miss = (
         ~direct
@@ -318,23 +376,38 @@ def _diagnose_aperture_obstruction(
 ) -> str | None:
     """Column-wise brightness profile: one aperture edge depressed against the middle.
 
-    Uses every row, not just clear-film rows: a real physical obstruction
-    -- carrier mask edge, curl shadow, tape, heavy edge fog -- depresses a
-    fixed band of columns whether that row is a gap or a photographed
-    frame, so the median over all rows is the more reliable read (a
-    genuine obstruction can push transmission on affected rows below the
-    direct gate everywhere, leaving too few clear-film rows to trust on
-    their own).
+    Measured over the raster's BRIGHTEST rows by middle-column level -- the
+    clear-film candidates. A real physical obstruction -- carrier mask
+    edge, curl shadow, tape, heavy edge fog -- depresses a fixed band of
+    columns on every row including the clear ones, while a roll whose
+    photographs simply carry dark content along one side (2026-08-08
+    review, S9) depresses that side only where there is picture. Judging
+    on bright rows keeps the first and drops the second: an obstruction
+    still shows there (its columns stay dark even when the film is clear),
+    but composition cannot (a bright/clear row has no dark subject edge).
     """
 
     lo, hi = aperture
     width = hi - lo
     if width < _APERTURE_MIN_WIDTH_FOR_OBSTRUCTION_CHECK:
         return None
-    column_level = np.median(rgb16[:, lo:hi].astype(np.float64).mean(axis=2), axis=0)
+    levels = rgb16[:, lo:hi].astype(np.float64).mean(axis=2)
     edge = max(1, round(width * _APERTURE_EDGE_FRACTION))
     if width - 2 * edge < edge:
         return None
+    row_middle = np.median(levels[:, edge:-edge], axis=1)
+    clear_reference = float(np.percentile(row_middle, 99.0))
+    if clear_reference <= 0:
+        return None
+    typical_row = float(np.median(row_middle))
+    if typical_row > 0 and clear_reference < (
+        _OBSTRUCTION_CLEAR_SEPARATION_RATIO * typical_row
+    ):
+        return None
+    bright_rows = row_middle >= _OBSTRUCTION_CLEAR_LEVEL_FRACTION * clear_reference
+    if int(bright_rows.sum()) < _OBSTRUCTION_MIN_BRIGHT_ROWS:
+        return None
+    column_level = np.median(levels[bright_rows], axis=0)
     middle = float(np.median(column_level[edge:-edge]))
     if middle <= 0:
         return None
@@ -387,11 +460,19 @@ def diagnose_roll_refusal(
         # nothing trustworthy left to diagnose.
         return None
 
+    # Obstruction runs BEFORE the contrast floor (adversarial review
+    # 2026-08-08, F5): a one-sided aperture band dims gap rows into the
+    # contrast check's 0.80-0.87 near-miss window, and the fog/dense-base
+    # sentence would then send the reporter chasing their film stock when
+    # the physically correct advice is to reseat the holder. The
+    # obstruction check is the more specific signal, so it speaks first.
     checks = (
         lambda: _diagnose_alternate_pitch(evidence, direct, nominal_frame_rows),
         lambda: _diagnose_gap_geometry(direct, nominal_frame_rows),
-        lambda: _diagnose_contrast_floor(transmission, nonuniformity, direct),
         lambda: _diagnose_aperture_obstruction(rgb16, aperture),
+        lambda: _diagnose_contrast_floor(
+            transmission, nonuniformity, direct, rgb16, aperture
+        ),
     )
     for check in checks:
         try:

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -931,6 +931,28 @@ def _gap_lattice_diagnostics(
     }
 
 
+def _diagnose_refusal_safely(
+    rgb16: np.ndarray, known: np.ndarray, nominal_frame_rows: int
+) -> str | None:
+    """Best-effort probable-cause sentence for a refusal about to be raised.
+
+    Deferred import breaks the two-module cycle -- roll_diagnosis.py imports
+    this module's own private evidence helpers -- and only needs to resolve
+    once a raise is already underway. The broad except is deliberate: a bug
+    in diagnosis must never replace or hide the real IndexDecodeError being
+    raised, so any failure in here is silently treated as "no diagnosis".
+    """
+
+    try:
+        from .roll_diagnosis import diagnose_roll_refusal
+
+        return diagnose_roll_refusal(
+            rgb16, known, nominal_frame_rows=nominal_frame_rows
+        )
+    except Exception:
+        return None
+
+
 def detect_roll_frames(
     rgb16: np.ndarray,
     known: np.ndarray,
@@ -947,6 +969,12 @@ def detect_roll_frames(
     as gap anchors. If recovery also fails, the *original* pass-1 error
     is re-raised with a recovery note appended to its diagnostics so
     field reports stay comparable across versions.
+
+    Both re-raise paths below also attach a best-effort plain-English
+    ``diagnostics["probable_cause"]`` sentence (roll_diagnosis.py) whenever
+    one fires with enough confidence to speak. This only ever adds that one
+    key: the error id, message prefix, and every other diagnostics key are
+    unchanged from today's behavior.
     """
 
     try:
@@ -960,7 +988,16 @@ def detect_roll_frames(
         raise
     except IndexDecodeError as primary:
         if primary.error_id not in _WIDE_GAP_RECOVERY_ERROR_IDS:
-            raise
+            cause = _diagnose_refusal_safely(rgb16, known, nominal_frame_rows)
+            if cause is None:
+                raise
+            diagnostics = dict(primary.diagnostics or {})
+            diagnostics["probable_cause"] = cause
+            raise IndexDecodeError(
+                str(primary).split(" [")[0],
+                error_id=primary.error_id,
+                diagnostics=diagnostics,
+            ) from None
         try:
             return _detect_roll_frames_single(
                 rgb16,
@@ -974,6 +1011,9 @@ def detect_roll_frames(
             diagnostics["wide_gap_recovery"] = (
                 f"attempted and failed: {recovery}"
             )
+            cause = _diagnose_refusal_safely(rgb16, known, nominal_frame_rows)
+            if cause is not None:
+                diagnostics["probable_cause"] = cause
             raise IndexDecodeError(
                 str(primary).split(" [")[0],
                 error_id=primary.error_id,

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -988,6 +988,16 @@ def detect_roll_frames(
         raise
     except IndexDecodeError as primary:
         if primary.error_id not in _WIDE_GAP_RECOVERY_ERROR_IDS:
+            # Reconstructing to attach the sentence is only safe for the
+            # exact base class: subclasses (e.g. a vendored tree's
+            # LeadingFrameClippedError) carry their own constructor
+            # signatures, structured fields, and dedicated downstream
+            # handling that a plain IndexDecodeError rebuild would silently
+            # erase. Those re-raise untouched -- their messages are already
+            # specific -- and only a bare IndexDecodeError gains the
+            # probable-cause key.
+            if type(primary) is not IndexDecodeError:
+                raise
             cause = _diagnose_refusal_safely(rgb16, known, nominal_frame_rows)
             if cause is None:
                 raise

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -42,6 +42,26 @@ GAP_COUNT_FLOOR_ERROR_ID = "gap-count-floor"
 GAP_LATTICE_ANCHOR_ERROR_ID = "gap-lattice-anchor-floor"
 GAP_DIRECT_SUPPORT_ERROR_ID = "gap-direct-support-floor"
 
+# Wide-gap recovery (FEEDING-DETECTOR-ROUND-20260807): a clear-film run
+# wider than the 12-row narrow ceiling but no wider than this is treated
+# as a candidate *wide* inter-frame gap during the recovery pass only.
+# 20 preview rows is ~5.3 mm of film: comfortably above the widest field-
+# reported gap (14 rows, ScanStudio #23/#24) and comfortably below
+# leader/trailer runs (38 rows observed) and any blank-frame-scale run
+# (~130 rows). Recovery can never produce an automatic, unattended, or
+# high-confidence result: slots anchored on wide runs are always manual
+# review and detection confidence is capped at medium.
+WIDE_GAP_CEILING_ROWS = 20
+WIDE_GAP_RECOVERY_WARNING = "wide-gap-recovery"
+WIDE_GAP_ANCHOR_REVIEW_REASON = "wide-gap-anchor"
+_WIDE_GAP_RECOVERY_ERROR_IDS = frozenset(
+    {
+        GAP_COUNT_FLOOR_ERROR_ID,
+        GAP_LATTICE_ANCHOR_ERROR_ID,
+        GAP_DIRECT_SUPPORT_ERROR_ID,
+    }
+)
+
 
 class IndexDecodeError(ValueError):
     """Input is not a self-consistent LS-5000 roll-index capture.
@@ -918,6 +938,57 @@ def detect_roll_frames(
     nominal_frame_rows: int,
     expected_frame_count: int | None = None,
 ) -> RollDetection:
+    """Two-pass wrapper: stock detection first, wide-gap recovery second.
+
+    Pass 1 is the unmodified stock detector; any raster it resolves is
+    returned bit-identically. Only when it raises one of the three
+    physical-gap floor errors is a single recovery pass attempted with
+    wide clear-film runs (12 < width <= WIDE_GAP_CEILING_ROWS) admitted
+    as gap anchors. If recovery also fails, the *original* pass-1 error
+    is re-raised with a recovery note appended to its diagnostics so
+    field reports stay comparable across versions.
+    """
+
+    try:
+        return _detect_roll_frames_single(
+            rgb16,
+            known,
+            nominal_frame_rows=nominal_frame_rows,
+            expected_frame_count=expected_frame_count,
+        )
+    except IncompleteIndexError:
+        raise
+    except IndexDecodeError as primary:
+        if primary.error_id not in _WIDE_GAP_RECOVERY_ERROR_IDS:
+            raise
+        try:
+            return _detect_roll_frames_single(
+                rgb16,
+                known,
+                nominal_frame_rows=nominal_frame_rows,
+                expected_frame_count=expected_frame_count,
+                wide_gap_ceiling=WIDE_GAP_CEILING_ROWS,
+            )
+        except IndexDecodeError as recovery:
+            diagnostics = dict(primary.diagnostics or {})
+            diagnostics["wide_gap_recovery"] = (
+                f"attempted and failed: {recovery}"
+            )
+            raise IndexDecodeError(
+                str(primary).split(" [")[0],
+                error_id=primary.error_id,
+                diagnostics=diagnostics,
+            ) from None
+
+
+def _detect_roll_frames_single(
+    rgb16: np.ndarray,
+    known: np.ndarray,
+    *,
+    nominal_frame_rows: int,
+    expected_frame_count: int | None = None,
+    wide_gap_ceiling: int | None = None,
+) -> RollDetection:
     """Detect arbitrary roll frames from physical clear-film gap evidence.
 
     The result contains N+1 lattice boundaries and N candidate slots.  The
@@ -948,7 +1019,16 @@ def detect_roll_frames(
     narrow_runs = [
         (start, end) for start, end in evidence_runs if 3 <= end - start <= 12
     ]
-    if len(narrow_runs) < 3:
+    wide_runs = (
+        [
+            (start, end)
+            for start, end in evidence_runs
+            if 12 < end - start <= wide_gap_ceiling
+        ]
+        if wide_gap_ceiling is not None
+        else []
+    )
+    if len(narrow_runs) + len(wide_runs) < 3:
         raise IndexDecodeError(
             "roll detector found too few distinct physical gaps",
             error_id=GAP_COUNT_FLOOR_ERROR_ID,
@@ -964,7 +1044,7 @@ def detect_roll_frames(
         )
     anchor_signal = np.zeros_like(evidence)
     anchor_centers = []
-    for start, end in narrow_runs:
+    for start, end in narrow_runs + wide_runs:
         anchor_signal[start:end] = evidence[start:end]
         anchor_centers.append((start + end - 1) / 2.0)
 
@@ -1104,6 +1184,13 @@ def detect_roll_frames(
             if 3 <= width <= 12:
                 support = "direct"
                 output_row = int(math.floor((run[0] + run[1] - 1) / 2.0 + 0.5))
+            elif (
+                wide_gap_ceiling is not None
+                and 12 < width <= wide_gap_ceiling
+            ):
+                support = "direct-wide"
+                output_row = int(math.floor((run[0] + run[1] - 1) / 2.0 + 0.5))
+                reasons.append(WIDE_GAP_ANCHOR_REVIEW_REASON)
             elif width > 12:
                 support = "cadence-broad"
                 reasons.append("broad-clear-region")
@@ -1128,7 +1215,7 @@ def detect_roll_frames(
 
     def boundary_is_supported(boundary: GapBoundary) -> bool:
         return bool(
-            boundary.support in {"direct", "cadence-broad"}
+            boundary.support in {"direct", "direct-wide", "cadence-broad"}
             and boundary.evidence >= 0.40
             and boundary.transmission >= 0.82
             and boundary.nonuniformity <= 0.22
@@ -1297,7 +1384,8 @@ def detect_roll_frames(
     alignment_boundary_count = alignment_end - cell_start + 1
     alignment_boundaries = boundaries[:alignment_boundary_count]
     direct_support_count = sum(
-        item.support == "direct" for item in alignment_boundaries
+        item.support in {"direct", "direct-wide"}
+        for item in alignment_boundaries
     )
     if direct_support_count < 3:
         raise IndexDecodeError(
@@ -1363,8 +1451,10 @@ def detect_roll_frames(
         [item.evidence for item in supported_alignment_boundaries], dtype=np.float64
     )
     direct_fraction = sum(
-        item.support == "direct" for item in alignment_boundaries[:-1]
+        item.support in {"direct", "direct-wide"}
+        for item in alignment_boundaries[:-1]
     ) / max(1, len(alignment_boundaries) - 1)
+    recovered_wide_gap = wide_gap_ceiling is not None
     if (
         lattice_score >= 0.65
         and lattice_margin >= 0.08
@@ -1376,9 +1466,13 @@ def detect_roll_frames(
         confidence = "medium"
     else:
         confidence = "low"
+    if recovered_wide_gap and confidence == "high":
+        confidence = "medium"
 
     expected_frame_count_matches: bool | None = None
     warnings: list[str] = []
+    if recovered_wide_gap:
+        warnings.append(WIDE_GAP_RECOVERY_WARNING)
     if expected_frame_count is not None:
         expected_frame_count_matches = expected_frame_count in content_end_candidates
         if expected_frame_count_matches:
@@ -1561,18 +1655,87 @@ def derive_transport_mapping(
         if leading_anchor is not None and len(fit_candidates) > 4
         else fit_candidates
     )
-    if len(fit_direct) < 3:
+    # Wide-gap recovery: a strip anchored on wide clear-film runs can
+    # carry fewer than three narrow direct gaps. Only in that case --
+    # never to perturb a fit that already has its three narrow anchors --
+    # admit direct-wide boundaries as additional fit anchors. A wide
+    # run's center is not offset from its trailing edge the way a narrow
+    # run's is, so its anchor x is its trailing edge translated into the
+    # narrow anchors' center space by their own measured center-to-
+    # trailing offset (3 rows on 90% of 1,272 archived direct anchors;
+    # per-capture median used here). Wide anchors never become
+    # automatic and every fit gate below is unchanged.
+    narrow_offsets = [
+        float(item.evidence_run[1] - item.output_row)
+        for item, _record in fit_direct
+        if item.evidence_run is not None
+    ]
+    # 3 rows on 1,146 of 1,272 archived direct anchors (min 2, max 6).
+    # The constant fallback is unreachable in practice -- every path to
+    # the affine fit carries at least one narrow anchor with an evidence
+    # run -- and exists as belt-and-braces only.
+    narrow_anchor_offset = (
+        float(np.median(narrow_offsets)) if narrow_offsets else 3.0
+    )
+    wide_fit: list[tuple[GapBoundary, TransportRecord, float]] = []
+    if len(fit_direct) < 3 and narrow_offsets:
+        for boundary in frame_boundaries:
+            if boundary.support != "direct-wide":
+                continue
+            if boundary.evidence_run is None:
+                continue
+            if (
+                boundary.evidence < 0.40
+                or boundary.transmission < 0.82
+                or boundary.nonuniformity > 0.22
+            ):
+                continue
+            lookup_row = boundary.evidence_run[1]
+            if not 0 <= lookup_row < len(records):
+                continue
+            record = records[lookup_row]
+            if tail_start is not None and record.row >= tail_start:
+                continue
+            # The last interior gap of a short strip can sit right
+            # where the live 0x8e ramp degrades (observed on the
+            # phoenix capture: clean 42/row through the gap's leading
+            # side, then -70/+154/-714 jitter immediately after,
+            # well before terminal_transport_tail_start). A wide
+            # anchor is admitted only when every single-row step of
+            # the table across its trailing edge is affine at the
+            # transport scale -- an endpoint chord would pass the
+            # observed single-record spikes (F2, adversarial review
+            # 2026-08-07). Otherwise the anchor is unusable and the
+            # mapping refuses rather than fitting to noise.
+            lo = max(0, lookup_row - 3)
+            hi = min(len(records) - 1, lookup_row + 3)
+            if hi <= lo:
+                continue
+            ramp_is_affine = all(
+                minimum_scale
+                <= records[r + 1].native_origin - records[r].native_origin
+                <= maximum_scale
+                for r in range(lo, hi)
+            )
+            if not ramp_is_affine:
+                continue
+            wide_fit.append(
+                (boundary, record, lookup_row - narrow_anchor_offset)
+            )
+    if len(fit_direct) + len(wide_fit) < 3:
         raise IndexDecodeError(
             "transport mapping requires at least three direct physical gaps "
             "before the terminal transport tail"
         )
 
     x = np.asarray(
-        [item.output_row for item, _record in fit_direct],
+        [item.output_row for item, _record in fit_direct]
+        + [anchor_x for _b, _r, anchor_x in wide_fit],
         dtype=np.float64,
     )
     y = np.asarray(
-        [record.native_origin for _item, record in fit_direct],
+        [record.native_origin for _item, record in fit_direct]
+        + [record.native_origin for _b, record, _x in wide_fit],
         dtype=np.float64,
     )
     design = np.column_stack((np.ones(len(x)), x))
@@ -1605,21 +1768,48 @@ def derive_transport_mapping(
         leading_anchor_requires_review = leading_error > maximum_anchor_error_rows
 
     direct_by_index = {item.index: record for item, record in direct}
+    wide_by_index = {
+        boundary.index: (record, anchor_x)
+        for boundary, record, anchor_x in wide_fit
+    }
     origins: list[NativeFrameOrigin] = []
     terminal_boundary_index: int | None = None
     for frame, boundary in enumerate(frame_boundaries, start=1):
         prediction = float(intercept + scale * boundary.output_row)
         record = direct_by_index.get(boundary.index)
+        wide_record = wide_by_index.get(boundary.index)
         if record is not None:
             method = "direct-gap-trailing-row"
             reasons = list(boundary.review_reasons)
             automatic = not boundary.manual_review
+        elif wide_record is not None:
+            record, wide_anchor_x = wide_record
+            # A wide gap's output_row is its run center, which sits
+            # farther from the frame's true start than the narrow-run
+            # convention the affine intercept absorbed. Predict (and, if
+            # the clamp fires, extrapolate) at the same translated
+            # trailing-edge x this anchor used in the fit, so the origin
+            # lands on the frame's actual leading edge.
+            prediction = float(intercept + scale * wide_anchor_x)
+            method = "wide-gap-trailing-row"
+            reasons = list(boundary.review_reasons)
+            automatic = False
         else:
             # The canonical Nikon detector selects roughly 2..5 rows after a
             # physical gap centre.  Restrict the search to that local trailing
             # neighborhood, then use the direct-anchor line only to choose a
             # record already supplied by this capture's transport table.
             centre = int(math.floor(boundary.fitted_row + 0.5))
+            if (
+                boundary.support == "direct-wide"
+                and boundary.evidence_run is not None
+            ):
+                centre = int(boundary.evidence_run[1]) - 1
+                prediction = float(
+                    intercept
+                    + scale
+                    * (boundary.evidence_run[1] - narrow_anchor_offset)
+                )
             start = max(0, centre + 1)
             end = min(len(records), centre + 8)
             if start >= end:

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
@@ -519,6 +519,12 @@ class LiveBatchJob:
     continuation_plan_sha256: str
     job_sha256: str
     exposure_override_10ns: tuple[int, int, int] | None = None
+    # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): see
+    # capture_process.CaptureBatchRequest.manual_boundary_rows -- the exact
+    # same value, carried through load_validated_batch_job's own parse of
+    # this untrusted job JSON, for _derive_live_batch_selections to replay
+    # fresh against this call's own live re-read bytes.
+    manual_boundary_rows: tuple[int, ...] | None = None
 
     @property
     def selected_slots(self) -> tuple[int, ...]:
@@ -1863,6 +1869,7 @@ def load_validated_batch_job(
         "expected_usb_bus",
         "exposure_override_10ns",
         "frames",
+        "manual_boundary_rows",
         "reviewed_roll_fingerprint",
         "session_id",
     }
@@ -1902,6 +1909,27 @@ def load_validated_batch_job(
                 )
             parsed_ticks.append(raw)
         exposure_override_10ns = (parsed_ticks[0], parsed_ticks[1], parsed_ticks[2])
+    # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): same
+    # defense-in-depth stance as exposure_override_10ns above -- the worker
+    # subprocess trusts nothing it reads from this job file, even though
+    # Roll/CaptureBatchRequest already only ever emit rows a manual session
+    # itself produced.
+    raw_manual_boundary_rows = payload.get("manual_boundary_rows")
+    manual_boundary_rows: tuple[int, ...] | None = None
+    if raw_manual_boundary_rows is not None:
+        if not isinstance(raw_manual_boundary_rows, list) or not raw_manual_boundary_rows:
+            raise ProtocolError(
+                "batch job manual_boundary_rows must be a nonempty array of "
+                "integer preview rows"
+            )
+        parsed_rows: list[int] = []
+        for row in raw_manual_boundary_rows:
+            if isinstance(row, bool) or not isinstance(row, int):
+                raise ProtocolError(
+                    "batch job manual_boundary_rows entries must be integers"
+                )
+            parsed_rows.append(row)
+        manual_boundary_rows = tuple(parsed_rows)
     session_id = payload.get("session_id")
     if (
         not isinstance(session_id, str)
@@ -2015,6 +2043,7 @@ def load_validated_batch_job(
         continuation_plan_sha256=expected_continuation_sha256,
         job_sha256=actual_job_sha256,
         exposure_override_10ns=exposure_override_10ns,
+        manual_boundary_rows=manual_boundary_rows,
     )
 
 
@@ -6051,6 +6080,7 @@ def run_live_capture(
                                 live_sub_8e_table,
                                 batch_job.frames,
                                 reviewed_fingerprint=(batch_job.reviewed_fingerprint),
+                                manual_boundary_rows=batch_job.manual_boundary_rows,
                             )
                             live_selection = batch_selections[0]
                             journal["batch_prevalidated_frame_selections"] = [
@@ -6803,6 +6833,7 @@ def run_live_capture(
                     live_sub_8e_table,
                     batch_job.frames,
                     reviewed_fingerprint=batch_job.reviewed_fingerprint,
+                    manual_boundary_rows=batch_job.manual_boundary_rows,
                 )
                 session_journal.update(
                     {

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
@@ -57,6 +57,10 @@ from .capture_process import (
     compare_reviewed_roll_fingerprints,
     compare_selected_roll_fingerprint,
 )
+from .manual_frames import (
+    MANUAL_PLACEMENT_WARNING,
+    build_manual_detection,
+)
 from .meter import (
     DEFAULT_EXPOSURES,
     EXPOSURE_MAX,
@@ -1369,35 +1373,125 @@ def _derive_live_frame_selection(
     manual_review_approved: bool = False,
     reviewed_as_automatic: bool = False,
     reviewed_leading_residual_rows: float | None = None,
+    manual_boundary_rows: tuple[int, ...] | None = None,
 ) -> LiveFrameSelection:
-    """Resolve one automatic frame origin from same-traversal live data."""
+    """Resolve one frame origin from same-traversal live data.
+
+    Automatic (default, ``manual_boundary_rows`` omitted): resolves via
+    ``detect_roll_frames``/``derive_transport_mapping`` exactly as this
+    function has always worked. See the gate comment below for the one new
+    path manual placement adds to this function's confidence gate.
+
+    Manual (Rung 4, FEEDING-UX-LADDER-OVERNIGHT-20260807.md):
+    ``manual_boundary_rows`` is never trusted as a serialized detection
+    blob. It is the small list of row numbers a human picked while
+    reviewing this same physical traversal's preview, replayed here through
+    the exact same pure ``manual_frames.build_manual_detection`` call the
+    review session used -- fresh, against THIS call's own freshly-decoded
+    ``rgb16``/``known``/``records``, exactly the way the automatic branch
+    below always re-derives ``detect_roll_frames`` from scratch rather than
+    trusting anything cached. If the bytes changed since the operator
+    reviewed them, this recompute reflects that change (it may now refuse,
+    or resolve to different origins); the reviewed_fingerprint comparison
+    further below independently proves the bytes still match what a human
+    actually reviewed before anything can bind.
+    """
 
     geometry = _derive_index_geometry(plan)
     validated_table, usable_rows = validate_live_0x8e_bytes(table_data, geometry.height)
     rgb16, known, decode_report = decode_full_index_bytes(
         preview_data, geometry, usable_rows=usable_rows
     )
-    detection = detect_roll_frames(
-        rgb16,
-        known,
-        nominal_frame_rows=FINE_NATIVE_HEIGHT // geometry.pitch,
-        expected_frame_count=expected_frame_count,
+
+    if manual_boundary_rows is not None:
+        records = parse_live_transport_records_bytes(
+            validated_table, maximum_rows=geometry.height
+        )
+        manual_result = build_manual_detection(
+            rgb16,
+            known,
+            manual_boundary_rows,
+            nominal_frame_rows=FINE_NATIVE_HEIGHT // geometry.pitch,
+            records=records,
+        )
+        detection = manual_result.detection
+        mapping = manual_result.mapping
+        scanner_frame_count = len(mapping.origins)
+        scanner_intervals = detection.intervals[:scanner_frame_count]
+    else:
+        detection = detect_roll_frames(
+            rgb16,
+            known,
+            nominal_frame_rows=FINE_NATIVE_HEIGHT // geometry.pitch,
+            expected_frame_count=expected_frame_count,
+        )
+        # Deferred to the "records is None" branch below, exactly where
+        # they were computed before this change, so a non-manual call never
+        # does this work when the gate is about to refuse anyway.
+        records = None
+        mapping = None
+        scanner_frame_count = None
+        scanner_intervals = None
+
+    # ------------------------------------------------------------------
+    # THE GATE (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, Rung 4 worker gate
+    # change -- deliberate, in scope by owner instruction. Adversarial
+    # review must attack this specifically).
+    #
+    # Unattended behavior for every NON-manual detection is byte-for-byte
+    # unchanged: any confidence below "high" refuses here, exactly as this
+    # function has always refused, full stop. The one new path this change
+    # adds: a detection carrying manual_frames' explicit
+    # MANUAL_PLACEMENT_WARNING marker -- which only build_manual_detection
+    # above can ever attach to a RollDetection.warnings tuple, never
+    # detect_roll_frames -- may bind at "medium" (build_manual_detection
+    # never emits anything higher; see manual_frames.py), but only when
+    # BOTH:
+    #   (a) this call actually took the manual branch above
+    #       (manual_boundary_rows is not None), and
+    #   (b) this call's caller also passes manual_review_approved=True: an
+    #       operator-approval receipt the caller must already hold (e.g.
+    #       from RollPreviewSession.approve_manual_origin on every
+    #       manual_review slot -- see BatchFrameSpec.manual_review_approval
+    #       and how _derive_live_batch_selections derives this flag).
+    # A caller cannot forge condition (a) by simply passing
+    # manual_review_approved=True against an automatic (wide-gap-recovery or
+    # any other) medium/low-confidence detection: MANUAL_PLACEMENT_WARNING
+    # is never present unless build_manual_detection itself ran and
+    # produced it, so the pre-existing refusal is intact for every
+    # non-manual detection no matter what approval flags a caller passes.
+    #
+    # Binding here is not the same as looking automatic: every manually
+    # placed origin already carries automatic=False, manual_review=True
+    # (build_manual_detection), so the per-origin manual-review handling
+    # later in this function -- and apply_batch_boundary_offsets's own
+    # approved_manual_slots gate, for the batch caller -- still applies to
+    # every one of these frames independently. This gate only decides
+    # whether the ROLL-level confidence check may be attempted at all; it
+    # grants no exemption from any other check in this function.
+    manual_placement = (
+        manual_boundary_rows is not None
+        and MANUAL_PLACEMENT_WARNING in detection.warnings
     )
-    if detection.confidence != "high":
+    if detection.confidence != "high" and not (
+        manual_placement and manual_review_approved
+    ):
         raise ProtocolError(
             f"roll boundary lattice confidence is {detection.confidence!r}; "
             "unattended frame binding requires 'high'"
         )
-    records = parse_live_transport_records_bytes(
-        validated_table, maximum_rows=geometry.height
-    )
-    scanner_frame_count = scanner_addressable_interval_count(detection.intervals)
-    scanner_intervals = detection.intervals[:scanner_frame_count]
-    mapping = derive_transport_mapping(
-        detection.boundaries,
-        scanner_frame_count,
-        records,
-    )
+
+    if records is None:
+        records = parse_live_transport_records_bytes(
+            validated_table, maximum_rows=geometry.height
+        )
+        scanner_frame_count = scanner_addressable_interval_count(detection.intervals)
+        scanner_intervals = detection.intervals[:scanner_frame_count]
+        mapping = derive_transport_mapping(
+            detection.boundaries,
+            scanner_frame_count,
+            records,
+        )
     fresh_fingerprint: ReviewedRollFingerprint | None = None
     fingerprint_comparison: RollFingerprintComparison | None = None
     if reviewed_fingerprint is not None:
@@ -1524,8 +1618,21 @@ def _derive_live_batch_selections(
     frames: Sequence[BatchFrameSpec],
     *,
     reviewed_fingerprint: ReviewedRollFingerprint,
+    manual_boundary_rows: tuple[int, ...] | None = None,
 ) -> tuple[LiveFrameSelection, ...]:
-    """Pre-bind every batch frame to one same-traversal transport table."""
+    """Pre-bind every batch frame to one same-traversal transport table.
+
+    ``manual_boundary_rows`` (Rung 4, FEEDING-UX-LADDER-OVERNIGHT-20260807.md):
+    the batch caller's one hook into the same manual-placement gate
+    ``_derive_live_frame_selection`` implements -- passed straight through to
+    the single context-establishing call below. Every other line in this
+    function is unchanged: the per-frame manual-review gate a manual batch
+    still has to pass lives in ``apply_batch_boundary_offsets``'s existing
+    ``approved_manual_slots`` check (every manually placed origin carries
+    ``automatic=False, manual_review=True``, so every frame in a manual
+    batch already has to appear in ``approved_manual_slots`` or that
+    pre-existing, unmodified check refuses it).
+    """
 
     if not frames:
         raise ProtocolError("live batch has no selected frames")
@@ -1555,6 +1662,7 @@ def _derive_live_batch_selections(
         reviewed_fingerprint=reviewed_fingerprint,
         manual_review_approved=frames[0].manual_review_approval is not None,
         reviewed_as_automatic=frames[0].slot in reviewed_automatic_slots,
+        manual_boundary_rows=manual_boundary_rows,
     )
     if context.fresh_fingerprint is None:
         raise ProtocolError("fresh batch roll fingerprint was not retained")

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
@@ -1571,11 +1571,24 @@ def _derive_live_frame_selection(
                 f"frame {frame} transport origin requires manual review; "
                 "refusing an unattended fine scan"
             )
+    # F4 rework: a manual placement is never eligible for the leading-anchor
+    # rebase, no matter how well its fingerprints match. Rebase exists for
+    # ONE narrow, physically-understood case -- Nikon's own leading-record
+    # wobble, bounded and reviewed elsewhere -- and it works by keeping the
+    # ALREADY-DERIVED origin even when a fresh table read disagrees with it
+    # (see apply_boundary_offset's own docstring/rebase_info handling). A
+    # manual origin's own resolution (manual_frames._resolve_boundary_
+    # transport_origin, F1) already re-derives from THIS traversal's live
+    # table every time it runs; a fresh disagreement there is not leading-
+    # anchor wobble, it is this specific placement failing to reproduce
+    # itself, and rebasing would launder that into a silently accepted,
+    # possibly displaced origin instead of the refusal it should be.
     origin_rebase_allowed = (
         fingerprint_comparison is not None
         and fingerprint_comparison.matches
         and selected_fingerprint_comparison is not None
         and selected_fingerprint_comparison.matches
+        and not manual_placement
     )
     mapping, selected, origin_rebase_info = apply_boundary_offset(
         mapping,
@@ -1701,10 +1714,55 @@ def _derive_live_batch_selections(
     # apply_boundary_offset can rebase a frame-1 leading offset onto the fresh
     # traversal's own detected origin when the resolved record lands outside
     # the two-row affine bound but inside the five-row leading-anchor bound.
+    #
+    # F4 rework: never for a manual placement, no matter how well its
+    # fingerprints match -- same reasoning as _derive_live_frame_selection's
+    # own origin_rebase_allowed (single-frame path); see that comment. Every
+    # frame in a manual batch shares the one manual_boundary_rows this
+    # function received, so this is a single placement-wide flag, not a
+    # per-slot one.
+    manual_placement = (
+        manual_boundary_rows is not None
+        and MANUAL_PLACEMENT_WARNING in context.detection.warnings
+    )
+    # S6 hardening (FEEDING-UX-LADDER-OVERNIGHT-20260807.md F1 rework):
+    # load_validated_batch_job already checked each approval's own
+    # self-digest, slot, offset, reviewed-fingerprint digest, and (as of
+    # this same hardening) manual_boundary_rows_sha256 -- all proving the
+    # receipt is internally consistent and was signed for THIS placement.
+    # None of that proves the receipt's own CLAIMED per-slot values
+    # (reviewed_lookup_row, reviewed_native_origin, review_reasons) are
+    # what this exact traversal's fresh resolution actually produces for
+    # that slot -- context.mapping, built above from manual_boundary_rows
+    # by this rework's own lattice-aware resolution
+    # (manual_frames._resolve_boundary_transport_origin), is the only
+    # thing that can prove that, and only once it exists. thumbnail_sha256
+    # is deliberately not re-verified here: it is not derivable from the
+    # mapping alone (it needs the raster plus the app's own cropping
+    # logic, a layer this protocol worker does not have), so re-checking
+    # it belongs at the layer that already recomputes it, not here.
+    if manual_placement:
+        for spec in frames:
+            approval = spec.manual_review_approval
+            if approval is None:
+                continue
+            if not 1 <= spec.slot <= len(context.mapping.origins):
+                continue  # refused elsewhere (addressable-count checks)
+            fresh_origin = context.mapping.origins[spec.slot - 1]
+            if (
+                approval.reviewed_lookup_row != fresh_origin.lookup_row
+                or approval.reviewed_native_origin != fresh_origin.native_origin
+                or not set(fresh_origin.review_reasons) <= set(approval.review_reasons)
+            ):
+                raise ProtocolError(
+                    f"frame {spec.slot} manual review approval does not match "
+                    "this traversal's freshly resolved origin"
+                )
     origin_rebase_slots = frozenset(
         spec.slot
         for spec in frames
-        if context.fingerprint_comparison is not None
+        if not manual_placement
+        and context.fingerprint_comparison is not None
         and context.fingerprint_comparison.matches
         and selected_fingerprint_comparisons.get(spec.slot) is not None
         and selected_fingerprint_comparisons[spec.slot].matches
@@ -2009,6 +2067,24 @@ def load_validated_batch_job(
             ):
                 raise ProtocolError(
                     f"batch frame {index} manual review approval belongs to another preview"
+                )
+            # S6 hardening (FEEDING-UX-LADDER-OVERNIGHT-20260807.md F1
+            # rework): same defense-in-depth shape as the checks just
+            # above, cheap and available before any scanner/table access.
+            # reviewed_fingerprint_sha256 alone is not enough: fingerprint
+            # comparison has deliberate tolerance for a legitimate re-read
+            # (compare_reviewed_roll_fingerprints), so two DIFFERENT
+            # placements of the same physical roll could still compare as
+            # matching. This job's own manual_boundary_rows (parsed above)
+            # is the exact placement this attempt is about to bind against;
+            # the receipt must have been signed for that exact placement,
+            # not merely "a" placement whose fingerprint happens to match.
+            if approval.manual_boundary_rows_sha256 != ManualFrameApproval.digest_manual_boundary_rows(
+                manual_boundary_rows
+            ):
+                raise ProtocolError(
+                    f"batch frame {index} manual review approval belongs to a "
+                    "different set of placed boundaries"
                 )
         expected_directory = f"frame-{slot:03d}"
         expected_paths = {

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/roll/preview_session.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/roll/preview_session.py
@@ -14,7 +14,7 @@ import stat
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Iterable, Literal, Mapping, cast
+from typing import Any, Iterable, Literal, Mapping, Sequence, cast
 
 import numpy as np
 
@@ -34,6 +34,10 @@ from coolscanpy.protocol.ls5000_single_pass.density import (
     NikonDensityExposureBinding,
     NikonDensitySourceBinding,
     density_source_geometry_for_startup_records,
+)
+from coolscanpy.protocol.ls5000_single_pass.manual_frames import (
+    MANUAL_PLACEMENT_WARNING,
+    build_manual_detection,
 )
 from coolscanpy.protocol.ls5000_single_pass.plan import (
     CANONICAL_PLAN_SHA256,
@@ -451,6 +455,18 @@ class RollPreviewSession:
             "material": self.material.value,
             "selected_slots": list(self.selected_slots),
             "boundary_offsets": [item.boundary_offset_rows for item in self.slots],
+            # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): additive-only
+            # provenance. None for an ordinary automatically-detected
+            # session; the exact final (post-snap-assist) boundary rows a
+            # human placed for a manual one. See
+            # _restore_roll_preview_session for why restoring a manual
+            # session from this JSON is deliberately refused rather than
+            # silently re-run through automatic detection.
+            "manual_boundary_rows": (
+                [boundary.output_row for boundary in self.detection.boundaries]
+                if MANUAL_PLACEMENT_WARNING in self.detection.warnings
+                else None
+            ),
         }
         return json.dumps(
             payload,
@@ -1282,6 +1298,120 @@ def build_roll_preview_session(
     )
 
 
+def build_manual_roll_preview_session(
+    preview: ValidatedRollPreview,
+    boundary_rows: Sequence[int],
+    *,
+    material: ScanMaterial = ScanMaterial.COLOR_NEGATIVE,
+    selected_slots: Iterable[int] = (),
+    snap_assist: bool = True,
+) -> RollPreviewSession:
+    """Build a reviewed roll session from operator-placed frame boundaries.
+
+    Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md). ``preview`` is a
+    ``ValidatedRollPreview`` already produced by an earlier preview attempt
+    on this same physical traversal -- typically one whose automatic
+    ``detect_roll_frames`` pass failed or scored low confidence, which is
+    exactly when manual placement applies. No film moves here, and the
+    persisted preview raster/table are not re-read or re-validated: this
+    function only re-slices the same already-decoded raster ``preview``
+    holds, at the rows a human picked, through ``manual_frames.
+    build_manual_detection``.
+
+    Everything downstream of frame geometry -- thumbnails, boundary-offset
+    re-cropping, manual-origin approval, JSON serialization -- reuses the
+    exact same ``RollPreviewSession``/``RollPreviewSlot`` machinery
+    ``build_roll_preview_session`` produces, unchanged.
+
+    ``known`` is not part of ``ValidatedRollPreview`` (its own
+    ``__post_init__`` already only accepts a fully decoded raster), so this
+    passes an all-True completeness mask -- exactly the value
+    ``decode_full_index_bytes`` itself always produces
+    (``known = np.ones(rgb16.shape, dtype=bool)``, unconditionally, in
+    roll_index.py), not an approximation of it.
+    """
+
+    if not isinstance(preview, ValidatedRollPreview):
+        raise TypeError("preview must be a ValidatedRollPreview")
+    if not isinstance(material, ScanMaterial):
+        raise TypeError("material must be a ScanMaterial")
+
+    result = build_manual_detection(
+        preview.rgb,
+        np.ones(preview.rgb.shape, dtype=bool),
+        tuple(boundary_rows),
+        nominal_frame_rows=LS5000_FINE_NATIVE_HEIGHT // preview.geometry.pitch,
+        records=preview.transport_records,
+        snap_assist=snap_assist,
+    )
+    detection = result.detection
+    mapping = result.mapping
+
+    scanner_frame_count = scanner_addressable_interval_count(detection.intervals)
+    slot_count = min(
+        SA30_ADAPTER_FRAME_CAPACITY,
+        scanner_frame_count,
+        len(mapping.origins),
+    )
+    if slot_count < 1:
+        raise RollSessionError(
+            "manual frame placement produced no scanner-addressable slots: "
+            + _roll_session_diagnostics(detection)
+        )
+
+    slots = []
+    for interval, origin in zip(
+        detection.intervals[:slot_count],
+        mapping.origins[:slot_count],
+    ):
+        warnings = _slot_warnings(interval.frame, interval, origin, detection)
+        # Same partial-frame computation build_roll_preview_session uses
+        # (#19/Lane C D2). manual_frames.build_manual_detection always sets
+        # unclamped_start_row/unclamped_end_row equal to the (raster-
+        # in-bounds, gate-checked) start_row/end_row, so this always
+        # resolves "full" for a manual slot -- written out in full anyway so
+        # a future change to either builder cannot silently diverge.
+        coverage_start = (
+            interval.unclamped_start_row
+            if interval.unclamped_start_row is not None
+            else interval.start_row
+        )
+        coverage_end = (
+            interval.unclamped_end_row
+            if interval.unclamped_end_row is not None
+            else interval.end_row
+        )
+        state = _crop_state(coverage_start, coverage_end, len(preview.rgb))
+        slots.append(
+            RollPreviewSlot(
+                slot_id=interval.frame,
+                start_boundary_row=interval.start_row,
+                end_boundary_row=interval.end_row,
+                base_origin=origin,
+                thumbnail=_thumbnail(
+                    preview.rgb, interval.start_row, interval.end_row
+                ),
+                warnings=warnings,
+                manual_review=bool(
+                    interval.manual_review or origin.manual_review or warnings
+                ),
+                partial=(True if state == "partial" else None),
+            )
+        )
+    selected = _validate_selected_slots(selected_slots, len(slots))
+    return RollPreviewSession(
+        preview=preview,
+        geometry=preview.geometry,
+        detection=detection,
+        mapping=mapping,
+        slots=tuple(slots),
+        material=material,
+        recipe=recipe_for_material(material),
+        selected_slots=selected,
+        warnings=tuple(detection.warnings),
+    )
+
+
 def _restore_roll_preview_session(payload: str) -> RollPreviewSession:
     if type(payload) is not str:
         raise TypeError("roll session JSON must be a string")
@@ -1304,9 +1434,31 @@ def _restore_roll_preview_session(payload: str) -> RollPreviewSession:
         "material",
         "selected_slots",
         "boundary_offsets",
+        "manual_boundary_rows",
     }
     if set(state) != expected_keys or state.get("version") != SESSION_VERSION:
         raise RollSessionIntegrityError("roll session JSON has an unsupported schema")
+    manual_boundary_rows_value = state.get("manual_boundary_rows")
+    if manual_boundary_rows_value is not None and (
+        not isinstance(manual_boundary_rows_value, list)
+        or any(type(item) is not int for item in manual_boundary_rows_value)
+    ):
+        raise RollSessionIntegrityError(
+            "roll session manual boundary rows are malformed"
+        )
+    if manual_boundary_rows_value is not None:
+        # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): to_json() persists
+        # a manual session's picked boundary rows as pure provenance --
+        # restoring one is deliberately NOT implemented yet. Everything below
+        # this point always replays through build_roll_preview_session's
+        # algorithmic detector, never build_manual_roll_preview_session's
+        # operator picks, so silently continuing here would hand back a
+        # session whose frame lattice does not match what a human actually
+        # reviewed. Refuse loudly instead of guessing.
+        raise RollSessionIntegrityError(
+            "roll session was built from manual frame placement; restoring "
+            "a manual session from JSON is not yet supported"
+        )
     journal_identity = state.get("journal")
     if type(journal_identity) is not dict or set(journal_identity) != {
         "path",
@@ -1417,6 +1569,7 @@ __all__ = [
     "RollSessionError",
     "RollSessionIntegrityError",
     "ValidatedRollPreview",
+    "build_manual_roll_preview_session",
     "build_roll_preview_session",
     "reload_thumbnail",
     "recipe_for_material",

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/roll/preview_session.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/roll/preview_session.py
@@ -340,6 +340,21 @@ class RollPreviewSession:
             source_table_sha256=self.preview.table_artifact.sha256,
         )
 
+    @property
+    def manual_boundary_rows(self) -> tuple[int, ...] | None:
+        """This session's exact picked boundary rows, or None if automatic.
+
+        Single source of truth for "what did the operator pick" -- to_json
+        (persisted provenance) and approve_manual_origin (S6 hardening:
+        ManualFrameApproval.manual_boundary_rows_sha256) both read this
+        instead of each re-deriving it from self.detection, so the two can
+        never independently drift on what counts as "this session's rows".
+        """
+
+        if MANUAL_PLACEMENT_WARNING not in self.detection.warnings:
+            return None
+        return tuple(boundary.output_row for boundary in self.detection.boundaries)
+
     def approve_manual_origin(
         self,
         slot_id: int,
@@ -373,6 +388,12 @@ class RollPreviewSession:
             reviewed_lookup_row=origin.lookup_row,
             reviewed_native_origin=origin.native_origin,
             review_reasons=reasons,
+            # S6 hardening: ties this receipt to the exact placement this
+            # whole session reviewed, not just this one slot's own
+            # resolved position -- see ManualFrameApproval's own docstring.
+            manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+                self.manual_boundary_rows
+            ),
         )
 
     def validate_manual_approval(
@@ -463,8 +484,8 @@ class RollPreviewSession:
             # session from this JSON is deliberately refused rather than
             # silently re-run through automatic detection.
             "manual_boundary_rows": (
-                [boundary.output_row for boundary in self.detection.boundaries]
-                if MANUAL_PLACEMENT_WARNING in self.detection.warnings
+                list(self.manual_boundary_rows)
+                if self.manual_boundary_rows is not None
                 else None
             ),
         }
@@ -1436,7 +1457,21 @@ def _restore_roll_preview_session(payload: str) -> RollPreviewSession:
         "boundary_offsets",
         "manual_boundary_rows",
     }
-    if set(state) != expected_keys or state.get("version") != SESSION_VERSION:
+    # F7 rework (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): to_json() always
+    # emits "manual_boundary_rows" now, but every session saved before this
+    # key existed has neither it nor anything to migrate -- manual
+    # placement did not exist yet, so an absent key means exactly the same
+    # thing an explicit null does below (state.get returns None either
+    # way). SESSION_VERSION stays 1: nothing about any OTHER field's
+    # meaning changed, so a pre-rework session still restores byte-for-byte
+    # the way it always did. Only an unsupported schema in some OTHER way
+    # -- missing/extra keys beyond this one additive field, or a value for
+    # this key that is neither absent, null, nor a row list -- still
+    # refuses exactly as before.
+    if (
+        set(state) not in (expected_keys, expected_keys - {"manual_boundary_rows"})
+        or state.get("version") != SESSION_VERSION
+    ):
         raise RollSessionIntegrityError("roll session JSON has an unsupported schema")
     manual_boundary_rows_value = state.get("manual_boundary_rows")
     if manual_boundary_rows_value is not None and (

--- a/ports/tauri/vendor/coolscanpy/tests/capture/test_ls5000_single_pass_workflow.py
+++ b/ports/tauri/vendor/coolscanpy/tests/capture/test_ls5000_single_pass_workflow.py
@@ -64,6 +64,9 @@ def _journal(
         reviewed_lookup_row=2_580 + boundary_offset_rows,
         reviewed_native_origin=origin,
         review_reasons=("transport-origin-inferred",),
+        manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+            None
+        ),
     ).to_payload()
     roll_comparison = RollFingerprintComparison(
         matches=True,

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
@@ -931,6 +931,7 @@ def test_prepare_batch_frames_every_selected_slot_as_one_future_child_session(
         "expected_usb_address": 2,
         "expected_usb_bus": 1,
         "exposure_override_10ns": None,
+        "manual_boundary_rows": None,
         "frames": [
             {
                 "ack": "frame-017/parent-ack.json",
@@ -998,6 +999,37 @@ def test_prepare_batch_session_threads_exposure_override_into_the_batch_job(
     job = json.loads(prepared.paths.job.read_text(encoding="utf-8"))
 
     assert job["exposure_override_10ns"] == [97_482, 195_597, 180_705]
+
+
+def test_prepare_batch_session_threads_manual_boundary_rows_into_the_batch_job(
+    tmp_path: Path,
+    binding: Binding,
+) -> None:
+    """Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): same choke point as
+    exposure_override_10ns above, for the operator-picked rows a manual
+    placement session hands Roll.scan_many() -- must reach the published
+    batch-job.json unchanged (as a plain array; JSON has no tuple type)."""
+
+    runner = FakeRunner(binding.worker_sha256)
+    adapter = _adapter(tmp_path, binding, runner)
+    request = capture.CaptureBatchRequest(
+        frames=(
+            capture.CaptureRequest(
+                mode=capture.CaptureMode.FULL,
+                selected_slot=1,
+                boundary_offset_rows=0,
+            ),
+        ),
+        reviewed_fingerprint=_reviewed_fingerprint(),
+        expected_usb_bus=1,
+        expected_usb_address=2,
+        manual_boundary_rows=(128, 271, 414),
+    )
+
+    prepared = adapter.prepare_batch_session(request)
+    job = json.loads(prepared.paths.job.read_text(encoding="utf-8"))
+
+    assert job["manual_boundary_rows"] == [128, 271, 414]
 
 
 @pytest.mark.parametrize(

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
@@ -452,6 +452,7 @@ def _manual_approval(
     *,
     slot: int,
     offset: int,
+    manual_boundary_rows: tuple[int, ...] | None = None,
 ) -> capture.ManualFrameApproval:
     return capture.ManualFrameApproval(
         reviewed_fingerprint_sha256=fingerprint.binding_sha256,
@@ -461,6 +462,9 @@ def _manual_approval(
         reviewed_lookup_row=2_400,
         reviewed_native_origin=100_000,
         review_reasons=("transport-origin-inferred",),
+        manual_boundary_rows_sha256=capture.ManualFrameApproval.digest_manual_boundary_rows(
+            manual_boundary_rows
+        ),
     )
 
 

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_manual_frames.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_manual_frames.py
@@ -1,0 +1,394 @@
+"""Regression contracts for Rung 4 manual frame placement.
+
+FEEDING-UX-LADDER-OVERNIGHT-20260807.md: the human supplies frame boundary
+rows on an already-captured preview raster; this module keeps the physical
+sanity checks. These tests exercise every validation gate plus the happy
+path's exact result shape, independent of and never calling
+detect_roll_frames/derive_transport_mapping.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from coolscanpy.protocol.ls5000_single_pass import manual_frames
+from coolscanpy.protocol.ls5000_single_pass.roll_index import (
+    IndexDecodeError,
+    TransportRecord,
+)
+
+
+def _synthetic_roll(
+    frame_count: int,
+    *,
+    pitch: int = 143,
+    leader: int = 24,
+    tail: int = 24,
+) -> tuple[np.ndarray, list[int]]:
+    """Same construction as test_roll_index.py's own helper: textured cells
+    separated by physical clear-film gaps six preview rows wide, centered on
+    each boundary row.
+    """
+
+    boundaries = [leader + index * pitch for index in range(frame_count + 1)]
+    height = boundaries[-1] + tail
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[:, :, channel] = base + texture * (3 - channel) // 2
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    clear_noise = ((x * 19 + y * 13) % 301 - 150)[:, :, None]
+    aperture[: boundaries[0]] = clear_base + clear_noise[: boundaries[0]]
+    aperture[boundaries[-1] :] = clear_base + clear_noise[boundaries[-1] :]
+    for boundary in boundaries:
+        start = max(0, boundary - 3)
+        end = min(height, boundary + 3)
+        aperture[start:end] = clear_base + clear_noise[start:end]
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16), boundaries
+
+
+def _clean_records(count: int) -> tuple[TransportRecord, ...]:
+    """Same-traversal transport table stepping at exactly 42 native units/row.
+
+    ``code=6*(row%18), selector=row//18`` is the standard synthetic-records
+    convention used throughout this package's tests (test_worker.py,
+    test_ls5000_roll_session.py); it decodes to ``native_origin = 42 * row``
+    exactly.
+    """
+
+    return tuple(
+        TransportRecord(
+            row=row,
+            code=6 * (row % 18),
+            selector=row // 18,
+            native_origin=42 * row,
+        )
+        for row in range(count)
+    )
+
+
+def _known(rgb: np.ndarray) -> np.ndarray:
+    return np.ones_like(rgb, dtype=bool)
+
+
+def _spike(
+    records: tuple[TransportRecord, ...], row: int, delta: int
+) -> tuple[TransportRecord, ...]:
+    patched = list(records)
+    victim = patched[row]
+    patched[row] = TransportRecord(
+        row=victim.row,
+        code=victim.code,
+        selector=victim.selector,
+        native_origin=victim.native_origin + delta,
+    )
+    return tuple(patched)
+
+
+# --------------------------------------------------------------------------
+# Happy path
+# --------------------------------------------------------------------------
+
+
+def test_exact_picks_produce_the_real_boundaries_with_no_snaps() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb,
+        _known(rgb),
+        boundaries,
+        nominal_frame_rows=143,
+        records=records,
+    )
+
+    assert result.snaps == ()
+    detection = result.detection
+    mapping = result.mapping
+
+    assert detection.confidence == "medium"
+    assert manual_frames.MANUAL_PLACEMENT_WARNING in detection.warnings
+    assert detection.nominal_frame_rows == 143
+    assert detection.candidate_cell_count == 6
+    assert detection.manual_review_frames == (1, 2, 3, 4, 5, 6)
+    assert len(detection.intervals) == 6
+    assert len(detection.boundaries) == 7
+    assert len(mapping.origins) == 6
+
+    for interval in detection.intervals:
+        assert interval.manual_review is True
+        assert "user-picked" in interval.review_reasons
+
+    for boundary in detection.boundaries:
+        assert boundary.support == "user-picked"
+        assert boundary.manual_review is True
+        assert "user-picked" in boundary.review_reasons
+
+    for frame, (origin, boundary_row) in enumerate(
+        zip(mapping.origins, boundaries), start=1
+    ):
+        assert origin.frame == frame
+        assert origin.native_origin == 42 * boundary_row
+        assert origin.method == "user-picked-row"
+        assert origin.automatic is False
+        assert origin.manual_review is True
+
+
+def test_picks_off_run_edges_snap_and_are_noted() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+    picks = list(boundaries)
+    # The evidence run at boundaries[2] is (boundary-3, boundary+3); picking
+    # 2 rows short of its leading edge should snap onto that edge.
+    picks[2] = boundaries[2] - 3 - 2
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), picks, nominal_frame_rows=143, records=records
+    )
+
+    assert len(result.snaps) == 1
+    snap = result.snaps[0]
+    assert snap.boundary_index == 2
+    assert snap.requested_row == picks[2]
+    assert snap.snapped_row == boundaries[2] - 3
+    assert result.detection.boundaries[2].output_row == boundaries[2] - 3
+    assert "snapped-to-clear-film-edge" in result.detection.boundaries[2].review_reasons
+
+
+def test_snap_assist_disabled_keeps_the_operators_exact_picks() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+    picks = list(boundaries)
+    picks[2] = boundaries[2] - 3 - 2
+
+    result = manual_frames.build_manual_detection(
+        rgb,
+        _known(rgb),
+        picks,
+        nominal_frame_rows=143,
+        records=records,
+        snap_assist=False,
+    )
+
+    assert result.snaps == ()
+    assert result.detection.boundaries[2].output_row == picks[2]
+
+
+def test_single_frame_minimum_two_boundaries_is_accepted() -> None:
+    rgb, boundaries = _synthetic_roll(1, pitch=143)
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=records
+    )
+
+    assert len(result.detection.intervals) == 1
+    assert len(result.mapping.origins) == 1
+
+
+# --------------------------------------------------------------------------
+# Structural gates
+# --------------------------------------------------------------------------
+
+
+def test_refuses_fewer_than_two_boundaries() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+
+    with pytest.raises(IndexDecodeError, match="at least 2 boundary rows"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), [boundaries[0]], nominal_frame_rows=143, records=records
+        )
+
+
+def test_refuses_non_monotonic_boundaries() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+
+    with pytest.raises(IndexDecodeError, match="strictly increasing order"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), [10, 5, 200], nominal_frame_rows=143, records=records
+        )
+
+
+def test_refuses_boundary_outside_the_raster() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+
+    with pytest.raises(IndexDecodeError, match="inside the captured preview"):
+        manual_frames.build_manual_detection(
+            rgb,
+            _known(rgb),
+            [10, len(rgb) + 5],
+            nominal_frame_rows=143,
+            records=records,
+        )
+
+
+def test_refuses_more_than_forty_frames() -> None:
+    height = 3_000
+    rgb = np.zeros((height, 96, 3), dtype=np.uint16)
+    records = _clean_records(height)
+    boundaries = list(range(10, 10 + 42 * 60, 60))  # 42 boundaries -> 41 frames
+
+    with pytest.raises(IndexDecodeError, match="at most 40 frames"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), boundaries, nominal_frame_rows=60, records=records
+        )
+
+
+def test_exactly_forty_frames_is_accepted() -> None:
+    height = 3_000
+    rgb = np.zeros((height, 96, 3), dtype=np.uint16)
+    records = _clean_records(height)
+    boundaries = list(range(10, 10 + 41 * 60, 60))  # 41 boundaries -> 40 frames
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=60, records=records
+    )
+
+    assert len(result.detection.intervals) == 40
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        (100, 110),  # ~3 mm, below the 15 mm floor
+        (100, 500),  # ~107 mm, above the 75 mm ceiling
+    ],
+)
+def test_refuses_absurd_frame_heights(start: int, end: int) -> None:
+    height = 3_000
+    rgb = np.zeros((height, 96, 3), dtype=np.uint16)
+    records = _clean_records(height)
+
+    with pytest.raises(IndexDecodeError, match="outside the 15-75 mm range"):
+        manual_frames.build_manual_detection(
+            rgb,
+            _known(rgb),
+            [start, end, end + 200],
+            nominal_frame_rows=143,
+            records=records,
+        )
+
+
+def test_half_frame_heights_are_accepted() -> None:
+    rgb, boundaries = _synthetic_roll(4, pitch=71, leader=20, tail=20)
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=71, records=records
+    )
+
+    assert len(result.detection.intervals) == 4
+    for interval in result.detection.intervals:
+        assert interval.height_rows == 71
+
+
+def test_panoramic_heights_are_accepted() -> None:
+    rgb, boundaries = _synthetic_roll(3, pitch=250, leader=30, tail=30)
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=250, records=records
+    )
+
+    assert len(result.detection.intervals) == 3
+    for interval in result.detection.intervals:
+        assert interval.height_rows == 250
+
+
+# --------------------------------------------------------------------------
+# Transport table gates
+# --------------------------------------------------------------------------
+
+
+def test_single_record_spike_near_a_boundary_refuses_the_whole_placement() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    spiked = _spike(_clean_records(len(rgb)), boundaries[2] + 1, 5_000)
+
+    with pytest.raises(IndexDecodeError, match="position readings look unreliable"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=spiked
+        )
+
+
+def test_spike_message_names_the_ordinal_edge_and_no_frames_are_returned() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    spiked = _spike(_clean_records(len(rgb)), boundaries[2] + 1, 5_000)
+
+    with pytest.raises(IndexDecodeError, match="3rd frame edge"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=spiked
+        )
+
+
+def test_non_affine_implied_scale_between_boundaries_refuses() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = list(_clean_records(len(rgb)))
+    # A jump well clear of every boundary's own +-3 row ramp-guard window
+    # (boundaries[2]=310, next boundary 453; the jump sits at 380) still
+    # skews the aggregate origins-vs-rows relationship between those two
+    # picked boundaries -- a distinct failure mode from the local guard.
+    jump_row = boundaries[2] + 70
+    for row in range(jump_row, len(records)):
+        victim = records[row]
+        records[row] = TransportRecord(
+            row=victim.row,
+            code=victim.code,
+            selector=victim.selector,
+            native_origin=victim.native_origin + 3_000,
+        )
+
+    with pytest.raises(IndexDecodeError, match="don't move at a steady rate"):
+        manual_frames.build_manual_detection(
+            rgb,
+            _known(rgb),
+            boundaries,
+            nominal_frame_rows=143,
+            records=tuple(records),
+        )
+
+
+def test_refuses_when_no_transport_records_are_supplied() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+
+    with pytest.raises(IndexDecodeError, match="scanner position table"):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=()
+        )
+
+
+# --------------------------------------------------------------------------
+# Shape/completeness gates
+# --------------------------------------------------------------------------
+
+
+def test_refuses_mismatched_raster_and_completeness_shapes() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+    wrong_known = np.ones((len(rgb) - 1, 96, 3), dtype=bool)
+
+    with pytest.raises(IndexDecodeError, match="shapes differ"):
+        manual_frames.build_manual_detection(
+            rgb, wrong_known, boundaries, nominal_frame_rows=143, records=records
+        )
+
+
+def test_refuses_an_incomplete_preview() -> None:
+    rgb, boundaries = _synthetic_roll(6)
+    records = _clean_records(len(rgb))
+    known = _known(rgb)
+    known[:200] = False
+
+    with pytest.raises(manual_frames.IncompleteIndexError, match="row coverage"):
+        manual_frames.build_manual_detection(
+            rgb, known, boundaries, nominal_frame_rows=143, records=records
+        )

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_manual_frames.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_manual_frames.py
@@ -5,6 +5,18 @@ rows on an already-captured preview raster; this module keeps the physical
 sanity checks. These tests exercise every validation gate plus the happy
 path's exact result shape, independent of and never calling
 detect_roll_frames/derive_transport_mapping.
+
+Rewritten 2026-08-08 after adversarial review rejected the original: gate 4
+used to require every single-row transport-table step within 3 rows of a
+pick to be 40..45 native units, which real LS-5000 tables never satisfy (see
+manual_frames.py's own module docstring for the measured lattice structure).
+``_lattice_records`` below builds a synthetic table with that same
+structure -- deterministic ~18-row-period selector-rollover and
+sub-rollover jumps, computed through the real ``transport_native_origin``
+identity, not approximated deltas -- so these tests, and the ones in this
+file that exercise the transport-table gates specifically, can never again
+diverge from hardware reality the way the plain 42-units/row ``_clean_
+records`` table did.
 """
 
 from __future__ import annotations
@@ -15,7 +27,9 @@ import pytest
 from coolscanpy.protocol.ls5000_single_pass import manual_frames
 from coolscanpy.protocol.ls5000_single_pass.roll_index import (
     IndexDecodeError,
+    TRANSPORT_ORIGIN_CLAMP_REASON,
     TransportRecord,
+    transport_native_origin,
 )
 
 
@@ -25,10 +39,14 @@ def _synthetic_roll(
     pitch: int = 143,
     leader: int = 24,
     tail: int = 24,
+    gap_half: int = 3,
 ) -> tuple[np.ndarray, list[int]]:
     """Same construction as test_roll_index.py's own helper: textured cells
-    separated by physical clear-film gaps six preview rows wide, centered on
-    each boundary row.
+    separated by physical clear-film gaps ``2 * gap_half`` preview rows
+    wide, centered on each boundary row. The leader and tail themselves are
+    one wide clear-film run each (``leader``/``tail`` rows), never a
+    ``gap_half``-narrow one -- this matters for tests that care whether a
+    boundary's evidence run classifies as narrow.
     """
 
     boundaries = [leader + index * pitch for index in range(frame_count + 1)]
@@ -44,8 +62,8 @@ def _synthetic_roll(
     aperture[: boundaries[0]] = clear_base + clear_noise[: boundaries[0]]
     aperture[boundaries[-1] :] = clear_base + clear_noise[boundaries[-1] :]
     for boundary in boundaries:
-        start = max(0, boundary - 3)
-        end = min(height, boundary + 3)
+        start = max(0, boundary - gap_half)
+        end = min(height, boundary + gap_half)
         aperture[start:end] = clear_base + clear_noise[start:end]
     rgb = np.empty((height, 96, 3), dtype=np.int64)
     rgb[:, 2:92] = aperture
@@ -54,13 +72,33 @@ def _synthetic_roll(
     return rgb.clip(0, 65_535).astype(np.uint16), boundaries
 
 
+def _blank_roll(height: int) -> np.ndarray:
+    """A raster with NO clear-film runs anywhere, so snap assist finds no
+    evidence and every pick resolves through the no-narrow-run path."""
+
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[:, :, channel] = base + texture * (3 - channel) // 2
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16)
+
+
 def _clean_records(count: int) -> tuple[TransportRecord, ...]:
     """Same-traversal transport table stepping at exactly 42 native units/row.
 
     ``code=6*(row%18), selector=row//18`` is the standard synthetic-records
     convention used throughout this package's tests (test_worker.py,
     test_ls5000_roll_session.py); it decodes to ``native_origin = 42 * row``
-    exactly.
+    exactly. A perfectly smooth ramp -- useful for gates that have nothing
+    to do with the transport table's own lattice structure, but never used
+    below for a test that is specifically about that structure; see
+    ``_lattice_records`` for those.
     """
 
     return tuple(
@@ -72,6 +110,65 @@ def _clean_records(count: int) -> tuple[TransportRecord, ...]:
         )
         for row in range(count)
     )
+
+
+# One ~18-row lattice period's ordinary (non-rollover) code progression,
+# transcribed from the archived 20260719-phoenix live capture inspected
+# during this rework (rows 1-16 of its first full period): the code's low
+# byte advances by 6 almost every row, with the high byte periodically
+# absorbing part of that advance (the "sub-rollover" jumps -- +28, +84
+# native units here, matching the task's own measured "-56/+98/+98/+0"
+# class of jump; the exact sub-rollover magnitudes are a hardware
+# implementation detail this generator does not need to reproduce exactly
+# to be a faithful stress test of "mostly steady, occasionally not").
+_LATTICE_CYCLE_CODES = (
+    0x0006, 0x000C, 0x0012, 0x0018, 0x001E, 0x0024, 0x002A,
+    0x0202, 0x0208, 0x020E, 0x0214, 0x021A, 0x0220, 0x0226,
+    0x0406, 0x040C,
+)
+
+
+def _lattice_records(count: int) -> tuple[TransportRecord, ...]:
+    """Same-traversal transport table with the REAL LS-5000 code lattice.
+
+    Real live READ(0x8e) tables are not a smooth ramp: every ~18 rows, the
+    selector rolls over, and the row at that rollover reports the NEXT
+    selector's own low code one row early -- a jump of roughly +798 native
+    units -- corrected the very next row by roughly -700 (measured on
+    archived captures during this rework; see manual_frames.py's module
+    docstring). Built from ``transport_native_origin`` itself rather than
+    hand-picked deltas, so every record this returns decodes losslessly the
+    same way a real table does, and the average rate across any complete
+    18-row cycle is exactly 42 native units/row (756 native units -- one
+    selector step -- over 18 rows), matching this driver's accepted
+    40..45 physical band.
+    """
+
+    cycle_len = len(_LATTICE_CYCLE_CODES)
+    period = cycle_len + 2
+    records = []
+    for row in range(count):
+        position = row % period
+        selector = row // period
+        if position < cycle_len:
+            code = _LATTICE_CYCLE_CODES[position]
+        elif position == cycle_len:
+            # Selector-rollover lookahead.
+            code = 0x0412
+            selector += 1
+        else:
+            # Selector-rollover correction.
+            code = 0x0004
+            selector += 1
+        records.append(
+            TransportRecord(
+                row=row,
+                code=code,
+                selector=selector,
+                native_origin=transport_native_origin(code, selector),
+            )
+        )
+    return tuple(records)
 
 
 def _known(rgb: np.ndarray) -> np.ndarray:
@@ -89,6 +186,34 @@ def _spike(
         selector=victim.selector,
         native_origin=victim.native_origin + delta,
     )
+    return tuple(patched)
+
+
+def _corrupt_span(
+    records: tuple[TransportRecord, ...], start: int, end: int, magnitude: int
+) -> tuple[TransportRecord, ...]:
+    """Displace every record in [start, end) by an independent random value
+    in [-magnitude, magnitude] -- a widespread, genuinely noisy corruption
+    with no steady rate left inside it, unlike ``_spike`` (one row) or a
+    uniform/alternating shift (either of which is really just a second
+    internally-consistent trend a robust fit can still lock onto -- a
+    uniform shift is caught by gate 5 instead, see
+    test_non_affine_implied_scale_between_boundaries_refuses; a fixed
+    alternation is, structurally, two interleaved uniform shifts, which a
+    median-based fit can still separate).  A seeded RNG keeps this
+    deterministic across runs."""
+
+    rng = np.random.default_rng(20260808)
+    patched = list(records)
+    for row in range(start, end):
+        victim = patched[row]
+        signed_delta = int(rng.integers(-magnitude, magnitude + 1))
+        patched[row] = TransportRecord(
+            row=victim.row,
+            code=victim.code,
+            selector=victim.selector,
+            native_origin=victim.native_origin + signed_delta,
+        )
     return tuple(patched)
 
 
@@ -130,19 +255,36 @@ def test_exact_picks_produce_the_real_boundaries_with_no_snaps() -> None:
         assert boundary.support == "user-picked"
         assert boundary.manual_review is True
         assert "user-picked" in boundary.review_reasons
+        # The VISUAL boundary position is always the exact row the operator
+        # placed, regardless of how its transport origin resolved.
+    assert [b.output_row for b in detection.boundaries] == boundaries
 
-    for frame, (origin, boundary_row) in enumerate(
-        zip(mapping.origins, boundaries), start=1
+    # Origins: boundary 0 sits in the wide (24-row) leader run, which is
+    # NOT a narrow inter-frame gap, so it resolves at the picked row
+    # itself. Boundaries 1-5 each sit at the center of an ordinary 6-row
+    # inter-frame gap -- a narrow run -- so each resolves at that run's
+    # OWN trailing edge (boundary + gap_half), mirroring
+    # derive_transport_mapping's "direct-gap-trailing-row" convention on
+    # the automatic path (see manual_frames.py's own docstring for why).
+    gap_half = 3
+    expected_lookup_rows = [boundaries[0]] + [b + gap_half for b in boundaries[1:6]]
+    for frame, (origin, lookup_row) in enumerate(
+        zip(mapping.origins, expected_lookup_rows), start=1
     ):
         assert origin.frame == frame
-        assert origin.native_origin == 42 * boundary_row
+        assert origin.lookup_row == lookup_row
+        assert origin.native_origin == 42 * lookup_row
         assert origin.method == "user-picked-row"
         assert origin.automatic is False
         assert origin.manual_review is True
+        assert manual_frames.MANUAL_ORIGIN_REVIEW_REASON in origin.review_reasons
 
 
 def test_picks_off_run_edges_snap_and_are_noted() -> None:
-    rgb, boundaries = _synthetic_roll(6)
+    # A shorter pitch than the happy-path test above so a boundary shifted
+    # a few rows by snap assist cannot itself brush the fine-capture-window
+    # ceiling (F2) -- this test is about snap mechanics, not that gate.
+    rgb, boundaries = _synthetic_roll(6, pitch=100, leader=20, tail=20)
     records = _clean_records(len(rgb))
     picks = list(boundaries)
     # The evidence run at boundaries[2] is (boundary-3, boundary+3); picking
@@ -150,7 +292,7 @@ def test_picks_off_run_edges_snap_and_are_noted() -> None:
     picks[2] = boundaries[2] - 3 - 2
 
     result = manual_frames.build_manual_detection(
-        rgb, _known(rgb), picks, nominal_frame_rows=143, records=records
+        rgb, _known(rgb), picks, nominal_frame_rows=100, records=records
     )
 
     assert len(result.snaps) == 1
@@ -163,7 +305,7 @@ def test_picks_off_run_edges_snap_and_are_noted() -> None:
 
 
 def test_snap_assist_disabled_keeps_the_operators_exact_picks() -> None:
-    rgb, boundaries = _synthetic_roll(6)
+    rgb, boundaries = _synthetic_roll(6, pitch=100, leader=20, tail=20)
     records = _clean_records(len(rgb))
     picks = list(boundaries)
     picks[2] = boundaries[2] - 3 - 2
@@ -172,7 +314,7 @@ def test_snap_assist_disabled_keeps_the_operators_exact_picks() -> None:
         rgb,
         _known(rgb),
         picks,
-        nominal_frame_rows=143,
+        nominal_frame_rows=100,
         records=records,
         snap_assist=False,
     )
@@ -257,26 +399,63 @@ def test_exactly_forty_frames_is_accepted() -> None:
     assert len(result.detection.intervals) == 40
 
 
-@pytest.mark.parametrize(
-    ("start", "end"),
-    [
-        (100, 110),  # ~3 mm, below the 15 mm floor
-        (100, 500),  # ~107 mm, above the 75 mm ceiling
-    ],
-)
-def test_refuses_absurd_frame_heights(start: int, end: int) -> None:
+# --------------------------------------------------------------------------
+# Physical frame-height gates (F2 + F3): 15 mm floor, fine-capture-window
+# ceiling, both enforced on the POST-SNAP rows.
+# --------------------------------------------------------------------------
+
+
+def test_refuses_a_frame_shorter_than_the_floor() -> None:
     height = 3_000
     rgb = np.zeros((height, 96, 3), dtype=np.uint16)
     records = _clean_records(height)
 
-    with pytest.raises(IndexDecodeError, match="outside the 15-75 mm range"):
+    with pytest.raises(IndexDecodeError, match=r"shorter than the 15 mm floor"):
         manual_frames.build_manual_detection(
             rgb,
             _known(rgb),
-            [start, end, end + 200],
+            [100, 110, 400],  # 10 rows, ~3 mm
             nominal_frame_rows=143,
             records=records,
         )
+
+
+def test_refuses_a_frame_taller_than_the_fine_capture_window() -> None:
+    """F2: the fine scan captures a fixed window; there is no multi-window
+    capture. A frame taller than that window must refuse honestly instead
+    of silently delivering a truncated capture."""
+
+    height = 3_000
+    rgb = np.zeros((height, 96, 3), dtype=np.uint16)
+    records = _clean_records(height)
+
+    with pytest.raises(
+        IndexDecodeError,
+        match=r"the scanner captures about 38\.8 mm per frame in one fine scan",
+    ):
+        manual_frames.build_manual_detection(
+            rgb,
+            _known(rgb),
+            [100, 100 + manual_frames.FINE_CAPTURE_WINDOW_ROWS + 1, 2_900],
+            nominal_frame_rows=143,
+            records=records,
+        )
+
+
+def test_frame_exactly_at_the_ceiling_is_accepted() -> None:
+    height = 3_000
+    rgb = np.zeros((height, 96, 3), dtype=np.uint16)
+    records = _clean_records(height)
+
+    result = manual_frames.build_manual_detection(
+        rgb,
+        _known(rgb),
+        [100, 100 + manual_frames.FINE_CAPTURE_WINDOW_ROWS],
+        nominal_frame_rows=143,
+        records=records,
+    )
+
+    assert len(result.detection.intervals) == 1
 
 
 def test_half_frame_heights_are_accepted() -> None:
@@ -292,51 +471,114 @@ def test_half_frame_heights_are_accepted() -> None:
         assert interval.height_rows == 71
 
 
-def test_panoramic_heights_are_accepted() -> None:
+def test_panoramic_heights_are_now_refused() -> None:
+    """F2 rework: panoramic acceptance is deliberately removed. The fine
+    scan cannot capture a ~66 mm frame in one pass, so this must refuse
+    rather than silently truncate -- manual mode still exists for film
+    automatic detection cannot handle, but panoramic is no longer one of
+    those cases."""
+
     rgb, boundaries = _synthetic_roll(3, pitch=250, leader=30, tail=30)
     records = _clean_records(len(rgb))
 
-    result = manual_frames.build_manual_detection(
-        rgb, _known(rgb), boundaries, nominal_frame_rows=250, records=records
-    )
-
-    assert len(result.detection.intervals) == 3
-    for interval in result.detection.intervals:
-        assert interval.height_rows == 250
-
-
-# --------------------------------------------------------------------------
-# Transport table gates
-# --------------------------------------------------------------------------
-
-
-def test_single_record_spike_near_a_boundary_refuses_the_whole_placement() -> None:
-    rgb, boundaries = _synthetic_roll(6)
-    spiked = _spike(_clean_records(len(rgb)), boundaries[2] + 1, 5_000)
-
-    with pytest.raises(IndexDecodeError, match="position readings look unreliable"):
+    with pytest.raises(
+        IndexDecodeError, match="there is no way to capture a taller frame"
+    ):
         manual_frames.build_manual_detection(
-            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=spiked
+            rgb, _known(rgb), boundaries, nominal_frame_rows=250, records=records
         )
 
 
-def test_spike_message_names_the_ordinal_edge_and_no_frames_are_returned() -> None:
+@pytest.mark.parametrize(
+    ("picks", "clear_runs", "expected_match"),
+    [
+        # P1 (adversarial review probe): a raw pick pair exactly at the 56-
+        # row floor, crafted so snap assist pulls them TOWARD each other,
+        # eroding the post-snap height to 48 rows (~12.8 mm). Must refuse.
+        ([100, 156], [(104, 110), (146, 153)], r"shorter than the 15 mm floor"),
+        # P1b: a raw pick pair exactly at the (old) 280-row ceiling,
+        # crafted so snap assist pushes them APART; under the new
+        # fine-window ceiling this is refused even more decisively.
+        ([100, 380], [(90, 97), (384, 390)], "there is no way to capture"),
+    ],
+)
+def test_height_gate_runs_on_post_snap_rows(
+    picks: list[int], clear_runs: list[tuple[int, int]], expected_match: str
+) -> None:
+    height = 700
+    rgb = _blank_roll(height)
+    clear = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    rgb_i = rgb.astype(np.int64)
+    for start, end in clear_runs:
+        rgb_i[start:end, 2:92] = clear
+    rgb = rgb_i.clip(0, 65_535).astype(np.uint16)
+    records = _clean_records(height)
+
+    with pytest.raises(IndexDecodeError, match=expected_match):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), picks, nominal_frame_rows=143, records=records
+        )
+
+
+# --------------------------------------------------------------------------
+# Transport table gates (F1 + F4 rework)
+# --------------------------------------------------------------------------
+
+
+def test_isolated_table_row_anomaly_near_a_boundary_is_tolerated() -> None:
+    """F1: a single-row transport-table anomaly -- exactly the shape a real
+    lattice rollover takes -- near a boundary no longer refuses the whole
+    placement. The local fit robustly resolves around it, the same way it
+    resolves around the real lattice's own rollover rows.
+    """
+
     rgb, boundaries = _synthetic_roll(6)
     spiked = _spike(_clean_records(len(rgb)), boundaries[2] + 1, 5_000)
 
-    with pytest.raises(IndexDecodeError, match="3rd frame edge"):
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=spiked
+    )
+
+    # Frame 3 (0-indexed origin 2) anchors on boundaries[2]'s own narrow-run
+    # trailing edge (boundaries[2] + 3), untouched by the spike at
+    # boundaries[2] + 1, so it resolves exactly as if the spike were absent.
+    assert result.mapping.origins[2].native_origin == 42 * (boundaries[2] + 3)
+
+
+def test_widespread_table_corruption_near_a_boundary_still_refuses() -> None:
+    """The tolerance F1 adds has a limit: when a boundary's ENTIRE local
+    neighborhood is corrupted (not one isolated row), there is no steady
+    rate left to find, and this must still refuse -- naming that specific
+    edge, not blaming the physical strip for a table-reading problem."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    # Wide enough to blank out this boundary's ENTIRE local-fit window
+    # (LOCAL_FIT_WINDOW_RADIUS_ROWS on each side) with alternating noise,
+    # leaving no steady-rate majority anywhere nearby to find.
+    radius = manual_frames.LOCAL_FIT_WINDOW_RADIUS_ROWS
+    corrupted = _corrupt_span(
+        _clean_records(len(rgb)),
+        boundaries[2] - radius - 5,
+        boundaries[2] + radius + 5,
+        30_000,
+    )
+
+    with pytest.raises(
+        IndexDecodeError, match=r"doesn't settle into a steady rate"
+    ):
         manual_frames.build_manual_detection(
-            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=spiked
+            rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=corrupted
         )
 
 
 def test_non_affine_implied_scale_between_boundaries_refuses() -> None:
     rgb, boundaries = _synthetic_roll(6)
     records = list(_clean_records(len(rgb)))
-    # A jump well clear of every boundary's own +-3 row ramp-guard window
-    # (boundaries[2]=310, next boundary 453; the jump sits at 380) still
-    # skews the aggregate origins-vs-rows relationship between those two
-    # picked boundaries -- a distinct failure mode from the local guard.
+    # A jump well clear of every boundary's own local-fit window (radius
+    # LOCAL_FIT_WINDOW_RADIUS_ROWS; boundaries[2]=310, next boundary 453,
+    # the jump sits at 380) still skews the relationship between those two
+    # picks' own resolved origins -- a distinct failure mode from gate 4's
+    # per-boundary local check.
     jump_row = boundaries[2] + 70
     for row in range(jump_row, len(records)):
         victim = records[row]
@@ -366,6 +608,200 @@ def test_refuses_when_no_transport_records_are_supplied() -> None:
         )
 
 
+def test_lattice_table_boundaries_resolve_despite_rollover_neighbors() -> None:
+    """F1's core regression: a REAL lattice table (see _lattice_records)
+    carries a selector-rollover jump pair roughly every 18 rows -- so a
+    typical local-fit window around any boundary contains at least one.
+    Every boundary here must still be accepted, and every resolved origin
+    must land on the true clean-ramp value (42 * lookup_row) despite that
+    neighbor, the same way real archived captures do (see this rework's
+    51-table regression in test_roll_index.py).
+    """
+
+    rgb, boundaries = _synthetic_roll(6)
+    records = _lattice_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=records
+    )
+
+    assert len(result.mapping.origins) == 6
+    for origin in result.mapping.origins:
+        expected = transport_native_origin(
+            records[origin.lookup_row].code, records[origin.lookup_row].selector
+        )
+        assert origin.native_origin == expected
+        # Every resolved origin must itself be an exact, real table read --
+        # never a value that does not correspond to any row in the table.
+        assert origin.native_origin == records[origin.lookup_row].native_origin
+
+
+def test_lattice_table_pick_exactly_on_a_rollover_row_is_tolerated() -> None:
+    """The narrowest version of F1's fix: the operator's own pick (not just
+    a nearby row) lands exactly on one of the lattice's rollover rows. No
+    narrow evidence run is nearby (a blank roll), so the pick row itself is
+    the anchor -- and it is NOT trustworthy on its own. Resolution must
+    still succeed, via the no-narrow-run forward search (the same
+    resolution shape a broad/weak-evidence pick always uses -- see
+    _resolve_boundary_transport_origin's own docstring), landing on a
+    nearby row the local fit does trust.
+    """
+
+    height = 900
+    rgb = _blank_roll(height)
+    records = _lattice_records(height)
+    period = len(_LATTICE_CYCLE_CODES) + 2
+
+    # A rollover-lookahead row (see _lattice_records) comfortably inside
+    # the table, far from either raster edge or the terminal-tail concept
+    # (records here have none).
+    rollover_row = next(
+        row for row in range(300, 340) if row % period == len(_LATTICE_CYCLE_CODES)
+    )
+    picks = [rollover_row - 100, rollover_row, rollover_row + 100]
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), picks, nominal_frame_rows=143, records=records
+    )
+
+    origin = result.mapping.origins[1]  # frame 2 starts at the rollover pick
+    assert origin.lookup_row != rollover_row
+    assert abs(origin.lookup_row - rollover_row) <= manual_frames.CANDIDATE_SEARCH_LOOKAHEAD_ROWS
+    assert manual_frames.INFERRED_ORIGIN_REVIEW_REASON in origin.review_reasons
+    assert origin.native_origin == records[origin.lookup_row].native_origin
+
+
+# --------------------------------------------------------------------------
+# Placement-wide affine-fit gate (F4)
+# --------------------------------------------------------------------------
+
+
+def test_placement_wide_drift_too_small_for_any_single_pair_still_refuses() -> None:
+    """A gentle, CONTINUOUS bow across the whole table -- a mild quadratic
+    offset, applied to every row, never a step -- curves too slowly to
+    disturb any one boundary's own local-fit window (gate 4) or any one
+    adjacent pair's implied scale (gate 5: a quadratic's local slope near
+    either end of an 8-frame placement is still well inside the 40..45
+    band), but a single straight line cannot fit a bow across the WHOLE
+    placement, and that is exactly the worst-case residual only the
+    placement-wide fit (>=3 boundaries) checks. (A step offset, tried
+    first while writing this test, is a much blunter tool: any discrete
+    jump has to sit inside SOME boundary's own window, so it trips gate 4
+    or gate 5 instead of demonstrating gate 6 specifically -- a bow is the
+    shape that is invisible to both of those and visible only in
+    aggregate.) The k=0.0015 coefficient below was chosen empirically
+    against this exact scenario: comfortably clear of gate 4 (which first
+    breaks around k=0.003) with about a 1.5-row aggregate drift, comfortably
+    past the gate 6 bounds (MAE 1.0, max 2.0 rows).
+    """
+
+    rgb, boundaries = _synthetic_roll(8, pitch=90, leader=30, tail=30)
+    records = list(_clean_records(len(rgb)))
+    center = len(records) / 2
+    curvature = 0.0015
+    for row in range(len(records)):
+        victim = records[row]
+        offset = int(round(curvature * (row - center) ** 2))
+        records[row] = TransportRecord(
+            row=victim.row,
+            code=victim.code,
+            selector=victim.selector,
+            native_origin=victim.native_origin + offset,
+        )
+    records_tuple = tuple(records)
+
+    with pytest.raises(
+        IndexDecodeError, match="don't agree on one steady rate"
+    ):
+        manual_frames.build_manual_detection(
+            rgb, _known(rgb), boundaries, nominal_frame_rows=90, records=records_tuple
+        )
+
+
+def test_two_boundary_placement_skips_the_placement_wide_gate() -> None:
+    """Documented limitation (F4): two points always fit a line exactly, so
+    the placement-wide MAE/max gate is vacuous for a single-frame
+    placement and is not enforced -- gate 4 (each pick's own local
+    neighborhood) and gate 5 (the one pairwise implied scale) are what
+    validate a 2-boundary placement instead."""
+
+    rgb, boundaries = _synthetic_roll(1, pitch=143)
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb, _known(rgb), boundaries, nominal_frame_rows=143, records=records
+    )
+
+    # A 2x2 least-squares solve through exactly 2 points is analytically
+    # exact but not always bit-exact in floating point.
+    assert result.mapping.anchor_mae_rows == pytest.approx(0.0, abs=1e-6)
+    assert result.mapping.anchor_max_error_rows == pytest.approx(0.0, abs=1e-6)
+
+
+# --------------------------------------------------------------------------
+# Idempotency (F3): build_manual_detection(final_rows) must accept its own
+# output rows unchanged -- the batch capture wire and the worker's live-scan
+# replay both resupply a prior call's own boundary output rows as the next
+# call's raw picks.
+# --------------------------------------------------------------------------
+
+
+def test_build_manual_detection_is_idempotent_on_its_own_output() -> None:
+    # Shorter pitch than the default 143: this test shifts a pick by 5 rows
+    # before snapping, and the resulting frame must stay comfortably clear
+    # of the fine-capture-window ceiling (F2) -- a different gate than the
+    # one this test exercises.
+    rgb, boundaries = _synthetic_roll(6, pitch=100, leader=20, tail=20)
+    records = _lattice_records(len(rgb))
+    picks = list(boundaries)
+    picks[2] = boundaries[2] - 5  # off the run edge, exercises a real snap
+
+    first = manual_frames.build_manual_detection(
+        rgb, _known(rgb), picks, nominal_frame_rows=100, records=records
+    )
+    replay_rows = tuple(b.output_row for b in first.detection.boundaries)
+
+    second = manual_frames.build_manual_detection(
+        rgb, _known(rgb), replay_rows, nominal_frame_rows=100, records=records
+    )
+
+    assert second.snaps == ()
+    assert [b.output_row for b in second.detection.boundaries] == list(replay_rows)
+    assert [o.native_origin for o in second.mapping.origins] == [
+        o.native_origin for o in first.mapping.origins
+    ]
+    assert [o.lookup_row for o in second.mapping.origins] == [
+        o.lookup_row for o in first.mapping.origins
+    ]
+
+
+def test_idempotency_holds_after_a_gate_3_snap_erosion_scenario() -> None:
+    """The exact P1 probe scenario (adversarial review), but confirming the
+    NEW behavior end to end: gate 3 now refuses the eroded placement
+    directly (test_height_gate_runs_on_post_snap_rows above), so there is
+    no approved-then-unreplayable placement left to deadlock on -- replay
+    of a placement that WAS accepted (picks safely clear of the floor)
+    still round-trips cleanly."""
+
+    height = 700
+    rgb = _blank_roll(height)
+    clear = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    rgb_i = rgb.astype(np.int64)
+    rgb_i[104:110, 2:92] = clear
+    rgb_i[146:153, 2:92] = clear
+    rgb = rgb_i.clip(0, 65_535).astype(np.uint16)
+    records = _clean_records(height)
+    # Snaps to (104, 152): 48 rows, short of the 56-row floor on purpose --
+    # must refuse identically on first call and replay.
+    picks = [100, 156]
+
+    for _ in range(2):
+        with pytest.raises(IndexDecodeError, match="shorter than the 15 mm floor"):
+            manual_frames.build_manual_detection(
+                rgb, _known(rgb), picks, nominal_frame_rows=143, records=records
+            )
+
+
 # --------------------------------------------------------------------------
 # Shape/completeness gates
 # --------------------------------------------------------------------------
@@ -392,3 +828,74 @@ def test_refuses_an_incomplete_preview() -> None:
         manual_frames.build_manual_detection(
             rgb, known, boundaries, nominal_frame_rows=143, records=records
         )
+
+
+def test_far_substitute_extrapolates_at_the_anchor_instead_of_drifting() -> None:
+    """Re-review 2026-08-08, F-A: symmetric corruption around a narrow run's
+    trailing edge left the local fit's median seed standing while pushing the
+    nearest trusted row far from the anchor. The uncapped nearest-inlier
+    substitute then silently displaced the origin by up to 22 rows through
+    gates that all read zero residual. Beyond the 3-row cap the origin must
+    now extrapolate AT the anchor from the surviving fit -- landing within
+    one step of the true line -- and carry the clamp reason truthfully."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    records = list(_clean_records(len(rgb)))
+    target = boundaries[3]
+    run_end = target + 3
+    for offset in range(-12, 13):
+        row = run_end + offset
+        if not 0 <= row < len(records):
+            continue
+        if abs(offset) <= 8:
+            spoiled = records[row]
+            records[row] = TransportRecord(
+                row=spoiled.row,
+                code=spoiled.code,
+                selector=spoiled.selector,
+                native_origin=spoiled.native_origin
+                + (30_000 if offset % 2 else -30_000),
+            )
+
+    result = manual_frames.build_manual_detection(
+        rgb,
+        np.ones_like(rgb, dtype=bool),
+        list(boundaries),
+        nominal_frame_rows=145,
+        records=records,
+    )
+
+    frame4 = result.mapping.origins[3]
+    assert abs(frame4.native_origin - 42 * run_end) <= 84
+    assert TRANSPORT_ORIGIN_CLAMP_REASON in frame4.review_reasons or (
+        manual_frames.INFERRED_ORIGIN_REVIEW_REASON in frame4.review_reasons
+    )
+
+
+def test_lookup_far_from_pick_earns_its_own_review_reason() -> None:
+    """Re-review 2026-08-08, F-B: an 18-row clear band inside a frame pulls
+    the trailing-edge anchor well away from the operator's line with no
+    other signal; the divergence now carries an explicit review reason."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    clear_row = rgb[boundaries[2]].copy()
+    # Extend boundary 2's natural clear run (rows b-3..b+3) to a 20-row
+    # band b-3..b+17 -- still narrow (<= 20), so the trailing-edge anchor
+    # lands at b+17 while the operator's line stays at b: a 17-row
+    # divergence with no snap and no other signal.
+    rgb[boundaries[2] + 3 : boundaries[2] + 17] = clear_row
+    records = _clean_records(len(rgb))
+
+    result = manual_frames.build_manual_detection(
+        rgb,
+        np.ones_like(rgb, dtype=bool),
+        list(boundaries),
+        nominal_frame_rows=145,
+        records=records,
+    )
+
+    frame3 = result.mapping.origins[2]
+    assert abs(frame3.lookup_row - result.detection.boundaries[2].output_row) > 4
+    assert (
+        manual_frames.LOOKUP_FAR_FROM_PICK_REVIEW_REASON in frame3.review_reasons
+    )

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_diagnosis.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_diagnosis.py
@@ -1,0 +1,389 @@
+"""Contracts for the read-only roll-refusal diagnosis pass.
+
+Reuses the synthetic raster builders from test_roll_index.py (the one
+cross-file test dependency documented in tests/conftest.py) instead of
+duplicating them, so a change to the builders' conventions cannot silently
+drift the two test files apart.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from coolscanpy.protocol.ls5000_single_pass import roll_diagnosis as diagnosis
+from coolscanpy.protocol.ls5000_single_pass import roll_index as roll
+from tests.protocol.ls5000_single_pass.test_roll_index import (
+    _synthetic_roll,
+    _synthetic_roll_with_gap_rows,
+)
+
+NOMINAL_FRAME_ROWS = 145
+
+
+def _low_contrast_roll() -> np.ndarray:
+    """A healthy roll whose interior inter-frame gaps read ~0.83-0.86 relative
+    transmission instead of the usual ~0.95+.
+
+    Scaling only the *interior* gap bands (never the leader/tail) keeps the
+    clear-film p99 reference anchored to unscaled film, so the scaled gaps
+    genuinely read as dim rather than silently re-normalizing away (the
+    detector's own clear-film reference is the raster's own p99 -- scaling
+    every clear-film row uniformly, leader and tail included, changes
+    nothing, per FEEDING-ROBUSTNESS-20260805.md Sec 0 finding 3).
+    """
+
+    rgb, boundaries = _synthetic_roll(8, leader=60, tail=60, pitch=143)
+    scaled = rgb.astype(np.float64)
+    for boundary in boundaries[1:-1]:
+        lo, hi = max(0, boundary - 3), min(len(rgb), boundary + 3)
+        scaled[lo:hi, 2:92] *= 0.85
+    return np.clip(scaled, 0, 65_535).astype(np.uint16)
+
+
+def _obstructed_roll() -> np.ndarray:
+    """A healthy roll with its leading ~18 aperture columns dimmed to 70%.
+
+    70% clears the measured obstruction cliff (15/96 columns @ 70% fails
+    detection with string A per FEEDING-ROBUSTNESS-20260805.md Sec 3.3) with
+    a wide margin, exactly like the field mechanism it stands in for: a
+    carrier mask edge or curl shadow depressing one side of the window.
+    """
+
+    rgb, _boundaries = _synthetic_roll(10, leader=30, tail=30)
+    dimmed = rgb.astype(np.float64)
+    dimmed[:, 2:20] *= 0.70
+    return np.clip(dimmed, 0, 65_535).astype(np.uint16)
+
+
+def _known(rgb: np.ndarray) -> np.ndarray:
+    return np.ones_like(rgb, dtype=bool)
+
+
+# ---------------------------------------------------------------------------
+# Structural guarantee: str | None, always -- never RollDetection/GapBoundary/
+# a raised exception, no matter what the input looks like.
+
+
+def _structural_scenarios() -> list[tuple[str, np.ndarray, np.ndarray, int]]:
+    healthy_rgb, _ = _synthetic_roll(24, leader=17, tail=21)
+    half_frame_rgb, _ = _synthetic_roll(20, pitch=71, leader=30, tail=30)
+    panorama_rgb, _ = _synthetic_roll(8, pitch=259, leader=30, tail=30)
+    narrow_boundary_rows = [200 + index * 143 for index in range(6)]
+    narrow_rgb = _synthetic_roll_with_gap_rows(
+        narrow_boundary_rows, height=6 * 145 + 200, band_halfwidth=1
+    )
+    wide_rgb = _synthetic_roll_with_gap_rows(
+        narrow_boundary_rows, height=6 * 145 + 200, band_halfwidth=13
+    )
+    low_contrast_rgb = _low_contrast_roll()
+    obstructed_rgb = _obstructed_roll()
+    too_short_rgb, _ = _synthetic_roll(2, leader=5, tail=5)
+    garbage_rgb = np.zeros((10, 96, 3), dtype=np.uint16)
+
+    return [
+        ("healthy", healthy_rgb, _known(healthy_rgb), NOMINAL_FRAME_ROWS),
+        ("half_frame", half_frame_rgb, _known(half_frame_rgb), NOMINAL_FRAME_ROWS),
+        ("panorama", panorama_rgb, _known(panorama_rgb), NOMINAL_FRAME_ROWS),
+        ("narrow_gaps", narrow_rgb, _known(narrow_rgb), NOMINAL_FRAME_ROWS),
+        ("wide_gaps", wide_rgb, _known(wide_rgb), NOMINAL_FRAME_ROWS),
+        (
+            "low_contrast",
+            low_contrast_rgb,
+            _known(low_contrast_rgb),
+            NOMINAL_FRAME_ROWS,
+        ),
+        ("obstructed", obstructed_rgb, _known(obstructed_rgb), NOMINAL_FRAME_ROWS),
+        (
+            "too_short_for_pitch_detection",
+            too_short_rgb,
+            _known(too_short_rgb),
+            NOMINAL_FRAME_ROWS,
+        ),
+        ("all_zero_garbage", garbage_rgb, _known(garbage_rgb), NOMINAL_FRAME_ROWS),
+        (
+            "mismatched_known_shape",
+            garbage_rgb,
+            np.ones((5, 96, 3), dtype=bool),
+            NOMINAL_FRAME_ROWS,
+        ),
+        (
+            "all_incomplete_known",
+            healthy_rgb,
+            np.zeros_like(healthy_rgb, dtype=bool),
+            NOMINAL_FRAME_ROWS,
+        ),
+        ("nominal_below_floor", healthy_rgb, _known(healthy_rgb), 5),
+        ("nominal_zero", healthy_rgb, _known(healthy_rgb), 0),
+        (
+            "one_dimensional_raster",
+            np.zeros(10, dtype=np.uint16),
+            np.ones(10, dtype=bool),
+            NOMINAL_FRAME_ROWS,
+        ),
+    ]
+
+
+_SCENARIOS = _structural_scenarios()
+
+
+@pytest.mark.parametrize(
+    ("label", "rgb16", "known", "nominal_frame_rows"),
+    _SCENARIOS,
+    ids=[scenario[0] for scenario in _SCENARIOS],
+)
+def test_diagnose_roll_refusal_always_returns_str_or_none(
+    label: str,
+    rgb16: np.ndarray,
+    known: np.ndarray,
+    nominal_frame_rows: int,
+) -> None:
+    result = diagnosis.diagnose_roll_refusal(
+        rgb16, known, nominal_frame_rows=nominal_frame_rows
+    )
+    assert result is None or isinstance(result, str)
+
+
+def test_module_never_references_detection_result_types_or_the_wrapper() -> None:
+    """Grep-level guarantee: this module cannot construct or even name a
+    detection result. Source-text check, not an import-time property, so a
+    future ``from .roll_index import RollDetection`` (even if unused) still
+    fails this the same way a real violation would.
+    """
+
+    source = Path(diagnosis.__file__).read_text()
+    for forbidden in ("RollDetection", "GapBoundary", "detect_roll_frames"):
+        assert forbidden not in source, (
+            f"{forbidden!r} must never appear in roll_diagnosis.py"
+        )
+
+
+# ---------------------------------------------------------------------------
+# One test per diagnosis class (priority order 1-4; half-frame and panorama
+# are both the alternate-pitch check, class 1).
+
+
+def test_half_frame_pitch_is_recognized() -> None:
+    rgb = _synthetic_roll(20, pitch=71, leader=30, tail=30)[0]
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "half-frame film" in sentence
+    assert "19 mm" in sentence
+    assert "standard 35 mm spacing" in sentence
+
+
+def test_panoramic_pitch_is_recognized() -> None:
+    rgb = _synthetic_roll(8, pitch=259, leader=30, tail=30)[0]
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "panoramic film" in sentence
+    assert "69 mm" in sentence
+    assert "standard 35 mm spacing" in sentence
+
+
+def test_narrow_gaps_are_recognized() -> None:
+    boundary_rows = [200 + index * 143 for index in range(6)]
+    rgb = _synthetic_roll_with_gap_rows(
+        boundary_rows, height=6 * 145 + 200, band_halfwidth=1
+    )
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "blank strips between your frames" in sentence
+    assert "0.5 mm" in sentence
+    assert "0.8 mm" in sentence
+
+
+def test_wide_gaps_are_recognized() -> None:
+    boundary_rows = [200 + index * 143 for index in range(6)]
+    rgb = _synthetic_roll_with_gap_rows(
+        boundary_rows, height=6 * 145 + 200, band_halfwidth=13
+    )
+    # Confirm the fixture actually exceeds the recovery ceiling, so this
+    # test is exercising "too wide", not some other accepted width.
+    aperture = roll._active_aperture(rgb)
+    _evidence, _transmission, _nonuniformity, direct = roll._physical_gap_evidence(
+        rgb, aperture
+    )
+    widths = [end - start for start, end in roll._true_runs(direct)]
+    assert all(width > roll.WIDE_GAP_CEILING_ROWS for width in widths)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "a blank region measures" in sentence
+    assert "wider than anything the detector accepts" in sentence
+
+
+def test_low_contrast_gaps_are_recognized() -> None:
+    rgb = _low_contrast_roll()
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "only slightly clearer than the frames themselves" in sentence
+    assert "fog or a dense film base" in sentence
+
+
+def test_aperture_obstruction_is_recognized() -> None:
+    rgb = _obstructed_roll()
+    sentence = diagnosis.diagnose_roll_refusal(
+        rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert sentence is not None
+    assert "partly blocked" in sentence
+    assert "leading side" in sentence
+    assert "film holder seating and film curl" in sentence
+
+
+# ---------------------------------------------------------------------------
+# Wiring: detect_roll_frames's failure paths attach diagnostics["probable_
+# cause"] when (and only when) a diagnosis fires, without touching the
+# error id, message prefix, or any pre-existing diagnostics key.
+
+
+def test_wiring_attaches_probable_cause_without_changing_error_id_or_existing_keys() -> (
+    None
+):
+    boundary_rows = [200 + index * 143 for index in range(6)]
+    rgb = _synthetic_roll_with_gap_rows(
+        boundary_rows, height=6 * 145 + 200, band_halfwidth=1
+    )
+    known = _known(rgb)
+
+    # The undecorated pass-1 error -- exactly what today's behavior is
+    # without any diagnosis wired in.
+    with pytest.raises(roll.IndexDecodeError) as baseline_excinfo:
+        roll._detect_roll_frames_single(
+            rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS
+        )
+    baseline = baseline_excinfo.value
+
+    with pytest.raises(roll.IndexDecodeError) as wired_excinfo:
+        roll.detect_roll_frames(rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS)
+    wired = wired_excinfo.value
+
+    assert wired.error_id == baseline.error_id == roll.GAP_COUNT_FLOOR_ERROR_ID
+    assert str(wired).split(" [")[0] == str(baseline).split(" [")[0]
+    for key, value in (baseline.diagnostics or {}).items():
+        assert wired.diagnostics[key] == value
+    assert set(wired.diagnostics) - set(baseline.diagnostics or {}) == {
+        "wide_gap_recovery",
+        "probable_cause",
+    }
+
+    expected_sentence = diagnosis.diagnose_roll_refusal(
+        rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert expected_sentence is not None
+    assert wired.diagnostics["probable_cause"] == expected_sentence
+
+
+def test_wiring_adds_no_probable_cause_key_when_no_check_fires() -> None:
+    """A raster whose actual failure mode (one gap 30 rows off-lattice) does
+    not match any of the four diagnosis classes must raise exactly today's
+    error -- diagnosis returning ``None`` must never add the key.
+    """
+
+    # Matches test_roll_index.py's own off-lattice-gap fixture: three narrow
+    # gaps clear the count floor, but the third is 30 rows off the pitch the
+    # other two establish.
+    boundary_rows = [200, 345, 520]
+    rgb = _synthetic_roll_with_gap_rows(boundary_rows, height=6 * 145, band_halfwidth=3)
+    known = _known(rgb)
+
+    assert (
+        diagnosis.diagnose_roll_refusal(
+            rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS
+        )
+        is None
+    )
+
+    with pytest.raises(roll.IndexDecodeError) as excinfo:
+        roll.detect_roll_frames(rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS)
+    error = excinfo.value
+    assert error.error_id == roll.GAP_LATTICE_ANCHOR_ERROR_ID
+    assert "probable_cause" not in error.diagnostics
+
+
+def test_incomplete_index_error_never_carries_probable_cause() -> None:
+    """IncompleteIndexError re-raises untouched (task boundary: this is not
+    a roll-geometry refusal the diagnosis pass has any business commenting
+    on -- the raster is simply missing rows).
+    """
+
+    rgb, _boundaries = _synthetic_roll(5)
+    known = _known(rgb)
+    known[: rgb.shape[0] // 10] = False
+
+    with pytest.raises(roll.IncompleteIndexError) as excinfo:
+        roll.detect_roll_frames(rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS)
+    error = excinfo.value
+    assert error.diagnostics is None
+    assert "probable_cause" not in str(error)
+
+
+# ---------------------------------------------------------------------------
+# No false positives: healthy film must never receive an invented cause.
+# Belt-and-braces -- diagnose_roll_refusal never runs on healthy film in
+# production (it is only ever called from a failure path), but the
+# structural contract holds regardless of what a caller hands it.
+
+
+@pytest.mark.parametrize(
+    ("frame_count", "pitch", "leader", "tail"),
+    [
+        (24, 143, 17, 21),
+        (8, 143, 91, 47),
+        (36, 143, 300, 21),
+        (6, 143, 0, 3),
+        (10, 143, 300, 260),
+        (4, 123, 30, 30),
+        (4, 167, 30, 30),
+        (20, 145, 30, 30),
+    ],
+    ids=[
+        "typical_leader_trailer",
+        "short_leader_long_trailer",
+        "long_leader_short_trailer",
+        "no_leader_minimal_trailer",
+        "very_long_leader_and_trailer",
+        "pitch_at_low_edge_of_standard_band",
+        "pitch_at_high_edge_of_standard_band",
+        "pitch_equals_nominal",
+    ],
+)
+def test_healthy_roll_never_invents_a_cause(
+    frame_count: int, pitch: int, leader: int, tail: int
+) -> None:
+    rgb, _boundaries = _synthetic_roll(
+        frame_count, pitch=pitch, leader=leader, tail=tail
+    )
+    assert (
+        diagnosis.diagnose_roll_refusal(
+            rgb, _known(rgb), nominal_frame_rows=NOMINAL_FRAME_ROWS
+        )
+        is None
+    )
+
+
+def test_healthy_roll_succeeds_normally_through_the_wrapper_with_no_probable_cause() -> (
+    None
+):
+    """End-to-end sanity: wiring diagnosis into the failure paths must not
+    perturb the success path at all."""
+
+    rgb, _boundaries = _synthetic_roll(24, leader=17, tail=21)
+    known = _known(rgb)
+    detection = roll.detect_roll_frames(
+        rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS
+    )
+    assert detection.confidence == "high"

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_diagnosis.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_diagnosis.py
@@ -387,3 +387,127 @@ def test_healthy_roll_succeeds_normally_through_the_wrapper_with_no_probable_cau
         rgb, known, nominal_frame_rows=NOMINAL_FRAME_ROWS
     )
     assert detection.confidence == "high"
+
+
+def test_one_sided_band_never_reads_as_fog(synthetic_roll_factory=None) -> None:
+    """Adversarial review 2026-08-08, F5: a mild one-sided aperture band
+    (84% brightness, sitting just above the obstruction check's own ratio)
+    dragged gap rows into the contrast near-miss window and fired the
+    fog/dense-base sentence -- physically wrong advice. The contrast check
+    now requires column symmetry, so this construction yields either the
+    obstruction sentence or silence, never fog."""
+
+    rgb, _boundaries = _synthetic_roll(6)
+    banded = rgb.astype(np.float64)
+    banded[:, 2:16] *= 0.84
+    banded = banded.astype(rgb.dtype)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        banded, np.ones_like(banded, dtype=bool), nominal_frame_rows=145
+    )
+
+    assert sentence is None or "partly blocked" in sentence
+    assert sentence is None or "fog" not in sentence
+
+
+def test_uniform_dimming_still_reads_as_fog_when_clustered() -> None:
+    """The symmetry guard must not silence the genuine fog case: a
+    column-uniform near-miss depression keeps its sentence."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    dimmed = rgb.astype(np.float64)
+    for boundary in boundaries:
+        lo = max(0, boundary - 3)
+        hi = min(len(dimmed), boundary + 3)
+        dimmed[lo:hi] *= 0.86
+    dimmed = dimmed.astype(rgb.dtype)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        dimmed, np.ones_like(dimmed, dtype=bool), nominal_frame_rows=145
+    )
+
+    assert sentence is not None and "fog" in sentence
+
+
+def test_subclassed_refusals_pass_through_unreconstructed(monkeypatch) -> None:
+    """Adversarial review 2026-08-08, F6: attaching a probable-cause
+    sentence must never rebuild an IndexDecodeError SUBCLASS into the bare
+    base class -- subclasses carry their own constructor signatures,
+    structured fields, and dedicated downstream handling."""
+
+    class StructuredRefusal(roll.IndexDecodeError):
+        def __init__(self) -> None:
+            super().__init__("structured refusal with its own contract")
+            self.structured_field = 42
+
+    def raise_structured(*args, **kwargs):
+        raise StructuredRefusal()
+
+    monkeypatch.setattr(roll, "_detect_roll_frames_single", raise_structured)
+    rgb, _boundaries = _synthetic_roll(4)
+
+    with pytest.raises(StructuredRefusal) as excinfo:
+        roll.detect_roll_frames(
+            rgb,
+            np.ones_like(rgb, dtype=bool),
+            nominal_frame_rows=145,
+            expected_frame_count=None,
+        )
+    assert excinfo.value.structured_field == 42
+    assert "probable_cause" not in str(excinfo.value)
+
+
+def test_dark_image_composition_along_one_side_is_not_an_obstruction() -> None:
+    """Adversarial review 2026-08-08, S9: a roll whose photographs carry
+    dark content along one side must not read as a blocked film window --
+    the depression exists only where there is picture, so the brightest
+    (clear-film) rows show no one-sided dip and the check stays silent."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    composed = rgb.astype(np.float64)
+    for start, end in zip(boundaries, boundaries[1:]):
+        frame_lo = start + 5
+        frame_hi = end - 5
+        composed[frame_lo:frame_hi, 2:20] *= 0.55  # dark subject edge, frames only
+    composed = composed.astype(rgb.dtype)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        composed, np.ones_like(composed, dtype=bool), nominal_frame_rows=145
+    )
+
+    assert sentence is None or "partly blocked" not in sentence
+
+
+def test_true_obstruction_on_clear_rows_still_reads_as_blocked() -> None:
+    """The bright-row restriction must not silence a genuine obstruction:
+    a fixed 70% band across every row (gaps included) keeps its sentence."""
+
+    rgb, _boundaries = _synthetic_roll(6)
+    blocked = rgb.astype(np.float64)
+    blocked[:, 2:20] *= 0.70
+    blocked = blocked.astype(rgb.dtype)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        blocked, np.ones_like(blocked, dtype=bool), nominal_frame_rows=145
+    )
+
+    assert sentence is not None and "partly blocked" in sentence
+
+
+def test_gapless_roll_never_reads_as_obstruction() -> None:
+    """Re-review 2026-08-08, F-C: on a roll with NO clear rows at all, the
+    p99 'clear' reference lands on bright frame rows, and one-sided scene
+    content resurrected the phantom blocked-window sentence. With the
+    separation floor, a raster whose brightest rows are not clearly apart
+    from typical rows stays silent on obstruction."""
+
+    gapless_rgb = _synthetic_roll_with_gap_rows([], height=6 * 145)
+    gapless = gapless_rgb.astype(np.float64)
+    gapless[:, 2:20] *= 0.55  # one-sided dark composition
+    gapless = gapless.astype(gapless_rgb.dtype)
+
+    sentence = diagnosis.diagnose_roll_refusal(
+        gapless, np.ones_like(gapless, dtype=bool), nominal_frame_rows=145
+    )
+
+    assert sentence is None or "partly blocked" not in sentence

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -1,5 +1,6 @@
 """Regression contracts for whole-roll index decoding and dynamic frame origins."""
 
+import hashlib
 import json
 import math
 import os
@@ -9,6 +10,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from coolscanpy.protocol.ls5000_single_pass import manual_frames
 from coolscanpy.protocol.ls5000_single_pass import roll_index as roll
 
 
@@ -36,6 +38,20 @@ LIVE_PREVIEW = (
     LIVE_PREVIEW_ATTEMPT / "capture-preview.bin" if LIVE_PREVIEW_ATTEMPT else None
 )
 LIVE_TABLE = LIVE_PREVIEW_ATTEMPT / "capture-008e.bin" if LIVE_PREVIEW_ATTEMPT else None
+
+# Manual-placement rework (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, F1/F4):
+# the 51-table regression. Every capture-preview.bin/capture-008e.bin pair
+# anywhere under this root is a real archived LS-5000 traversal from this
+# project's own reverse-engineering and live-validation work -- exactly the
+# corpus the adversarial review used to prove the pre-rework gate 4 refused
+# 51 of 51 real captures at the first frame edge. Defaults to this
+# developer machine's own copy (present for this project's own contributor;
+# absent everywhere else, including CI), and skips cleanly either way,
+# following the same convention as COOLSCANPY_SINGLE_PASS_WIRE_DIR and
+# COOLSCANPY_LIVE_PREVIEW_ATTEMPT_DIR above.
+_ARCHIVE_ROOT_ENV = "COOLSCANPY_ARCHIVE_ROOT"
+_default_archive_root = "/Users/rohan/Downloads/digital-ice-2026"
+ARCHIVE_ROOT = Path(os.environ.get(_ARCHIVE_ROOT_ENV, _default_archive_root))
 
 
 def _encode_index(rgb16: np.ndarray) -> bytes:
@@ -1507,3 +1523,197 @@ def test_all_wide_no_narrow_anchors_refuses_mapping() -> None:
 
     with pytest.raises(roll.IndexDecodeError, match="three direct physical gaps"):
         roll.derive_transport_mapping(boundaries, 3, records)
+
+
+# ---------------------------------------------------------------------------
+# Manual placement rework (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, F1/F4):
+# the 51-table archive regression.
+# ---------------------------------------------------------------------------
+
+
+def _archive_capture_pairs(root: Path) -> list[tuple[Path, Path]]:
+    """Every (preview, table) pair under root, deduped by preview SHA-256."""
+
+    if not root.is_dir():
+        return []
+    seen: set[str] = set()
+    pairs: list[tuple[Path, Path]] = []
+    for preview_path in sorted(root.rglob("capture-preview.bin")):
+        table_path = preview_path.with_name("capture-008e.bin")
+        if not table_path.is_file():
+            continue
+        digest = hashlib.sha256(preview_path.read_bytes()).hexdigest()
+        if digest in seen:
+            continue
+        seen.add(digest)
+        pairs.append((preview_path, table_path))
+    return pairs
+
+
+_ARCHIVE_PAIRS = _archive_capture_pairs(ARCHIVE_ROOT)
+
+
+@pytest.mark.skipif(
+    not _ARCHIVE_PAIRS,
+    reason=(
+        "no archived capture-preview.bin/capture-008e.bin pairs found; set "
+        f"{_ARCHIVE_ROOT_ENV} to a directory tree containing them to run "
+        "this regression"
+    ),
+)
+def test_manual_placement_accepts_every_archived_automatic_boundary_set() -> None:
+    """F1/F4 acceptance gate: feed every real archived capture's own
+    AUTOMATIC boundary rows into build_manual_detection, using the exact
+    same same-traversal transport table. The placement must be accepted --
+    this is the specific defect the pre-rework gate 4 had: adversarial
+    review measured it refusing 51 of 51 real captures at the first frame
+    edge, because a real live 0x8e table's deterministic ~18-row code
+    lattice (selector-rollover jumps of roughly +798/-700 native units,
+    smaller sub-rollover jumps within each cycle -- see manual_frames.py's
+    own module docstring) fails a per-step "every row within 3 of a pick
+    must be 40..45 units" guard almost everywhere.
+
+    Every resolved origin must also land close to derive_transport_
+    mapping's own origin for the same boundary. Origins derive_transport_
+    mapping itself marks "automatic" (a clean, directly-read narrow gap --
+    the overwhelming majority in this corpus) must match within 2.0
+    preview rows (~85 native units), the same interior-anchor bound the
+    automatic path enforces on itself. Origins it marks manual_review (a
+    broad or weak-evidence region even automatic could not read directly --
+    a small minority) are held to a looser, still-bounded 5.0 rows, the
+    same wobble allowance this codebase already grants its own
+    leading-anchor divergence (MAXIMUM_LEADING_ANCHOR_ERROR_ROWS in this
+    module) -- comparing two independent estimates of an already-uncertain
+    position is not the same claim as comparing against a proven direct
+    read, and this test does not pretend otherwise.
+    """
+
+    accepted = 0
+    expected_ceiling_refusals = 0
+    trusted_deltas: list[float] = []
+    inferred_deltas: list[float] = []
+
+    for preview_path, table_path in _ARCHIVE_PAIRS:
+        preview_bytes = preview_path.read_bytes()
+        table_bytes = table_path.read_bytes()
+        # IndexGeometry derived purely from the preview file's own byte
+        # length (decode_full_index_bytes needs nothing more than height,
+        # width, block_bytes, and their product) -- this corpus spans many
+        # independent capture campaigns with different allocated preview
+        # heights, and native_height is not needed by anything this test
+        # calls (it matters to worker.py's own fine-window-overflow check,
+        # out of scope here).
+        height = len(preview_bytes) // (roll.INDEX_ROW_WORDS * 2)
+        geometry = roll.IndexGeometry(
+            requested_resolution=97,
+            native_resolution=4_000,
+            pitch=41,
+            native_width=3_946,
+            native_height=height * 41,
+            width=96,
+            height=height,
+            block_bytes=2_048,
+            expected_stream_bytes=height * roll.INDEX_ROW_WORDS * 2,
+        )
+        table, usable_rows = roll.validate_live_0x8e_bytes(table_bytes, geometry.height)
+        rgb, known, _report = roll.decode_full_index_bytes(
+            preview_bytes, geometry, usable_rows=usable_rows
+        )
+        try:
+            detection = roll.detect_roll_frames(
+                rgb, known, nominal_frame_rows=5_959 // geometry.pitch
+            )
+        except roll.IndexDecodeError:
+            # Automatic detection itself refused this capture (e.g. the
+            # vendored tree's leading-frame-clip gate on a strip whose
+            # first frame starts before the raster) -- out of this gate's
+            # scope exactly like a below-high confidence result.
+            continue
+        if detection.confidence != "high":
+            continue  # automatic did not succeed; out of this gate's scope
+        records = roll.parse_live_transport_records_bytes(
+            table, maximum_rows=geometry.height
+        )
+        scanner_frame_count = roll.scanner_addressable_interval_count(detection.intervals)
+        try:
+            auto_mapping = roll.derive_transport_mapping(
+                detection.boundaries, scanner_frame_count, records
+            )
+        except roll.IndexDecodeError:
+            continue  # automatic itself did not succeed; out of scope
+
+        boundary_rows = [
+            b.output_row for b in detection.boundaries[: scanner_frame_count + 1]
+        ]
+        try:
+            manual_result = manual_frames.build_manual_detection(
+                rgb,
+                known,
+                boundary_rows,
+                nominal_frame_rows=5_959 // geometry.pitch,
+                records=records,
+            )
+        except roll.IndexDecodeError as error:
+            # F2 (this same rework) is a deliberate NEW restriction: a
+            # frame taller than the fine capture window now refuses rather
+            # than silently truncating. If automatic's own high-confidence
+            # lattice fit happened to place two boundaries far enough apart
+            # to trip that new ceiling, refusing here is correct, not a
+            # regression -- count it, but do not let it slip past as an
+            # unnoticed acceptance failure either.
+            if "there is no way to capture a taller frame" in str(error):
+                expected_ceiling_refusals += 1
+                continue
+            pytest.fail(
+                f"{preview_path}: manual placement refused automatic's own "
+                f"boundary rows: {error}"
+            )
+
+        accepted += 1
+        scale = auto_mapping.native_units_per_preview_row
+        for auto_origin, manual_origin in zip(
+            auto_mapping.origins, manual_result.mapping.origins
+        ):
+            delta_rows = (manual_origin.native_origin - auto_origin.native_origin) / scale
+            if auto_origin.automatic:
+                trusted_deltas.append(delta_rows)
+            else:
+                inferred_deltas.append(delta_rows)
+
+    total_eligible = accepted + expected_ceiling_refusals
+    print(
+        f"\ngate A: {len(_ARCHIVE_PAIRS)} unique archived captures; "
+        f"{total_eligible} automatic-high-confidence and eligible; "
+        f"{accepted} accepted, {expected_ceiling_refusals} correctly refused "
+        "(F2 fine-capture-window ceiling)"
+    )
+    assert accepted > 0, "no eligible archived captures were accepted -- check ARCHIVE_ROOT"
+
+    trusted = np.abs(np.asarray(trusted_deltas, dtype=np.float64))
+    inferred = np.abs(np.asarray(inferred_deltas, dtype=np.float64))
+    if len(trusted):
+        print(
+            f"origin deltas vs automatic, preview rows -- trusted: n={len(trusted)} "
+            f"mean={trusted.mean():.4f} p95={np.percentile(trusted, 95):.4f} "
+            f"max={trusted.max():.4f}"
+        )
+    if len(inferred):
+        print(
+            f"origin deltas vs automatic, preview rows -- inferred: n={len(inferred)} "
+            f"mean={inferred.mean():.4f} median={np.median(inferred):.4f} "
+            f"max={inferred.max():.4f}"
+        )
+
+    if len(trusted):
+        assert trusted.max() <= 2.0, (
+            f"an automatic-trusted origin diverged {trusted.max():.3f} rows "
+            "from derive_transport_mapping's own answer for the same "
+            "boundary -- expected <= 2.0"
+        )
+    if len(inferred):
+        assert inferred.max() <= 5.0, (
+            f"an automatic-inferred origin diverged {inferred.max():.3f} "
+            "rows from derive_transport_mapping's own answer for the same "
+            "boundary -- expected <= 5.0 (this codebase's own leading-"
+            "anchor wobble allowance)"
+        )

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -526,13 +526,14 @@ def _synthetic_roll_with_gap_rows(
 
 
 def test_wide_gaps_raise_gap_count_floor_with_numeric_diagnostics() -> None:
-    """P1, site :810.  Six gaps widened to 20 rows (>12, discarded as "wide")
-    leaves zero narrow runs -- confirms the id and every field the predicate
-    actually evaluated.
+    """P1, site :810.  Six gaps widened to 26 rows -- past even the recovery
+    ceiling (FEEDING-DETECTOR-ROUND-20260807) -- leaves zero anchorable runs
+    in both passes: confirms the id, every field the predicate evaluated,
+    and the recovery note the failed second pass appends.
     """
     boundary_rows = [200 + index * 143 for index in range(6)]
     rgb = _synthetic_roll_with_gap_rows(
-        boundary_rows, height=6 * 145 + 200, band_halfwidth=10
+        boundary_rows, height=6 * 145 + 200, band_halfwidth=13
     )
 
     with pytest.raises(roll.IndexDecodeError) as excinfo:
@@ -545,10 +546,11 @@ def test_wide_gaps_raise_gap_count_floor_with_numeric_diagnostics() -> None:
     assert diagnostics["narrow_run_count"] == 0
     assert diagnostics["narrow_run_count_required"] == 3
     assert diagnostics["evidence_run_count"] == 6
-    assert diagnostics["discarded_wide_widths"] == [20] * 6
+    assert diagnostics["discarded_wide_widths"] == [26] * 6
     assert diagnostics["discarded_narrow_widths"] == []
     assert diagnostics["raster_rows"] == rgb.shape[0]
     assert diagnostics["aperture_width"] == 90
+    assert "wide_gap_recovery" in diagnostics
     assert json.dumps(diagnostics, sort_keys=True) in str(error)
 
 
@@ -1258,3 +1260,250 @@ def test_persisted_gold36_expected_count_and_frame18_origin() -> None:
     )
     assert mismatched.frame_starts == detection.frame_starts
     assert not mismatched.expected_frame_count_matches
+
+
+# ---------------------------------------------------------------------------
+# Wide-gap recovery (FEEDING-DETECTOR-ROUND-20260807): pass 1 is the stock
+# detector, byte-identical; a single recovery pass runs only when pass 1
+# raises one of the three physical-gap floors, admits wide clear-film runs
+# (12 < width <= WIDE_GAP_CEILING_ROWS) as gap anchors, and can never
+# produce an automatic, unattended, or high-confidence result.
+
+
+def _synthetic_roll_with_mixed_gap_rows(
+    gaps: list[tuple[int, int]],
+    *,
+    height: int,
+) -> np.ndarray:
+    """Like ``_synthetic_roll_with_gap_rows`` but with a per-gap half-width,
+    so one raster can carry narrow, wide, and sliver clear-film runs at once
+    (the webmogul1 beta.3 field signature, ScanStudio #23/#24)."""
+
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[:, :, channel] = base + texture * (3 - channel) // 2
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    clear_noise = ((x * 19 + y * 13) % 301 - 150)[:, :, None]
+    for boundary, half_width in gaps:
+        lo = max(0, boundary - half_width)
+        hi = min(height, boundary + half_width)
+        aperture[lo:hi] = clear_base + clear_noise[lo:hi]
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16)
+
+
+def test_wide_gap_recovery_rescues_two_narrow_plus_one_wide_gap() -> None:
+    """The field signature: two narrow gaps plus one wide (14-row) gap on a
+    short strip. Pass 1 refuses at the count floor; the recovery pass
+    resolves it -- capped at medium, wide slot under manual review, recovery
+    warning present, and the wide boundary carries the distinct support
+    class instead of ``cadence-broad``."""
+
+    gaps = [(200, 2), (343, 3), (486, 7)]  # widths 4, 6, 14
+    rgb = _synthetic_roll_with_mixed_gap_rows(gaps, height=4 * 145 + 200)
+
+    detection = _detect(rgb)
+
+    assert detection.confidence == "medium"
+    assert "wide-gap-recovery" in detection.warnings
+    supports = [boundary.support for boundary in detection.boundaries]
+    assert supports.count("direct-wide") == 1
+    wide = next(b for b in detection.boundaries if b.support == "direct-wide")
+    assert wide.manual_review
+    assert "wide-gap-anchor" in wide.review_reasons
+    assert wide.evidence_run is not None
+    assert wide.evidence_run[1] - wide.evidence_run[0] == 14
+
+
+def test_pass_one_success_never_enters_recovery_even_with_a_wide_gap() -> None:
+    """Strict superset: a roll pass 1 already resolves -- plenty of narrow
+    gaps, one broad clear region -- must return the stock single-pass result
+    exactly, bit-identical: no recovery warning, no direct-wide support, no
+    confidence cap."""
+
+    rgb, boundaries = _synthetic_roll(8)
+    lo, hi = boundaries[4] - 8, boundaries[4] + 8  # broaden one gap to 16 rows
+    clear = rgb[boundaries[4]].copy()
+    rgb[lo:hi] = clear
+
+    detection = _detect(rgb)
+    stock = roll._detect_roll_frames_single(
+        rgb,
+        np.ones_like(rgb, dtype=bool),
+        nominal_frame_rows=145,
+        expected_frame_count=None,
+    )
+
+    assert detection == stock
+    assert "wide-gap-recovery" not in detection.warnings
+    supports = {boundary.support for boundary in detection.boundaries}
+    assert "direct-wide" not in supports
+    assert "cadence-broad" in supports
+
+
+def test_recovery_slivers_never_anchor_and_failure_keeps_the_original_error() -> None:
+    """F1 (adversarial review 2026-08-07): 1-2-row slivers are not wide gaps.
+    Two narrow gaps plus slivers must still refuse -- with the pass-1 error
+    id and the recovery note -- rather than letting slivers vote. And a gap
+    past the recovery ceiling (26 rows) must refuse identically."""
+
+    for extra in [(486, 1), (486, 13)]:  # width-2 sliver / width-26 run
+        gaps = [(200, 2), (343, 3), extra]
+        rgb = _synthetic_roll_with_mixed_gap_rows(gaps, height=4 * 145 + 200)
+        with pytest.raises(roll.IndexDecodeError) as excinfo:
+            _detect(rgb)
+        error = excinfo.value
+        assert error.error_id == roll.GAP_COUNT_FLOOR_ERROR_ID
+        assert "wide_gap_recovery" in error.diagnostics
+        assert error.diagnostics["narrow_run_count"] == 2
+
+
+def test_recovery_confidence_cap_is_keyed_to_the_mode() -> None:
+    """F3b (adversarial review 2026-08-07): the medium cap and the warning
+    come from running in recovery mode, not from whether a direct-wide
+    boundary survived to the output."""
+
+    gaps = [(200, 2), (343, 3), (486, 7)]
+    rgb = _synthetic_roll_with_mixed_gap_rows(gaps, height=4 * 145 + 200)
+
+    detection = _detect(rgb)
+
+    assert detection.confidence != "high"
+    assert "wide-gap-recovery" in detection.warnings
+
+
+def test_incomplete_index_never_triggers_recovery() -> None:
+    """IncompleteIndexError is a subclass of IndexDecodeError; it must pass
+    through the two-pass wrapper untouched, with no recovery note."""
+
+    rgb, _boundaries = _synthetic_roll(5)
+    known = np.ones_like(rgb, dtype=bool)
+    known[: rgb.shape[0] // 10] = False
+
+    with pytest.raises(roll.IncompleteIndexError) as excinfo:
+        roll.detect_roll_frames(
+            rgb, known, nominal_frame_rows=145, expected_frame_count=None
+        )
+    assert "wide_gap_recovery" not in str(excinfo.value)
+
+
+def _wide_boundary(index: int, row: int, run: tuple[int, int]) -> roll.GapBoundary:
+    return roll.GapBoundary(
+        index=index,
+        output_row=row,
+        fitted_row=float(row),
+        evidence=0.9,
+        transmission=0.95,
+        nonuniformity=0.08,
+        support="direct-wide",
+        evidence_run=run,
+        manual_review=True,
+        review_reasons=("wide-gap-anchor",),
+    )
+
+
+def _clean_records(count: int) -> list[roll.TransportRecord]:
+    return [
+        roll.TransportRecord(
+            row=row,
+            code=6 * (row % 18),
+            selector=row // 18,
+            native_origin=42 * row,
+        )
+        for row in range(count)
+    ]
+
+
+def test_wide_anchor_joins_the_fit_by_trailing_edge_when_narrow_count_is_two() -> None:
+    """With only two narrow direct anchors the stock fit refuses; a healthy
+    direct-wide boundary supplies the third anchor at its trailing edge
+    translated into the narrow anchors' centre space. The wide slot resolves
+    through its own trailing-edge record, never automatic; narrow slots stay
+    automatic; the fit gates are unchanged."""
+
+    records = _clean_records(900)
+    boundaries = [
+        _boundary(0, 20),
+        _boundary(1, 163),
+        _wide_boundary(2, 306, (299, 313)),
+        _boundary(3, 449, support="cadence-broad", evidence_run=(429, 469)),
+    ]
+
+    mapping = roll.derive_transport_mapping(boundaries, 4, records)
+
+    assert mapping.native_units_per_preview_row == pytest.approx(42.0)
+    wide_origin = mapping.origins[2]
+    assert wide_origin.method == "wide-gap-trailing-row"
+    assert wide_origin.native_origin == 42 * 313
+    assert not wide_origin.automatic
+    assert wide_origin.manual_review
+    assert mapping.origins[0].automatic
+    assert mapping.origins[1].automatic
+
+
+def test_wide_anchor_is_refused_when_the_local_ramp_is_spiked() -> None:
+    """F2 (adversarial review 2026-08-07): a single-record spike at the wide
+    anchor's trailing edge -- endpoints clean -- must reject the anchor
+    (per-step ramp check), leaving the fit under three anchors and the
+    mapping refused, instead of fitting to noise."""
+
+    records = _clean_records(900)
+    spiked = records[313]
+    records[313] = roll.TransportRecord(
+        row=spiked.row,
+        code=spiked.code,
+        selector=spiked.selector,
+        native_origin=spiked.native_origin + 150,
+    )
+    boundaries = [
+        _boundary(0, 20),
+        _boundary(1, 163),
+        _wide_boundary(2, 306, (299, 313)),
+        _boundary(3, 449, support="cadence-broad", evidence_run=(429, 469)),
+    ]
+
+    with pytest.raises(roll.IndexDecodeError, match="three direct physical gaps"):
+        roll.derive_transport_mapping(boundaries, 4, records)
+
+
+def test_fit_satisfied_by_narrow_anchors_resolves_wide_slot_at_trailing_edge() -> None:
+    """F4 (adversarial review 2026-08-07): when the fit already has its three
+    narrow anchors, a direct-wide slot outside the fit must still resolve at
+    its trailing edge -- the stock centre-keyed window lands ~half a gap
+    early and cannot contain the true record for wide runs."""
+
+    records = _clean_records(900)
+    boundaries = [
+        _boundary(0, 20),
+        _boundary(1, 163),
+        _boundary(2, 306),
+        _wide_boundary(3, 449, (442, 456)),
+    ]
+
+    mapping = roll.derive_transport_mapping(boundaries, 4, records)
+
+    wide_origin = mapping.origins[3]
+    assert wide_origin.native_origin == 42 * 456
+    assert not wide_origin.automatic
+    assert wide_origin.manual_review
+
+
+def test_all_wide_no_narrow_anchors_refuses_mapping() -> None:
+    """Zero narrow anchors means no measured centre-to-trailing offset; wide
+    anchors alone must not fabricate one -- the mapping refuses."""
+
+    records = _clean_records(900)
+    boundaries = [
+        _wide_boundary(0, 20, (13, 27)),
+        _wide_boundary(1, 163, (156, 170)),
+        _wide_boundary(2, 306, (299, 313)),
+    ]
+
+    with pytest.raises(roll.IndexDecodeError, match="three direct physical gaps"):
+        roll.derive_transport_mapping(boundaries, 3, records)

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -44,14 +44,15 @@ LIVE_TABLE = LIVE_PREVIEW_ATTEMPT / "capture-008e.bin" if LIVE_PREVIEW_ATTEMPT e
 # anywhere under this root is a real archived LS-5000 traversal from this
 # project's own reverse-engineering and live-validation work -- exactly the
 # corpus the adversarial review used to prove the pre-rework gate 4 refused
-# 51 of 51 real captures at the first frame edge. Defaults to this
-# developer machine's own copy (present for this project's own contributor;
-# absent everywhere else, including CI), and skips cleanly either way,
-# following the same convention as COOLSCANPY_SINGLE_PASS_WIRE_DIR and
+# 51 of 51 real captures at the first frame edge. Env-only, no baked-in
+# default: the packaged-bridge self-containment check rightly refuses any
+# bundle retaining a private source path, so the archive location lives
+# solely in the contributor's environment. Unset skips cleanly, following
+# the same convention as COOLSCANPY_SINGLE_PASS_WIRE_DIR and
 # COOLSCANPY_LIVE_PREVIEW_ATTEMPT_DIR above.
 _ARCHIVE_ROOT_ENV = "COOLSCANPY_ARCHIVE_ROOT"
-_default_archive_root = "/Users/rohan/Downloads/digital-ice-2026"
-ARCHIVE_ROOT = Path(os.environ.get(_ARCHIVE_ROOT_ENV, _default_archive_root))
+_archive_root_value = os.environ.get(_ARCHIVE_ROOT_ENV)
+ARCHIVE_ROOT = Path(_archive_root_value) if _archive_root_value else None
 
 
 def _encode_index(rgb16: np.ndarray) -> bytes:
@@ -1531,10 +1532,10 @@ def test_all_wide_no_narrow_anchors_refuses_mapping() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _archive_capture_pairs(root: Path) -> list[tuple[Path, Path]]:
+def _archive_capture_pairs(root: Path | None) -> list[tuple[Path, Path]]:
     """Every (preview, table) pair under root, deduped by preview SHA-256."""
 
-    if not root.is_dir():
+    if root is None or not root.is_dir():
         return []
     seen: set[str] = set()
     pairs: list[tuple[Path, Path]] = []

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
@@ -1467,6 +1467,11 @@ def test_batch_job_loader_binds_ordered_frame_paths_and_parent_ack_contract(
         reviewed_lookup_row=2_400,
         reviewed_native_origin=100_000,
         review_reasons=("transport-origin-inferred",),
+        # Matches this job payload's own "manual_boundary_rows": None below
+        # -- load_validated_batch_job cross-checks the two (S6 hardening).
+        manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+            None
+        ),
     )
     job_path = tmp_path / "batch-job.json"
     job_path.write_text(
@@ -1608,6 +1613,56 @@ def test_batch_job_loader_parses_valid_manual_boundary_rows(tmp_path: Path) -> N
     )
 
     assert job.manual_boundary_rows == (128, 271, 414)
+
+
+def test_batch_job_loader_refuses_a_receipt_bound_to_different_boundary_rows(
+    tmp_path: Path,
+) -> None:
+    """S6 hardening (FEEDING-UX-LADDER-OVERNIGHT-20260807.md F1 rework): a
+    manual approval receipt is only valid for the EXACT set of boundary
+    rows it was signed for. reviewed_fingerprint_sha256 alone is not
+    enough -- fingerprint comparison has deliberate tolerance for a
+    legitimate re-read (compare_reviewed_roll_fingerprints), so two
+    DIFFERENT placements of the same physical roll could still compare as
+    matching. Here the receipt was signed for [128, 271, 414] (matching
+    test_batch_job_loader_parses_valid_manual_boundary_rows's own honest
+    case) but the job claims a different placement, [128, 271, 500] --
+    same slot, same offset, same reviewed_fingerprint_sha256, everything
+    the pre-hardening checks looked at unchanged, only the actual placed
+    rows different.
+    """
+
+    fingerprint = _reviewed_fingerprint()
+    approval = ManualFrameApproval(
+        reviewed_fingerprint_sha256=fingerprint.binding_sha256,
+        slot=1,
+        boundary_offset_rows=0,
+        thumbnail_sha256="5" * 64,
+        reviewed_lookup_row=2_400,
+        reviewed_native_origin=100_000,
+        review_reasons=("user-picked-origin",),
+        manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+            (128, 271, 414)
+        ),
+    )
+    payload = _one_frame_job_payload(
+        fingerprint,
+        exposure_override_10ns=None,
+        manual_boundary_rows=[128, 271, 500],
+    )
+    payload["frames"][0]["manual_review_approval"] = approval.to_payload()
+    job_path = tmp_path / "batch-job.json"
+    job_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        ProtocolError, match="different set of placed boundaries"
+    ):
+        load_validated_batch_job(
+            job_path,
+            expected_job_sha256=hashlib.sha256(job_path.read_bytes()).hexdigest(),
+            expected_plan_sha256="a" * 64,
+            expected_continuation_sha256="b" * 64,
+        )
 
 
 def test_batch_job_loader_refuses_malformed_manual_boundary_rows(
@@ -3392,6 +3447,101 @@ def test_manual_selection_still_refuses_on_fingerprint_mismatch(
         )
 
 
+def test_manual_selection_never_qualifies_for_origin_rebase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F4 rework, single-frame path: a manual placement must not be
+    granted the leading-anchor rebase, no matter how well its fingerprints
+    match. Frame 1's live record is displaced by ~3.5 rows (inside the
+    2..5-row band that WOULD rebase for an automatic origin with matching
+    fingerprints) while every other condition for rebase is satisfied
+    (operator approval given, whole-roll and selected-slot fingerprints
+    both matching this exact displaced table); only origin_rebase_allowed
+    excluding this manual placement stands between that and a silently
+    displaced bound origin. See test_manual_batch_selection_never_
+    qualifies_for_origin_rebase for the batch-path equivalent.
+    """
+
+    # Textured, not all-zero: the reviewed fingerprint's visual signature
+    # needs real dynamic range in the signed frame region (rows 0..99) or
+    # the comparison below reports "visual-signature-indeterminate" rather
+    # than matching -- and this test needs it to match, on purpose, so
+    # origin_rebase_allowed is the only thing left to decide the outcome.
+    y = np.arange(500, dtype=np.int64)[:, None]
+    x = np.arange(96, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    rgb = np.stack([texture, texture // 2, texture // 3], axis=2).astype(np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+
+    # Frame 1's OWN live record (lookup_row=10, see _manual_gate_mapping)
+    # displaced by +147 native units (~3.5 rows). A different, still
+    # internally-consistent code (147 = 7 * 21, a reachable subposition
+    # step) keeps transport_native_origin's own identity check satisfied,
+    # the same way test_manual_batch_selection_never_qualifies_for_origin_
+    # rebase's displacement does.
+    base_records = _manual_gate_records()
+    victim = base_records[10]
+    displaced_code = victim.code + 21
+    displaced_records = (
+        base_records[:10]
+        + (
+            TransportRecord(
+                row=victim.row,
+                code=displaced_code,
+                selector=victim.selector,
+                native_origin=worker_module.transport_native_origin(
+                    displaced_code, victim.selector
+                ),
+            ),
+        )
+        + base_records[11:]
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "parse_live_transport_records_bytes",
+        lambda *_a, **_k: displaced_records,
+    )
+
+    mapping = _manual_gate_mapping()
+    detection = _manual_gate_detection(confidence="medium", user_picked=True)
+    monkeypatch.setattr(
+        worker_module,
+        "build_manual_detection",
+        lambda *_a, **_k: SimpleNamespace(
+            detection=detection, mapping=mapping, snaps=()
+        ),
+    )
+
+    # A reviewed fingerprint built from exactly the same inputs
+    # _derive_live_frame_selection will freshly recompute (mapping.origins
+    # is unchanged -- only the raw records table was displaced above, the
+    # same way a real reviewed session's own signed origin would not move
+    # just because a LATER traversal's table read differently) --
+    # constructed to match on purpose, so origin_rebase_allowed is the
+    # only thing left to decide whether this binds.
+    reviewed = build_reviewed_roll_fingerprint(
+        rgb,
+        frame_intervals=((0, 100),),
+        frame_native_origins=(420,),
+        source_preview_sha256=hashlib.sha256(b"fresh-preview").hexdigest(),
+        source_table_sha256=hashlib.sha256(b"fresh-table").hexdigest(),
+    )
+
+    with pytest.raises(
+        ProtocolError,
+        match=r"frame 1 boundary offset resolves to a transport origin",
+    ):
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            reviewed_fingerprint=reviewed,
+            manual_review_approved=True,
+            manual_boundary_rows=(10, 200),
+        )
+
+
 def test_live8_frame_table_is_the_exact_firmware_accepted_payload() -> None:
     payload = build_live_frame_table_payload(_mapping(LIVE8_TRANSPORT_FIELDS))
     send = next(entry for entry in load_canonical_plan() if entry["seq"] == 174)
@@ -4273,6 +4423,231 @@ def test_batch_selections_accept_one_addressable_sliver_beyond_reviewed(
 
     assert [selection.frame for selection in selections] == [1]
     assert bound_frames == [1]
+
+
+def test_manual_batch_selection_never_qualifies_for_origin_rebase(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F4 rework: a manual placement must not be granted the leading-anchor
+    rebase, no matter how well its fingerprints match. Frame 1's live
+    record is displaced by ~3.6 rows (inside the 2..5-row band that WOULD
+    rebase for an automatic origin -- see
+    test_leading_anchor_divergence_narrowly_auto_accepted_when_reviewed_
+    automatic for that accepted case); with every other condition for
+    rebase satisfied, only origin_rebase_slots excluding this manual
+    placement stands between that and a silently displaced bound origin.
+    """
+
+    mapping, records = _short_strip_mapping(6)
+    # Every origin manual: automatic=False, manual_review=True, exactly
+    # build_manual_detection's own shape for every frame it places.
+    mapping = replace(
+        mapping,
+        origins=tuple(
+            replace(
+                origin,
+                automatic=False,
+                manual_review=True,
+                method="user-picked-row",
+            )
+            for origin in mapping.origins
+        ),
+    )
+    # Frame 1's OWN live record (lookup_row=100, see _short_strip_mapping)
+    # displaced by +147 native units (~3.5 rows) -- apply_boundary_offset
+    # re-reads this fresh, it does not trust the origin's own stored value.
+    # A different, still internally-consistent code (147 = 7 * 21, so this
+    # stays a reachable subposition) keeps transport_native_origin's own
+    # identity check satisfied -- a real live record could not desync from
+    # that identity, and this displacement should look exactly like one.
+    records = list(records)
+    victim = records[100]
+    displaced_code = victim.code + 21
+    records[100] = TransportRecord(
+        row=victim.row,
+        code=displaced_code,
+        selector=victim.selector,
+        native_origin=worker_module.transport_native_origin(
+            displaced_code, victim.selector
+        ),
+    )
+    records = tuple(records)
+
+    reviewed = _reviewed_fingerprint_with_count(6)
+    context = _batch_selection_context(mapping, records, reviewed)
+    context.detection = SimpleNamespace(
+        warnings=(manual_frames.MANUAL_PLACEMENT_WARNING,)
+    )
+    frame_root = tmp_path / "manual-rebase-attempt"
+    # A genuine (self-consistent) receipt whose claimed values match the
+    # MAPPING's own (undisplaced) origin -- exactly what an honest approval
+    # would have recorded, since the operator reviewed this before the
+    # live table above was displaced. This is what lets the scenario reach
+    # the rebase decision this test is actually about, rather than
+    # tripping the S6 fresh-recomputation cross-check first.
+    approval = ManualFrameApproval(
+        reviewed_fingerprint_sha256=reviewed.binding_sha256,
+        slot=1,
+        boundary_offset_rows=0,
+        thumbnail_sha256="4" * 64,
+        reviewed_lookup_row=mapping.origins[0].lookup_row,
+        reviewed_native_origin=mapping.origins[0].native_origin,
+        review_reasons=("user-picked-origin",),
+        manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+            (10, 200)
+        ),
+    )
+    frames = (
+        worker_module.BatchFrameSpec(
+            slot=1,
+            boundary_offset_rows=0,
+            manual_review_approval=approval,
+            output=frame_root / "frame-001" / "capture.bin",
+            journal=frame_root / "frame-001" / "journal.json",
+            ack=frame_root / "frame-001" / "parent-ack.json",
+        ),
+    )
+
+    monkeypatch.setattr(
+        worker_module, "_derive_live_frame_selection", lambda *_a, **_k: context
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "compare_selected_roll_fingerprint",
+        lambda *_a, **_k: SimpleNamespace(matches=True, reason="matched"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "validate_live_0x8e_bytes",
+        lambda table, _height: (table, len(records)),
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "parse_live_transport_records_bytes",
+        lambda *_a, **_k: records,
+    )
+
+    with pytest.raises(
+        ProtocolError,
+        match=r"frame 1 boundary offset resolves to a transport origin",
+    ):
+        worker_module._derive_live_batch_selections(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frames,
+            reviewed_fingerprint=reviewed,
+            # Required for the manual_placement check itself (worker.py
+            # cannot infer "this batch is manual" from context.detection
+            # alone -- see the comment at that computation site): without
+            # this, the fix under test would not even engage, and the old,
+            # buggy rebase-eligible path would silently pass instead.
+            manual_boundary_rows=(10, 200),
+        )
+
+
+def test_manual_batch_selection_refuses_when_approval_disagrees_with_fresh_origin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S6 hardening: load_validated_batch_job proves a receipt is
+    internally consistent and was signed for this exact placement's
+    boundary rows (see test_batch_job_loader_refuses_a_receipt_bound_to_
+    different_boundary_rows), but proves nothing about whether its
+    CLAIMED per-slot values (reviewed_lookup_row, reviewed_native_origin,
+    review_reasons) match what this traversal's fresh manual resolution
+    actually produced for that slot -- only context.mapping, built from
+    this rework's own lattice-aware resolution
+    (manual_frames._resolve_boundary_transport_origin), can prove that.
+    Here the receipt claims frame 1's reviewed_native_origin is 4200 + 147
+    -- disagreeing with the mapping's own (undisplaced, correctly
+    resolved) native_origin of 4200 -- with every job-file-level check
+    otherwise satisfied (matching fingerprint, matching manual_boundary_
+    rows digest, matching slot/offset). A malformed trusted-parent job
+    fabricating this field is exactly the attack this closes.
+    """
+
+    mapping, records = _short_strip_mapping(6)
+    mapping = replace(
+        mapping,
+        origins=tuple(
+            replace(
+                origin,
+                automatic=False,
+                manual_review=True,
+                method="user-picked-row",
+            )
+            for origin in mapping.origins
+        ),
+    )
+    reviewed = _reviewed_fingerprint_with_count(6)
+    context = _batch_selection_context(mapping, records, reviewed)
+    context.detection = SimpleNamespace(
+        warnings=(manual_frames.MANUAL_PLACEMENT_WARNING,)
+    )
+    frame_root = tmp_path / "manual-fresh-mismatch"
+    fresh_origin = mapping.origins[0]
+    approval = ManualFrameApproval(
+        reviewed_fingerprint_sha256=reviewed.binding_sha256,
+        slot=1,
+        boundary_offset_rows=0,
+        thumbnail_sha256="6" * 64,
+        # Disagrees with fresh_origin.native_origin (4_200) by 147 native
+        # units (~3.5 rows) -- everything else about this receipt is
+        # genuine and self-consistent.
+        reviewed_lookup_row=fresh_origin.lookup_row,
+        reviewed_native_origin=fresh_origin.native_origin + 147,
+        review_reasons=("user-picked-origin",),
+        manual_boundary_rows_sha256=ManualFrameApproval.digest_manual_boundary_rows(
+            (10, 200)
+        ),
+    )
+    frames = (
+        worker_module.BatchFrameSpec(
+            slot=1,
+            boundary_offset_rows=0,
+            manual_review_approval=approval,
+            output=frame_root / "frame-001" / "capture.bin",
+            journal=frame_root / "frame-001" / "journal.json",
+            ack=frame_root / "frame-001" / "parent-ack.json",
+        ),
+    )
+
+    monkeypatch.setattr(
+        worker_module, "_derive_live_frame_selection", lambda *_a, **_k: context
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "compare_selected_roll_fingerprint",
+        lambda *_a, **_k: SimpleNamespace(matches=True, reason="matched"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "validate_live_0x8e_bytes",
+        lambda table, _height: (table, len(records)),
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "parse_live_transport_records_bytes",
+        lambda *_a, **_k: records,
+    )
+
+    with pytest.raises(
+        ProtocolError,
+        match=r"frame 1 manual review approval does not match this traversal's "
+        r"freshly resolved origin",
+    ):
+        worker_module._derive_live_batch_selections(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frames,
+            reviewed_fingerprint=reviewed,
+            manual_boundary_rows=(10, 200),
+        )
 
 
 def test_batch_selections_accept_a_live_count_several_frames_below_reviewed(

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest
 
 from coolscanpy.protocol.ls5000_single_pass import worker as worker_module
+from coolscanpy.protocol.ls5000_single_pass import manual_frames
 from coolscanpy.protocol.ls5000_single_pass.capture_process import (
     AttemptPaths,
     CaptureAttemptResult,
@@ -3128,6 +3129,211 @@ def test_derive_live_frame_selection_still_refuses_on_fingerprint_mismatch(
             manual_review_approved=False,
             reviewed_as_automatic=True,
             reviewed_leading_residual_rows=-1.525,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): the manual-placement
+# worker gate. build_manual_detection is monkeypatched to a canned result --
+# manual_frames.py's own gates are exercised in test_manual_frames.py; these
+# tests attack _derive_live_frame_selection's gate wiring specifically.
+# ---------------------------------------------------------------------------
+
+
+def _manual_gate_records() -> tuple[TransportRecord, ...]:
+    return tuple(
+        TransportRecord(
+            row=row,
+            code=6 * (row % 18),
+            selector=row // 18,
+            native_origin=42 * row,
+        )
+        for row in range(500)
+    )
+
+
+def _manual_gate_mapping() -> TransportMapping:
+    origin = NativeFrameOrigin(
+        frame=1,
+        boundary_index=0,
+        boundary_output_row=10,
+        lookup_row=10,
+        code=6 * (10 % 18),
+        selector=10 // 18,
+        native_origin=420,
+        method="user-picked-row",
+        automatic=False,
+        manual_review=True,
+        review_reasons=("user-picked-origin",),
+        affine_residual_rows=0.0,
+    )
+    return TransportMapping(
+        record_count=500,
+        native_intercept=0.0,
+        native_units_per_preview_row=42.0,
+        anchor_mae_rows=0.0,
+        anchor_max_error_rows=0.0,
+        origins=(origin,),
+    )
+
+
+def _manual_gate_detection(*, confidence: str, user_picked: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        confidence=confidence,
+        warnings=(
+            (manual_frames.MANUAL_PLACEMENT_WARNING,)
+            if user_picked
+            else ("wide-gap-recovery",)
+        ),
+        boundaries=(),
+        intervals=(SimpleNamespace(start_row=0, end_row=100),),
+    )
+
+
+def _wire_manual_gate_common(
+    monkeypatch: pytest.MonkeyPatch, rgb: np.ndarray
+) -> None:
+    geometry = SimpleNamespace(height=500, pitch=41, native_height=250_278)
+    monkeypatch.setattr(worker_module, "_derive_index_geometry", lambda _plan: geometry)
+    monkeypatch.setattr(
+        worker_module,
+        "validate_live_0x8e_bytes",
+        lambda table, _height: (table, len(rgb)),
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "decode_full_index_bytes",
+        lambda *_a, **_k: (rgb, np.ones(rgb.shape, dtype=bool), {}),
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "parse_live_transport_records_bytes",
+        lambda *_a, **_k: _manual_gate_records(),
+    )
+
+
+def test_manual_selection_with_approval_binds_at_medium_confidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rgb = np.zeros((500, 96, 3), dtype=np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+    mapping = _manual_gate_mapping()
+    detection = _manual_gate_detection(confidence="medium", user_picked=True)
+    monkeypatch.setattr(
+        worker_module,
+        "build_manual_detection",
+        lambda *_a, **_k: SimpleNamespace(
+            detection=detection, mapping=mapping, snaps=()
+        ),
+    )
+
+    selection = worker_module._derive_live_frame_selection(
+        [],
+        b"fresh-preview",
+        b"fresh-table",
+        frame=1,
+        manual_review_approved=True,
+        manual_boundary_rows=(10, 200),
+    )
+
+    assert selection.detection.confidence == "medium"
+    assert selection.selected.native_origin == 420
+    assert selection.selected.manual_review is True
+    assert selection.selected.automatic is False
+
+
+def test_manual_selection_without_approval_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rgb = np.zeros((500, 96, 3), dtype=np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+    mapping = _manual_gate_mapping()
+    detection = _manual_gate_detection(confidence="medium", user_picked=True)
+    monkeypatch.setattr(
+        worker_module,
+        "build_manual_detection",
+        lambda *_a, **_k: SimpleNamespace(
+            detection=detection, mapping=mapping, snaps=()
+        ),
+    )
+
+    with pytest.raises(
+        ProtocolError, match="unattended frame binding requires 'high'"
+    ):
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            manual_review_approved=False,
+            manual_boundary_rows=(10, 200),
+        )
+
+
+def test_non_manual_medium_detection_still_refuses_even_with_approval_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pre-existing gate is untouched: passing manual_review_approved=True
+    on a NON-manual (e.g. wide-gap-recovery) medium-confidence detection must
+    still refuse -- MANUAL_PLACEMENT_WARNING can only ever come from
+    build_manual_detection, which this call never even reaches.
+    """
+
+    rgb = np.zeros((500, 96, 3), dtype=np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+    detection = _manual_gate_detection(confidence="medium", user_picked=False)
+    monkeypatch.setattr(worker_module, "detect_roll_frames", lambda *_a, **_k: detection)
+
+    with pytest.raises(
+        ProtocolError, match="unattended frame binding requires 'high'"
+    ):
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            manual_review_approved=True,
+            # manual_boundary_rows intentionally omitted: the automatic path.
+        )
+
+
+def test_manual_selection_still_refuses_on_fingerprint_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rgb = np.zeros((500, 96, 3), dtype=np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+    mapping = _manual_gate_mapping()
+    detection = _manual_gate_detection(confidence="medium", user_picked=True)
+    monkeypatch.setattr(
+        worker_module,
+        "build_manual_detection",
+        lambda *_a, **_k: SimpleNamespace(
+            detection=detection, mapping=mapping, snaps=()
+        ),
+    )
+    # A different preview width is an immediate, deterministic mismatch
+    # (compare_reviewed_roll_fingerprints's first check), independent of any
+    # visual-hash heuristics.
+    mismatched_rgb = np.zeros((500, 80, 3), dtype=np.uint16)
+    reviewed = build_reviewed_roll_fingerprint(
+        mismatched_rgb,
+        frame_intervals=((0, 100),),
+        frame_native_origins=(420,),
+        source_preview_sha256="a" * 64,
+        source_table_sha256="b" * 64,
+    )
+
+    with pytest.raises(
+        ProtocolError, match="does not match the reviewed roll fingerprint"
+    ):
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            reviewed_fingerprint=reviewed,
+            manual_review_approved=True,
+            manual_boundary_rows=(10, 200),
         )
 
 

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
@@ -1478,6 +1478,7 @@ def test_batch_job_loader_binds_ordered_frame_paths_and_parent_ack_contract(
                 "expected_usb_address": 2,
                 "expected_usb_bus": 1,
                 "exposure_override_10ns": None,
+                "manual_boundary_rows": None,
                 "frames": [
                     {
                         "ack": "frame-017/parent-ack.json",
@@ -1531,6 +1532,7 @@ def _one_frame_job_payload(
     fingerprint: ReviewedRollFingerprint,
     *,
     exposure_override_10ns: object,
+    manual_boundary_rows: object = None,
 ) -> dict[str, object]:
     return {
         "apply_all_boundary_offsets_before_first_frame": True,
@@ -1539,6 +1541,7 @@ def _one_frame_job_payload(
         "expected_usb_bus": 1,
         "expected_usb_address": 2,
         "exposure_override_10ns": exposure_override_10ns,
+        "manual_boundary_rows": manual_boundary_rows,
         "frames": [
             {
                 "ack": "frame-001/parent-ack.json",
@@ -1578,6 +1581,57 @@ def test_batch_job_loader_parses_a_valid_exposure_override(tmp_path: Path) -> No
     )
 
     assert job.exposure_override_10ns == (97_482, 195_597, 180_705)
+
+
+def test_batch_job_loader_parses_valid_manual_boundary_rows(tmp_path: Path) -> None:
+    """Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): same choke point as
+    exposure_override_10ns above -- the operator-picked rows a manual
+    placement session hands Roll.scan_many() must survive the batch-job.json
+    round trip so _derive_live_batch_selections can replay them fresh."""
+    job_path = tmp_path / "batch-job.json"
+    job_path.write_text(
+        json.dumps(
+            _one_frame_job_payload(
+                _reviewed_fingerprint(),
+                exposure_override_10ns=None,
+                manual_boundary_rows=[128, 271, 414],
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    job = load_validated_batch_job(
+        job_path,
+        expected_job_sha256=hashlib.sha256(job_path.read_bytes()).hexdigest(),
+        expected_plan_sha256="a" * 64,
+        expected_continuation_sha256="b" * 64,
+    )
+
+    assert job.manual_boundary_rows == (128, 271, 414)
+
+
+def test_batch_job_loader_refuses_malformed_manual_boundary_rows(
+    tmp_path: Path,
+) -> None:
+    job_path = tmp_path / "batch-job.json"
+    job_path.write_text(
+        json.dumps(
+            _one_frame_job_payload(
+                _reviewed_fingerprint(),
+                exposure_override_10ns=None,
+                manual_boundary_rows=[128, "271"],
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ProtocolError, match="manual_boundary_rows"):
+        load_validated_batch_job(
+            job_path,
+            expected_job_sha256=hashlib.sha256(job_path.read_bytes()).hexdigest(),
+            expected_plan_sha256="a" * 64,
+            expected_continuation_sha256="b" * 64,
+        )
 
 
 @pytest.mark.parametrize(
@@ -2246,6 +2300,7 @@ def test_batch_cli_dry_run_validates_one_session_without_single_frame_flags(
                 "expected_usb_address": 2,
                 "expected_usb_bus": 1,
                 "exposure_override_10ns": None,
+                "manual_boundary_rows": None,
                 "frames": [
                     {
                         "ack": "frame-017/parent-ack.json",
@@ -5141,6 +5196,7 @@ def test_live_two_frame_batch_uses_one_combined_table_and_one_release(
         frames: tuple[worker_module.BatchFrameSpec, ...],
         *,
         reviewed_fingerprint: ReviewedRollFingerprint,
+        manual_boundary_rows: tuple[int, ...] | None = None,
     ) -> tuple[SimpleNamespace, ...]:
         nonlocal prevalidated
         assert len(preview) == len(worker_module.PREVIEW_READ_SEQUENCES)
@@ -5807,6 +5863,7 @@ def test_preview_and_hold_two_rounds_share_one_reservation_then_eject_after(
             "expected_usb_bus": 1,
             "expected_usb_address": 2,
             "exposure_override_10ns": None,
+            "manual_boundary_rows": None,
             "frames": [
                 {
                     "ack": f"frame-{frame.slot:03d}/parent-ack.json",
@@ -5856,6 +5913,7 @@ def test_preview_and_hold_two_rounds_share_one_reservation_then_eject_after(
         frames: tuple,
         *,
         reviewed_fingerprint: ReviewedRollFingerprint,
+        manual_boundary_rows: tuple[int, ...] | None = None,
     ) -> tuple:
         assert len(preview) == len(worker_module.PREVIEW_READ_SEQUENCES)
         assert table == header_8e
@@ -6332,6 +6390,7 @@ def test_preview_and_hold_resume_binds_density_ownership_to_calibration_identity
             "expected_usb_bus": 1,
             "expected_usb_address": 2,
             "exposure_override_10ns": None,
+            "manual_boundary_rows": None,
             "frames": [
                 {
                     "ack": f"frame-{frame.slot:03d}/parent-ack.json",
@@ -6381,6 +6440,7 @@ def test_preview_and_hold_resume_binds_density_ownership_to_calibration_identity
         frames: tuple,
         *,
         reviewed_fingerprint: ReviewedRollFingerprint,
+        manual_boundary_rows: tuple[int, ...] | None = None,
     ) -> tuple:
         assert len(preview) == len(worker_module.PREVIEW_READ_SEQUENCES)
         assert table == header_8e

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_worker_streaming_integration.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_worker_streaming_integration.py
@@ -666,7 +666,9 @@ def _drive_two_frame_batch(
         def dispose_resources(_device):
             pass
 
-    def derive_batch(_plan, preview, table, frames, *, reviewed_fingerprint):
+    def derive_batch(
+        _plan, preview, table, frames, *, reviewed_fingerprint, manual_boundary_rows=None
+    ):
         state["prevalidated"] = True
         return selections
 

--- a/ports/tauri/vendor/coolscanpy/tests/roll/test_ls5000_roll_session.py
+++ b/ports/tauri/vendor/coolscanpy/tests/roll/test_ls5000_roll_session.py
@@ -972,13 +972,22 @@ def test_manual_session_yields_slots_with_boundary_offset_still_working() -> Non
     assert len(session.slots) == 6
     assert session.detection.confidence == "medium"
     assert all(slot.manual_review for slot in session.slots)
-    for frame, (slot, boundary_row) in enumerate(
-        zip(session.slots, boundaries), start=1
+    # Boundary 0 sits in the wide (128-row) leader run -- not a narrow
+    # inter-frame gap -- so it resolves at the picked row itself. The rest
+    # each sit at the center of an ordinary 6-row inter-frame gap, so each
+    # resolves at that run's OWN trailing edge (boundary + 3), mirroring
+    # derive_transport_mapping's "direct-gap-trailing-row" convention (see
+    # manual_frames.py's own docstring for why manual placement's F1
+    # rework does the same).
+    expected_lookup_rows = [boundaries[0]] + [b + 3 for b in boundaries[1:6]]
+    for frame, (slot, lookup_row) in enumerate(
+        zip(session.slots, expected_lookup_rows), start=1
     ):
-        assert slot.base_origin.native_origin == 42 * boundary_row
+        assert slot.base_origin.lookup_row == lookup_row
+        assert slot.base_origin.native_origin == 42 * lookup_row
         assert slot.base_origin.method == "user-picked-row"
 
-    picked_slot = session.slots[1]  # frame 2, base lookup row = boundaries[1]
+    picked_slot = session.slots[1]  # frame 2, base lookup row = boundaries[1] + 3
     adjusted = session.with_boundary_offset(2, -10)
 
     assert adjusted.slots[1].boundary_offset_rows == -10
@@ -1022,6 +1031,42 @@ def test_automatic_session_json_has_no_manual_provenance(tmp_path: Path) -> None
     # now that the schema carries this additive key.
     restored = type(session).from_json(session.to_json())
     assert restored.preview.preview_artifact == session.preview.preview_artifact
+
+
+def test_pre_rework_session_json_without_manual_boundary_rows_key_still_restores(
+    tmp_path: Path,
+) -> None:
+    """F7 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): to_json() started always
+    emitting "manual_boundary_rows" the same night manual placement shipped.
+    A session persisted by the PREVIOUS build never had that key at all --
+    simulated here by deleting it from an otherwise-real payload -- and must
+    restore exactly as it always did, not refuse on an unsupported schema.
+    """
+
+    session = build_roll_preview_session(_preview_fixture(tmp_path).result)
+    payload = json.loads(session.to_json())
+    assert "manual_boundary_rows" in payload
+    del payload["manual_boundary_rows"]
+    pre_rework_json = json.dumps(payload)
+
+    restored = type(session).from_json(pre_rework_json)
+
+    assert restored.preview.preview_artifact == session.preview.preview_artifact
+    assert restored.selected_slots == session.selected_slots
+
+
+def test_session_json_with_an_unrelated_missing_key_still_refuses(
+    tmp_path: Path,
+) -> None:
+    """The tolerance above is scoped to exactly one additive key -- any
+    OTHER missing key is still an unsupported schema."""
+
+    session = build_roll_preview_session(_preview_fixture(tmp_path).result)
+    payload = json.loads(session.to_json())
+    del payload["slot_count"]
+
+    with pytest.raises(RollSessionIntegrityError, match="unsupported schema"):
+        type(session).from_json(json.dumps(payload))
 
 
 def test_session_json_round_trip_revalidates_sources_and_restores_operator_state(

--- a/ports/tauri/vendor/coolscanpy/tests/roll/test_ls5000_roll_session.py
+++ b/ports/tauri/vendor/coolscanpy/tests/roll/test_ls5000_roll_session.py
@@ -27,11 +27,14 @@ from coolscanpy.protocol.ls5000_single_pass.density import (
 )
 from coolscanpy.roll.preview_session import (
     PARTIAL_FRAME_MIN_COVERAGE,
+    ArtifactIdentity,
     CaptureRoute,
     RollSessionIntegrityError,
+    ValidatedRollPreview,
     _crop_coverage,
     _crop_state,
     _preview_binding_contract,
+    build_manual_roll_preview_session,
     build_roll_preview_session,
     reload_thumbnail,
 )
@@ -895,6 +898,130 @@ def test_boundary_offset_reloads_only_that_slot_and_resolves_exact_table_record(
         adjusted.slots[17].thumbnail,
         reload_thumbnail(session.preview, base, -21),
     )
+
+
+def _clean_transport_records(count: int) -> tuple[roll_index.TransportRecord, ...]:
+    """Same-traversal table stepping at exactly 42 native units/row (matches
+    test_manual_frames.py's convention: ``code=6*(row%18), selector=row//18``
+    decodes to ``native_origin = 42 * row`` exactly).
+    """
+
+    return tuple(
+        roll_index.TransportRecord(
+            row=row,
+            code=6 * (row % 18),
+            selector=row // 18,
+            native_origin=42 * row,
+        )
+        for row in range(count)
+    )
+
+
+def _synthetic_validated_preview(
+    *, frame_count: int = 6, leader: int = 128
+) -> tuple[ValidatedRollPreview, list[int]]:
+    """A directly-constructed ValidatedRollPreview, bypassing the full
+    attempt-journal simulation _preview_fixture uses -- Rung 4 manual
+    placement's whole premise is that this object already exists (from an
+    earlier, possibly failed, preview attempt) by the time a human places
+    boundaries, so tests exercise build_manual_roll_preview_session against
+    it directly.
+    """
+
+    pitch = 143
+    boundaries = [leader + index * pitch for index in range(frame_count + 1)]
+    height = boundaries[-1] + 24
+    rgb = _synthetic_index(height=height, frame_count=frame_count, leader=leader)
+    records = _clean_transport_records(height)
+    geometry = roll_index.IndexGeometry(
+        requested_resolution=97,
+        native_resolution=4_000,
+        pitch=41,
+        native_width=3_946,
+        native_height=height * 41,
+        width=96,
+        height=height,
+        block_bytes=2_048,
+        expected_stream_bytes=height * roll_index.INDEX_ROW_WORDS * 2,
+    )
+    preview = ValidatedRollPreview(
+        preview_artifact=ArtifactIdentity(
+            path=Path("/fake/capture-preview.bin"), byte_length=0, sha256="a" * 64
+        ),
+        table_artifact=ArtifactIdentity(
+            path=Path("/fake/capture-008e.bin"), byte_length=0, sha256="b" * 64
+        ),
+        journal_artifact=ArtifactIdentity(
+            path=Path("/fake/journal.json"), byte_length=0, sha256="c" * 64
+        ),
+        usb_topology=(1, 2),
+        geometry=geometry,
+        usable_rows=height,
+        rgb=rgb,
+        transport_records=records,
+        decode_report={},
+    )
+    return preview, boundaries
+
+
+def test_manual_session_yields_slots_with_boundary_offset_still_working() -> None:
+    preview, boundaries = _synthetic_validated_preview()
+
+    session = build_manual_roll_preview_session(preview, boundaries)
+
+    assert len(session.slots) == 6
+    assert session.detection.confidence == "medium"
+    assert all(slot.manual_review for slot in session.slots)
+    for frame, (slot, boundary_row) in enumerate(
+        zip(session.slots, boundaries), start=1
+    ):
+        assert slot.base_origin.native_origin == 42 * boundary_row
+        assert slot.base_origin.method == "user-picked-row"
+
+    picked_slot = session.slots[1]  # frame 2, base lookup row = boundaries[1]
+    adjusted = session.with_boundary_offset(2, -10)
+
+    assert adjusted.slots[1].boundary_offset_rows == -10
+    resolved = adjusted.resolve_origin(2, -10)
+    assert resolved.lookup_row == picked_slot.base_origin.lookup_row - 10
+    assert resolved.native_origin == 42 * resolved.lookup_row
+    np.testing.assert_array_equal(
+        adjusted.slots[1].thumbnail,
+        reload_thumbnail(session.preview, picked_slot, -10),
+    )
+    # The unmodified session and its other slots are untouched (RollPreviewSession
+    # is immutable, same contract build_roll_preview_session's own sessions have).
+    assert session.slots[1].boundary_offset_rows == 0
+    assert adjusted.slots[0] is session.slots[0]
+
+
+def test_manual_session_provenance_round_trips_through_to_json_only() -> None:
+    """to_json persists the picked boundary rows (additive field); from_json
+    deliberately refuses to restore a manual session rather than silently
+    re-running automatic detection against it.
+    """
+
+    preview, boundaries = _synthetic_validated_preview()
+    session = build_manual_roll_preview_session(preview, boundaries)
+
+    payload = json.loads(session.to_json())
+
+    assert payload["manual_boundary_rows"] == boundaries
+
+    with pytest.raises(RollSessionIntegrityError, match="manual frame placement"):
+        type(session).from_json(session.to_json())
+
+
+def test_automatic_session_json_has_no_manual_provenance(tmp_path: Path) -> None:
+    session = build_roll_preview_session(_preview_fixture(tmp_path).result)
+
+    payload = json.loads(session.to_json())
+
+    assert payload["manual_boundary_rows"] is None
+    # And the ordinary round trip (already covered above) still restores fine
+    # now that the schema carries this additive key.
+    restored = type(session).from_json(session.to_json())
+    assert restored.preview.preview_artifact == session.preview.preview_artifact
 
 
 def test_session_json_round_trip_revalidates_sources_and_restores_operator_state(

--- a/ports/tauri/vendor/engine/src/bin/mock_bridge.rs
+++ b/ports/tauri/vendor/engine/src/bin/mock_bridge.rs
@@ -296,6 +296,13 @@ fn main() {
         .map(|v| !v.is_empty())
         .unwrap_or(false);
     let call_log_path = std::env::var_os("MOCK_BRIDGE_CALL_LOG").map(PathBuf::from);
+    // Rung 4 validation-passthrough seam: when set, `roll.manualFrames`
+    // refuses every request with this exact `INVALID_PARAMS` message,
+    // unmodified -- proves the real engine forwards the bridge's
+    // plain-English validation text verbatim rather than reshaping it.
+    let manual_frames_error = std::env::var("MOCK_BRIDGE_MANUAL_FRAMES_ERROR")
+        .ok()
+        .filter(|v| !v.is_empty());
 
     let (tx, rx) = mpsc::channel::<String>();
 
@@ -411,6 +418,7 @@ fn main() {
             &preview_approval_slots,
             inter_frame_delay_extra_ms,
             scan_upfront_burst,
+            manual_frames_error.clone(),
         ) {
             Ok(result) => {
                 if request.method == "bridge.hello" {
@@ -453,6 +461,7 @@ fn handle_request(
     preview_approval_slots: &[u32],
     inter_frame_delay_extra_ms: u64,
     scan_upfront_burst: bool,
+    manual_frames_error: Option<String>,
 ) -> Result<serde_json::Value, (BridgeErrorCode, String)> {
     match request.method.as_str() {
         "bridge.hello" => {
@@ -583,6 +592,67 @@ fn handle_request(
                     warnings: vec![],
                     image_path: path.to_string_lossy().into_owned(),
                 },
+            })
+        }
+        "roll.manualFrames" => {
+            require_open(state)?;
+            let params: BridgeManualFramesParams = parse_params(&request.params)?;
+            if let Some(message) = manual_frames_error.as_ref() {
+                return Err((BridgeErrorCode::InvalidParams, message.clone()));
+            }
+            if params.rows.len() < 2 {
+                return Err((
+                    BridgeErrorCode::InvalidParams,
+                    "manual frame placement needs at least 2 boundary rows".to_string(),
+                ));
+            }
+            let frame_count = (params.rows.len() - 1) as u32;
+            let thumbnails: Vec<BridgeThumbnail> = params
+                .rows
+                .windows(2)
+                .enumerate()
+                .map(|(index, pair)| {
+                    let slot = (index + 1) as u32;
+                    state.thumbnail_counter += 1;
+                    let path = std::env::temp_dir().join(format!(
+                        "mock-bridge-manual-frame-slot-{:04}-{:08}.tif",
+                        slot, state.thumbnail_counter
+                    ));
+                    BridgeThumbnail {
+                        slot,
+                        boundary_rows: (pair[0], pair[1]),
+                        spacing_offset: 0,
+                        needs_approval: true,
+                        warnings: vec!["user-picked".to_string()],
+                        image_path: path.to_string_lossy().into_owned(),
+                    }
+                })
+                .collect();
+            // manual_frames() arms a usable bridge-side session exactly
+            // like a successful roll.preview does (BRIDGE.md), without a
+            // prior roll.preview ever having run this session -- mirrored
+            // here so a following scan.start is no longer refused with
+            // NO_PREVIEW purely because of test ordering.
+            state.preview_established.store(true, Ordering::Release);
+            state.preview_slot_count.store(frame_count, Ordering::Release);
+            to_json(&BridgeManualFramesResult {
+                count: frame_count,
+                fingerprint: "mock-manual-fp".to_string(),
+                thumbnails,
+                snaps: vec![],
+            })
+        }
+        "roll.previewStrip" => {
+            require_open(state)?;
+            state.thumbnail_counter += 1;
+            let path = std::env::temp_dir().join(format!(
+                "mock-bridge-preview-strip-{:08}.tif",
+                state.thumbnail_counter
+            ));
+            to_json(&BridgePreviewStripResult {
+                image_path: path.to_string_lossy().into_owned(),
+                row_count: 4800,
+                pixels_per_row: 1,
             })
         }
         "scan.start" => {

--- a/ports/tauri/vendor/engine/src/bridge_protocol.rs
+++ b/ports/tauri/vendor/engine/src/bridge_protocol.rs
@@ -255,6 +255,48 @@ pub struct BridgeRollSetSpacingOffsetResult {
 }
 
 // ---------------------------------------------------------------------
+// roll.manualFrames / roll.previewStrip (additive, 2026-08-07 -- Rung 4 of
+// the feeding UX ladder, BRIDGE.md "roll.manualFrames"/"roll.previewStrip").
+// ---------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeManualFramesParams {
+    pub rows: Vec<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeManualFramesResult {
+    pub count: u32,
+    pub fingerprint: String,
+    pub thumbnails: Vec<BridgeThumbnail>,
+    pub snaps: Vec<BridgeBoundarySnap>,
+}
+
+/// One snap-assist adjustment `roll.manualFrames` applied to a picked
+/// boundary row (BRIDGE.md "Types" -> `BoundarySnap`).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeBoundarySnap {
+    pub boundary_index: u32,
+    pub requested_row: u32,
+    pub snapped_row: u32,
+    pub evidence_run: (u32, u32),
+}
+
+/// `roll.previewStrip`'s result (BRIDGE.md "Types" -> `PreviewStrip`). No
+/// params type: the request carries `{}` on the wire, same as
+/// `device.eject`/`bridge.shutdown`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgePreviewStripResult {
+    pub image_path: String,
+    pub row_count: u32,
+    pub pixels_per_row: u32,
+}
+
+// ---------------------------------------------------------------------
 // Scan progress + telemetry vocabulary (BRIDGE.md "Types": ScanProgress,
 // ExposureVector, ClippingTelemetry, FocusDetailTelemetry,
 // TransportSmearAssessment, ArtifactEvidence, ApprovalReceipt,
@@ -501,6 +543,17 @@ pub struct BridgeRollPreviewAck {
 #[serde(rename_all = "camelCase")]
 pub struct BridgeRollApproveParams {
     pub slot: u32,
+    /// Additive (2026-08-08 adversarial review, S1): the Roll fingerprint
+    /// the approval being submitted was minted against. `None` for the
+    /// existing automatic-preview approval path -- omitted from the wire
+    /// entirely (`skip_serializing_if`) so a bridge or bridge test double
+    /// that predates this field sees byte-identical params to before it
+    /// existed. Only `RealLs5000::roll_manual_frames`'s own binding
+    /// populates this today; the bridge refuses the approval with
+    /// `FINGERPRINT_REFUSED` when it is present and does not match the
+    /// roll's current fingerprint (BRIDGE.md `roll.approve`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fingerprint: Option<String>,
 }
 
 // ---------------------------------------------------------------------
@@ -959,5 +1012,93 @@ mod tests {
         }))
         .expect("an unrecognized code string must not fail deserialization");
         assert_eq!(future_code.code, "SOME_FUTURE_CODE_NOT_YET_INVENTED");
+    }
+
+    /// Field values taken from `bridge/tests/test_service_dispatch.py`'s own
+    /// `test_roll_manual_frames_dispatch_routes_rows_and_rearms_scan_gate` --
+    /// pins the Rust mirror to the exact wire shape the real Python bridge
+    /// emits, not just an internally-consistent round trip.
+    #[test]
+    fn bridge_manual_frames_result_matches_python_bridge_worked_example() {
+        let result = BridgeManualFramesResult {
+            count: 2,
+            fingerprint: "stub-manual-fp".to_string(),
+            thumbnails: vec![
+                BridgeThumbnail {
+                    slot: 1,
+                    boundary_rows: (100, 300),
+                    spacing_offset: 0,
+                    needs_approval: true,
+                    warnings: vec!["user-picked".to_string()],
+                    image_path: "/tmp/stub-manual/slot-0001.tif".to_string(),
+                },
+                BridgeThumbnail {
+                    slot: 2,
+                    boundary_rows: (300, 500),
+                    spacing_offset: 0,
+                    needs_approval: true,
+                    warnings: vec!["user-picked".to_string()],
+                    image_path: "/tmp/stub-manual/slot-0002.tif".to_string(),
+                },
+            ],
+            snaps: vec![BridgeBoundarySnap {
+                boundary_index: 0,
+                requested_row: 100,
+                snapped_row: 100,
+                evidence_run: (98, 102),
+            }],
+        };
+        let value = serde_json::to_value(&result).unwrap();
+        assert_eq!(value["count"], json!(2));
+        assert_eq!(value["fingerprint"], json!("stub-manual-fp"));
+        assert_eq!(
+            value["thumbnails"].as_array().unwrap().iter().map(|t| t["slot"].clone()).collect::<Vec<_>>(),
+            vec![json!(1), json!(2)]
+        );
+        assert_eq!(value["thumbnails"][0]["boundaryRows"], json!([100, 300]));
+        assert_eq!(value["thumbnails"][0]["needsApproval"], json!(true));
+        assert_eq!(
+            value["snaps"],
+            json!([{
+                "boundaryIndex": 0,
+                "requestedRow": 100,
+                "snappedRow": 100,
+                "evidenceRun": [98, 102],
+            }])
+        );
+        round_trip(&result);
+    }
+
+    /// Field values taken from `bridge/tests/test_service_dispatch.py`'s own
+    /// `test_roll_preview_strip_dispatch_returns_wire_shape`.
+    #[test]
+    fn bridge_preview_strip_result_matches_python_bridge_worked_example() {
+        let result = BridgePreviewStripResult {
+            image_path: "/tmp/stub-preview/strip.tif".to_string(),
+            row_count: 4800,
+            pixels_per_row: 1,
+        };
+        let value = serde_json::to_value(&result).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "imagePath": "/tmp/stub-preview/strip.tif",
+                "rowCount": 4800,
+                "pixelsPerRow": 1,
+            })
+        );
+        round_trip(&result);
+    }
+
+    #[test]
+    fn bridge_manual_frames_params_round_trips_rows() {
+        let params = BridgeManualFramesParams {
+            rows: vec![100, 300, 500],
+        };
+        assert_eq!(
+            serde_json::to_value(&params).unwrap(),
+            json!({"rows": [100, 300, 500]})
+        );
+        round_trip(&params);
     }
 }

--- a/ports/tauri/vendor/engine/src/protocol.rs
+++ b/ports/tauri/vendor/engine/src/protocol.rs
@@ -359,6 +359,80 @@ pub struct Thumbnail {
 }
 
 // ---------------------------------------------------------------------
+// roll.manualFrames / roll.previewStrip (additive, 2026-08-07 -- Rung 4 of
+// the feeding UX ladder). Both are non-motion-capable and synchronous (no
+// events): `roll.previewStrip` renders the last completed preview attempt's
+// whole captured raster to one image for a manual-placement editor;
+// `roll.manualFrames` re-slices that raster at operator-picked boundary
+// rows in place of automatic detection. Usable any time a preview attempt
+// exists on disk -- including one that ended in `scanner.thumbnailsFailed`
+// (REFEED_REQUIRED) -- see BRIDGE.md's own "roll.manualFrames" section.
+// Unlike `roll.approve`/`roll.setSpacingOffset`, neither method takes an
+// `operationId` param: BRIDGE.md's bridge-level contract has none (no
+// "exact completed preview" binding is required to call them), so
+// `RollManualFramesResult.operationId` is engine-minted, not
+// client-supplied -- it arms the SAME approval binding a successful
+// `roll.preview` would have, so the existing `roll.approve`/
+// `roll.setSpacingOffset`/manual-review-sheet flow keeps working unchanged
+// on the resulting frames (see `RealLs5000::roll_manual_frames`).
+// ---------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RollManualFramesParams {
+    /// At least 2 strictly increasing preview rows (N rows define N-1
+    /// frames), in the same `0..PreviewStripResult.rowCount-1` coordinate
+    /// space `PreviewStripResult` reports.
+    pub rows: Vec<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RollManualFramesResult {
+    pub count: u32,
+    pub fingerprint: String,
+    /// Fresh operation id the engine minted for this placement, binding the
+    /// resulting slots the same way a normal preview's operationId does --
+    /// pass it to `roll.approve`/`roll.setSpacingOffset` for these frames.
+    pub operation_id: String,
+    pub thumbnails: Vec<ManualFrameThumbnail>,
+    pub snaps: Vec<BoundarySnap>,
+}
+
+/// One resulting slot from `roll.manualFrames`, paired with its frame
+/// index -- BRIDGE.md's wire `Thumbnail.slot` maps one-to-one onto the
+/// public engine protocol's `frameIndex` vocabulary, the same translation
+/// `ThumbnailPayload` already performs for the ordinary preview-event path.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManualFrameThumbnail {
+    pub frame_index: u32,
+    pub thumbnail: Thumbnail,
+}
+
+/// One snap-assist adjustment `roll.manualFrames` applied to a picked
+/// boundary row (BRIDGE.md "Types" -> `BoundarySnap`).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BoundarySnap {
+    pub boundary_index: u32,
+    pub requested_row: u32,
+    pub snapped_row: u32,
+    pub evidence_run: (u32, u32),
+}
+
+/// `roll.previewStrip`'s result (BRIDGE.md "Types" -> `PreviewStrip`). No
+/// params type: the request carries `{}` on the wire, matching
+/// `scanner.status`'s existing no-params dispatch.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewStripResult {
+    pub image_path: String,
+    pub row_count: u32,
+    pub pixels_per_row: u32,
+}
+
+// ---------------------------------------------------------------------
 // scan.start / scan.stop / scan.skipCurrentFrame
 // ---------------------------------------------------------------------
 
@@ -1087,5 +1161,80 @@ mod tests {
 
         assert_eq!(failed["operationId"], serde_json::json!("preview-op-456"));
         assert_eq!(complete["operationId"], serde_json::json!("preview-op-456"));
+    }
+
+    #[test]
+    fn roll_manual_frames_params_round_trips_rows() {
+        let params = RollManualFramesParams {
+            rows: vec![100, 300, 500],
+        };
+        assert_eq!(
+            serde_json::to_value(&params).unwrap(),
+            json!({"rows": [100, 300, 500]})
+        );
+        let decoded: RollManualFramesParams =
+            serde_json::from_value(json!({"rows": [100, 300, 500]})).unwrap();
+        assert_eq!(decoded, params);
+    }
+
+    #[test]
+    fn roll_manual_frames_result_carries_frame_index_and_operation_id() {
+        let result = RollManualFramesResult {
+            count: 1,
+            fingerprint: "manual-fp".to_string(),
+            operation_id: "manual-1".to_string(),
+            thumbnails: vec![ManualFrameThumbnail {
+                frame_index: 1,
+                thumbnail: Thumbnail {
+                    brightness: None,
+                    tint: None,
+                    image_path: Some("/tmp/manual/slot-0001.tif".to_string()),
+                    boundary_rows: Some((100, 300)),
+                    spacing_offset: Some(0),
+                    needs_approval: true,
+                    warnings: vec!["user-picked".to_string()],
+                },
+            }],
+            snaps: vec![BoundarySnap {
+                boundary_index: 0,
+                requested_row: 100,
+                snapped_row: 102,
+                evidence_run: (98, 106),
+            }],
+        };
+        let value = serde_json::to_value(&result).unwrap();
+        assert_eq!(value["operationId"], json!("manual-1"));
+        assert_eq!(value["thumbnails"][0]["frameIndex"], json!(1));
+        assert_eq!(
+            value["thumbnails"][0]["thumbnail"]["needsApproval"],
+            json!(true)
+        );
+        assert_eq!(
+            value["thumbnails"][0]["thumbnail"]["warnings"],
+            json!(["user-picked"])
+        );
+        assert_eq!(value["snaps"][0]["snappedRow"], json!(102));
+        let decoded: RollManualFramesResult = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded, result);
+    }
+
+    #[test]
+    fn preview_strip_result_round_trips_camel_case() {
+        let result = PreviewStripResult {
+            image_path: "/tmp/strip.tif".to_string(),
+            row_count: 4800,
+            pixels_per_row: 1,
+        };
+        let value = serde_json::to_value(&result).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "imagePath": "/tmp/strip.tif",
+                "rowCount": 4800,
+                "pixelsPerRow": 1,
+            })
+        );
+        let decoded: PreviewStripResult = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded, result);
     }
 }

--- a/ports/tauri/vendor/engine/src/real_backend.rs
+++ b/ports/tauri/vendor/engine/src/real_backend.rs
@@ -731,6 +731,16 @@ struct CompletedPreviewApproval {
     session_epoch: u64,
     bridge_generation: u64,
     thumbnails: HashMap<u32, BridgeThumbnail>,
+    /// Additive (2026-08-08 adversarial review, S1): the bridge-reported
+    /// Roll fingerprint (`PreviewResult.fingerprint`, BRIDGE.md) this exact
+    /// binding was minted against, threaded through `roll_approve` to the
+    /// bridge so it can refuse a stale approval instead of silently
+    /// honoring it against whatever session is current now. `None` for a
+    /// binding armed by the automatic-preview path
+    /// (`finalize_active_preview_terminal`) -- that path's own approval
+    /// flow is unaffected by this field's existence; only
+    /// `roll_manual_frames`'s own binding populates it today.
+    fingerprint: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1423,6 +1433,12 @@ impl RealLs5000 {
                     session_epoch,
                     bridge_generation,
                     thumbnails,
+                    // The automatic-preview path mints no fingerprint
+                    // binding of its own (see CompletedPreviewApproval's
+                    // own field comment) -- roll_approve's wire call omits
+                    // the additive param entirely for this binding,
+                    // byte-identical to before it existed.
+                    fingerprint: None,
                 });
             }
         }
@@ -1750,7 +1766,29 @@ impl RealLs5000 {
                 "operationId does not match a successfully completed preview in the current bridge session",
             ));
         }
-        let params = BridgeRollApproveParams { slot: frame_index };
+        // Adversarial review S3 (2026-08-08): matching operationId/session
+        // identity is not enough on its own -- without this, any frame
+        // index could be "approved" under a valid operationId, including
+        // one the completed preview never returned at all, or one that was
+        // never flagged for review in the first place. `binding` is `Some`
+        // here (proven by the check immediately above).
+        let thumbnail = binding
+            .as_ref()
+            .and_then(|binding| binding.thumbnails.get(&frame_index));
+        if !thumbnail.is_some_and(|thumbnail| thumbnail.needs_approval) {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                "frameIndex is not a frame the completed preview flagged for manual review",
+            ));
+        }
+        // S1: carry the binding's own expected fingerprint (if any) through
+        // to the bridge -- `None` for an automatic-preview binding, which
+        // keeps this wire call byte-identical to before this field
+        // existed (see BridgeRollApproveParams's own field comment).
+        let params = BridgeRollApproveParams {
+            slot: frame_index,
+            fingerprint: binding.as_ref().and_then(|binding| binding.fingerprint.clone()),
+        };
         let value = serde_json::to_value(params).expect("BridgeRollApproveParams serializes");
         self.call_session_scoped(
             session_epoch,
@@ -1815,6 +1853,151 @@ impl RealLs5000 {
             spacing_offset: Some(result.thumbnail.spacing_offset),
             needs_approval: result.thumbnail.needs_approval,
             warnings: result.thumbnail.warnings,
+        })
+    }
+
+    /// Re-slices the last completed preview attempt's already-decoded
+    /// raster at operator-picked boundary rows (BRIDGE.md
+    /// `roll.manualFrames`, additive 2026-08-07 -- Rung 4 of the feeding UX
+    /// ladder). Usable any time a preview attempt exists on disk --
+    /// including one that ended in `roll.previewError` -- so, unlike
+    /// `roll_approve`/`roll_set_spacing_offset` above, this deliberately
+    /// does NOT require an operator-reviewed "completed" preview binding
+    /// before it can run: the bridge's own `manual_frames()` re-arms a
+    /// usable session from whatever attempt is on disk and answers
+    /// `NO_PREVIEW` itself when none exists (BRIDGE.md: "no partial
+    /// acceptance" is about the placement's own validity, not about
+    /// requiring a prior success here). Not motion-capable: no film moves,
+    /// no transport read happens, nothing is re-fed.
+    ///
+    /// On success, this mints a fresh `operationId` and arms this backend's
+    /// own `preview_approval_state.completed` binding with it -- exactly as
+    /// a successful `roll.preview`'s `finalize_active_preview_terminal`
+    /// would have -- so the existing `roll.approve`/`roll.setSpacingOffset`/
+    /// manual-review-sheet flow keeps working completely unchanged on the
+    /// resulting frames. There is no client-supplied operation id to reuse
+    /// here (BRIDGE.md's `roll.manualFrames` has no such param), so the
+    /// engine mints one and reports it back via
+    /// `RollManualFramesResult.operationId` for the app to bind subsequent
+    /// calls to.
+    ///
+    /// 2026-08-08 adversarial review, S1 (part 4): whatever completed
+    /// binding this session currently holds is retired BEFORE the
+    /// `roll.manualFrames` request is even issued, and stays retired on any
+    /// failure below (nothing here ever restores it) -- only a full, clean
+    /// success re-arms a completed binding, with this call's own fresh
+    /// operationId and fingerprint. Without this, a stale approval for an
+    /// earlier completed preview/placement could still be honored by
+    /// `roll_approve` while a replacement placement is in flight or has
+    /// just failed, even though the UI has moved on to a different
+    /// operation entirely.
+    pub fn roll_manual_frames(
+        &self,
+        rows: Vec<u32>,
+    ) -> Result<crate::protocol::RollManualFramesResult, EngineError> {
+        let (session_epoch, bridge_generation) = self.active_session_identity()?;
+        self.clear_completed_preview_approval_for_epoch(session_epoch);
+        let value = self.call_session_scoped(
+            session_epoch,
+            bridge_generation,
+            "roll.manualFrames",
+            serde_json::to_value(BridgeManualFramesParams { rows })
+                .expect("BridgeManualFramesParams serializes"),
+        )?;
+        let result: BridgeManualFramesResult = serde_json::from_value(value).map_err(|error| {
+            EngineError::new(
+                ErrorCode::Internal,
+                format!("malformed roll.manualFrames result: {error}"),
+            )
+        })?;
+
+        // Reuses the existing per-preview token counter purely as a source
+        // of a fresh, monotonically unique integer -- `CompletedPreviewApproval`
+        // has no `token` field of its own to collide with, so this never
+        // interacts with `ActivePreviewApproval`/`PoisonedPreviewStream`'s
+        // own token matching.
+        let operation_suffix = self.next_preview_token.fetch_add(1, Ordering::AcqRel) + 1;
+        let operation_id = format!("manual-{operation_suffix}");
+
+        let mut thumbnails_by_slot: HashMap<u32, BridgeThumbnail> = HashMap::new();
+        let mut thumbnails = Vec::with_capacity(result.thumbnails.len());
+        for thumbnail in result.thumbnails {
+            thumbnails_by_slot.insert(thumbnail.slot, thumbnail.clone());
+            thumbnails.push(crate::protocol::ManualFrameThumbnail {
+                frame_index: thumbnail.slot,
+                thumbnail: crate::protocol::Thumbnail {
+                    brightness: None,
+                    tint: None,
+                    image_path: Some(thumbnail.image_path),
+                    boundary_rows: Some(thumbnail.boundary_rows),
+                    spacing_offset: Some(thumbnail.spacing_offset),
+                    needs_approval: thumbnail.needs_approval,
+                    warnings: thumbnail.warnings,
+                },
+            });
+        }
+
+        // Arm the SAME approval binding a successful preview's own
+        // `finalize_active_preview_terminal` would have -- only while this
+        // exact session is still current, mirroring that function's own
+        // defensive re-check immediately before it commits state.
+        if self.session_identity_is_current(session_epoch, bridge_generation) {
+            let mut state = self.preview_approval_state.lock().unwrap();
+            state.active = None;
+            state.completed = Some(CompletedPreviewApproval {
+                operation_id: operation_id.clone(),
+                session_epoch,
+                bridge_generation,
+                thumbnails: thumbnails_by_slot,
+                // S1 (part 4): this is the one binding source that DOES
+                // supply an expected fingerprint -- roll_approve threads it
+                // through to the bridge, which refuses the approval if the
+                // roll's fingerprint has since moved on.
+                fingerprint: Some(result.fingerprint.clone()),
+            });
+        }
+
+        Ok(crate::protocol::RollManualFramesResult {
+            count: result.count,
+            fingerprint: result.fingerprint,
+            operation_id,
+            thumbnails,
+            snaps: result
+                .snaps
+                .into_iter()
+                .map(|snap| crate::protocol::BoundarySnap {
+                    boundary_index: snap.boundary_index,
+                    requested_row: snap.requested_row,
+                    snapped_row: snap.snapped_row,
+                    evidence_run: snap.evidence_run,
+                })
+                .collect(),
+        })
+    }
+
+    /// Renders the last completed preview attempt's whole captured raster
+    /// to one image (BRIDGE.md `roll.previewStrip`, additive 2026-08-07).
+    /// Same precondition and non-motion-capable contract as
+    /// `roll_manual_frames` above; touches no session or approval state,
+    /// purely a read.
+    pub fn roll_preview_strip(&self) -> Result<crate::protocol::PreviewStripResult, EngineError> {
+        let (session_epoch, bridge_generation) = self.active_session_identity()?;
+        let value = self.call_session_scoped(
+            session_epoch,
+            bridge_generation,
+            "roll.previewStrip",
+            serde_json::json!({}),
+        )?;
+        let result: BridgePreviewStripResult = serde_json::from_value(value).map_err(|error| {
+            EngineError::new(
+                ErrorCode::Internal,
+                format!("malformed roll.previewStrip result: {error}"),
+            )
+        })?;
+        Ok(crate::protocol::PreviewStripResult {
+            image_path: result.image_path,
+            row_count: result.row_count,
+            pixels_per_row: result.pixels_per_row,
         })
     }
 }
@@ -2379,6 +2562,45 @@ impl ScannerBackend for RealLs5000 {
     ) -> Result<String, EngineError> {
         let (session_epoch, bridge_generation) = backend.active_session_identity()?;
         backend.ensure_preview_stream_allows_scan(session_epoch, bridge_generation)?;
+        // Adversarial review S3 (2026-08-08): when this exact session has a
+        // completed-preview binding (BRIDGE.md's own "slots must be a
+        // subset of the last preview's detected slots" is bridge-enforced,
+        // but the engine must not rely on the bridge alone to catch a
+        // "hidden slot" request), every requested frame must be one the
+        // binding's own completed preview actually returned -- otherwise a
+        // caller could request a frame the operator was never shown at all.
+        //
+        // Deliberately conditional on a binding actually existing, not an
+        // unconditional requirement: a preview whose thumbnail STREAM
+        // partially failed to decode (`dropped_count > 0` in
+        // `acquire_thumbnails`'s worker) still lets `scan.start` proceed
+        // today for the frames that DID decode, even though this backend's
+        // own `completed` binding is deliberately left unset for that
+        // narrow case (see `finalize_active_preview_terminal`'s caller).
+        // Falling through here for a `None` binding keeps that existing,
+        // already-shipped path byte-identical; the bridge's own subset
+        // check still applies to it exactly as before.
+        {
+            let binding = backend.preview_approval_state.lock().unwrap().completed.clone();
+            let binding_is_current_session = binding.as_ref().is_some_and(|binding| {
+                binding.session_epoch == session_epoch
+                    && binding.bridge_generation == bridge_generation
+            });
+            if binding_is_current_session {
+                let binding = binding.expect("checked by binding_is_current_session above");
+                if let Some(&missing_frame) = frames
+                    .iter()
+                    .find(|frame_index| !binding.thumbnails.contains_key(frame_index))
+                {
+                    return Err(EngineError::new(
+                        ErrorCode::InvalidParams,
+                        format!(
+                            "frame {missing_frame} was never returned by the completed preview and cannot be scanned"
+                        ),
+                    ));
+                }
+            }
+        }
         let processing = processing.effective();
         let recipe = recipe.effective_for_process(processing.film_process);
         // Device-sourced, model-agnostic (see

--- a/ports/tauri/vendor/engine/src/server.rs
+++ b/ports/tauri/vendor/engine/src/server.rs
@@ -319,10 +319,13 @@ impl Backends {
                 .as_ref()
                 .unwrap()
                 .roll_approve(frame_index, operation_id),
-            Some(ActiveDevice::Sim) => Err(EngineError::new(
-                ErrorCode::InvalidParams,
-                "roll.approve is available only for an active real-device preview; the simulator has no manual-review gate",
-            )),
+            // S7a (adversarial review, 2026-08-08): the simulator now has
+            // exactly one manual-review gate -- a frame its own last
+            // successful `manual_frames()` call returned, under that exact
+            // operationId (see `SimulatedLs5000::roll_approve`'s own doc
+            // comment). Every other case is refused with the same
+            // "no manual-review gate" message as before this change.
+            Some(ActiveDevice::Sim) => self.sim.roll_approve(frame_index, operation_id),
             None => Err(EngineError::new(
                 ErrorCode::NotConnected,
                 "scanner is not connected",
@@ -374,6 +377,39 @@ impl Backends {
                 ErrorCode::InvalidParams,
                 "roll.setSpacingOffset is available only for an active real-device preview",
             )),
+            None => Err(EngineError::new(
+                ErrorCode::NotConnected,
+                "scanner is not connected",
+            )),
+        }
+    }
+
+    /// `roll.manualFrames` (additive, 2026-08-07 -- Rung 4): unlike
+    /// `roll_approve`/`roll_set_spacing_offset`, this has sim parity rather
+    /// than a real-device-only refusal -- BRIDGE.md's contract requires no
+    /// prior successful preview (it works after a refused one too), so the
+    /// simulator can honestly answer it from a synthesized strip instead of
+    /// needing a real bridge-owned manual-review gate the way approval does.
+    fn roll_manual_frames(
+        &self,
+        rows: Vec<u32>,
+    ) -> Result<protocol::RollManualFramesResult, EngineError> {
+        match self.active {
+            Some(ActiveDevice::Sim) => self.sim.manual_frames(rows),
+            Some(ActiveDevice::Real) => self.real.as_ref().unwrap().roll_manual_frames(rows),
+            None => Err(EngineError::new(
+                ErrorCode::NotConnected,
+                "scanner is not connected",
+            )),
+        }
+    }
+
+    /// `roll.previewStrip` (additive, 2026-08-07 -- Rung 4): same sim-parity
+    /// reasoning as `roll_manual_frames` above.
+    fn roll_preview_strip(&self) -> Result<protocol::PreviewStripResult, EngineError> {
+        match self.active {
+            Some(ActiveDevice::Sim) => self.sim.preview_strip(),
+            Some(ActiveDevice::Real) => self.real.as_ref().unwrap().roll_preview_strip(),
             None => Err(EngineError::new(
                 ErrorCode::NotConnected,
                 "scanner is not connected",
@@ -802,6 +838,15 @@ fn handle_request(
                 &params.operation_id,
             )?;
             to_json(&protocol::RollSetSpacingOffsetResult { thumbnail })
+        }
+        "roll.manualFrames" => {
+            let params: protocol::RollManualFramesParams = parse_params(&request.params)?;
+            let result = backends.roll_manual_frames(params.rows)?;
+            to_json(&result)
+        }
+        "roll.previewStrip" => {
+            let result = backends.roll_preview_strip()?;
+            to_json(&result)
         }
         "scan.start" => {
             let mut params: protocol::ScanStartParams = parse_params(&request.params)?;
@@ -3835,5 +3880,134 @@ mod tests {
         assert_eq!(err.code, ErrorCode::InvalidParams);
 
         let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// Connects and loads a 36-frame roll on the simulator only -- shared
+    /// setup for the `roll.manualFrames`/`roll.previewStrip` dispatch tests
+    /// below, which need no project (both methods are project-independent).
+    fn connected_sim_backends_with_media() -> (Backends, mpsc::Sender<String>, ProjectState) {
+        let mut backends = Backends {
+            sim: Arc::new(SimulatedLs5000::new()),
+            real: None,
+            active: None,
+        };
+        let (tx, _rx) = mpsc::channel();
+        let mut project_state = ProjectState::default();
+
+        let connect_request = Request {
+            id: 1,
+            method: "scanner.connect".into(),
+            params: serde_json::json!({ "deviceId": "sim-ls5000-0" }),
+        };
+        handle_request(&mut backends, &tx, &connect_request, &mut project_state)
+            .expect("scanner.connect");
+
+        let load_media_request = Request {
+            id: 2,
+            method: "sim.loadMedia".into(),
+            params: serde_json::json!({ "carrier": "roll36" }),
+        };
+        handle_request(&mut backends, &tx, &load_media_request, &mut project_state)
+            .expect("sim.loadMedia");
+
+        (backends, tx, project_state)
+    }
+
+    #[test]
+    fn roll_preview_strip_returns_a_synthesized_image_through_dispatch() {
+        let (mut backends, tx, mut project_state) = connected_sim_backends_with_media();
+
+        let request = Request {
+            id: 3,
+            method: "roll.previewStrip".into(),
+            params: serde_json::Value::Null,
+        };
+        let result = handle_request(&mut backends, &tx, &request, &mut project_state)
+            .expect("roll.previewStrip");
+
+        assert_eq!(result["pixelsPerRow"], serde_json::json!(1));
+        let row_count = result["rowCount"].as_u64().expect("rowCount is a number");
+        assert!(row_count > 0, "a loaded 36-frame roll must report a positive rowCount");
+        let image_path = result["imagePath"].as_str().expect("imagePath is a string");
+        assert!(
+            std::path::Path::new(image_path).is_file(),
+            "roll.previewStrip must write a real, readable file: {image_path}"
+        );
+
+        let _ = std::fs::remove_file(image_path);
+    }
+
+    #[test]
+    fn roll_manual_frames_returns_needs_approval_thumbnails_through_dispatch() {
+        let (mut backends, tx, mut project_state) = connected_sim_backends_with_media();
+
+        let request = Request {
+            id: 3,
+            method: "roll.manualFrames".into(),
+            params: serde_json::json!({ "rows": [0, 135, 270] }),
+        };
+        let result = handle_request(&mut backends, &tx, &request, &mut project_state)
+            .expect("roll.manualFrames with structurally valid rows");
+
+        assert_eq!(result["count"], serde_json::json!(2));
+        assert!(result["operationId"].as_str().is_some_and(|s| !s.is_empty()));
+        let thumbnails = result["thumbnails"].as_array().expect("thumbnails array");
+        assert_eq!(thumbnails.len(), 2);
+        assert_eq!(thumbnails[0]["frameIndex"], serde_json::json!(1));
+        assert_eq!(thumbnails[0]["thumbnail"]["needsApproval"], serde_json::json!(true));
+        assert_eq!(
+            thumbnails[0]["thumbnail"]["warnings"],
+            serde_json::json!(["user-picked"])
+        );
+        // The simulator has no clear-film evidence signal to snap against;
+        // it must honestly report zero snaps rather than fabricate one.
+        assert_eq!(result["snaps"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn roll_manual_frames_rejects_too_few_rows_through_dispatch() {
+        let (mut backends, tx, mut project_state) = connected_sim_backends_with_media();
+
+        let request = Request {
+            id: 3,
+            method: "roll.manualFrames".into(),
+            params: serde_json::json!({ "rows": [42] }),
+        };
+        let err = handle_request(&mut backends, &tx, &request, &mut project_state).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(
+            err.message.contains("at least 2"),
+            "expected a plain-English explanation, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn roll_manual_frames_and_preview_strip_require_a_connection() {
+        let mut backends = Backends {
+            sim: Arc::new(SimulatedLs5000::new()),
+            real: None,
+            active: None,
+        };
+        let (tx, _rx) = mpsc::channel();
+        let mut project_state = ProjectState::default();
+
+        let manual_request = Request {
+            id: 1,
+            method: "roll.manualFrames".into(),
+            params: serde_json::json!({ "rows": [0, 200] }),
+        };
+        let err =
+            handle_request(&mut backends, &tx, &manual_request, &mut project_state).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NotConnected);
+
+        let strip_request = Request {
+            id: 2,
+            method: "roll.previewStrip".into(),
+            params: serde_json::Value::Null,
+        };
+        let err =
+            handle_request(&mut backends, &tx, &strip_request, &mut project_state).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NotConnected);
     }
 }

--- a/ports/tauri/vendor/engine/src/sim.rs
+++ b/ports/tauri/vendor/engine/src/sim.rs
@@ -20,9 +20,10 @@ use crate::domain::{
 };
 use crate::protocol::{
     ConnectOptions, ConnectResult, ErrorCode, ErrorPayload, Event, FaultInjection,
-    FrameCompletedPayload, FrameStatePayload, JobStatePayload, Lamp, ScanCompletedPayload,
-    ScanProgressPayload, ScanSummary, ScannerStatus, StopMode, Thumbnail, ThumbnailPayload,
-    ThumbnailsCompletePayload, Transport,
+    FrameCompletedPayload, FrameStatePayload, JobStatePayload, Lamp, ManualFrameThumbnail,
+    PreviewStripResult, RollManualFramesResult, ScanCompletedPayload, ScanProgressPayload,
+    ScanSummary, ScannerStatus, StopMode, Thumbnail, ThumbnailPayload, ThumbnailsCompletePayload,
+    Transport,
 };
 
 const DEVICE_ID: &str = "sim-ls5000-0";
@@ -60,6 +61,117 @@ pub fn thumbnail_for(device_id: &str, frame_index: u32) -> Thumbnail {
         needs_approval: false,
         warnings: vec![],
     }
+}
+
+// ---------------------------------------------------------------------
+// roll.manualFrames / roll.previewStrip sim parity (additive, 2026-08-07 --
+// Rung 4 of the feeding UX ladder). Unlike `roll.approve`/
+// `roll.setSpacingOffset` (real-device-only: the simulator has no
+// bridge-owned manual-review gate to arm), BRIDGE.md's contract for these
+// two methods requires no prior successful preview at all -- they work
+// after a refused one too -- so the simulator can honestly answer them
+// without needing that gate. Deliberately minimal: no clear-film evidence
+// signal exists in sim data, so snap assist is never simulated (an honest
+// empty `snaps`, never fabricated); the synthesized strip image exists only
+// so a manual-placement editor has *something* plausible to draw boundary
+// lines on, and is never claimed to be real film content.
+// ---------------------------------------------------------------------
+
+/// Rows-per-nominal-frame the simulator assumes when it has no real
+/// transport table to consult -- matches coolscanpy's own documented
+/// approximation (`manual_frames.py`: `MANUAL_FRAME_HEIGHT_MM_PER_ROW =
+/// 0.267`, so ~36mm / 0.267mm-per-row =~ 135 rows for a standard 35mm
+/// frame).
+const SIM_NOMINAL_FRAME_PITCH_ROWS: u32 = 135;
+/// Floor mirrors coolscanpy's `manual_frames.py`
+/// `MINIMUM_MANUAL_FRAME_HEIGHT_ROWS`/`MANUAL_FRAME_HEIGHT_MM_PER_ROW`
+/// verbatim -- a real, physical fact about film, deliberately wider than
+/// automatic detection's tolerance.
+const SIM_MINIMUM_MANUAL_FRAME_HEIGHT_ROWS: u32 = 56;
+/// Ceiling is tighter than `manual_frames.py`'s own (still 280 today) --
+/// adversarial review S7b (2026-08-08): 280 rows is not the scanner's real
+/// per-frame limit for something that must actually be fine-scanned
+/// afterward. The fixed single-pass fine capture window is
+/// `worker.py`'s `FINE_NATIVE_HEIGHT = 5_959` native pixels, which divided
+/// by this same driver's 40-45 native-units-per-row transport pitch lands
+/// at roughly 132-149 preview rows -- ~145 at the middle of that range.
+/// See `Sources/ScanStudioKit/ManualFramePlacementValidation.swift`'s own
+/// doc comment for the identical derivation and reasoning; this constant
+/// and that one must stay in lockstep so the simulator's own gate matches
+/// what the client-side editor already refuses to build.
+const SIM_MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS: u32 = 145;
+const SIM_MAXIMUM_MANUAL_FRAMES: usize = 40;
+const SIM_MANUAL_FRAME_HEIGHT_MM_PER_ROW: f64 = 0.267;
+/// Cross-strip axis of the synthesized preview strip image, in pixels.
+/// Arbitrary but fixed -- the simulator has no real frame width to derive
+/// this from.
+const SIM_STRIP_HEIGHT_PX: u32 = 96;
+/// Every `GAP_ROWS`-wide slice at the start of each nominal frame pitch
+/// renders as a brighter "clear film" band, purely so the synthesized strip
+/// has some visible structure to place boundaries against.
+const SIM_STRIP_GAP_ROWS: u32 = 10;
+
+/// The coordinate space every `roll.manualFrames`/`roll.previewStrip` row
+/// is validated/rendered against: `frame_count` nominal frames end to end,
+/// each `SIM_NOMINAL_FRAME_PITCH_ROWS` rows tall. Shared by both methods so
+/// a row `roll.previewStrip` reports as in-bounds is the exact same row
+/// `roll.manualFrames` will accept.
+fn sim_strip_row_count(frame_count: Option<u32>) -> u32 {
+    frame_count.unwrap_or(1).max(1) * SIM_NOMINAL_FRAME_PITCH_ROWS
+}
+
+fn sim_manual_frame_ordinal(index: usize) -> String {
+    format!("frame {}", index + 1)
+}
+
+/// Writes a small synthesized "whole roll" preview strip image for
+/// `roll.previewStrip`'s sim parity. The transport/row axis is the image's
+/// WIDTH axis, exactly like a real bridge-rendered strip (BRIDGE.md
+/// `PreviewStrip.imagePath`'s own doc note: "the raster's row axis... is
+/// the image's WIDTH axis, not its height, exactly like every existing
+/// `Thumbnail` crop already is") -- getting this backwards would silently
+/// break every row<->pixel calculation a manual-placement editor makes.
+/// Alternating bands are driven by the same `thumbnail_for` hash already
+/// used for simulated thumbnails, purely so the strip has *some* visible
+/// structure; this never claims to be real film content.
+fn synthesize_preview_strip(
+    device_id: &str,
+    row_count: u32,
+) -> Result<std::path::PathBuf, EngineError> {
+    let width = row_count.max(1);
+    let image = image::RgbImage::from_fn(width, SIM_STRIP_HEIGHT_PX, |x, _y| {
+        let cycle = x % SIM_NOMINAL_FRAME_PITCH_ROWS;
+        if cycle < SIM_STRIP_GAP_ROWS {
+            image::Rgb([228, 228, 228])
+        } else {
+            let nominal_frame = x / SIM_NOMINAL_FRAME_PITCH_ROWS + 1;
+            let h = fnv1a64(&format!("{device_id}:strip:{nominal_frame}"));
+            let gray = (80 + (h >> 8) % 120) as u8;
+            image::Rgb([gray, gray, gray])
+        }
+    });
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let dir = std::env::temp_dir()
+        .join("scanstudio-sim-previews")
+        .join(format!("strip-{nanos:x}"));
+    std::fs::create_dir_all(&dir).map_err(|err| {
+        EngineError::new(
+            ErrorCode::Internal,
+            format!("failed to create simulator preview strip directory: {err}"),
+        )
+    })?;
+    let path = dir.join("strip.png");
+    image.save(&path).map_err(|err| {
+        EngineError::new(
+            ErrorCode::Internal,
+            format!("failed to write simulator preview strip image: {err}"),
+        )
+    })?;
+    Ok(path)
 }
 
 /// Lowercase 16-hex-char FNV-1a 64 of
@@ -139,6 +251,17 @@ fn is_job_terminal(state: JobState) -> bool {
     )
 }
 
+/// The most recent successful `manual_frames()` call's operator-approval
+/// binding (adversarial review S7a, 2026-08-08). The simulator otherwise
+/// has no manual-review gate at all; this exists solely so a simulated
+/// manual placement -- which always arrives `needsApproval: true` -- is
+/// not a permanent dead end with nothing that could ever clear it.
+#[derive(Debug, Clone)]
+struct ManualApprovalBinding {
+    operation_id: String,
+    frame_indices: HashSet<u32>,
+}
+
 struct State {
     connected: bool,
     adapter: Option<String>,
@@ -152,6 +275,7 @@ struct State {
     fault_injection: FaultInjection,
     job_seq: u64,
     thumbnail_operation_active: bool,
+    manual_approval_binding: Option<ManualApprovalBinding>,
 }
 
 impl Default for State {
@@ -169,6 +293,7 @@ impl Default for State {
             fault_injection: FaultInjection::NoFault,
             job_seq: 0,
             thumbnail_operation_active: false,
+            manual_approval_binding: None,
         }
     }
 }
@@ -265,6 +390,201 @@ impl SimulatedLs5000 {
             )),
         }
     }
+
+    /// `roll.previewStrip` sim parity (additive, 2026-08-07). Renders a
+    /// synthesized whole-roll strip sized from the loaded carrier's frame
+    /// count, purely so a manual-placement editor has something to draw on
+    /// without a real bridge attached. Not part of `ScannerBackend`: like
+    /// `roll_approve`/`roll_set_spacing_offset`, this is dispatched
+    /// directly from `Backends` rather than through the trait.
+    pub fn preview_strip(&self) -> Result<PreviewStripResult, EngineError> {
+        let (device_id, frame_count) = {
+            let state = self.state.lock().unwrap();
+            if !state.connected {
+                return Err(EngineError::new(
+                    ErrorCode::NotConnected,
+                    "scanner is not connected",
+                ));
+            }
+            if !state.media_loaded {
+                return Err(EngineError::new(ErrorCode::NoMedia, "no media is loaded"));
+            }
+            if transport_is_busy(&state) {
+                return Err(EngineError::new(
+                    ErrorCode::ScannerBusy,
+                    "a scanner transport operation is active",
+                ));
+            }
+            (self.device.device_id.clone(), state.frame_count)
+        };
+        let row_count = sim_strip_row_count(frame_count);
+        let path = synthesize_preview_strip(&device_id, row_count)?;
+        Ok(PreviewStripResult {
+            image_path: path.display().to_string(),
+            row_count,
+            pixels_per_row: 1,
+        })
+    }
+
+    /// `roll.manualFrames` sim parity (additive, 2026-08-07). Validates the
+    /// same structural and frame-height gates coolscanpy's
+    /// `manual_frames.py` enforces server-side (count, strictly increasing,
+    /// in-raster, frame count, 15-75mm height); deliberately does NOT
+    /// attempt the snap-assist or same-traversal transport-table sanity
+    /// gates, since the simulator has no clear-film evidence signal or real
+    /// transport table to check either against -- an honest `snaps: []`
+    /// rather than a fabricated one. Deterministic per-frame thumbnails
+    /// reuse `thumbnail_for`, exactly like a normal `acquire_thumbnails`
+    /// tile, with `needsApproval`/`warnings` overridden to match BRIDGE.md's
+    /// "every resulting slot arrives `needsApproval: true` with a
+    /// `\"user-picked\"` warning" contract.
+    pub fn manual_frames(&self, rows: Vec<u32>) -> Result<RollManualFramesResult, EngineError> {
+        let (device_id, frame_count_hint) = {
+            let state = self.state.lock().unwrap();
+            if !state.connected {
+                return Err(EngineError::new(
+                    ErrorCode::NotConnected,
+                    "scanner is not connected",
+                ));
+            }
+            if !state.media_loaded {
+                return Err(EngineError::new(ErrorCode::NoMedia, "no media is loaded"));
+            }
+            if transport_is_busy(&state) {
+                return Err(EngineError::new(
+                    ErrorCode::ScannerBusy,
+                    "a scanner transport operation is active",
+                ));
+            }
+            (self.device.device_id.clone(), state.frame_count)
+        };
+        let row_count = sim_strip_row_count(frame_count_hint);
+
+        if rows.len() < 2 {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                format!(
+                    "manual frame placement needs at least 2 boundary rows (1 frame); only {} were given",
+                    rows.len()
+                ),
+            ));
+        }
+        if rows.windows(2).any(|pair| pair[0] >= pair[1]) {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                "frame boundary rows must be placed in strictly increasing order, top to bottom of the preview",
+            ));
+        }
+        if rows.iter().any(|&row| row >= row_count) {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                format!(
+                    "every boundary row must lie inside the captured preview (0..{}); a boundary was placed outside it",
+                    row_count.saturating_sub(1)
+                ),
+            ));
+        }
+        let frame_count = rows.len() - 1;
+        if frame_count > SIM_MAXIMUM_MANUAL_FRAMES {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                format!(
+                    "manual placement supports at most {SIM_MAXIMUM_MANUAL_FRAMES} frames; {} boundary rows would create {frame_count}",
+                    rows.len()
+                ),
+            ));
+        }
+        for (index, pair) in rows.windows(2).enumerate() {
+            let height_rows = pair[1] - pair[0];
+            if height_rows < SIM_MINIMUM_MANUAL_FRAME_HEIGHT_ROWS
+                || height_rows > SIM_MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS
+            {
+                let approx_mm = f64::from(height_rows) * SIM_MANUAL_FRAME_HEIGHT_MM_PER_ROW;
+                let ceiling_mm = f64::from(SIM_MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS)
+                    * SIM_MANUAL_FRAME_HEIGHT_MM_PER_ROW;
+                let reason = if height_rows < SIM_MINIMUM_MANUAL_FRAME_HEIGHT_ROWS {
+                    "real frames are at least 15 mm".to_string()
+                } else {
+                    format!("the scanner captures about {ceiling_mm:.0} mm per frame")
+                };
+                return Err(EngineError::new(
+                    ErrorCode::InvalidParams,
+                    format!(
+                        "the {} you placed is about {approx_mm:.0} mm tall (between rows {} and {}) -- {reason}",
+                        sim_manual_frame_ordinal(index),
+                        pair[0],
+                        pair[1]
+                    ),
+                ));
+            }
+        }
+
+        let thumbnails: Vec<ManualFrameThumbnail> = (1..=frame_count as u32)
+            .map(|frame_index| {
+                let mut thumbnail = thumbnail_for(&device_id, frame_index);
+                thumbnail.needs_approval = true;
+                thumbnail.warnings = vec!["user-picked".to_string()];
+                ManualFrameThumbnail {
+                    frame_index,
+                    thumbnail,
+                }
+            })
+            .collect();
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let operation_id = format!("manual-sim-{nanos:x}");
+        let fingerprint = format!("{:016x}", fnv1a64(&format!("{device_id}:manual:{rows:?}")));
+
+        // Arm the sim-side approval binding (S7a) only after every gate
+        // above has passed -- a refused placement must never leave a
+        // binding an operator could later approve against.
+        self.state.lock().unwrap().manual_approval_binding = Some(ManualApprovalBinding {
+            operation_id: operation_id.clone(),
+            frame_indices: (1..=frame_count as u32).collect(),
+        });
+
+        Ok(RollManualFramesResult {
+            count: frame_count as u32,
+            fingerprint,
+            operation_id,
+            thumbnails,
+            // The simulator has no clear-film evidence signal to snap
+            // against (see `synthesize_preview_strip`'s own doc comment) --
+            // it never fabricates a snap; every real snap comes only from a
+            // real bridge.
+            snaps: vec![],
+        })
+    }
+
+    /// `roll.approve` sim parity for manually-placed frames (adversarial
+    /// review S7a, 2026-08-08). The simulator otherwise has NO
+    /// manual-review gate -- every other case is refused with the same
+    /// message as before this change. Only a frame this backend's own
+    /// last successful `manual_frames()` call actually returned, under
+    /// that exact `operation_id`, can be approved; the binding is cleared
+    /// on connect/disconnect/load_media/eject so a stale approval can
+    /// never survive a session or media change (mirrors the S2 fix's own
+    /// "never let frame-indexed state silently outlive the placement that
+    /// produced it" principle). Not part of `ScannerBackend`: dispatched
+    /// directly from `Backends::roll_approve`, exactly like every other
+    /// roll.* method that is real-only or sim-only.
+    pub fn roll_approve(&self, frame_index: u32, operation_id: &str) -> Result<(), EngineError> {
+        let state = self.state.lock().unwrap();
+        let approvable = state.manual_approval_binding.as_ref().is_some_and(|binding| {
+            binding.operation_id == operation_id && binding.frame_indices.contains(&frame_index)
+        });
+        if approvable {
+            return Ok(());
+        }
+        Err(EngineError::new(
+            ErrorCode::InvalidParams,
+            "roll.approve is available on the simulator only for a frame returned by this \
+             session's own manual frame placement; the simulator has no other manual-review gate",
+        ))
+    }
 }
 
 impl Default for SimulatedLs5000 {
@@ -302,6 +622,10 @@ impl ScannerBackend for SimulatedLs5000 {
         state.lamp = Lamp::Stable;
         state.transport = Transport::Idle;
         state.job_slot = None;
+        // A fresh session starts with no manual-placement approval binding
+        // (S7a/S2 principle): a stale one from an earlier connection must
+        // never carry over.
+        state.manual_approval_binding = None;
         state.time_scale = if options.time_scale > 0.0 {
             options.time_scale
         } else {
@@ -338,6 +662,7 @@ impl ScannerBackend for SimulatedLs5000 {
         state.frame_count = None;
         state.lamp = Lamp::Off;
         state.transport = Transport::Idle;
+        state.manual_approval_binding = None;
         Ok(status_snapshot(&state))
     }
 
@@ -375,6 +700,9 @@ impl ScannerBackend for SimulatedLs5000 {
         state.carrier = Some(carrier);
         state.frame_count = Some(frame_count);
         state.adapter = Some(adapter.to_string());
+        // Newly loaded media invalidates any manual placement made against
+        // whatever was loaded before.
+        state.manual_approval_binding = None;
         Ok(status_snapshot(&state))
     }
 
@@ -406,6 +734,7 @@ impl ScannerBackend for SimulatedLs5000 {
         state.carrier = None;
         state.frame_count = None;
         state.adapter = None;
+        state.manual_approval_binding = None;
         Ok(status_snapshot(&state))
     }
 
@@ -2200,5 +2529,299 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&project_dir);
         let _ = std::fs::remove_dir_all(&output_dir);
+    }
+
+    // -- roll.previewStrip / roll.manualFrames sim parity (Rung 4) ---------
+
+    #[test]
+    fn preview_strip_reports_row_count_from_loaded_frame_count_and_writes_a_real_file() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let strip = sim.preview_strip().expect("preview_strip");
+        assert_eq!(strip.row_count, 36 * SIM_NOMINAL_FRAME_PITCH_ROWS);
+        assert_eq!(strip.pixels_per_row, 1);
+        let metadata = std::fs::metadata(&strip.image_path)
+            .unwrap_or_else(|err| panic!("preview strip file must exist: {err}"));
+        assert!(metadata.len() > 0, "preview strip file must not be empty");
+
+        let _ = std::fs::remove_file(&strip.image_path);
+    }
+
+    #[test]
+    fn preview_strip_two_calls_write_two_distinct_files() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Strip6).expect("load media");
+
+        let first = sim.preview_strip().expect("first preview_strip");
+        let second = sim.preview_strip().expect("second preview_strip");
+        assert_ne!(
+            first.image_path, second.image_path,
+            "every preview_strip call must write a fresh file so no image cache reuses a stale one"
+        );
+
+        let _ = std::fs::remove_file(&first.image_path);
+        let _ = std::fs::remove_file(&second.image_path);
+    }
+
+    #[test]
+    fn preview_strip_requires_connection() {
+        let sim = SimulatedLs5000::new();
+        let err = sim.preview_strip().unwrap_err();
+        assert_eq!(err.code, ErrorCode::NotConnected);
+    }
+
+    #[test]
+    fn preview_strip_requires_loaded_media() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        let err = sim.preview_strip().unwrap_err();
+        assert_eq!(err.code, ErrorCode::NoMedia);
+    }
+
+    #[test]
+    fn manual_frames_accepts_valid_rows_and_marks_every_slot_user_picked() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let result = sim
+            .manual_frames(vec![0, 135, 270])
+            .expect("structurally valid rows");
+        assert_eq!(result.count, 2);
+        assert!(!result.operation_id.is_empty());
+        assert!(!result.fingerprint.is_empty());
+        assert_eq!(result.thumbnails.len(), 2);
+        assert_eq!(result.thumbnails[0].frame_index, 1);
+        assert_eq!(result.thumbnails[1].frame_index, 2);
+        for entry in &result.thumbnails {
+            assert!(entry.thumbnail.needs_approval);
+            assert_eq!(entry.thumbnail.warnings, vec!["user-picked".to_string()]);
+            // Simulator thumbnails stay simulator-shaped (brightness/tint,
+            // never imagePath) -- the same one-of contract every other
+            // simulated thumbnail already honors.
+            assert!(entry.thumbnail.brightness.is_some());
+            assert!(entry.thumbnail.image_path.is_none());
+        }
+        assert!(
+            result.snaps.is_empty(),
+            "the simulator must never fabricate a snap"
+        );
+    }
+
+    #[test]
+    fn manual_frames_two_calls_return_stable_deterministic_thumbnails() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let first = sim.manual_frames(vec![0, 135, 270]).expect("first call");
+        let second = sim.manual_frames(vec![0, 135, 270]).expect("second call");
+        assert_eq!(
+            first.thumbnails[0].thumbnail.brightness,
+            second.thumbnails[0].thumbnail.brightness,
+            "D-08/SIM-03 determinism: identical rows must hash to identical simulated tiles"
+        );
+        assert_ne!(
+            first.operation_id, second.operation_id,
+            "each placement arms its own fresh approval binding"
+        );
+    }
+
+    #[test]
+    fn manual_frames_rejects_fewer_than_two_rows() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let err = sim.manual_frames(vec![100]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("at least 2"));
+    }
+
+    #[test]
+    fn manual_frames_rejects_non_increasing_rows() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let err = sim.manual_frames(vec![200, 100, 400]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("strictly increasing"));
+    }
+
+    #[test]
+    fn manual_frames_rejects_a_row_outside_the_raster() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Mounted).expect("load media");
+
+        let row_count = sim_strip_row_count(Some(1));
+        let err = sim.manual_frames(vec![0, row_count + 50]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("lie inside the captured preview"));
+    }
+
+    #[test]
+    fn manual_frames_rejects_a_frame_shorter_than_the_15mm_floor() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        // 10 rows =~ 2.7 mm, well under the 15 mm floor.
+        let err = sim.manual_frames(vec![0, 10]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("real frames are at least 15 mm"));
+    }
+
+    /// S7b (adversarial review round 2, 2026-08-08): the ceiling is now the
+    /// scanner's fine-scan capture window (145 rows), tighter than
+    /// `manual_frames.py`'s own still-280-row gate -- proves the sim
+    /// refuses a frame between the two with the hardware-framed message,
+    /// not the old "real frames are at most 75 mm" film-framed one.
+    #[test]
+    fn manual_frames_rejects_a_frame_taller_than_the_scanner_capture_window() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        // 200 rows =~ 53.4 mm: comfortably a real film frame height, but
+        // past the 145-row capture-window ceiling.
+        let err = sim.manual_frames(vec![0, 200]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("the scanner captures about"));
+        assert!(!err.message.contains("real frames are at most"));
+    }
+
+    #[test]
+    fn manual_frames_accepts_exactly_at_the_145_row_capture_window_ceiling() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        sim.manual_frames(vec![0, SIM_MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS])
+            .expect("exactly at the ceiling must still be accepted");
+        let err = sim
+            .manual_frames(vec![0, SIM_MAXIMUM_MANUAL_FRAME_HEIGHT_ROWS + 1])
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn manual_frames_requires_connection() {
+        let sim = SimulatedLs5000::new();
+        let err = sim.manual_frames(vec![0, 200]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NotConnected);
+    }
+
+    #[test]
+    fn manual_frames_requires_loaded_media() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        let err = sim.manual_frames(vec![0, 200]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NoMedia);
+    }
+
+    // -- S7a (adversarial review round 2, 2026-08-08): sim manual-approval --
+    // -- binding, so a simulated manual placement is not a dead end --------
+
+    #[test]
+    fn a_manually_placed_frame_is_approvable_through_sim_roll_approve() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let result = sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
+        sim.roll_approve(1, &result.operation_id)
+            .expect("a frame this placement returned must be approvable");
+        sim.roll_approve(2, &result.operation_id)
+            .expect("every returned frame is individually approvable");
+    }
+
+    #[test]
+    fn sim_roll_approve_still_refuses_every_non_manual_case_unchanged() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        // No manual_frames() call was ever made this session -- the
+        // simulator's pre-existing "no manual-review gate" refusal must be
+        // completely unchanged.
+        let err = sim.roll_approve(1, "some-operation-id").unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.contains("no other manual-review gate"));
+    }
+
+    #[test]
+    fn sim_roll_approve_rejects_a_frame_outside_the_manual_binding() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        let result = sim.manual_frames(vec![0, 135, 270]).expect("2-frame placement");
+        let err = sim.roll_approve(99, &result.operation_id).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn sim_roll_approve_rejects_a_mismatched_operation_id() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+
+        sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
+        let err = sim.roll_approve(1, "not-the-real-operation-id").unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn sim_manual_approval_binding_does_not_survive_a_fresh_load_media() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+        let result = sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
+
+        // A different carrier loaded afterward invalidates the old binding
+        // (S2's own "stale frame-indexed state must never survive a
+        // materially different registration" principle, applied here to
+        // the simulator's session-scoped approval binding).
+        sim.load_media(MediaCarrier::Strip6).expect("reload media");
+        let err = sim.roll_approve(1, &result.operation_id).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn sim_manual_approval_binding_does_not_survive_reconnect() {
+        let sim = SimulatedLs5000::new();
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("connect");
+        sim.load_media(MediaCarrier::Roll36).expect("load media");
+        let result = sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
+
+        sim.disconnect().expect("disconnect");
+        sim.connect(DEVICE_ID, &ConnectOptions::default())
+            .expect("reconnect");
+        sim.load_media(MediaCarrier::Roll36).expect("reload media");
+        let err = sim.roll_approve(1, &result.operation_id).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
     }
 }

--- a/ports/tauri/vendor/engine/tests/end_to_end_real_backend.rs
+++ b/ports/tauri/vendor/engine/tests/end_to_end_real_backend.rs
@@ -349,7 +349,16 @@ fn roll_approve_for_previewed_real_frame_forwards_one_non_motion_bridge_call() {
     let log_path_string = log_path.display().to_string();
     let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
         "e2e-roll-approve",
-        &[("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str())],
+        &[
+            ("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str()),
+            // Adversarial review S3 (2026-08-08): roll_approve now requires
+            // the approved frame to be one the completed preview flagged
+            // `needsApproval: true` -- mark frame 2 (the one this test
+            // approves) so this test keeps exercising its own actual
+            // subject (one clean, unpolled bridge call) rather than
+            // tripping the new gate.
+            ("MOCK_BRIDGE_PREVIEW_APPROVAL_SLOTS", "2"),
+        ],
     );
 
     send(
@@ -945,7 +954,14 @@ fn roll_approve_rejects_an_operation_stale_after_a_newer_preview_without_bridge_
     let log_path_string = log_path.display().to_string();
     let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
         "e2e-roll-approve-stale-preview",
-        &[("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str())],
+        &[
+            ("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str()),
+            // Adversarial review S3 (2026-08-08): flag frame 1 in both
+            // previews so this test's real subject (stale vs. current
+            // operationId) is what decides the outcome, not the new
+            // needsApproval gate.
+            ("MOCK_BRIDGE_PREVIEW_APPROVAL_SLOTS", "1"),
+        ],
     );
 
     for (id, operation_id) in [(3, "first-preview"), (4, "second-preview")] {
@@ -1211,6 +1227,11 @@ fn roll_approve_session_loss_is_not_retried_and_requires_reconnect() {
         &[
             ("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str()),
             ("MOCK_BRIDGE_CRASH_ON", "roll.approve"),
+            // Adversarial review S3 (2026-08-08): flag frame 1 so the
+            // approve request reaches the bridge (and hits the crash
+            // injection this test is actually about) instead of being
+            // refused earlier by the new needsApproval gate.
+            ("MOCK_BRIDGE_PREVIEW_APPROVAL_SLOTS", "1"),
         ],
     );
 
@@ -3942,4 +3963,409 @@ fn scan_progress_ordinal_tracks_completions_not_the_upfront_burst() {
     let status = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
     assert!(status.success(), "engine did not exit 0: {status:?}");
     let _ = reader_handle.join();
+}
+
+// -- roll.manualFrames / roll.previewStrip (Rung 4 of the feeding UX ladder) ----
+
+/// End-to-end proof of the whole point of `RealLs5000::roll_manual_frames`'s
+/// approval-binding logic: `roll.manualFrames` never went through
+/// `roll.preview`'s own async worker (so `finalize_active_preview_terminal`
+/// never ran), yet the frame it returns must still be approvable through
+/// the exact same `roll.approve` path a normal preview's flagged frame
+/// uses -- using the `operationId` THIS response minted, not one the app
+/// supplied. Mirrors the Python bridge's own
+/// `test_roll_manual_frames_dispatch_routes_rows_and_rearms_scan_gate`.
+#[test]
+fn roll_manual_frames_arms_a_session_whose_frame_is_approvable() {
+    let (mut child, mut stdin, rx, reader_handle) =
+        spawn_connected_engine_with_bridge_env("e2e-manual-frames-approve", &[]);
+
+    send(
+        &mut stdin,
+        3,
+        "roll.manualFrames",
+        json!({"rows": [100, 300, 500]}),
+    );
+    let manual = recv_response_for(&rx, 3, |_| {});
+    assert!(
+        manual.get("error").is_none(),
+        "a structurally valid manual placement must be accepted: {manual:#?}"
+    );
+    assert_eq!(manual["result"]["count"], json!(2));
+    assert_eq!(manual["result"]["fingerprint"], json!("mock-manual-fp"));
+    let operation_id = manual["result"]["operationId"]
+        .as_str()
+        .expect("roll.manualFrames must mint an operationId")
+        .to_string();
+    assert!(!operation_id.is_empty());
+
+    let thumbnails = manual["result"]["thumbnails"]
+        .as_array()
+        .expect("thumbnails array");
+    assert_eq!(thumbnails.len(), 2);
+    assert_eq!(thumbnails[0]["frameIndex"], json!(1));
+    assert_eq!(thumbnails[0]["thumbnail"]["boundaryRows"], json!([100, 300]));
+    assert_eq!(thumbnails[0]["thumbnail"]["needsApproval"], json!(true));
+    assert_eq!(
+        thumbnails[0]["thumbnail"]["warnings"],
+        json!(["user-picked"])
+    );
+    assert_eq!(manual["result"]["snaps"], json!([]));
+
+    // The real proof: roll.approve works on this frame using the
+    // engine-minted operationId, even though roll.preview was never called
+    // this session.
+    send(
+        &mut stdin,
+        4,
+        "roll.approve",
+        json!({"frameIndex": 1, "operationId": operation_id}),
+    );
+    let approval = recv_response_for(&rx, 4, |_| {});
+    assert!(
+        approval.get("error").is_none(),
+        "the frame roll.manualFrames returned must be approvable with its own operationId: {approval:#?}"
+    );
+
+    send(&mut stdin, 5, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 5, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}
+
+/// `roll.approve` must still refuse a stale/mismatched operationId after a
+/// manual placement -- the new binding logic must not accidentally become
+/// permissive of any string.
+#[test]
+fn roll_manual_frames_frame_rejects_approval_with_a_foreign_operation_id() {
+    let (mut child, mut stdin, rx, reader_handle) =
+        spawn_connected_engine_with_bridge_env("e2e-manual-frames-wrong-op-id", &[]);
+
+    send(
+        &mut stdin,
+        3,
+        "roll.manualFrames",
+        json!({"rows": [100, 300, 500]}),
+    );
+    let manual = recv_response_for(&rx, 3, |_| {});
+    assert!(manual.get("error").is_none(), "{manual:#?}");
+
+    send(
+        &mut stdin,
+        4,
+        "roll.approve",
+        json!({"frameIndex": 1, "operationId": "not-the-real-operation-id"}),
+    );
+    let approval = recv_response_for(&rx, 4, |_| {});
+    assert!(
+        approval.get("error").is_some(),
+        "a foreign operationId must never be accepted: {approval:#?}"
+    );
+    assert_eq!(approval["error"]["code"], json!("INVALID_PARAMS"));
+
+    send(&mut stdin, 5, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 5, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}
+
+/// 2026-08-08 adversarial review, S1 (part 4): a completed preview binding
+/// must be retired the moment a `roll.manualFrames` request is issued, and
+/// stay retired if that request fails -- never left honorable against a
+/// replacement session that never actually arrived. Without this, an old
+/// approval (still shown by a UI that has not yet learned the replacement
+/// placement failed) could be submitted while the driver's Roll session
+/// itself has already moved on.
+#[test]
+fn roll_manual_frames_retires_the_prior_completed_binding_before_and_on_failure() {
+    let log_directory = unique_output_destination("roll-manual-frames-retires-binding");
+    let log_path = log_directory.join("bridge-calls.log");
+    std::fs::write(&log_path, "").expect("create mock bridge call log");
+    let log_path_string = log_path.display().to_string();
+    let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
+        "e2e-manual-frames-retires-binding",
+        &[
+            ("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str()),
+            (
+                "MOCK_BRIDGE_MANUAL_FRAMES_ERROR",
+                "manual placement rejected for this test",
+            ),
+        ],
+    );
+
+    // Establish a completed binding ("binding-a") via a normal preview --
+    // the exact "placement/preview A completed" half of the S1 scenario.
+    send(
+        &mut stdin,
+        3,
+        "scanner.acquireThumbnails",
+        json!({"frames": [1, 2, 3], "operationId": "binding-a"}),
+    );
+    assert!(recv_response_for(&rx, 3, |_| {}).get("error").is_none());
+    let _ = drain_until(&rx, Duration::from_secs(5), |event| {
+        event["event"] == "scanner.status" && event["payload"]["operationId"] == "binding-a"
+    });
+    std::fs::write(&log_path, "").expect("reset mock bridge call log");
+
+    // A replacement manual placement is attempted and fails (mock bridge
+    // configured to reject every roll.manualFrames call).
+    send(
+        &mut stdin,
+        4,
+        "roll.manualFrames",
+        json!({"rows": [100, 300, 500]}),
+    );
+    let manual = recv_response_for(&rx, 4, |_| {});
+    assert!(
+        manual.get("error").is_some(),
+        "expected the mock bridge's configured manual-frames rejection: {manual:#?}"
+    );
+    assert_eq!(
+        read_mock_bridge_calls(&log_path),
+        vec!["roll.manualFrames"],
+        "the failed placement must still have reached the bridge exactly once"
+    );
+
+    // Binding A must no longer be approvable: it was retired BEFORE the
+    // (failing) roll.manualFrames request was even issued, and the failure
+    // never restored it. This must be refused client-side, before any
+    // bridge call -- the log below must show nothing new.
+    send(
+        &mut stdin,
+        5,
+        "roll.approve",
+        json!({"frameIndex": 1, "operationId": "binding-a"}),
+    );
+    let approval = recv_response_for(&rx, 5, |_| {});
+    let error = approval
+        .get("error")
+        .expect("binding A must stay retired after a failed replacement placement");
+    assert_eq!(error["code"], json!("INVALID_PARAMS"));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("does not match")),
+        "{error:#?}"
+    );
+    assert_eq!(
+        read_mock_bridge_calls(&log_path),
+        vec!["roll.manualFrames"],
+        "a retired binding must be refused before any roll.approve bridge call"
+    );
+
+    send(&mut stdin, 6, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 6, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+    let _ = std::fs::remove_dir_all(log_directory);
+}
+
+/// `roll.previewStrip` returns the wire shape a manual-placement editor
+/// needs to seed itself: a loadable path plus the row<->pixel coordinate
+/// space `roll.manualFrames`'s own `rows` are given in.
+#[test]
+fn roll_preview_strip_returns_the_wire_shape() {
+    let (mut child, mut stdin, rx, reader_handle) =
+        spawn_connected_engine_with_bridge_env("e2e-preview-strip", &[]);
+
+    send(&mut stdin, 3, "roll.previewStrip", json!({}));
+    let strip = recv_response_for(&rx, 3, |_| {});
+    assert!(strip.get("error").is_none(), "{strip:#?}");
+    assert_eq!(strip["result"]["rowCount"], json!(4800));
+    assert_eq!(strip["result"]["pixelsPerRow"], json!(1));
+    let image_path = strip["result"]["imagePath"]
+        .as_str()
+        .expect("imagePath is a string");
+    assert!(!image_path.is_empty());
+
+    send(&mut stdin, 4, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 4, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}
+
+/// The bridge's own plain-English `INVALID_PARAMS` text (manual_frames.py's
+/// gates) must survive into the public engine error unmodified, the same
+/// "never reshape a validation message" contract `roll.setSpacingOffset`
+/// and every other bridge-rejection path already honors.
+#[test]
+fn roll_manual_frames_propagates_invalid_params_message_unmodified() {
+    let sentence = "the 1st frame you placed is about 8 mm tall (between rows 10 and 40), \
+        outside the 15-75 mm range this driver accepts for manual placement";
+    let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
+        "e2e-manual-frames-invalid-params",
+        &[("MOCK_BRIDGE_MANUAL_FRAMES_ERROR", sentence)],
+    );
+
+    send(&mut stdin, 3, "roll.manualFrames", json!({"rows": [10, 40]}));
+    let manual = recv_response_for(&rx, 3, |_| {});
+    let error = manual.get("error").expect("expected a rejected placement");
+    assert_eq!(error["code"], json!("INVALID_PARAMS"));
+    let message = error["message"].as_str().expect("message is a string");
+    assert!(
+        message.contains(sentence),
+        "expected the exact bridge sentence to survive unmodified, got: {message}"
+    );
+
+    send(&mut stdin, 4, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 4, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}
+
+// -- Adversarial review round 2 (2026-08-08): S3, approval/scan constrained --
+// -- to frames actually shown by the completed preview ----------------------
+
+/// S3: matching operationId/session identity alone must not be enough to
+/// approve an arbitrary frame index -- the frame must be one the completed
+/// preview actually returned AND actually flagged `needsApproval: true`.
+/// Frame 2 here is previewed (so it exists) but never flagged, proving both
+/// halves of the gate: existence in the binding is not sufficient on its
+/// own either.
+#[test]
+fn roll_approve_rejects_a_frame_the_completed_preview_never_flagged() {
+    let log_directory = unique_output_destination("roll-approve-unflagged-frame");
+    let log_path = log_directory.join("bridge-calls.log");
+    std::fs::write(&log_path, "").expect("create mock bridge call log");
+    let log_path_string = log_path.display().to_string();
+    // Deliberately no MOCK_BRIDGE_PREVIEW_APPROVAL_SLOTS: every previewed
+    // frame comes back needsApproval: false.
+    let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
+        "e2e-roll-approve-unflagged",
+        &[("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str())],
+    );
+
+    send(
+        &mut stdin,
+        3,
+        "scanner.acquireThumbnails",
+        json!({"frames": [1, 2, 3], "operationId": "unflagged-preview"}),
+    );
+    assert!(recv_response_for(&rx, 3, |_| {}).get("error").is_none());
+    let _ = drain_until(&rx, Duration::from_secs(5), |event| {
+        event["event"] == "scanner.status"
+            && event["payload"]["operationId"] == "unflagged-preview"
+    });
+    std::fs::write(&log_path, "").expect("reset mock bridge call log");
+
+    send(
+        &mut stdin,
+        4,
+        "roll.approve",
+        json!({"frameIndex": 2, "operationId": "unflagged-preview"}),
+    );
+    let approval = recv_response_for(&rx, 4, |_| {});
+    let error = approval.get("error").expect("an unflagged frame must never be approvable");
+    assert_eq!(error["code"], json!("INVALID_PARAMS"));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("flagged for manual review")),
+        "{error:#?}"
+    );
+    assert!(
+        read_mock_bridge_calls(&log_path).is_empty(),
+        "an unflagged approval must be refused before any bridge call"
+    );
+
+    send(&mut stdin, 5, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 5, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}
+
+/// S3: `scan.start` must refuse a requested frame the completed preview
+/// never returned at all -- the mock bridge's preview worker always
+/// returns exactly slots {1, 2, 3} (BRIDGE.md: "the bridge always
+/// physically reads the full roll regardless of `slots`" -- a `frames`
+/// filter on `scanner.acquireThumbnails` narrows which events a caller is
+/// told about, not which slots the completed preview binding contains), so
+/// requesting frame 4 alongside frame 1 must name frame 4 and never reach
+/// the bridge, closing the "hidden slot" gap a caller could otherwise
+/// exploit by asking for a frame the operator was never shown at all.
+#[test]
+fn scan_start_rejects_a_frame_the_completed_preview_never_returned() {
+    let log_directory = unique_output_destination("scan-start-hidden-frame-call-log");
+    let log_path = log_directory.join("bridge-calls.log");
+    std::fs::write(&log_path, "").expect("create mock bridge call log");
+    let log_path_string = log_path.display().to_string();
+    let (mut child, mut stdin, rx, reader_handle) = spawn_connected_engine_with_bridge_env(
+        "e2e-scan-start-hidden-frame",
+        &[("MOCK_BRIDGE_CALL_LOG", log_path_string.as_str())],
+    );
+
+    send(
+        &mut stdin,
+        3,
+        "scanner.acquireThumbnails",
+        json!({"frames": [1], "operationId": "hidden-frame-preview"}),
+    );
+    assert!(recv_response_for(&rx, 3, |_| {}).get("error").is_none());
+    let _ = drain_until(&rx, Duration::from_secs(5), |event| {
+        event["event"] == "scanner.status"
+            && event["payload"]["operationId"] == "hidden-frame-preview"
+    });
+    std::fs::write(&log_path, "").expect("reset mock bridge call log");
+
+    let output_directory = unique_output_destination("scan-start-hidden-frame-output");
+    send(
+        &mut stdin,
+        4,
+        "scan.start",
+        json!({
+            "frames": [1, 4],
+            "recipe": {
+                "resolutionDpi": 4000,
+                "bitDepth": 16,
+                "multisamplePasses": 4,
+                "channels": "rgbi",
+                "autofocusEachFrame": true,
+                "autoExposureEachFrame": true
+            },
+            "output": {
+                "archive": {
+                    "enabled": false,
+                    "fullCapturePackage": false,
+                    "destination": output_directory.join("disabled-archive").display().to_string(),
+                    "filenameTemplate": "frame-####"
+                },
+                "positive": {
+                    "enabled": true,
+                    "destination": output_directory.join("positive").display().to_string(),
+                    "filenameTemplate": "frame-####",
+                    "fileFormat": "tiff",
+                    "colorProfile": "adobeRgb1998"
+                },
+                "preview": {"enabled": false}
+            }
+        }),
+    );
+    let start = recv_response_for(&rx, 4, |_| {});
+    let error = start
+        .get("error")
+        .expect("a frame the completed preview never returned must refuse scan.start");
+    assert_eq!(error["code"], json!("INVALID_PARAMS"));
+    assert!(
+        error["message"].as_str().is_some_and(|m| m.contains("frame 4")),
+        "expected the refusal to name the hidden frame: {error:#?}"
+    );
+    assert!(
+        read_mock_bridge_calls(&log_path)
+            .iter()
+            .all(|method| method != "scan.start"),
+        "a hidden-frame request must be refused before any bridge call"
+    );
+
+    send(&mut stdin, 5, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 5, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+    let _ = std::fs::remove_dir_all(output_directory);
 }

--- a/ports/tauri/vendor/engine/tests/real_backend_mapping.rs
+++ b/ports/tauri/vendor/engine/tests/real_backend_mapping.rs
@@ -501,6 +501,15 @@ fn restart_during_preview_keeps_old_reader_attached_until_it_detaches() {
                 ("MOCK_BRIDGE_PREVIEW_DELAY_MS", "2000"),
                 ("MOCK_BRIDGE_HANG_ON_STATUS_WHILE_PREVIEW_PENDING", "1"),
                 ("MOCK_BRIDGE_CALL_LOG", call_log_path_string.as_str()),
+                // Adversarial review S3 (2026-08-08): roll_approve now
+                // requires the approved frame to be one the completed
+                // preview flagged `needsApproval: true` -- flag frame 1
+                // (the one both the predecessor and replacement preview
+                // approve below) so this test keeps exercising its own
+                // actual subject (stale vs. current vs. premature
+                // approval across a bridge restart) rather than tripping
+                // the new gate.
+                ("MOCK_BRIDGE_PREVIEW_APPROVAL_SLOTS", "1"),
             ],
         )
         .expect("preview-status fault does not affect bridge startup")

--- a/ports/tauri/vendor/protocol/BRIDGE.md
+++ b/ports/tauri/vendor/protocol/BRIDGE.md
@@ -54,6 +54,8 @@ Errors that can occur on any request — `UNKNOWN_METHOD` (unrecognized method n
 | `roll.preview` | `{material: "colorNegative"\|"blackAndWhiteNegative", slots?: [number]}` | `{accepted: true}` | `NOT_CONNECTED`, `HW_MOTION_NOT_ARMED`, `HARDWARE_LANE_BUSY`; via `roll.previewError`: `FEEDER_PARKED`, `REFEED_REQUIRED`, `DEVICE_BUSY`, `ROLL_MISMATCH` |
 | `roll.approve` | `{slot: number}` | `{}` | `NOT_CONNECTED`, `NO_PREVIEW` |
 | `roll.setSpacingOffset` | `{slot: number, offsetRows: number}` | `{thumbnail: Thumbnail}` | `NOT_CONNECTED`, `NO_PREVIEW`, `INVALID_PARAMS` |
+| `roll.manualFrames` | `{rows: [number]}` | `{count: number, fingerprint: string, thumbnails: [Thumbnail], snaps: [BoundarySnap]}` | `NOT_CONNECTED`, `NO_PREVIEW`, `HARDWARE_LANE_BUSY`, `INVALID_PARAMS`, `METER_UNUSABLE` |
+| `roll.previewStrip` | `{}` | `PreviewStrip` | `NOT_CONNECTED`, `NO_PREVIEW`, `HARDWARE_LANE_BUSY`, `METER_UNUSABLE` |
 | `scan.start` | `{slots: [number], recipe: CaptureRecipe, output: OutputSpec}` | `{jobId: string}` | `NOT_CONNECTED`, `NO_PREVIEW`, `HW_MOTION_NOT_ARMED`, `HARDWARE_LANE_BUSY`, `INVALID_PARAMS`, `REFEED_REQUIRED`; via `scan.error`/`scan.frameFailed`: `ROLL_MISMATCH` |
 | `scan.stop` | `{jobId: string}` | `{acknowledged: bool}` | `UNKNOWN_JOB` |
 | `device.eject` | `{}` | `{}` | `NOT_CONNECTED`, `HW_MOTION_NOT_ARMED`, `HARDWARE_LANE_BUSY`, `EJECT_FAILED`, `FEEDER_PARKED` |
@@ -89,6 +91,14 @@ the same offset when that slot is captured. It is non-motion-capable, so it
 does not check the motion latch or move film. Valid offsets are `0...144` for
 slot 1 and `-144...144` for every other slot. Changing an offset invalidates
 that slot's prior manual approval.
+
+### `roll.manualFrames` (additive, 2026-08-07)
+
+Rung 4 of the feeding UX ladder: re-slices the last completed preview attempt's already-decoded whole-roll raster at operator-picked boundary rows, in place of automatic detection. Usable any time a preview attempt exists on disk — including one whose `roll.previewComplete`/`roll.previewError` already fired, successful or refused; this is the intended recovery path for a `REFEED_REQUIRED` whose message names a `probable_cause` the operator can work around by hand. Not motion-capable: no film moves, no transport read happens, nothing is re-fed. `rows` is at least 2 strictly increasing row numbers in `0..PreviewStrip.rowCount-1` (N rows define N-1 frames); each resulting frame's height must fall inside 15–75 mm, deliberately wider than automatic detection's tolerance so half-frame and panoramic film work. A pick within a few rows of a clear-film edge snaps to it by default (reported per-boundary in `snaps`); the underlying same-traversal transport table must still confirm the picks are physically plausible, or the whole placement is refused together — no partial acceptance. Every resulting slot arrives `needsApproval: true` with a `"user-picked"` warning: `roll.approve`, `roll.setSpacingOffset`, and `scan.start` all work on the resulting slots exactly as they do after a normal `roll.preview`, with no wire-shape difference. A validation failure (structure, frame height, or transport-table sanity) is `INVALID_PARAMS` naming the operator's own pick, in plain English — distinct from `REFEED_REQUIRED`, which means "the physical strip," not "try different rows here."
+
+### `roll.previewStrip` (additive, 2026-08-07)
+
+Renders the last completed preview attempt's whole captured raster to one image, for a manual-placement editor to draw draggable boundary lines on before any row has been picked (`roll.manualFrames` itself requires at least 2 rows, so it cannot answer "what does the film look like" on its own). Same precondition, same non-motion-capable contract, and the same underlying attempt-on-disk as `roll.manualFrames` — call this first to seed the editor, then `roll.manualFrames` once the operator has picked rows. Touches no session or approval state; purely a read.
 
 ### `scan.start` (MOTION-CAPABLE)
 
@@ -203,6 +213,17 @@ Strictly-below-90% coverage is not a thumbnail at all: it is a `REFEED_REQUIRED`
 failure. An absent/omitted `partial` means a full frame; old readers ignore the
 additive key.
 
+BoundarySnap
+  boundaryIndex: number
+  requestedRow: number
+  snappedRow: number
+  evidenceRun: [number, number]
+
+PreviewStrip
+  imagePath: string
+  rowCount: number
+  pixelsPerRow: number
+
 ScanProgress
   jobId: string
   slot: number
@@ -297,6 +318,8 @@ ScanReceipt
 `storageTransform` is mandatory, never `null` or empty: it is the versioned identifier for the numpy transform CoolscanPy applied between the scanner-native RGB/IR planes it captured and this receipt's `rgbPath`/`irPath` orientation, mirrored verbatim from CoolscanPy's own `Receipt.storage_transform`. Today every live capture reports exactly one value, `"swapaxes01-scanner-native-to-nikon-render-parity-v2"` (`coolscanpy.types.DIGITAL_ICE_STORAGE_TRANSFORM`). A historical value, `"rot90k1-scanner-native-to-storage-v1"`, may appear in archives whose provenance predates this field, but it is never emitted by a live bridge. A consumer that needs to bring CoolscanPy's main raster (`rgbPath`/`irPath`) into the same coordinate system as `meterRgbiPath` (scanner-native) MUST branch on this value and MUST refuse rather than guess when it sees a value it does not recognize. The two known transforms differ by a vertical flip, so silently picking one is worse than refusing.
 
 `Thumbnail.imagePath` is also bridge-added, not a CoolscanPy path: the bridge transposes that slot's raw scanner-linear HxWx3 uint16 preview crop with `swapaxes(0,1)` (the same scanner-native-to-Nikon-render orientation as a saved capture; no axis is flipped), applies a 0.5th/99.5th percentile stretch, and writes the already-thumbnail-sized result as an 8-bit TIFF. A `roll.preview` uses `~/.scanstudio/previews/{preview-session-uuid}/slot-{NNNN}.tif`; every `roll.setSpacingOffset` response uses another fresh UUID path so image caches cannot keep showing the previous crop. This does not relax "Image payloads"'s no-bytes-on-the-wire rule: only a path crosses the wire, exactly like `rgbPath`/`irPath` already do.
+
+`PreviewStrip.imagePath` (additive, 2026-08-07) is rendered through the identical transform `Thumbnail.imagePath` already uses (`swapaxes(0,1)`, 0.5th/99.5th percentile stretch, 8-bit TIFF) applied once to the whole captured raster instead of one frame's crop — so the raster's row axis (the coordinate space `roll.manualFrames`'s `rows` are given in, `0..rowCount-1`) is the image's WIDTH axis, not its height, exactly like every existing `Thumbnail` crop already is. `pixelsPerRow` is always `1` today (native resolution, never resized); carried explicitly so a future downsampled strip cannot silently break row-to-pixel math on either side of the wire.
 
 `DeviceStatus.filmPresent` is a live, no-motion film-presence read, distinct from `previewEstablished` (which only means "a preview has run this session," never "film is physically loaded right now"). The bundled CoolScanPy asks the exact opened LS-5000 with TEST UNIT READY: `true` means the scanner reports medium gripped, `false` means its verified MEDIUM NOT PRESENT sense was observed, and `null` means no trustworthy verdict was available (for example, an active capture owns the interface, an older dependency lacks the method, or the scanner returned an unrecognised/malformed reply). A verified `false` retires the stale preview registration in the same status snapshot (`previewEstablished: false`, `slotCount: null`) and gates the next scan on a fresh preview. `null` is never interpreted as absence. Presence is not motion readiness: a short strip parked at the transport end-stop can still report `true`.
 

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/domain.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/domain.py
@@ -24,6 +24,8 @@ __all__ = [
     "OutputSpec",
     "SlotOutputSpec",
     "Thumbnail",
+    "BoundarySnap",
+    "PreviewStrip",
     "ScanProgress",
     "ExposureVector",
     "ClippingTelemetry",
@@ -124,6 +126,48 @@ class Thumbnail:
     # but not all of it. Emitted only when true (strictly additive); see
     # service._thumbnail_to_wire for why it is not a plain to_wire field.
     partial: bool | None = None
+
+
+# Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): manual frame placement.
+
+
+@dataclass(frozen=True)
+class BoundarySnap:
+    """One snap-assist adjustment `roll.manualFrames` applied to a picked
+    boundary row -- bridge-wire mirror of CoolscanPy's own
+    `manual_frames.BoundarySnap` (coolscanpy never crosses the wire
+    directly; see `_thumbnail_from_coolscanpy`/`_approval_receipt_from_coolscanpy`
+    for the same translate-not-passthrough pattern elsewhere in this
+    codebase)."""
+
+    boundary_index: int
+    requested_row: int
+    snapped_row: int
+    evidence_run: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class PreviewStrip:
+    """One rendered image of the whole captured preview raster, for the
+    manual-placement editor to draw draggable boundary lines on before any
+    row has been picked (`roll.manualFrames` requires at least 2 rows, so it
+    cannot itself hand back a "nothing picked yet" view). Same
+    normalize-and-write tile path a slot `Thumbnail` uses, applied once to
+    the entire raster instead of one frame's crop.
+
+    `row_count` is the coordinate space `roll.manualFrames`'s `rows` are
+    given in -- every picked row must lie in `0..row_count-1`.
+    `pixels_per_row` is how many image pixels (along the image axis that
+    corresponds to a preview row -- the same axis `Thumbnail.imagePath`'s
+    existing swapaxes orientation already uses) one preview row occupies;
+    always `1` today (the strip is written at native resolution, never
+    resized), carried explicitly so a future downsampled strip does not
+    silently break row<->pixel math on either side of the wire.
+    """
+
+    image_path: str
+    row_count: int
+    pixels_per_row: int = 1
 
 
 @dataclass(frozen=True)

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
@@ -351,7 +351,21 @@ class BridgeService:
             return self._handle_roll_preview(request, emit)
         if method == "roll.approve":
             params = request.get("params") or {}
-            self._transport.approve(int(_require_param(params, "slot")))
+            # Additive (2026-08-08 adversarial review, S1): `fingerprint` is
+            # optional on the wire -- omitted entirely by every pre-existing
+            # caller, unchanged. When present it must be a string; passed
+            # through to the transport, which refuses the approval with
+            # FINGERPRINT_REFUSED if it no longer matches the roll's current
+            # state (see coolscanpy_transport.CoolscanPyTransport.approve).
+            fingerprint = params.get("fingerprint")
+            if fingerprint is not None and not isinstance(fingerprint, str):
+                raise BridgeError(
+                    ErrorCode.INVALID_PARAMS,
+                    "fingerprint must be a string when present",
+                )
+            self._transport.approve(
+                int(_require_param(params, "slot")), fingerprint=fingerprint
+            )
             return {}
         if method == "roll.setSpacingOffset":
             if not self._device_open:

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
@@ -652,7 +652,20 @@ class BridgeService:
                 "a motion operation is still active; retry after it finishes",
             )
         params = request.get("params") or {}
-        rows = [int(row) for row in _require_param(params, "rows")]
+        raw_rows = _require_param(params, "rows")
+        # Strict wire check (adversarial review 2026-08-08, F8a): int() would
+        # silently truncate JSON floats, explode a string into digits, and
+        # turn a non-numeric into an INTERNAL error. The driver's own gates
+        # are strict; the wire deserves the same.
+        if not isinstance(raw_rows, list) or not all(
+            isinstance(row, int) and not isinstance(row, bool) for row in raw_rows
+        ):
+            raise BridgeError(
+                ErrorCode.INVALID_PARAMS,
+                "rows must be a list of whole numbers (the preview row of "
+                "each frame boundary)",
+            )
+        rows = list(raw_rows)
         preview_result, thumbnails, snaps, material = self._transport.manual_frames(
             rows
         )

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
@@ -372,6 +372,17 @@ class BridgeService:
                 int(_require_param(params, "offsetRows")),
             )
             return {"thumbnail": _thumbnail_to_wire(thumbnail)}
+        if method == "roll.manualFrames":
+            return self._handle_roll_manual_frames(request)
+        if method == "roll.previewStrip":
+            if not self._device_open:
+                raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
+            if self._motion_op_active:
+                raise BridgeError(
+                    ErrorCode.HARDWARE_LANE_BUSY,
+                    "a motion operation is still active; retry after it finishes",
+                )
+            return to_wire(self._transport.preview_strip())
         if method == "scan.start":
             return self._handle_scan_start(request, emit)
         if method == "scan.stop":
@@ -623,6 +634,40 @@ class BridgeService:
 
         threading.Thread(target=worker, daemon=True).start()
         return {"accepted": True}
+
+    # -- roll.manualFrames (Rung 4) --------------------------------------------------
+
+    def _handle_roll_manual_frames(self, request: dict) -> dict:
+        # Same NOT_CONNECTED/HARDWARE_LANE_BUSY shape as roll.setSpacingOffset
+        # (both non-motion-capable, synchronous) -- deliberately NOT gated on
+        # self._preview_material being set: manual placement's whole reason
+        # to exist is re-slicing a preview attempt that may have FAILED
+        # (never set self._preview_material at all). The transport itself
+        # raises NO_PREVIEW when no preview attempt exists on disk at all.
+        if not self._device_open:
+            raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
+        if self._motion_op_active:
+            raise BridgeError(
+                ErrorCode.HARDWARE_LANE_BUSY,
+                "a motion operation is still active; retry after it finishes",
+            )
+        params = request.get("params") or {}
+        rows = [int(row) for row in _require_param(params, "rows")]
+        preview_result, thumbnails, snaps, material = self._transport.manual_frames(
+            rows
+        )
+        # manual_frames() arms a usable session exactly like a successful
+        # roll.preview does, but carries no material param of its own (the
+        # session already has one) -- scan.start's own NO_PREVIEW gate
+        # (self._preview_material) is re-armed here, from the transport's
+        # answer, instead of from this request's params.
+        self._preview_material = material
+        return {
+            "count": preview_result.count,
+            "fingerprint": preview_result.fingerprint,
+            "thumbnails": [_thumbnail_to_wire(t) for t in thumbnails],
+            "snaps": [to_wire(s) for s in snaps],
+        }
 
     # -- scan.start / scan.stop --------------------------------------------------------
 

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/__init__.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/__init__.py
@@ -68,7 +68,16 @@ class Transport(Protocol):
         on_thumbnail: Callable[[domain.Thumbnail], None],
     ) -> domain.PreviewResult: ...
 
-    def approve(self, slot: int) -> None: ...
+    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
+        """Approve `slot`. `fingerprint`, when given, is the Roll
+        fingerprint (BRIDGE.md's `roll.approve`) the approval being
+        submitted was minted against -- additive (2026-08-08 adversarial
+        review, S1): `None` is the pre-existing behavior (no comparison); a
+        given value that no longer matches the roll's CURRENT fingerprint
+        must be refused with `FINGERPRINT_REFUSED` before any underlying
+        approval call, never silently approved against whatever session
+        happens to be current now."""
+        ...
 
     def set_spacing_offset(
         self, slot: int, offset_rows: int

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/__init__.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/__init__.py
@@ -74,6 +74,34 @@ class Transport(Protocol):
         self, slot: int, offset_rows: int
     ) -> domain.Thumbnail: ...
 
+    def manual_frames(
+        self, rows: list[int]
+    ) -> tuple[
+        domain.PreviewResult,
+        tuple[domain.Thumbnail, ...],
+        tuple[domain.BoundarySnap, ...],
+        domain.Material,
+    ]:
+        """Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): re-slice the
+        last completed preview attempt's already-decoded raster at
+        operator-picked boundary rows -- no hardware call, no film
+        movement. Usable only when a preview attempt (successful or
+        refused) already exists this session; raises `NO_PREVIEW`
+        otherwise. Leaves roll/session state armed exactly like a
+        successful `preview()` -- the returned `domain.Material` is what
+        the caller must re-arm `scan.start`'s own NO_PREVIEW gate with,
+        since this call carries no `material` param of its own (the
+        session already has one)."""
+        ...
+
+    def preview_strip(self) -> domain.PreviewStrip:
+        """Rung 4: render the last completed preview attempt's whole
+        captured raster to one image, for a manual-placement editor to
+        draw boundary lines on before any row has been picked. Same
+        precondition and NO_PREVIEW failure as `manual_frames`; no hardware
+        call."""
+        ...
+
     def start_scan(
         self,
         slots: list[int],

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -11,6 +11,7 @@ level -- every other module stays hardware-library-free.
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import time
@@ -37,10 +38,49 @@ import tifffile
 from coolscanpy.protocol.ls5000_single_pass.roll_index import (
     IndexDecodeError,
     LeadingFrameClippedError,
+    decode_full_index_bytes,
+    parse_live_transport_records_bytes,
+    validate_live_0x8e_bytes,
+)
+
+# Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): SNAP_REVIEW_REASON is a
+# plain module-level string constant (not underscore-prefixed, not part of
+# manual_frames.__all__ either) -- read, never imported for behavior, the
+# same "reach past the public taxonomy with a documented reason" precedent
+# as IndexDecodeError/LeadingFrameClippedError above.
+from coolscanpy.protocol.ls5000_single_pass.manual_frames import SNAP_REVIEW_REASON
+from coolscanpy.protocol.ls5000_single_pass.capture_process import (
+    AttemptPaths,
+    CaptureAttemptResult,
+    CaptureMode,
+    CaptureOutcome,
+    CaptureRequest,
 )
 from coolscanpy.roll.preview_session import (
     RollSessionError,
     RollSessionIntegrityError,
+    ValidatedRollPreview,
+    build_manual_roll_preview_session,
+    # `_validate_preview_result`/`_derive_geometry`/
+    # `_validated_preview_density_evidence` are underscore-private module
+    # functions, not exported from preview_session.__all__. They are
+    # imported here anyway, deliberately, because they are the exact
+    # validate-and-decode PREFIX `build_roll_preview_session` itself runs
+    # before it ever calls `detect_roll_frames` -- and manual_frames()
+    # below needs precisely that prefix, without the automatic detector
+    # that follows it in build_roll_preview_session (which is exactly what
+    # already refused on a "completed-but-refused" attempt, and would
+    # refuse again the same way if re-run). No public coolscanpy function
+    # returns a bare ValidatedRollPreview independent of detection; rather
+    # than duplicate this validation logic (SHA256 cross-checks, USB
+    # topology, startup-table/preview-binding-contract matching, density
+    # evidence replay) a second time in the bridge, this reuses the
+    # driver's own already-tested implementation. It becomes dead,
+    # harmless code the day coolscanpy exposes this prefix as a public
+    # function of its own.
+    _derive_geometry,
+    _validate_preview_result,
+    _validated_preview_density_evidence,
 )
 
 from scanstudio_bridge import domain, safety
@@ -64,6 +104,21 @@ _MATERIAL_TO_COOLSCANPY: dict[domain.Material, coolscanpy.Material] = {
     domain.Material.COLOR_NEGATIVE: coolscanpy.Material.COLOR_NEGATIVE,
     domain.Material.BLACK_AND_WHITE_NEGATIVE: coolscanpy.Material.BLACK_AND_WHITE_NEGATIVE,
 }
+# Rung 4: manual_frames() has no material param of its own (the roll already
+# has one -- see coolscanpy.Roll.material) but must still hand the bridge
+# service a domain.Material so scan.start's NO_PREVIEW gate re-arms
+# correctly. Exact inverse of the mapping above -- never hand-maintained
+# separately.
+_COOLSCANPY_TO_MATERIAL: dict[coolscanpy.Material, domain.Material] = {
+    value: key for key, value in _MATERIAL_TO_COOLSCANPY.items()
+}
+
+# capture_process._prepare_attempt_paths' own mkdtemp prefix for a
+# CaptureMode.PREVIEW request ("preview-" + a random tempfile suffix, no
+# selected_slot so no "-slotNN" infix) -- mirrored here as a glob, never
+# imported, since it is assembled from CaptureMode.PREVIEW.value privately
+# inside that method rather than exposed as a constant of its own.
+_PREVIEW_ATTEMPT_GLOB = "preview-*/journal.json"
 
 
 def _coolscanpy_git_head_sha(package_dir: Path) -> str | None:
@@ -398,6 +453,161 @@ def _scan_receipt_from_coolscanpy(
     )
 
 
+# -- Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): manual frame placement --
+#
+# manual_frames()/preview_strip() below both need a ValidatedRollPreview from
+# the LAST preview attempt on this Roll -- successful or refused -- purely
+# from what is already on disk under attempts_root, with no hardware call and
+# no dependence on whatever self._roll's own in-memory state currently holds
+# (a refused preview leaves self._roll without a usable session at all). The
+# three helpers below do exactly that, in three separate steps mirroring
+# preview_session.py's own internal shape: locate the attempt directory,
+# reconstruct its CaptureAttemptResult from disk, then validate+decode it
+# into a ValidatedRollPreview without ever calling detect_roll_frames.
+
+
+def _last_preview_attempt_journal_path(attempts_root: Path) -> Path:
+    """The most recently written preview attempt's journal.json under
+    `attempts_root`. Mirrors exposure_authority._find_frame_attempt_
+    directory's own mtime-pick-and-refuse-on-tie pattern, applied to
+    CaptureMode.PREVIEW's own attempt-directory shape (one per roll.preview
+    call on this Roll -- see capture_process._prepare_attempt_paths) instead
+    of a batch frame directory."""
+    candidates = sorted(
+        attempts_root.glob(_PREVIEW_ATTEMPT_GLOB),
+        key=lambda path: path.stat().st_mtime,
+    )
+    if not candidates:
+        raise BridgeError(
+            ErrorCode.NO_PREVIEW,
+            "no preview attempt evidence was found under this roll's "
+            "attempts directory; run roll.preview first",
+        )
+    if (
+        len(candidates) > 1
+        and candidates[-1].stat().st_mtime == candidates[-2].stat().st_mtime
+    ):
+        raise BridgeError(
+            ErrorCode.INTERNAL,
+            f"{len(candidates)} preview attempts under {attempts_root} are "
+            "mtime-indistinguishable; refusing to guess which one is current",
+        )
+    try:
+        # Fully resolved (symlinks included, e.g. macOS /var -> /private/var)
+        # -- preview_session._artifact_path requires every path it validates
+        # to already equal its own .resolve() exactly, the same invariant
+        # _restore_roll_preview_session's own reconstruction depends on. A
+        # bare glob() result inherits attempts_root's own possibly-unresolved
+        # form, so it is resolved once, here, before anything downstream
+        # sees it.
+        return candidates[-1].resolve(strict=True)
+    except OSError as exc:
+        raise BridgeError(
+            ErrorCode.INTERNAL,
+            f"preview attempt journal is unavailable: {exc}",
+        ) from exc
+
+
+def _reconstruct_last_preview_attempt(attempts_root: Path) -> CaptureAttemptResult:
+    """Rebuild a CaptureAttemptResult purely from the persisted journal.json
+    of the most recent roll.preview attempt on this Roll -- no film
+    movement, no live coolscanpy.Roll state touched. Mirrors
+    coolscanpy.roll.preview_session._restore_roll_preview_session's own
+    attempt reconstruction (there, replaying an operator-approved AUTOMATIC
+    session restored from RollPreviewSession.to_json()); this is the
+    identical shape, sourced from disk directly instead of a saved session
+    blob, because a refused preview never produced a session to serialize in
+    the first place -- the journal on disk is the only surviving evidence."""
+    journal_path = _last_preview_attempt_journal_path(attempts_root)
+    try:
+        journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BridgeError(
+            ErrorCode.INTERNAL,
+            f"preview attempt journal could not be read: {exc}",
+        ) from exc
+    if not isinstance(journal, dict):
+        raise BridgeError(
+            ErrorCode.INTERNAL, f"{journal_path}: journal is not a JSON object"
+        )
+    output_value = journal.get("output")
+    if not isinstance(output_value, str):
+        raise BridgeError(
+            ErrorCode.INTERNAL, f"{journal_path}: journal has no output path"
+        )
+    root = journal_path.parent
+    paths = AttemptPaths(
+        directory=root,
+        output=Path(output_value),
+        journal=journal_path,
+        # None of these three are ever read by _validate_preview_result/
+        # _derive_geometry/_validated_preview_density_evidence -- only
+        # .directory/.output/.journal are (see preview_session.py) --
+        # placeholders exactly like _restore_roll_preview_session's own
+        # reconstruction uses.
+        plan=root / "replay-first-rgbi4-plan.jsonl",
+        manifest=root / "replay-first-rgbi4-manifest.json",
+        bootstrap_status=root / "worker-bootstrap.json",
+        stdout=root / "stdout.txt",
+        stderr=root / "stderr.txt",
+    )
+    return CaptureAttemptResult(
+        outcome=CaptureOutcome.COMPLETE,
+        request=CaptureRequest(mode=CaptureMode.PREVIEW),
+        paths=paths,
+        argv=(),
+        returncode=0,
+        stdout="",
+        stderr="",
+        journal=journal,
+    )
+
+
+def _validated_preview_from_attempt(
+    attempt: CaptureAttemptResult,
+) -> ValidatedRollPreview:
+    """Validate and decode one completed preview attempt into its raw
+    whole-roll raster, WITHOUT running frame detection -- the exact prefix
+    build_roll_preview_session itself runs before detect_roll_frames (see
+    this module's import comment above). May raise RollSessionIntegrityError
+    (artifact/journal self-check failure -- a driver-side defect, not an
+    operator condition) or coolscanpy.MeterUnusableError (#17: no usable
+    density meter mean while replaying this preview's evidence) -- both
+    handled the same way preview() itself already handles them."""
+    (
+        journal,
+        preview_artifact,
+        preview_bytes,
+        table_artifact,
+        table_bytes,
+        journal_artifact,
+        _capacity,
+        usb_topology,
+    ) = _validate_preview_result(attempt)
+    geometry = _derive_geometry(journal, len(preview_bytes))
+    _validated_preview_density_evidence(attempt, journal, preview_bytes, geometry)
+    validated_table, usable_rows = validate_live_0x8e_bytes(
+        table_bytes, geometry.height
+    )
+    rgb, _known, decode_report = decode_full_index_bytes(
+        preview_bytes, geometry, usable_rows=usable_rows
+    )
+    records = parse_live_transport_records_bytes(
+        validated_table, maximum_rows=geometry.height
+    )
+    return ValidatedRollPreview(
+        preview_artifact=preview_artifact,
+        table_artifact=table_artifact,
+        journal_artifact=journal_artifact,
+        usb_topology=usb_topology,
+        geometry=geometry,
+        usable_rows=usable_rows,
+        rgb=rgb,
+        transport_records=records,
+        decode_report=decode_report,
+    )
+
+
 class CoolscanPyTransport:
     """Thin real adapter over CoolscanPy's `Device`/`Roll` API. Satisfies
     `transport.Transport` structurally -- no explicit inheritance needed,
@@ -697,6 +907,189 @@ class CoolscanPyTransport:
                 f"and a fresh preview is required ({type(exc).__name__}: {exc})",
             ) from exc
         return _thumbnail_from_coolscanpy(thumbnail, image_path=str(tile_path))
+
+    # -- manual frame placement (Rung 4) -----------------------------------------
+
+    def manual_frames(
+        self, rows: list[int]
+    ) -> tuple[
+        domain.PreviewResult,
+        tuple[domain.Thumbnail, ...],
+        tuple[domain.BoundarySnap, ...],
+        domain.Material,
+    ]:
+        """Re-slice the last completed preview attempt's already-decoded
+        raster at operator-picked boundary rows.
+
+        No hardware call, no film movement -- this is a pure re-slice of
+        bytes already on disk from an earlier roll.preview attempt
+        (successful, or completed-but-refused: the exact case this exists
+        for). Leaves self._roll's session armed exactly like a successful
+        preview() left it, so approve()/set_spacing_offset()/start_scan()
+        all keep working on the resulting manual slots unchanged.
+        """
+        if self._device is None:
+            raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
+        if self._scanning:
+            raise BridgeError(
+                ErrorCode.HARDWARE_LANE_BUSY, "a scan job holds the hardware lane"
+            )
+        if self._roll is None or self.attempts_root is None:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "manual frame placement requires a completed roll.preview "
+                "attempt first",
+            )
+        attempt = _reconstruct_last_preview_attempt(self.attempts_root)
+        try:
+            preview = _validated_preview_from_attempt(attempt)
+        except coolscanpy.MeterUnusableError as exc:
+            # #17, same handling as preview()'s own: fail-closed, no
+            # fabricated exposure, a friendly METER_UNUSABLE card rather
+            # than INTERNAL.
+            raise BridgeError(ErrorCode.METER_UNUSABLE, str(exc)) from exc
+
+        try:
+            session = build_manual_roll_preview_session(
+                preview, rows, material=self._roll.material
+            )
+        except IndexDecodeError as exc:
+            # manual_frames.py's own plain-English gates (structure, frame
+            # height, transport-table sanity) -- about the operator's picks,
+            # not a hardware fault. IndexDecodeError is the SAME exception
+            # class preview()'s own REFEED_REQUIRED mapping catches above,
+            # for the automatic detector's transport-table faults -- it
+            # means something different from this different call site
+            # (different rows, different meaning), so it gets a different
+            # mapping: INVALID_PARAMS, matching set_spacing_offset's own
+            # ValueError->INVALID_PARAMS precedent for "the operator's
+            # request doesn't check out" rather than "refeed the strip".
+            raise BridgeError(ErrorCode.INVALID_PARAMS, str(exc)) from exc
+        except RollSessionIntegrityError:
+            # Artifact/journal integrity faults are driver-side defects, not
+            # operator conditions -- same precedent as preview()'s own
+            # handling; let it reach the wire as INTERNAL.
+            raise
+        except RollSessionError as exc:
+            # build_manual_roll_preview_session's own "produced no
+            # scanner-addressable slots" refusal -- also about the
+            # operator's picks, so the same INVALID_PARAMS mapping as the
+            # IndexDecodeError branch above.
+            raise BridgeError(ErrorCode.INVALID_PARAMS, str(exc)) from exc
+
+        # Arm self._roll's session state exactly like Roll.preview()'s own
+        # success tail does (_roll.py: "self._session = session;
+        # self._session_usb_topology = topology; self._approvals.clear()").
+        # Reaching into these three private fields directly -- never a
+        # public Roll method -- because Roll.restore_preview_session()
+        # explicitly, deliberately refuses a manual session
+        # (preview_session.py's _restore_roll_preview_session: "roll
+        # session was built from manual frame placement; restoring... is
+        # not yet supported. Refuse loudly instead of guessing.") and no
+        # OTHER public Roll API exists for installing an already-built
+        # RollPreviewSession without a fresh hardware read. This is not a
+        # hardware attempt, so it does not acquire the HardwareLane or
+        # require safety.require_armed() the way roll.preview/scan.start/
+        # device.eject do -- self._scanning (checked above) is still
+        # respected as a plain busy-guard against racing an ACTUAL transport
+        # read, but manual_frames() itself never becomes one; a real
+        # preview()/scan_many() call still goes through their own unmodified
+        # code paths, hardware lane, and locking exactly as before. Locked
+        # the same way Roll.preview()/set_spacing_offset()/approve()
+        # themselves protect this exact state, so a concurrent Roll caller
+        # can never observe a half-armed session.
+        with self._roll._state_condition:  # noqa: SLF001
+            self._roll._session = session
+            self._roll._session_usb_topology = preview.usb_topology
+            self._roll._approvals.clear()
+
+        preview_dir = safety.DEFAULT_BASE_DIR / "previews" / uuid.uuid4().hex
+        preview_dir.mkdir(parents=True, exist_ok=True)
+        thumbnails: list[domain.Thumbnail] = []
+        for slot in session.slots:
+            tile_path = preview_dir / f"slot-{slot.slot_id:04d}.tif"
+            tifffile.imwrite(
+                tile_path, _normalize_preview_tile(slot.thumbnail), photometric="rgb"
+            )
+            thumbnails.append(
+                domain.Thumbnail(
+                    slot=slot.slot_id,
+                    boundary_rows=slot.boundary_rows,
+                    spacing_offset=slot.boundary_offset_rows,
+                    needs_approval=slot.manual_review,
+                    warnings=slot.warnings,
+                    image_path=str(tile_path),
+                    partial=slot.partial,
+                )
+            )
+
+        # Per-boundary snap notes (BRIDGE.md's contract): derived from the
+        # session's own boundaries rather than re-running
+        # build_manual_detection a second time for its ManualFrameDetection.
+        # snaps -- SNAP_REVIEW_REASON is present on boundary `i` if and only
+        # if build_manual_detection's own final_rows[i] != rows[i] (see
+        # manual_frames.py: the reason is appended exactly when a boundary's
+        # snapped index is in `snapped_indices`, the same set that decided
+        # final_rows[i] != row); `rows[i]` (the operator's own request,
+        # already in hand here) and `boundary.output_row` (the resolved,
+        # possibly-snapped row) reconstruct the identical BoundarySnap this
+        # module's own manual_frames.py would have returned.
+        snaps: list[domain.BoundarySnap] = []
+        for index, (requested_row, boundary) in enumerate(
+            zip(rows, session.detection.boundaries)
+        ):
+            if SNAP_REVIEW_REASON in boundary.review_reasons:
+                assert boundary.evidence_run is not None
+                snaps.append(
+                    domain.BoundarySnap(
+                        boundary_index=index,
+                        requested_row=requested_row,
+                        snapped_row=boundary.output_row,
+                        evidence_run=boundary.evidence_run,
+                    )
+                )
+
+        material = _COOLSCANPY_TO_MATERIAL[self._roll.material]
+        self._material = material
+        self._preview_established = True
+        result = domain.PreviewResult(
+            count=len(thumbnails), fingerprint=self._roll.fingerprint.sha256
+        )
+        return result, tuple(thumbnails), tuple(snaps), material
+
+    def preview_strip(self) -> domain.PreviewStrip:
+        """Render the last completed preview attempt's whole captured raster
+        to one image, for a manual-placement editor to draw boundary lines
+        on before any row has been picked.
+
+        Same precondition as manual_frames() (a completed preview attempt,
+        successful or refused, already on disk); no hardware call, and no
+        session/approval state is touched -- purely a read.
+        """
+        if self._device is None:
+            raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
+        if self._roll is None or self.attempts_root is None:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "roll.previewStrip requires a completed roll.preview attempt first",
+            )
+        attempt = _reconstruct_last_preview_attempt(self.attempts_root)
+        try:
+            preview = _validated_preview_from_attempt(attempt)
+        except coolscanpy.MeterUnusableError as exc:
+            raise BridgeError(ErrorCode.METER_UNUSABLE, str(exc)) from exc
+
+        strip_dir = safety.DEFAULT_BASE_DIR / "previews" / uuid.uuid4().hex
+        strip_dir.mkdir(parents=True, exist_ok=True)
+        strip_path = strip_dir / "strip.tif"
+        tifffile.imwrite(
+            strip_path, _normalize_preview_tile(preview.rgb), photometric="rgb"
+        )
+        return domain.PreviewStrip(
+            image_path=str(strip_path),
+            row_count=len(preview.rgb),
+            pixels_per_row=1,
+        )
 
     # -- scanning -----------------------------------------------------------------
 

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -12,6 +12,7 @@ level -- every other module stays hardware-library-free.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import time
@@ -456,69 +457,88 @@ def _scan_receipt_from_coolscanpy(
 # -- Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): manual frame placement --
 #
 # manual_frames()/preview_strip() below both need a ValidatedRollPreview from
-# the LAST preview attempt on this Roll -- successful or refused -- purely
+# the CURRENT preview attempt on this Roll -- successful or refused -- purely
 # from what is already on disk under attempts_root, with no hardware call and
 # no dependence on whatever self._roll's own in-memory state currently holds
 # (a refused preview leaves self._roll without a usable session at all). The
-# three helpers below do exactly that, in three separate steps mirroring
-# preview_session.py's own internal shape: locate the attempt directory,
-# reconstruct its CaptureAttemptResult from disk, then validate+decode it
-# into a ValidatedRollPreview without ever calling detect_roll_frames.
+# helpers below do exactly that, in steps mirroring preview_session.py's own
+# internal shape: identify the exact attempt directory, reconstruct its
+# CaptureAttemptResult from disk, then validate+decode it into a
+# ValidatedRollPreview without ever calling detect_roll_frames.
+#
+# 2026-08-08 adversarial review, S5: identifying "the current attempt" used
+# to mean globbing every "preview-*/journal.json" under attempts_root and
+# trusting whichever had the newest st_mtime -- an unrelated process
+# touching an older attempt's journal, or a newer attempt failing before it
+# ever wrote one, could both make that glob silently resolve to stale
+# evidence with no signal anything was wrong. `CoolscanPyTransport.preview()`
+# now records the *identity* of each attempt itself, the moment that attempt
+# is known (see its own comment), instead of asking the filesystem to guess
+# afterward from timestamps. `_sole_new_attempt_journal` below is that
+# recording mechanism's own helper -- a pure before/after set difference,
+# never a modification-time comparison.
 
 
-def _last_preview_attempt_journal_path(attempts_root: Path) -> Path:
-    """The most recently written preview attempt's journal.json under
-    `attempts_root`. Mirrors exposure_authority._find_frame_attempt_
-    directory's own mtime-pick-and-refuse-on-tie pattern, applied to
-    CaptureMode.PREVIEW's own attempt-directory shape (one per roll.preview
-    call on this Roll -- see capture_process._prepare_attempt_paths) instead
-    of a batch frame directory."""
-    candidates = sorted(
-        attempts_root.glob(_PREVIEW_ATTEMPT_GLOB),
-        key=lambda path: path.stat().st_mtime,
-    )
-    if not candidates:
-        raise BridgeError(
-            ErrorCode.NO_PREVIEW,
-            "no preview attempt evidence was found under this roll's "
-            "attempts directory; run roll.preview first",
-        )
-    if (
-        len(candidates) > 1
-        and candidates[-1].stat().st_mtime == candidates[-2].stat().st_mtime
-    ):
-        raise BridgeError(
-            ErrorCode.INTERNAL,
-            f"{len(candidates)} preview attempts under {attempts_root} are "
-            "mtime-indistinguishable; refusing to guess which one is current",
-        )
+def _sole_new_attempt_journal(
+    attempts_root: Path, attempt_journals_before: frozenset[Path]
+) -> Path | None:
+    """The one preview attempt journal that appeared under `attempts_root`
+    since `attempt_journals_before` was captured -- or `None` if the
+    just-finished `Roll.preview()` call left none (a hard failure before any
+    journal was ever written -- e.g. a bootstrap failure or a parked
+    feeder) or, astonishingly, more than one. Pure set membership against a
+    snapshot taken immediately before the call: unlike a modification-time
+    comparison, this cannot be fooled by an unrelated process touching an
+    older attempt's journal, and a newer attempt that never wrote a journal
+    simply never becomes a member of either set."""
+    attempt_journals_after = frozenset(attempts_root.glob(_PREVIEW_ATTEMPT_GLOB))
+    new_journals = attempt_journals_after - attempt_journals_before
+    if len(new_journals) != 1:
+        return None
+    (only,) = new_journals
     try:
         # Fully resolved (symlinks included, e.g. macOS /var -> /private/var)
         # -- preview_session._artifact_path requires every path it validates
         # to already equal its own .resolve() exactly, the same invariant
-        # _restore_roll_preview_session's own reconstruction depends on. A
-        # bare glob() result inherits attempts_root's own possibly-unresolved
-        # form, so it is resolved once, here, before anything downstream
-        # sees it.
-        return candidates[-1].resolve(strict=True)
-    except OSError as exc:
-        raise BridgeError(
-            ErrorCode.INTERNAL,
-            f"preview attempt journal is unavailable: {exc}",
-        ) from exc
+        # _restore_roll_preview_session's own reconstruction depends on.
+        return only.resolve(strict=True)
+    except OSError:
+        return None
 
 
-def _reconstruct_last_preview_attempt(attempts_root: Path) -> CaptureAttemptResult:
-    """Rebuild a CaptureAttemptResult purely from the persisted journal.json
-    of the most recent roll.preview attempt on this Roll -- no film
-    movement, no live coolscanpy.Roll state touched. Mirrors
+def _fsync_path(path: Path) -> None:
+    """fsync one file's own contents, then fsync its containing directory so
+    the directory entry itself is durable too -- the two-step durability a
+    bare write()/close() does not guarantee. 2026-08-08 adversarial review,
+    S1: every manual-placement thumbnail must actually be safely on disk,
+    not merely buffered, before this bridge ever mutates the driver's Roll
+    session state -- see manual_frames()'s own comment."""
+    file_descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(file_descriptor)
+    finally:
+        os.close(file_descriptor)
+    directory_descriptor = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_descriptor)
+    finally:
+        os.close(directory_descriptor)
+
+
+def _reconstruct_preview_attempt(journal_path: Path) -> CaptureAttemptResult:
+    """Rebuild a CaptureAttemptResult purely from one already-identified
+    preview attempt's persisted journal.json -- no film movement, no live
+    coolscanpy.Roll state touched, and no selection logic of its own:
+    `journal_path` must already be the exact attempt
+    `CoolscanPyTransport.preview()` itself recorded (S5 fix, see this
+    module's own comment above) -- picking among candidates is the caller's
+    job, not this function's. Mirrors
     coolscanpy.roll.preview_session._restore_roll_preview_session's own
     attempt reconstruction (there, replaying an operator-approved AUTOMATIC
     session restored from RollPreviewSession.to_json()); this is the
     identical shape, sourced from disk directly instead of a saved session
     blob, because a refused preview never produced a session to serialize in
     the first place -- the journal on disk is the only surviving evidence."""
-    journal_path = _last_preview_attempt_journal_path(attempts_root)
     try:
         journal = json.loads(journal_path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -628,6 +648,16 @@ class CoolscanPyTransport:
         # own copy is a private attribute) -- this is simply the value we
         # ourselves chose and passed in.
         self.attempts_root: Path | None = None
+        # 2026-08-08 adversarial review, S5: the resolved journal.json path
+        # of the CURRENT preview attempt -- the one this transport's own
+        # preview() call most recently confirmed produced evidence on disk,
+        # successful or completed-but-refused. `None` means either no
+        # preview() has run yet, or the most recent one left no usable
+        # evidence at all (a hard failure before any journal was written).
+        # manual_frames()/preview_strip() read only this recorded identity,
+        # never a fresh glob of attempts_root -- see preview()'s own
+        # comment for why a filesystem scan is no longer trusted here.
+        self._recorded_preview_attempt_journal: Path | None = None
 
     # -- device lifecycle -----------------------------------------------------
 
@@ -702,6 +732,7 @@ class CoolscanPyTransport:
         self._device_id = None
         self._material = None
         self._preview_established = False
+        self._recorded_preview_attempt_journal = None
 
     # -- preview / approve ------------------------------------------------------
 
@@ -728,6 +759,12 @@ class CoolscanPyTransport:
         # the moment a new attempt starts, the old session is gone whether
         # or not this attempt completes.
         self._preview_established = False
+        # S5 fix (see this module's comment above _sole_new_attempt_journal):
+        # invalidate whatever attempt was previously recorded as current the
+        # MOMENT a new attempt starts, before we know whether it will
+        # succeed -- never left pointing at stale evidence if this attempt
+        # fails to produce any of its own.
+        self._recorded_preview_attempt_journal = None
         if self._roll is not None and self._material != material:
             self._roll.close()
             self._roll = None
@@ -757,66 +794,84 @@ class CoolscanPyTransport:
                 material=translated, attempts_root=self.attempts_root
             )
 
+        # S5 fix: a snapshot taken immediately before the call, so the
+        # `finally` below can identify exactly which attempt (if any) THIS
+        # call itself produced -- by set membership, never by trusting
+        # whichever candidate happens to carry the newest mtime.
+        attempt_journals_before = frozenset(
+            self.attempts_root.glob(_PREVIEW_ATTEMPT_GLOB)
+        )
         try:
-            # A SINGLE blocking CoolscanPy call that returns the complete
-            # list once the whole-roll transport read finishes -- there is
-            # no per-thumbnail streaming under the hood. `on_thumbnail` is
-            # invoked once per item below, simulating the bridge's own
-            # one-event-per-slot wire behavior on top of this atomic call.
-            thumbnails = self._roll.preview(slots=slots)
-        except coolscanpy.CaptureWorkerBootstrapFailed as exc:
-            raise BridgeError(ErrorCode.INTERNAL, str(exc)) from exc
-        except coolscanpy.FeederParked as exc:
-            raise BridgeError(ErrorCode.FEEDER_PARKED, str(exc)) from exc
-        except coolscanpy.RefeedRequired as exc:
-            raise BridgeError(ErrorCode.REFEED_REQUIRED, str(exc)) from exc
-        except coolscanpy.DeviceBusy as exc:
-            raise BridgeError(ErrorCode.DEVICE_BUSY, str(exc)) from exc
-        except LeadingFrameClippedError as exc:
-            # This is a proven physical-registration condition, unlike the
-            # broader IndexDecodeError bucket below. Preserve its precise
-            # deeper-refeed guidance in both the UI and diagnostics.
-            raise BridgeError(ErrorCode.REFEED_REQUIRED, str(exc)) from exc
-        except IndexDecodeError as exc:
-            # Hedged wording (2026-07-25 adversarial-review finding): the
-            # IndexDecodeError class also covers malformed envelopes and
-            # geometry defects, which are capture/driver faults a refeed
-            # cannot fix -- refeed-and-retry stays the first move, but the
-            # message must not sell a software fault as a film problem.
-            raise BridgeError(
-                ErrorCode.REFEED_REQUIRED,
-                "transport read was not one uniform traversal; eject or refeed "
-                "the strip and run the preview again -- if this recurs on "
-                f"clean feeds it may be a capture or driver defect ({exc})",
-            ) from exc
-        except RollSessionIntegrityError:
-            # Artifact/journal integrity faults are driver-side defects, not
-            # operator conditions -- let service.py's boundary report them as
-            # INTERNAL with the exception class preserved in the message.
-            raise
-        except RollSessionError as exc:
-            raise BridgeError(
-                ErrorCode.REFEED_REQUIRED,
-                "preview could not establish a usable roll session; refeed the "
-                "strip and retry -- if this recurs on clean feeds it may be a "
-                f"capture or driver defect ({exc})",
-            ) from exc
-        except coolscanpy.MeterUnusableError as exc:
-            # #17: no usable meter mean for a channel while replaying this
-            # preview's density evidence (density metering runs as part of
-            # Roll.preview, not just scan_many -- see preview_session.py's
-            # _validated_preview_density_evidence). Fail-closed -- no
-            # fabricated exposure -- surfaced as a friendly METER_UNUSABLE
-            # card, never INTERNAL. Guidance text is in the exception.
-            # Mirrors the start_scan handler below.
-            raise BridgeError(ErrorCode.METER_UNUSABLE, str(exc)) from exc
-        except coolscanpy.RollMismatch as exc:
-            # Base-class fallback AFTER every mapped subclass (RefeedRequired
-            # above; FingerprintRefused/ManualReviewRequired are scan-time
-            # concepts that preview() does not raise). CoolscanPy raises the
-            # bare base for e.g. a completed preview whose evidence belongs
-            # to a different USB topology -- typed, never INTERNAL.
-            raise BridgeError(ErrorCode.ROLL_MISMATCH, str(exc)) from exc
+            try:
+                # A SINGLE blocking CoolscanPy call that returns the complete
+                # list once the whole-roll transport read finishes -- there is
+                # no per-thumbnail streaming under the hood. `on_thumbnail` is
+                # invoked once per item below, simulating the bridge's own
+                # one-event-per-slot wire behavior on top of this atomic call.
+                thumbnails = self._roll.preview(slots=slots)
+            except coolscanpy.CaptureWorkerBootstrapFailed as exc:
+                raise BridgeError(ErrorCode.INTERNAL, str(exc)) from exc
+            except coolscanpy.FeederParked as exc:
+                raise BridgeError(ErrorCode.FEEDER_PARKED, str(exc)) from exc
+            except coolscanpy.RefeedRequired as exc:
+                raise BridgeError(ErrorCode.REFEED_REQUIRED, str(exc)) from exc
+            except coolscanpy.DeviceBusy as exc:
+                raise BridgeError(ErrorCode.DEVICE_BUSY, str(exc)) from exc
+            except LeadingFrameClippedError as exc:
+                # This is a proven physical-registration condition, unlike the
+                # broader IndexDecodeError bucket below. Preserve its precise
+                # deeper-refeed guidance in both the UI and diagnostics.
+                raise BridgeError(ErrorCode.REFEED_REQUIRED, str(exc)) from exc
+            except IndexDecodeError as exc:
+                # Hedged wording (2026-07-25 adversarial-review finding): the
+                # IndexDecodeError class also covers malformed envelopes and
+                # geometry defects, which are capture/driver faults a refeed
+                # cannot fix -- refeed-and-retry stays the first move, but the
+                # message must not sell a software fault as a film problem.
+                raise BridgeError(
+                    ErrorCode.REFEED_REQUIRED,
+                    "transport read was not one uniform traversal; eject or refeed "
+                    "the strip and run the preview again -- if this recurs on "
+                    f"clean feeds it may be a capture or driver defect ({exc})",
+                ) from exc
+            except RollSessionIntegrityError:
+                # Artifact/journal integrity faults are driver-side defects, not
+                # operator conditions -- let service.py's boundary report them as
+                # INTERNAL with the exception class preserved in the message.
+                raise
+            except RollSessionError as exc:
+                raise BridgeError(
+                    ErrorCode.REFEED_REQUIRED,
+                    "preview could not establish a usable roll session; refeed the "
+                    "strip and retry -- if this recurs on clean feeds it may be a "
+                    f"capture or driver defect ({exc})",
+                ) from exc
+            except coolscanpy.MeterUnusableError as exc:
+                # #17: no usable meter mean for a channel while replaying this
+                # preview's density evidence (density metering runs as part of
+                # Roll.preview, not just scan_many -- see preview_session.py's
+                # _validated_preview_density_evidence). Fail-closed -- no
+                # fabricated exposure -- surfaced as a friendly METER_UNUSABLE
+                # card, never INTERNAL. Guidance text is in the exception.
+                # Mirrors the start_scan handler below.
+                raise BridgeError(ErrorCode.METER_UNUSABLE, str(exc)) from exc
+            except coolscanpy.RollMismatch as exc:
+                # Base-class fallback AFTER every mapped subclass (RefeedRequired
+                # above; FingerprintRefused/ManualReviewRequired are scan-time
+                # concepts that preview() does not raise). CoolscanPy raises the
+                # bare base for e.g. a completed preview whose evidence belongs
+                # to a different USB topology -- typed, never INTERNAL.
+                raise BridgeError(ErrorCode.ROLL_MISMATCH, str(exc)) from exc
+        finally:
+            # S5 fix: record the current attempt's identity regardless of
+            # how the block above exited -- a clean return, a typed
+            # BridgeError (a "completed but refused" attempt still writes a
+            # valid journal), or a bare re-raised RollSessionIntegrityError.
+            # Left `None` (its state from the top of this method) if this
+            # call wrote no new journal at all.
+            self._recorded_preview_attempt_journal = _sole_new_attempt_journal(
+                self.attempts_root, attempt_journals_before
+            )
 
         # Fresh UUID directory per roll.preview call, mirroring the
         # existing hw-telemetry/{session_id}.jsonl convention (see
@@ -834,12 +889,34 @@ class CoolscanPyTransport:
         self._preview_established = True
         return domain.PreviewResult(count=len(thumbnails), fingerprint=self._roll.fingerprint.sha256)
 
-    def approve(self, slot: int) -> None:
+    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
         if self._device is None:
             raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
         if not self._preview_established:
             raise BridgeError(
                 ErrorCode.NO_PREVIEW, "roll.approve requires a completed roll.preview first"
+            )
+        # Additive (2026-08-08 adversarial review, S1). `fingerprint`, when
+        # supplied, is the Roll fingerprint the approval being submitted was
+        # minted against -- today only RealLs5000::roll_approve (the engine)
+        # supplies it, and only when its own completed-preview binding
+        # carries one (currently: manual placement's own binding; see
+        # manual_frames() below). `None` is the existing, unchanged
+        # behavior: no comparison, exactly as before this parameter
+        # existed. A caller-supplied value that does not match this Roll's
+        # CURRENT fingerprint means the session moved on since that
+        # approval was computed -- e.g. a replacement manual placement
+        # installed a different session in between -- so it is refused
+        # here, before ever reaching coolscanpy's own Roll.approve(), which
+        # has no way to know the approval's own origin and would otherwise
+        # approve whatever slot number happens to exist in its CURRENT
+        # session.
+        if fingerprint is not None and self._roll.fingerprint.sha256 != fingerprint:
+            raise BridgeError(
+                ErrorCode.FINGERPRINT_REFUSED,
+                "this approval was computed against an earlier preview session "
+                "that no longer matches the roll's current state; acquire a "
+                "fresh preview or placement and approve again",
             )
         try:
             self._roll.approve(slot)
@@ -918,8 +995,8 @@ class CoolscanPyTransport:
         tuple[domain.BoundarySnap, ...],
         domain.Material,
     ]:
-        """Re-slice the last completed preview attempt's already-decoded
-        raster at operator-picked boundary rows.
+        """Re-slice the CURRENT preview attempt's already-decoded raster at
+        operator-picked boundary rows.
 
         No hardware call, no film movement -- this is a pure re-slice of
         bytes already on disk from an earlier roll.preview attempt
@@ -940,7 +1017,18 @@ class CoolscanPyTransport:
                 "manual frame placement requires a completed roll.preview "
                 "attempt first",
             )
-        attempt = _reconstruct_last_preview_attempt(self.attempts_root)
+        # 2026-08-08 adversarial review, S5: only the exact attempt this
+        # transport itself recorded as current is ever used -- never a
+        # fresh filesystem scan, and never a silent fallback to an older
+        # attempt when the current one left no usable evidence.
+        if self._recorded_preview_attempt_journal is None:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "the most recent preview attempt on this roll left no usable "
+                "evidence to place frames from; acquire a fresh preview and "
+                "try again",
+            )
+        attempt = _reconstruct_preview_attempt(self._recorded_preview_attempt_journal)
         try:
             preview = _validated_preview_from_attempt(attempt)
         except coolscanpy.MeterUnusableError as exc:
@@ -977,51 +1065,48 @@ class CoolscanPyTransport:
             # IndexDecodeError branch above.
             raise BridgeError(ErrorCode.INVALID_PARAMS, str(exc)) from exc
 
-        # Arm self._roll's session state exactly like Roll.preview()'s own
-        # success tail does (_roll.py: "self._session = session;
-        # self._session_usb_topology = topology; self._approvals.clear()").
-        # Reaching into these three private fields directly -- never a
-        # public Roll method -- because Roll.restore_preview_session()
-        # explicitly, deliberately refuses a manual session
-        # (preview_session.py's _restore_roll_preview_session: "roll
-        # session was built from manual frame placement; restoring... is
-        # not yet supported. Refuse loudly instead of guessing.") and no
-        # OTHER public Roll API exists for installing an already-built
-        # RollPreviewSession without a fresh hardware read. This is not a
-        # hardware attempt, so it does not acquire the HardwareLane or
-        # require safety.require_armed() the way roll.preview/scan.start/
-        # device.eject do -- self._scanning (checked above) is still
-        # respected as a plain busy-guard against racing an ACTUAL transport
-        # read, but manual_frames() itself never becomes one; a real
-        # preview()/scan_many() call still goes through their own unmodified
-        # code paths, hardware lane, and locking exactly as before. Locked
-        # the same way Roll.preview()/set_spacing_offset()/approve()
-        # themselves protect this exact state, so a concurrent Roll caller
-        # can never observe a half-armed session.
-        with self._roll._state_condition:  # noqa: SLF001
-            self._roll._session = session
-            self._roll._session_usb_topology = preview.usb_topology
-            self._roll._approvals.clear()
-
+        # 2026-08-08 adversarial review, S1 (part 1): render and fsync every
+        # thumbnail this replacement session produces BEFORE touching
+        # self._roll's state at all. Previously the Roll-state swap below
+        # ran FIRST -- if the thumbnail-write loop then failed partway
+        # through, the OLD session/approvals were already gone (replaced
+        # and cleared) while the operator-visible thumbnails for the NEW
+        # one were incomplete or absent, and self._preview_established was
+        # not touched by that failure either -- a stale approve() against
+        # the operation the UI still showed would then silently reach the
+        # NEW session. Ordering this first means a write failure here
+        # raises before any Roll state -- or self._preview_established --
+        # has changed at all: approve()/set_spacing_offset() keep working
+        # exactly as they did before this call, against whatever session
+        # was already installed.
         preview_dir = safety.DEFAULT_BASE_DIR / "previews" / uuid.uuid4().hex
-        preview_dir.mkdir(parents=True, exist_ok=True)
         thumbnails: list[domain.Thumbnail] = []
-        for slot in session.slots:
-            tile_path = preview_dir / f"slot-{slot.slot_id:04d}.tif"
-            tifffile.imwrite(
-                tile_path, _normalize_preview_tile(slot.thumbnail), photometric="rgb"
-            )
-            thumbnails.append(
-                domain.Thumbnail(
-                    slot=slot.slot_id,
-                    boundary_rows=slot.boundary_rows,
-                    spacing_offset=slot.boundary_offset_rows,
-                    needs_approval=slot.manual_review,
-                    warnings=slot.warnings,
-                    image_path=str(tile_path),
-                    partial=slot.partial,
+        try:
+            preview_dir.mkdir(parents=True, exist_ok=True)
+            for slot in session.slots:
+                tile_path = preview_dir / f"slot-{slot.slot_id:04d}.tif"
+                tifffile.imwrite(
+                    tile_path, _normalize_preview_tile(slot.thumbnail), photometric="rgb"
                 )
-            )
+                _fsync_path(tile_path)
+                thumbnails.append(
+                    domain.Thumbnail(
+                        slot=slot.slot_id,
+                        boundary_rows=slot.boundary_rows,
+                        spacing_offset=slot.boundary_offset_rows,
+                        needs_approval=slot.manual_review,
+                        warnings=slot.warnings,
+                        image_path=str(tile_path),
+                        partial=slot.partial,
+                    )
+                )
+        except Exception as exc:
+            raise BridgeError(
+                ErrorCode.INTERNAL,
+                "manual frame placement could not persist its preview "
+                "thumbnails to disk; the previous preview session was left "
+                f"unchanged -- try again ({type(exc).__name__}: {exc})",
+            ) from exc
 
         # Per-boundary snap notes (BRIDGE.md's contract): derived from the
         # session's own boundaries rather than re-running
@@ -1033,7 +1118,10 @@ class CoolscanPyTransport:
         # final_rows[i] != row); `rows[i]` (the operator's own request,
         # already in hand here) and `boundary.output_row` (the resolved,
         # possibly-snapped row) reconstruct the identical BoundarySnap this
-        # module's own manual_frames.py would have returned.
+        # module's own manual_frames.py would have returned. Pure
+        # computation over `session`/`rows`, no I/O, so its position
+        # relative to the thumbnail writes above and the Roll-state install
+        # below has no observable effect either way.
         snaps: list[domain.BoundarySnap] = []
         for index, (requested_row, boundary) in enumerate(
             zip(rows, session.detection.boundaries)
@@ -1049,6 +1137,29 @@ class CoolscanPyTransport:
                     )
                 )
 
+        # S1 (part 3): fail closed the instant a mutation is attempted --
+        # re-armed only after install_manual_session below returns
+        # successfully. If it raises, this stays False rather than keeping
+        # whatever it was before, so a stale approve() against the OLD
+        # operation cannot slip through NO_PREVIEW's own guard while the
+        # Roll's state is ambiguous (busy/mismatch mid-install, never a
+        # partial write -- install_manual_session is itself transactional).
+        self._preview_established = False
+        # S1 (part 2): the transactional install itself -- locked-state and
+        # USB-topology checks, approvals clearing, and the atomic session
+        # swap all live in coolscanpy now (Roll.install_manual_session).
+        # This bridge no longer reaches into _session/_approvals/
+        # _state_condition directly; DeviceBusy/RollMismatch are this
+        # method's own typed mappings for that method's two failure modes,
+        # matching this file's existing DeviceBusy/RollMismatch precedents
+        # elsewhere (preview(), start_scan()).
+        try:
+            self._roll.install_manual_session(session)
+        except coolscanpy.DeviceBusy as exc:
+            raise BridgeError(ErrorCode.DEVICE_BUSY, str(exc)) from exc
+        except coolscanpy.RollMismatch as exc:
+            raise BridgeError(ErrorCode.ROLL_MISMATCH, str(exc)) from exc
+
         material = _COOLSCANPY_TO_MATERIAL[self._roll.material]
         self._material = material
         self._preview_established = True
@@ -1058,13 +1169,14 @@ class CoolscanPyTransport:
         return result, tuple(thumbnails), tuple(snaps), material
 
     def preview_strip(self) -> domain.PreviewStrip:
-        """Render the last completed preview attempt's whole captured raster
-        to one image, for a manual-placement editor to draw boundary lines
-        on before any row has been picked.
+        """Render the CURRENT preview attempt's whole captured raster to one
+        image, for a manual-placement editor to draw boundary lines on
+        before any row has been picked.
 
         Same precondition as manual_frames() (a completed preview attempt,
-        successful or refused, already on disk); no hardware call, and no
-        session/approval state is touched -- purely a read.
+        successful or refused, already on disk, and recorded as the current
+        one -- see manual_frames()'s own S5 comment); no hardware call, and
+        no session/approval state is touched -- purely a read.
         """
         if self._device is None:
             raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
@@ -1073,7 +1185,14 @@ class CoolscanPyTransport:
                 ErrorCode.NO_PREVIEW,
                 "roll.previewStrip requires a completed roll.preview attempt first",
             )
-        attempt = _reconstruct_last_preview_attempt(self.attempts_root)
+        if self._recorded_preview_attempt_journal is None:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "the most recent preview attempt on this roll left no usable "
+                "evidence to render a strip from; acquire a fresh preview and "
+                "try again",
+            )
+        attempt = _reconstruct_preview_attempt(self._recorded_preview_attempt_journal)
         try:
             preview = _validated_preview_from_attempt(attempt)
         except coolscanpy.MeterUnusableError as exc:

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/mock.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/mock.py
@@ -446,9 +446,16 @@ class MockTransport:
                 ErrorCode.NO_PREVIEW,
                 "roll.previewStrip requires a completed roll.preview attempt first",
             )
-        row_count = self._slot_count * 1200
+        # The wire contract promises the image's width axis carries exactly
+        # row_count columns at pixels_per_row=1 (the real transport writes
+        # the raster unresized). The mock keeps the file small by capping
+        # the synthetic strip, so its REPORTED row_count is the written
+        # width -- an honest miniature, never a contradiction the editor's
+        # row-to-pixel mapping would silently mis-scale on (2026-08-08
+        # second-opinion review, finding 2).
+        row_count = min(self._slot_count * 1200, 4_096)
         tile_path = self._preview_dir / f"strip-{uuid.uuid4().hex}.tif"
-        strip = np.zeros((_SYNTHETIC_PREVIEW_WIDTH, min(row_count, 4096), 3), dtype=np.uint8)
+        strip = np.zeros((_SYNTHETIC_PREVIEW_WIDTH, row_count, 3), dtype=np.uint8)
         tifffile.imwrite(tile_path, strip, photometric="rgb")
         return domain.PreviewStrip(
             image_path=str(tile_path), row_count=row_count, pixels_per_row=1

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/mock.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/mock.py
@@ -184,6 +184,12 @@ class MockTransport:
         self._spacing_offsets: dict[int, int] = {}
         self._scanning = False
         self._stop_event = threading.Event()
+        # 2026-08-08 adversarial review, S1: the fingerprint the last
+        # successful preview()/manual_frames() call returned -- mirrors the
+        # real transport's `self._roll.fingerprint.sha256`, kept here since
+        # this double has no real Roll object of its own. See approve()'s
+        # own docstring for how this is used.
+        self._fingerprint: str | None = None
 
     # -- device lifecycle -----------------------------------------------------
 
@@ -202,6 +208,7 @@ class MockTransport:
         self._approved_slots.clear()
         self._needs_approval_slots.clear()
         self._spacing_offsets.clear()
+        self._fingerprint = None
         return self._device_info()
 
     def status(self) -> domain.DeviceStatus:
@@ -231,6 +238,7 @@ class MockTransport:
         self._approved_slots.clear()
         self._needs_approval_slots.clear()
         self._spacing_offsets.clear()
+        self._fingerprint = None
 
     # -- preview / approve ------------------------------------------------------
 
@@ -273,10 +281,22 @@ class MockTransport:
         self._preview_established = True
         self._last_preview_material = material
         fingerprint = hashlib.sha256(f"{material}:{self._slot_count}".encode()).hexdigest()
+        self._fingerprint = fingerprint
         return domain.PreviewResult(count=self._slot_count, fingerprint=fingerprint)
 
-    def approve(self, slot: int) -> None:
+    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
         self._require_connected()
+        # Additive (2026-08-08 adversarial review, S1) -- see
+        # transport.Transport.approve's own docstring. `None` (the default,
+        # and every pre-existing caller) skips the comparison entirely,
+        # unchanged from before this parameter existed.
+        if fingerprint is not None and self._fingerprint != fingerprint:
+            raise BridgeError(
+                ErrorCode.FINGERPRINT_REFUSED,
+                "this approval was computed against an earlier preview session "
+                "that no longer matches the roll's current state; acquire a "
+                "fresh preview or placement and approve again",
+            )
         if slot < 1 or slot > self._slot_count or slot not in self._needs_approval_slots:
             raise BridgeError(ErrorCode.INVALID_PARAMS, f"slot {slot} does not need approval")
         self._approved_slots.add(slot)
@@ -410,6 +430,7 @@ class MockTransport:
         fingerprint = hashlib.sha256(
             f"manual:{tuple(rows)}".encode()
         ).hexdigest()
+        self._fingerprint = fingerprint
         self._preview_established = True
         return (
             domain.PreviewResult(count=self._slot_count, fingerprint=fingerprint),

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/mock.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/mock.py
@@ -60,6 +60,32 @@ def _synthetic_preview_tile(slot: int, offset_rows: int = 0) -> np.ndarray:
     return np.roll(tile, -offset_rows, axis=1)
 
 
+def _validate_manual_rows(rows: object) -> None:
+    """Mock-only structural check -- a deliberately loose shadow of
+    coolscanpy's real `manual_frames.build_manual_detection` gates (structure,
+    physical frame-height range, transport-table sanity). This mock has no
+    raster or transport table to check against, so it only enforces what it
+    can: at least 2 plain-integer rows, strictly increasing. See
+    coolscanpy_transport.py's `manual_frames` for the real physical gates."""
+    if not isinstance(rows, list) or len(rows) < 2:
+        raise BridgeError(
+            ErrorCode.INVALID_PARAMS,
+            "manual frame placement needs at least 2 boundary rows (1 frame); "
+            f"only {len(rows) if isinstance(rows, list) else 0} were given",
+        )
+    if any(type(row) is not int or isinstance(row, bool) for row in rows):
+        raise BridgeError(
+            ErrorCode.INVALID_PARAMS,
+            "manual frame boundary rows must be plain integers",
+        )
+    if any(a >= b for a, b in zip(rows, rows[1:])):
+        raise BridgeError(
+            ErrorCode.INVALID_PARAMS,
+            "frame boundary rows must be placed in strictly increasing order, "
+            "top to bottom of the preview",
+        )
+
+
 def _synthetic_receipt(
     *,
     slot: int,
@@ -313,6 +339,98 @@ class MockTransport:
             needs_approval=is_last,
             warnings=("ambiguous-content-tail-boundary",) if is_last else (),
             image_path=str(tile_path),
+        )
+
+    # -- manual frame placement (Rung 4) -----------------------------------------
+
+    def manual_frames(
+        self, rows: list[int]
+    ) -> tuple[
+        domain.PreviewResult,
+        tuple[domain.Thumbnail, ...],
+        tuple[domain.BoundarySnap, ...],
+        domain.Material,
+    ]:
+        self._require_connected()
+        if self._scanning:
+            raise BridgeError(
+                ErrorCode.HARDWARE_LANE_BUSY,
+                "a scan job holds the hardware lane",
+            )
+        if not self._preview_established:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "manual frame placement requires a completed roll.preview attempt first",
+            )
+        _validate_manual_rows(rows)
+
+        # A manual placement replaces the whole roll's addressable slot
+        # lattice -- mirrors preview()'s own clear-and-rebuild of approval/
+        # offset bookkeeping (real CoolscanPy: a fresh RollPreviewSession
+        # with its own fixed, 1-based, contiguous slots).
+        self._slot_count = len(rows) - 1
+        self._approved_slots.clear()
+        self._needs_approval_slots.clear()
+        self._spacing_offsets.clear()
+
+        thumbnails: list[domain.Thumbnail] = []
+        snaps: list[domain.BoundarySnap] = []
+        for i in range(self._slot_count):
+            slot = i + 1
+            self._needs_approval_slots.add(slot)
+            tile_path = self._preview_dir / f"slot-{slot:04d}-manual.tif"
+            tifffile.imwrite(
+                tile_path, _synthetic_preview_tile(slot), photometric="rgb"
+            )
+            thumbnails.append(
+                domain.Thumbnail(
+                    slot=slot,
+                    boundary_rows=(rows[i], rows[i + 1]),
+                    spacing_offset=0,
+                    needs_approval=True,
+                    warnings=("user-picked",),
+                    image_path=str(tile_path),
+                )
+            )
+        # Deterministic, mock-only "snap": a picked row exactly divisible by
+        # 100 is reported as having snapped 1 row -- exercises the wire
+        # shape without needing real clear-film evidence. Real snap
+        # detection lives entirely in coolscanpy_transport.py.
+        for index, row in enumerate(rows):
+            if row % 100 == 0 and row > 0:
+                snaps.append(
+                    domain.BoundarySnap(
+                        boundary_index=index,
+                        requested_row=row,
+                        snapped_row=row - 1,
+                        evidence_run=(row - 4, row + 4),
+                    )
+                )
+
+        fingerprint = hashlib.sha256(
+            f"manual:{tuple(rows)}".encode()
+        ).hexdigest()
+        self._preview_established = True
+        return (
+            domain.PreviewResult(count=self._slot_count, fingerprint=fingerprint),
+            tuple(thumbnails),
+            tuple(snaps),
+            self._last_preview_material,
+        )
+
+    def preview_strip(self) -> domain.PreviewStrip:
+        self._require_connected()
+        if not self._preview_established:
+            raise BridgeError(
+                ErrorCode.NO_PREVIEW,
+                "roll.previewStrip requires a completed roll.preview attempt first",
+            )
+        row_count = self._slot_count * 1200
+        tile_path = self._preview_dir / f"strip-{uuid.uuid4().hex}.tif"
+        strip = np.zeros((_SYNTHETIC_PREVIEW_WIDTH, min(row_count, 4096), 3), dtype=np.uint8)
+        tifffile.imwrite(tile_path, strip, photometric="rgb")
+        return domain.PreviewStrip(
+            image_path=str(tile_path), row_count=row_count, pixels_per_row=1
         )
 
     # -- scanning -----------------------------------------------------------------

--- a/ports/tauri/vendor/scanstudio-bridge/tests/test_service_dispatch.py
+++ b/ports/tauri/vendor/scanstudio-bridge/tests/test_service_dispatch.py
@@ -145,6 +145,7 @@ class _StubTransport:
         *,
         preview_thumbnails: int = 2,
         start_scan_raises: Exception | None = None,
+        manual_frames_raises: Exception | None = None,
     ) -> None:
         self.device_open = False
         self.approved: list[int] = []
@@ -154,6 +155,9 @@ class _StubTransport:
         self.close_called = False
         self._preview_thumbnails = preview_thumbnails
         self._start_scan_raises = start_scan_raises
+        self.manual_frames_calls: list[tuple[int, ...]] = []
+        self.preview_strip_calls = 0
+        self._manual_frames_raises = manual_frames_raises
 
     def list_devices(self) -> list[domain.DeviceInfo]:
         return [_device_info()]
@@ -195,6 +199,49 @@ class _StubTransport:
             needs_approval=True,
             warnings=("manual-review-required",),
             image_path=f"/tmp/stub-preview/adjusted-slot-{slot:04d}-{offset_rows}.tif",
+        )
+
+    def manual_frames(
+        self, rows: list[int]
+    ) -> tuple[
+        domain.PreviewResult,
+        tuple[domain.Thumbnail, ...],
+        tuple[domain.BoundarySnap, ...],
+        domain.Material,
+    ]:
+        self.manual_frames_calls.append(tuple(rows))
+        if self._manual_frames_raises is not None:
+            raise self._manual_frames_raises
+        thumbnails = tuple(
+            domain.Thumbnail(
+                slot=i + 1,
+                boundary_rows=(rows[i], rows[i + 1]),
+                spacing_offset=0,
+                needs_approval=True,
+                warnings=("user-picked",),
+                image_path=f"/tmp/stub-preview/manual-slot-{i + 1:04d}.tif",
+            )
+            for i in range(len(rows) - 1)
+        )
+        snaps = (
+            domain.BoundarySnap(
+                boundary_index=0,
+                requested_row=rows[0],
+                snapped_row=rows[0],
+                evidence_run=(max(0, rows[0] - 2), rows[0] + 2),
+            ),
+        )
+        return (
+            domain.PreviewResult(count=len(thumbnails), fingerprint="stub-manual-fp"),
+            thumbnails,
+            snaps,
+            domain.Material.COLOR_NEGATIVE,
+        )
+
+    def preview_strip(self) -> domain.PreviewStrip:
+        self.preview_strip_calls += 1
+        return domain.PreviewStrip(
+            image_path="/tmp/stub-preview/strip.tif", row_count=4800, pixels_per_row=1
         )
 
     def start_scan(self, slots, recipe, output, on_progress, on_retry, on_frame, on_call=None):
@@ -761,6 +808,169 @@ def test_roll_set_spacing_offset_is_refused_while_scan_job_is_active(
     finally:
         transport.release.set()
         _wait_for(lambda: emit.has("scan.completed"))
+
+
+# -- roll.manualFrames / roll.previewStrip (Rung 4) --------------------------------
+
+
+def test_roll_manual_frames_dispatch_routes_rows_and_rearms_scan_gate(
+    tmp_path: Path,
+) -> None:
+    """Proves the dispatch shape end to end: roll.manualFrames reaches
+    transport.manual_frames() with the exact rows requested, the wire result
+    carries count/fingerprint/thumbnails/snaps, and -- since manual_frames()
+    arms a usable session without ever calling roll.preview -- a following
+    scan.start is no longer refused with NO_PREVIEW (BridgeService's
+    self._preview_material must have been re-armed from the transport's
+    returned material, not from a roll.preview request that never
+    happened)."""
+    transport = _StubTransport()
+    svc = _opened_service(tmp_path, transport)
+
+    result = svc.dispatch(
+        {
+            "id": 2,
+            "method": "roll.manualFrames",
+            "params": {"rows": [100, 300, 500]},
+        },
+        lambda *_a: None,
+    )
+
+    assert transport.manual_frames_calls == [(100, 300, 500)]
+    assert result["count"] == 2
+    assert result["fingerprint"] == "stub-manual-fp"
+    assert [t["slot"] for t in result["thumbnails"]] == [1, 2]
+    assert result["thumbnails"][0]["boundaryRows"] == [100, 300]
+    assert result["thumbnails"][0]["needsApproval"] is True
+    assert result["snaps"] == [
+        {
+            "boundaryIndex": 0,
+            "requestedRow": 100,
+            "snappedRow": 100,
+            "evidenceRun": [98, 102],
+        }
+    ]
+
+    # The real proof this armed a usable session: scan.start no longer
+    # raises NO_PREVIEW, even though roll.preview was never called this
+    # session.
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch(
+            {
+                "id": 3,
+                "method": "scan.start",
+                "params": {
+                    "slots": [1],
+                    "recipe": _wire_recipe(),
+                    "output": {
+                        "destination": str(tmp_path / "out"),
+                        "filenameTemplate": "frame-####.tif",
+                    },
+                },
+            },
+            lambda *_a: None,
+        )
+    # HW_MOTION_NOT_ARMED (the latch was never armed in this test) proves
+    # scan.start got PAST its NO_PREVIEW gate -- the one thing this test is
+    # pinning -- and was refused for an unrelated, later reason instead.
+    assert excinfo.value.code is ErrorCode.HW_MOTION_NOT_ARMED
+
+
+def test_roll_manual_frames_without_open_device_is_not_connected(
+    tmp_path: Path,
+) -> None:
+    transport = _StubTransport()
+    svc = _make_service(tmp_path, transport)
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch(
+            {
+                "id": 2,
+                "method": "roll.manualFrames",
+                "params": {"rows": [100, 300]},
+            },
+            lambda *_a: None,
+        )
+
+    assert excinfo.value.code is ErrorCode.NOT_CONNECTED
+    assert transport.manual_frames_calls == []
+
+
+def test_roll_manual_frames_missing_rows_is_invalid_params(tmp_path: Path) -> None:
+    transport = _StubTransport()
+    svc = _opened_service(tmp_path, transport)
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch(
+            {"id": 2, "method": "roll.manualFrames", "params": {}},
+            lambda *_a: None,
+        )
+
+    assert excinfo.value.code is ErrorCode.INVALID_PARAMS
+    assert "rows" in str(excinfo.value)
+    assert transport.manual_frames_calls == []
+
+
+def test_roll_manual_frames_propagates_transport_validation_error_unmodified(
+    tmp_path: Path,
+) -> None:
+    """service.py must not truncate or reshape a validation-failure
+    BridgeError raised from the transport -- the plain-English sentence
+    manual_frames.py's own gates produce is what the operator needs to see,
+    unmodified, at the dispatch boundary."""
+    sentence = (
+        "the 1st frame you placed is about 8 mm tall (between rows 10 and "
+        "40), outside the 15-75 mm range this driver accepts for manual "
+        "placement"
+    )
+    transport = _StubTransport(
+        manual_frames_raises=BridgeError(ErrorCode.INVALID_PARAMS, sentence)
+    )
+    svc = _opened_service(tmp_path, transport)
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch(
+            {
+                "id": 2,
+                "method": "roll.manualFrames",
+                "params": {"rows": [10, 40]},
+            },
+            lambda *_a: None,
+        )
+
+    assert excinfo.value.code is ErrorCode.INVALID_PARAMS
+    assert str(excinfo.value) == sentence
+
+
+def test_roll_preview_strip_dispatch_returns_wire_shape(tmp_path: Path) -> None:
+    transport = _StubTransport()
+    svc = _opened_service(tmp_path, transport)
+
+    result = svc.dispatch(
+        {"id": 2, "method": "roll.previewStrip", "params": {}}, lambda *_a: None
+    )
+
+    assert transport.preview_strip_calls == 1
+    assert result == {
+        "imagePath": "/tmp/stub-preview/strip.tif",
+        "rowCount": 4800,
+        "pixelsPerRow": 1,
+    }
+
+
+def test_roll_preview_strip_without_open_device_is_not_connected(
+    tmp_path: Path,
+) -> None:
+    transport = _StubTransport()
+    svc = _make_service(tmp_path, transport)
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch(
+            {"id": 2, "method": "roll.previewStrip", "params": {}}, lambda *_a: None
+        )
+
+    assert excinfo.value.code is ErrorCode.NOT_CONNECTED
+    assert transport.preview_strip_calls == 0
 
 
 def test_roll_preview_error_telemetry_includes_message(

--- a/ports/tauri/vendor/scanstudio-bridge/tests/test_service_dispatch.py
+++ b/ports/tauri/vendor/scanstudio-bridge/tests/test_service_dispatch.py
@@ -1789,3 +1789,23 @@ def test_failed_preview_does_not_claim_a_preview_material(
             emit,
         )
     assert excinfo.value.code == ErrorCode.NO_PREVIEW
+
+
+def test_roll_manual_frames_rejects_non_integer_rows(tmp_path: Path) -> None:
+    """Wire strictness (adversarial review 2026-08-08, F8a): floats, digit
+    strings, booleans, and non-lists must all refuse as INVALID_PARAMS with
+    a plain sentence -- never truncate, explode into digits, or surface as
+    INTERNAL -- and must never reach the transport."""
+
+    transport = _StubTransport()
+    svc = _opened_service(tmp_path, transport)
+
+    for bad in ([12.5, 200], ["123"], [True, 200], "12,200", [12, "x"]):
+        with pytest.raises(BridgeError) as excinfo:
+            svc.dispatch(
+                {"id": 3, "method": "roll.manualFrames", "params": {"rows": bad}},
+                lambda *_a: None,
+            )
+        assert excinfo.value.code is ErrorCode.INVALID_PARAMS, bad
+        assert "whole numbers" in str(excinfo.value), bad
+    assert transport.manual_frames_calls == []

--- a/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
+++ b/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
@@ -14,15 +14,27 @@ adapter/workflow injection seams. No hardware is touched by any test here.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
+import json
+import struct
 import tempfile
 import threading
 import time
+import uuid
 from pathlib import Path
 
 import coolscanpy
 import numpy as np
 import pytest
 import tifffile
+
+from coolscanpy.protocol.ls5000_single_pass import roll_index as _roll_index_module
+from coolscanpy.protocol.ls5000_single_pass.density import (
+    DensityCalibration,
+    build_nikon_density_evidence,
+)
+from coolscanpy.protocol.ls5000_single_pass.plan import CANONICAL_PLAN_SHA256
+from coolscanpy.roll.preview_session import _preview_binding_contract
 
 from scanstudio_bridge import domain, safety, service
 from scanstudio_bridge.protocol import BridgeError, ErrorCode
@@ -53,6 +65,7 @@ class _FakeRoll:
         thumbnails: list["coolscanpy.Thumbnail"] | None = None,
         fingerprint_sha256: str = "f" * 64,
         scan_results: dict[int, list[object]] | None = None,
+        material: "coolscanpy.Material" = coolscanpy.Material.COLOR_NEGATIVE,
     ) -> None:
         self._thumbnails = thumbnails or []
         self._fingerprint_sha256 = fingerprint_sha256
@@ -63,6 +76,19 @@ class _FakeRoll:
         self.safe_stop_calls = 0
         self.closed = False
         self._safe_stop_requested = False
+        # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md):
+        # CoolscanPyTransport.manual_frames() arms a manually-built
+        # RollPreviewSession by reaching into these exact private
+        # coolscanpy.Roll attributes directly -- no public Roll API installs
+        # an already-built session without a fresh hardware read (see that
+        # method's own comment). This fake carries the same attribute names,
+        # real types, and locking shape so that code path runs unmodified
+        # against this double, exactly as it would against a real Roll.
+        self.material = material
+        self._state_condition = threading.Condition(threading.RLock())
+        self._session: object | None = None
+        self._session_usb_topology: tuple[int, int] | None = None
+        self._approvals: dict[int, object] = {}
 
     def preview(self, slots: list[int] | None = None) -> list["coolscanpy.Thumbnail"]:
         if slots is None:
@@ -310,6 +336,238 @@ def _opened_transport(
 
 def _output(destination: Path, filename_template: str = "frame-####.tif") -> domain.OutputSpec:
     return domain.OutputSpec(destination=str(destination), filename_template=filename_template)
+
+
+# -- Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): synthetic on-disk preview ---
+# attempt. manual_frames()/preview_strip() read straight from disk
+# (attempts_root), bypassing the _FakeRoll double this file otherwise uses
+# everywhere else -- see coolscanpy_transport.py's own
+# _reconstruct_last_preview_attempt/_validated_preview_from_attempt. The
+# helpers below build one REAL, byte-valid preview attempt directory
+# (journal.json + capture-preview.bin + capture-008e.bin +
+# capture-frame-map.json). Ported byte-for-byte from coolscanpy's own test
+# fixture (coolscanpy/tests/roll/test_ls5000_roll_session.py's
+# _preview_fixture/_synthetic_index/_encode_index/_transport_table -- the
+# owner's already-proven encoding, not re-derived here), landed under a real
+# attempts_root with the CaptureMode.PREVIEW "preview-" mkdtemp prefix
+# CoolscanPyTransport's own glob expects instead of a bare test directory
+# name. The transport-table encoding (code=6*(row%18), selector=row//18) is
+# the same 42-native-units-per-row convention coolscanpy's own
+# test_manual_frames.py/test_ls5000_roll_session.py fixtures use, comfortably
+# inside build_manual_detection's 40..45 ramp-guard gate.
+
+_SYNTHETIC_DENSITY_CALIBRATION_PAYLOADS = tuple(
+    bytes.fromhex(value)
+    for value in (
+        "8c20000000040000df1a",
+        "8c20000000040000bba4",
+        "8c200000000400007fab",
+    )
+)
+_SYNTHETIC_DENSITY_CALIBRATION_NUMERATORS = (57_114, 48_036, 32_683)
+
+
+def _synthetic_density_calibration(session_id: str) -> DensityCalibration:
+    return DensityCalibration(
+        session_id=session_id,
+        numerators=_SYNTHETIC_DENSITY_CALIBRATION_NUMERATORS,
+        payload_hex=tuple(
+            payload.hex() for payload in _SYNTHETIC_DENSITY_CALIBRATION_PAYLOADS
+        ),
+        payload_sha256=tuple(
+            hashlib.sha256(payload).hexdigest()
+            for payload in _SYNTHETIC_DENSITY_CALIBRATION_PAYLOADS
+        ),
+    )
+
+
+def _encode_synthetic_index(rgb16: np.ndarray) -> bytes:
+    """Encode the compact RGB96 index rows the scanner itself would have
+    written -- byte-for-byte port of test_ls5000_roll_session.py's own
+    _encode_index."""
+    blocks = np.zeros(
+        (rgb16.shape[0] // 2, _roll_index_module.INDEX_BLOCK_WORDS),
+        dtype=np.uint16,
+    )
+    blocks[:, 0:96] = rgb16[0::2, :, 0]
+    blocks[:, 96:192] = rgb16[0::2, :, 1]
+    blocks[:, 192:288] = rgb16[0::2, :, 2]
+    blocks[:, 512:608] = rgb16[1::2, :, 0]
+    blocks[:, 608:704] = rgb16[1::2, :, 1]
+    blocks[:, 704:800] = rgb16[1::2, :, 2]
+    blocks[:, 800::2] = _roll_index_module.INDEX_TRAILER_MARK
+    blocks[:, 801::2] = np.arange(
+        _roll_index_module.INDEX_TRAILER_COUNTER0,
+        _roll_index_module.INDEX_TRAILER_COUNTER0
+        + _roll_index_module.INDEX_TRAILER_WORDS // 2,
+        dtype=np.uint16,
+    )
+    return blocks.astype(">u2", copy=False).tobytes()
+
+
+def _synthetic_preview_index(
+    *, height: int, frame_count: int = 40, content_frames: int = 40, leader: int = 128
+) -> np.ndarray:
+    """Textured cells separated by physical clear-film gaps, at the pitch=143
+    convention coolscanpy's own manual-session fixtures use -- byte-for-byte
+    port of test_ls5000_roll_session.py's own _synthetic_index."""
+    pitch = 143
+    boundaries = [leader + index * pitch for index in range(frame_count + 1)]
+    y = np.arange(height, dtype=np.int64)[:, None]
+    x = np.arange(90, dtype=np.int64)[None, :]
+    texture = (x * 173 + y * 71 + (x * y) % 997) % 7_000
+    aperture = np.empty((height, 90, 3), dtype=np.int64)
+    for channel, base in enumerate((7_000, 5_500, 4_000)):
+        aperture[:, :, channel] = base + texture * (3 - channel) // 2
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    clear_noise = ((x * 19 + y * 13) % 301 - 150)[:, :, None]
+    aperture[: boundaries[0]] = clear_base + clear_noise[: boundaries[0]]
+    aperture[boundaries[-1] :] = clear_base + clear_noise[boundaries[-1] :]
+    for boundary in boundaries:
+        start = max(0, boundary - 3)
+        end = min(height, boundary + 3)
+        aperture[start:end] = clear_base + clear_noise[start:end]
+    if content_frames < frame_count:
+        clear_start = boundaries[content_frames]
+        aperture[clear_start:] = clear_base + clear_noise[clear_start:]
+    rgb = np.empty((height, 96, 3), dtype=np.int64)
+    rgb[:, 2:92] = aperture
+    rgb[:, :2] = np.asarray((1_300, 1_000, 700))
+    rgb[:, 92:] = np.asarray((1_100, 850, 600))
+    return rgb.clip(0, 65_535).astype(np.uint16)
+
+
+def _synthetic_transport_table(rows: int) -> bytes:
+    """42-native-units-per-row same-traversal table -- byte-for-byte port of
+    test_ls5000_roll_session.py's own _transport_table."""
+    records = bytearray()
+    for row in range(rows):
+        records.extend(struct.pack(">HH", 6 * (row % 18), row // 18))
+    total = 8 + len(records)
+    return b"\x00\x8e\x00\x00" + total.to_bytes(2, "big") + b"\x00\x00" + bytes(records)
+
+
+def _write_synthetic_preview_attempt(
+    attempts_root: Path, *, slot_capacity_hint: int = 40
+) -> Path:
+    """Write one complete, byte-valid preview attempt directory under
+    ``attempts_root`` with CoolscanPyTransport's own "preview-" mkdtemp
+    prefix -- everything manual_frames()/preview_strip()'s
+    _reconstruct_last_preview_attempt/_validated_preview_from_attempt need to
+    find and validate it, exactly as if a real roll.preview attempt had just
+    completed (this journal shape is "preview-only"/"complete"/released --
+    see preview_session.py's _validate_preview_result: both that shape and
+    the "preview-and-hold" shape a real Roll.preview() always uses today
+    validate identically). Returns the attempt directory."""
+    contract = _preview_binding_contract(slot_capacity_hint)
+    native_height = contract["native_height"]
+    decoded_height = contract["decoded_height"]
+    startup_status = contract["startup_status"]
+    preview_binding = {
+        key: value for key, value in contract.items() if key != "startup_status"
+    }
+
+    attempt = attempts_root / f"preview-{uuid.uuid4().hex}"
+    attempt.mkdir(parents=True)
+    output = attempt / "capture.bin"
+    output.write_bytes(b"")
+    preview_path = attempt / "capture-preview.bin"
+    table_path = attempt / "capture-008e.bin"
+    mapping_path = attempt / "capture-frame-map.json"
+
+    rgb = _synthetic_preview_index(height=decoded_height)
+    usable_rows = len(rgb)
+    preview = _encode_synthetic_index(rgb)
+    table = _synthetic_transport_table(usable_rows)
+    preview_path.write_bytes(preview)
+    table_path.write_bytes(table)
+
+    density_session_id = "single-reservation-roll-preview"
+    density_exposures = (71_373, 137_524, 126_126)
+    preview_sha256 = hashlib.sha256(preview).hexdigest()
+    density_evidence = build_nikon_density_evidence(
+        preview,
+        calibration=_synthetic_density_calibration(density_session_id),
+        density_f03_exposures_raw_10ns=density_exposures,
+        session_id=density_session_id,
+        capture_attempt_id=attempt.name,
+        scan_identity=f"{density_session_id}:density-97dpi:{preview_sha256}",
+        source_native_height=native_height,
+        source_height=decoded_height,
+    )
+    receipt = {
+        "status": "preview-only-complete",
+        "slot_capacity_hint": slot_capacity_hint,
+        "slot_capacity_semantics": (
+            "scanner-addressable preview slots; not an exposure count"
+        ),
+        "preview_bytes": len(preview),
+        "preview_sha256": preview_sha256,
+        "table_bytes": len(table),
+        "table_sha256": hashlib.sha256(table).hexdigest(),
+        "frame_detection": "deferred-offline",
+        "startup_table": {
+            "count": slot_capacity_hint,
+            "sha256": "a" * 64,
+            "status": startup_status,
+        },
+        "preview_binding": preview_binding,
+    }
+    mapping_path.write_text(json.dumps(receipt), encoding="utf-8")
+    journal = {
+        "status": "complete",
+        "capture_mode": "preview-only",
+        "requested_frame": None,
+        "requested_boundary_offset_rows": 0,
+        "expected_frame_count": None,
+        "expected_reads": 0,
+        "completed_reads": 0,
+        "expected_bytes": 0,
+        "completed_bytes": 0,
+        "disk_bytes": 0,
+        "unit_released": True,
+        "output": str(output.resolve()),
+        "output_sha256": hashlib.sha256(b"").hexdigest(),
+        "plan_sha256": CANONICAL_PLAN_SHA256,
+        "capture_engine_sha256": "b" * 64,
+        "scanner_identity": "Nikon LS-5000 ED 1.03",
+        "expected_usb_bus": 1,
+        "expected_usb_address": 2,
+        "actual_usb_bus": 1,
+        "actual_usb_address": 2,
+        "preview_geometry_validated_before_reads": True,
+        "preview_windows": [
+            {
+                "color_id": color,
+                "resolution": [97, 97],
+                "origin": [0, 0],
+                "size": [3_946, native_height],
+                "bit_depth": 16,
+                "density_f03_exposure_raw_10ns": exposure,
+            }
+            for color, exposure in zip((1, 2, 3), density_exposures, strict=True)
+        ],
+        "density_calibration_session_id": density_session_id,
+        "nikon_density_evidence": density_evidence.to_dict(),
+        "live_startup_0x8f": {"count": slot_capacity_hint, "sha256": "a" * 64},
+        "live_startup_0x8f_status": startup_status,
+        "live_preview_binding": preview_binding,
+        "live_index_artifacts": {
+            "mapping": str(mapping_path.resolve()),
+            "preview": str(preview_path.resolve()),
+            "table": str(table_path.resolve()),
+        },
+        "live_index_evidence": {
+            "status": "persisted-before-frame-detection",
+            "preview_bytes": len(preview),
+            "preview_sha256": preview_sha256,
+            "table_bytes": len(table),
+            "table_sha256": hashlib.sha256(table).hexdigest(),
+        },
+        "preview_only_receipt": receipt,
+    }
+    (attempt / "journal.json").write_text(json.dumps(journal), encoding="utf-8")
+    return attempt
 
 
 # -- list_devices / open_device ----------------------------------------------------
@@ -982,6 +1240,191 @@ def test_preview_maps_base_roll_mismatch(monkeypatch: pytest.MonkeyPatch) -> Non
         transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
     assert excinfo.value.code == ErrorCode.ROLL_MISMATCH
     assert "different USB topology" in str(excinfo.value)
+
+
+def test_preview_probable_cause_survives_into_refeed_required_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rung 3 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): detect_roll_frames's
+    failure paths attach a best-effort plain-English
+    diagnostics["probable_cause"] sentence to the IndexDecodeError they raise
+    (roll_index.py). IndexDecodeError.__str__ already embeds its full
+    diagnostics dict (json.dumps) in the message, and preview()'s own
+    existing except IndexDecodeError branch already interpolates str(exc)
+    into its REFEED_REQUIRED message -- so the sentence should ride through
+    automatically, with no bridge change needed. This test pins that so a
+    future refactor of either side can't silently drop it."""
+    from coolscanpy.protocol.ls5000_single_pass.roll_index import IndexDecodeError
+
+    sentence = (
+        "this looks like half-frame film (frames about every 19 mm); this "
+        "driver expects standard 35 mm spacing"
+    )
+
+    class _ProbableCauseRoll(_FakeRoll):
+        def preview(self, slots: list[int] | None = None) -> list["coolscanpy.Thumbnail"]:
+            raise IndexDecodeError(
+                "transport anchor residual is inconsistent with one affine "
+                "preview traversal (MAE 4.447 rows, max 11.241 rows)",
+                error_id="gap-lattice-anchor",
+                diagnostics={"probable_cause": sentence},
+            )
+
+    transport, _device = _opened_transport(monkeypatch, _ProbableCauseRoll())
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert excinfo.value.code == ErrorCode.REFEED_REQUIRED
+    message = str(excinfo.value)
+    assert sentence in message
+    assert "MAE 4.447" in message
+
+
+# -- roll.manualFrames / roll.previewStrip (Rung 4) --------------------------------
+
+
+def test_manual_frames_without_any_preview_attempt_is_no_preview(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """manual_frames() is usable only after at least one roll.preview
+    attempt (successful or refused) exists on disk -- before that, self._roll
+    and self.attempts_root are both still None."""
+    transport, _device = _opened_transport(monkeypatch, _FakeRoll())
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128, 271, 414])
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+
+
+def test_preview_strip_without_any_preview_attempt_is_no_preview(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport, _device = _opened_transport(monkeypatch, _FakeRoll())
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview_strip()
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+
+
+def _transport_with_synthetic_preview_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[CoolscanPyTransport, _FakeRoll, Path]:
+    """An opened transport whose attempts_root already holds one real,
+    byte-valid preview attempt on disk -- the "completed-but-refused (or
+    completed) preview attempt" manual_frames()/preview_strip() require.
+    Runs one (successful, contents-irrelevant) fake preview() first purely
+    to let CoolscanPyTransport.preview()'s own existing code create
+    self._roll/self.attempts_root exactly as it would in production; the
+    attempt this test actually reads back is a separately-written synthetic
+    one, matching how a real refused preview would leave its own evidence
+    on disk without ever producing a _FakeRoll-shaped in-memory session."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)])
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert transport.attempts_root is not None
+    attempt_dir = _write_synthetic_preview_attempt(transport.attempts_root)
+    return transport, roll, attempt_dir
+
+
+def test_manual_frames_happy_path_arms_session_for_approve_and_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport, roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+
+    result, thumbnails, snaps, material = transport.manual_frames([128, 271, 414])
+
+    assert material is domain.Material.COLOR_NEGATIVE
+    assert result.count == 2
+    assert len(thumbnails) == 2
+    assert [t.slot for t in thumbnails] == [1, 2]
+    assert thumbnails[0].boundary_rows == (128, 271)
+    assert thumbnails[1].boundary_rows == (271, 414)
+    assert thumbnails[0].needs_approval is True
+    assert "user-picked" in thumbnails[0].warnings
+    assert Path(thumbnails[0].image_path).is_file()
+    # Picked rows land exactly on the synthetic raster's own clear-film gap
+    # centers -- snap assist finds a zero-distance match at every boundary,
+    # so nothing moves and no snap note is produced.
+    assert snaps == ()
+
+    # The transport's own bookkeeping is re-armed exactly like a successful
+    # preview() leaves it.
+    assert transport._material is domain.Material.COLOR_NEGATIVE
+    assert transport._preview_established is True
+
+    # The real proof of "armed exactly like a successful preview": the SAME
+    # coolscanpy.Roll instance's session/approvals state now reflects the
+    # manual session, and the EXISTING, unmodified approve()/
+    # set_spacing_offset() methods keep working against it unchanged.
+    assert roll._session is not None
+    assert len(roll._session.slots) == 2
+    assert roll._approvals == {}
+    transport.approve(1)
+    assert roll.approve_calls == [1]
+    # _FakeRoll.set_spacing_offset resolves against its OWN _thumbnails list
+    # (slot 1, from the fixture's setup preview() call above) -- unrelated to
+    # the manual session's own slot numbering, but exactly enough to prove
+    # set_spacing_offset() itself still runs unmodified, end to end, after
+    # manual_frames() armed the roll.
+    adjusted = transport.set_spacing_offset(1, 0)
+    assert adjusted.slot == 1
+    assert roll.spacing_offset_calls == [(1, 0)]
+
+
+def test_manual_frames_validation_failure_maps_to_invalid_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """manual_frames.py's own plain-English physical-frame-height gate (15-75
+    mm) refuses a too-short pick -- surfaced as INVALID_PARAMS (the operator's
+    rows, not a hardware fault), with the exact sentence preserved."""
+    transport, _roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128, 140])
+
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+    message = str(excinfo.value)
+    assert "outside the 15-75 mm range" in message
+    assert "manual placement" in message
+
+
+def test_manual_frames_structural_failure_maps_to_invalid_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single boundary row (0 frames) fails manual_frames.py's own
+    structural gate before any physical check runs -- also INVALID_PARAMS."""
+    transport, _roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128])
+
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+    assert "at least 2 boundary rows" in str(excinfo.value)
+
+
+def test_preview_strip_happy_path_renders_whole_raster(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport, _roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+
+    strip = transport.preview_strip()
+
+    assert strip.row_count == 6_104  # the 40-record contract's decoded_height
+    assert strip.pixels_per_row == 1
+    assert Path(strip.image_path).is_file()
+    with tifffile.TiffFile(strip.image_path) as handle:
+        image = handle.asarray()
+    # _normalize_preview_tile's swapaxes(0,1): the raster's row axis (what
+    # roll.manualFrames's rows address) becomes the image's WIDTH axis.
+    assert image.shape == (96, 6_104, 3)
 
 
 def test_start_scan_maps_base_roll_mismatch(

--- a/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
+++ b/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import json
+import os
 import struct
 import tempfile
 import threading
@@ -66,6 +67,7 @@ class _FakeRoll:
         fingerprint_sha256: str = "f" * 64,
         scan_results: dict[int, list[object]] | None = None,
         material: "coolscanpy.Material" = coolscanpy.Material.COLOR_NEGATIVE,
+        install_manual_session_effect: BaseException | None = None,
     ) -> None:
         self._thumbnails = thumbnails or []
         self._fingerprint_sha256 = fingerprint_sha256
@@ -76,19 +78,37 @@ class _FakeRoll:
         self.safe_stop_calls = 0
         self.closed = False
         self._safe_stop_requested = False
-        # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md):
-        # CoolscanPyTransport.manual_frames() arms a manually-built
-        # RollPreviewSession by reaching into these exact private
-        # coolscanpy.Roll attributes directly -- no public Roll API installs
-        # an already-built session without a fresh hardware read (see that
-        # method's own comment). This fake carries the same attribute names,
-        # real types, and locking shape so that code path runs unmodified
-        # against this double, exactly as it would against a real Roll.
+        # Rung 4 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md) / S1 fix
+        # (2026-08-08 adversarial review): _session/_session_usb_topology/
+        # _approvals/_state_condition mirror real coolscanpy.Roll's own
+        # private attribute names, types, and locking shape purely so
+        # install_manual_session() below can behave like the real one
+        # (coolscanpy's own _roll.py) without duplicating it -- nothing in
+        # coolscanpy_transport.py reaches into these directly any more (see
+        # manual_frames()'s own comment); this fake's PUBLIC
+        # install_manual_session is the only thing that touches them now.
         self.material = material
         self._state_condition = threading.Condition(threading.RLock())
         self._session: object | None = None
         self._session_usb_topology: tuple[int, int] | None = None
         self._approvals: dict[int, object] = {}
+        self.install_manual_session_calls: list[object] = []
+        # Test-driven failure injection, mirroring _FakeDevice.eject_effect
+        # below -- lets a test prove manual_frames() maps
+        # coolscanpy.DeviceBusy/RollMismatch from install_manual_session to
+        # the right BridgeError, and that a raise here leaves _session/
+        # _approvals exactly as they were (install_manual_session's own
+        # transactional contract).
+        self._install_manual_session_effect = install_manual_session_effect
+
+    def install_manual_session(self, session: object) -> None:
+        self.install_manual_session_calls.append(session)
+        if self._install_manual_session_effect is not None:
+            raise self._install_manual_session_effect
+        with self._state_condition:
+            self._session = session
+            self._session_usb_topology = session.preview.usb_topology
+            self._approvals.clear()
 
     def preview(self, slots: list[int] | None = None) -> list["coolscanpy.Thumbnail"]:
         if slots is None:
@@ -1317,12 +1337,26 @@ def _transport_with_synthetic_preview_attempt(
     self._roll/self.attempts_root exactly as it would in production; the
     attempt this test actually reads back is a separately-written synthetic
     one, matching how a real refused preview would leave its own evidence
-    on disk without ever producing a _FakeRoll-shaped in-memory session."""
+    on disk without ever producing a _FakeRoll-shaped in-memory session.
+
+    S5 fix (2026-08-08 adversarial review): manual_frames()/preview_strip()
+    now read ONLY `transport._recorded_preview_attempt_journal`, never a
+    fresh glob of attempts_root -- production sets that from what
+    preview()'s own before/after snapshot actually saw appear on disk
+    (see coolscanpy_transport.py's own comment), which is necessarily empty
+    here since `_FakeRoll.preview()` writes nothing at all. This fixture's
+    whole point is a synthetic attempt written OUT OF BAND from any real
+    preview() call, so it sets the recorded identity directly too --
+    exactly the side effect a real preview() call would have performed had
+    this synthetic attempt actually been the product of one."""
     roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)])
     transport, _device = _opened_transport(monkeypatch, roll)
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
     assert transport.attempts_root is not None
     attempt_dir = _write_synthetic_preview_attempt(transport.attempts_root)
+    transport._recorded_preview_attempt_journal = (
+        attempt_dir / "journal.json"
+    ).resolve(strict=True)
     return transport, roll, attempt_dir
 
 
@@ -1388,7 +1422,7 @@ def test_manual_frames_validation_failure_maps_to_invalid_params(
 
     assert excinfo.value.code == ErrorCode.INVALID_PARAMS
     message = str(excinfo.value)
-    assert "outside the 15-75 mm range" in message
+    assert "15 mm floor" in message
     assert "manual placement" in message
 
 
@@ -1425,6 +1459,257 @@ def test_preview_strip_happy_path_renders_whole_raster(
     # _normalize_preview_tile's swapaxes(0,1): the raster's row axis (what
     # roll.manualFrames's rows address) becomes the image's WIDTH axis.
     assert image.shape == (96, 6_104, 3)
+
+
+def test_preview_strip_refuses_when_current_attempt_has_no_recorded_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S5, previewStrip's own half of the same fix: no recorded current
+    attempt means refuse, never a filesystem scan for something older."""
+    transport, _roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+    transport._recorded_preview_attempt_journal = None
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview_strip()
+
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+    assert "left no usable evidence" in str(excinfo.value)
+    assert "acquire a fresh preview" in str(excinfo.value)
+
+
+# -- 2026-08-08 adversarial review, S1 (manual placement replacement safety) --
+# and S5 (stale-attempt evidence selection) -------------------------------------
+
+
+def test_manual_frames_thumbnail_write_failure_leaves_roll_state_and_preview_established_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S1, part 1: rendering B's thumbnails happens BEFORE any Roll state
+    mutation. A completed placement A is already installed and approved;
+    a replacement placement B passes validation but its thumbnail disk
+    write fails. Roll's session/approvals (A's) must be completely
+    untouched -- install_manual_session must never even be called -- and
+    self._preview_established must stay at its PREVIOUS value (True, from
+    A) rather than being left False or flipped mid-mutation. A subsequent
+    approve() must therefore still cleanly reach A's own (unchanged)
+    session, exactly as if B had never been attempted."""
+    transport, roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch
+    )
+
+    # Placement A: completes cleanly, arms roll._session/approvals and
+    # self._preview_established -- exactly today's already-tested happy
+    # path (test_manual_frames_happy_path_arms_session_for_approve_and_scan).
+    transport.manual_frames([128, 271, 414])
+    assert transport._preview_established is True
+    session_a = roll._session
+    assert session_a is not None
+    # A sentinel approval "on file" for operation A -- proves it survives
+    # byte-for-byte (not just "still non-None") through the failed B
+    # attempt below.
+    roll._approvals[1] = "operation-a-approval-sentinel"
+    approvals_a = dict(roll._approvals)
+    # install_manual_session_calls already holds A's own (legitimate) call
+    # from the successful placement above -- capture that count so the
+    # assertion below proves B added NONE, not that the list is empty.
+    install_calls_after_a = len(roll.install_manual_session_calls)
+
+    def _failing_imwrite(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated disk write failure")
+
+    monkeypatch.setattr(tifffile, "imwrite", _failing_imwrite)
+
+    # Placement B: same evidence, same valid rows -- passes every gate
+    # build_manual_roll_preview_session checks -- but its thumbnail render
+    # fails partway through persisting to disk.
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128, 271, 414])
+    assert excinfo.value.code == ErrorCode.INTERNAL
+    assert "left unchanged" in str(excinfo.value)
+
+    # Roll state: completely untouched -- the exact same session object,
+    # the exact same approvals, and install_manual_session was never
+    # called again for B (the write failure is caught before any Roll
+    # mutation is attempted at all).
+    assert roll._session is session_a
+    assert roll._approvals == approvals_a
+    assert len(roll.install_manual_session_calls) == install_calls_after_a
+
+    # self._preview_established stayed at its PREVIOUS value (True, from
+    # A's own successful placement) -- never touched by B's failure.
+    assert transport._preview_established is True
+
+    # A subsequent approve() against the operation the UI still shows (A)
+    # must still cleanly reach A's own, unchanged session -- never
+    # NO_PREVIEW, and never silently landing on some half-installed B.
+    transport.approve(1)
+    assert roll.approve_calls == [1]
+
+
+def test_manual_frames_maps_install_failure_without_reporting_partial_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S1, part 2/3: install_manual_session's own failure modes (locked
+    state / USB-topology mismatch, modeled here as DeviceBusy/RollMismatch)
+    must map to typed BridgeErrors, and self._preview_established must be
+    left False (not re-armed) since install is where the fail-closed marker
+    is set immediately before this call."""
+    roll = _FakeRoll(
+        install_manual_session_effect=coolscanpy.DeviceBusy("another roll batch is active")
+    )
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert transport.attempts_root is not None
+    attempt_dir = _write_synthetic_preview_attempt(transport.attempts_root)
+    transport._recorded_preview_attempt_journal = (
+        attempt_dir / "journal.json"
+    ).resolve(strict=True)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128, 271, 414])
+    assert excinfo.value.code == ErrorCode.DEVICE_BUSY
+    assert transport._preview_established is False
+    assert len(roll.install_manual_session_calls) == 1
+
+
+def test_approve_refuses_on_fingerprint_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """S1, part 4: an approval computed against an earlier session
+    (identified by its expected fingerprint) must be refused before ever
+    reaching coolscanpy's own Roll.approve() -- a stale click must never
+    silently approve whatever slot number happens to exist in the roll's
+    CURRENT session."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)], fingerprint_sha256="c" * 64)
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.approve(1, fingerprint="d" * 64)
+
+    assert excinfo.value.code == ErrorCode.FINGERPRINT_REFUSED
+    assert roll.approve_calls == []
+
+
+def test_approve_succeeds_when_fingerprint_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The additive fingerprint check is a comparison, not a blanket
+    refusal: a caller-supplied value equal to the roll's current
+    fingerprint approves normally."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)], fingerprint_sha256="c" * 64)
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    transport.approve(1, fingerprint="c" * 64)
+
+    assert roll.approve_calls == [1]
+
+
+def test_approve_with_no_fingerprint_keeps_pre_existing_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every existing caller (no `fingerprint` argument at all) must be
+    completely unaffected: `None` is the default and skips the comparison
+    entirely, exactly as before this parameter existed."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)], fingerprint_sha256="c" * 64)
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    transport.approve(1)
+
+    assert roll.approve_calls == [1]
+
+
+def test_manual_frames_refuses_when_current_attempt_has_no_recorded_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S5: attempt A completed and is still on disk; a NEWER attempt B's
+    directory also exists (a retried preview's transport read started) but
+    B failed before it ever wrote a journal.json of its own. The most
+    recent attempt (B) left no usable evidence, so manual placement must
+    refuse outright -- it must NEVER silently fall back to A's older,
+    physically-superseded evidence, even though A is still present and
+    perfectly well-formed on disk."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)])
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert transport.attempts_root is not None
+    _write_synthetic_preview_attempt(transport.attempts_root)  # attempt A: complete
+    stale_dir = transport.attempts_root / f"preview-{uuid.uuid4().hex}"
+    stale_dir.mkdir(parents=True)  # attempt B: started, no journal.json ever written
+    # What a real preview() call for B would itself have recorded: its own
+    # before/after snapshot diff finds no new journal at all (B wrote
+    # none), so the previously-invalidated candidate stays None -- see
+    # preview()'s own S5 comment. Never falls back to A.
+    transport._recorded_preview_attempt_journal = None
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([128, 271, 414])
+
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+    message = str(excinfo.value)
+    assert "left no usable evidence" in message
+    assert "acquire a fresh preview" in message
+    assert roll.install_manual_session_calls == []
+
+
+def test_sole_new_attempt_journal_ignores_mtime_and_identifies_the_new_candidate(
+    tmp_path: Path,
+) -> None:
+    """S5's core selection primitive: identifying the attempt a preview()
+    call itself just produced is pure set membership against a snapshot
+    taken immediately beforehand -- NEVER a modification-time comparison.
+    Here the OLDER attempt's journal is touched (its mtime pushed into the
+    future, past the newer attempt's own) after the newer one is written --
+    exactly the "A's journal is touched later" S5 scenario -- and the
+    correct (new) candidate must still be the one identified."""
+    attempts_root = tmp_path
+    old_dir = attempts_root / "preview-old"
+    old_dir.mkdir()
+    old_journal = old_dir / "journal.json"
+    old_journal.write_text("{}", encoding="utf-8")
+    before = frozenset(
+        attempts_root.glob(coolscanpy_transport_module._PREVIEW_ATTEMPT_GLOB)
+    )
+
+    new_dir = attempts_root / "preview-new"
+    new_dir.mkdir()
+    new_journal = new_dir / "journal.json"
+    new_journal.write_text("{}", encoding="utf-8")
+    # Touch the OLDER journal so it carries a strictly newer mtime than the
+    # attempt that actually just happened -- an mtime-sorting selection
+    # would incorrectly pick this one.
+    future = time.time() + 10_000
+    os.utime(old_journal, (future, future))
+    assert old_journal.stat().st_mtime > new_journal.stat().st_mtime
+
+    resolved = coolscanpy_transport_module._sole_new_attempt_journal(
+        attempts_root, before
+    )
+
+    assert resolved == new_journal.resolve()
+
+
+def test_sole_new_attempt_journal_is_none_when_nothing_new_appeared(
+    tmp_path: Path,
+) -> None:
+    """A hard failure that writes no journal at all (e.g. a bootstrap
+    failure before the transport read even starts) must resolve to `None`,
+    never to whatever older attempt happens to already be on disk."""
+    attempts_root = tmp_path
+    old_dir = attempts_root / "preview-old"
+    old_dir.mkdir()
+    (old_dir / "journal.json").write_text("{}", encoding="utf-8")
+    before = frozenset(
+        attempts_root.glob(coolscanpy_transport_module._PREVIEW_ATTEMPT_GLOB)
+    )
+
+    # Nothing new is written under attempts_root this time.
+
+    resolved = coolscanpy_transport_module._sole_new_attempt_journal(
+        attempts_root, before
+    )
+
+    assert resolved is None
 
 
 def test_start_scan_maps_base_roll_mismatch(

--- a/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_mock.py
+++ b/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_mock.py
@@ -741,3 +741,97 @@ def test_close_device_then_reopen_resets_preview_state() -> None:
 
 def test_eject_always_returns_true() -> None:
     assert MockTransport().eject() is True
+
+
+# -- manual frame placement (Rung 4) -----------------------------------------------
+
+
+def test_manual_frames_without_any_preview_is_no_preview() -> None:
+    transport = _opened(slot_count=4)
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([100, 300])
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+
+
+def test_manual_frames_rejects_fewer_than_two_rows() -> None:
+    transport = _opened(slot_count=4)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([100])
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+    assert "at least 2 boundary rows" in str(excinfo.value)
+
+
+def test_manual_frames_rejects_non_increasing_rows() -> None:
+    transport = _opened(slot_count=4)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    with pytest.raises(BridgeError) as excinfo:
+        transport.manual_frames([300, 100, 500])
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+    assert "strictly increasing" in str(excinfo.value)
+
+
+def test_manual_frames_happy_path_replaces_slot_lattice_and_rearms_approve() -> None:
+    transport = _opened(slot_count=6)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    # None of these rows is a multiple of 100 -- the mock's deterministic
+    # "snap" trigger (see test_manual_frames_reports_deterministic_snap_notes
+    # below) never fires, so this is the plain no-snap happy path.
+    result, thumbnails, snaps, material = transport.manual_frames([101, 301, 501])
+
+    assert material is domain.Material.COLOR_NEGATIVE
+    assert result.count == 2
+    assert [t.slot for t in thumbnails] == [1, 2]
+    assert thumbnails[0].boundary_rows == (101, 301)
+    assert thumbnails[1].boundary_rows == (301, 501)
+    assert all(t.needs_approval for t in thumbnails)
+    assert all("user-picked" in t.warnings for t in thumbnails)
+    assert snaps == ()
+
+    # The manual placement replaces the roll's own slot lattice: status now
+    # reports the manual frame count, and approve()/set_spacing_offset() work
+    # unchanged against the new 1-based slot numbering.
+    assert transport.status().slot_count == 2
+    transport.approve(1)
+    transport.approve(2)
+    adjusted = transport.set_spacing_offset(1, 0)
+    assert adjusted.slot == 1
+
+
+def test_manual_frames_reports_deterministic_snap_notes() -> None:
+    transport = _opened(slot_count=4)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    _result, _thumbnails, snaps, _material = transport.manual_frames([100, 250])
+
+    assert snaps == (
+        domain.BoundarySnap(
+            boundary_index=0,
+            requested_row=100,
+            snapped_row=99,
+            evidence_run=(96, 104),
+        ),
+    )
+
+
+def test_preview_strip_without_any_preview_is_no_preview() -> None:
+    transport = _opened(slot_count=4)
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview_strip()
+    assert excinfo.value.code == ErrorCode.NO_PREVIEW
+
+
+def test_preview_strip_happy_path_returns_row_count_and_image() -> None:
+    transport = _opened(slot_count=4)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    strip = transport.preview_strip()
+
+    assert strip.row_count == min(4 * 1200, 4_096)  # honest cap: width == rows
+    import tifffile as _tifffile
+
+    written = _tifffile.imread(strip.image_path)
+    assert written.shape[1] == strip.row_count  # width axis == reported rows
+    assert strip.pixels_per_row == 1
+    assert Path(strip.image_path).is_file()

--- a/scripts/check_coolscanpy_pypi_sync.sh
+++ b/scripts/check_coolscanpy_pypi_sync.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Release gate: the driver inside this release must already be published on
+# PyPI, so a standalone `pip install coolscanpy` user and a ScanStudio app
+# user always run the same driver generation. A version delta between the
+# two produces incomparable field reports for the same film -- the exact
+# debugging confusion the instrumented-refusal work exists to prevent
+# (owner policy, 2026-08-08: "keep them in sync so there's no delta").
+#
+# Mechanics: download the latest published coolscanpy sdist and compare its
+# src/coolscanpy tree byte-for-byte against this repo's vendored
+# coolscanpy/src/coolscanpy. Version strings are NOT trusted as the primary
+# signal (an unbumped version with changed code is precisely the failure
+# mode this gate exists to catch); the pyproject version is checked second,
+# as bump discipline.
+#
+# The vendored tree deliberately diverges from the published package in a
+# small, documented set of files (ScanStudio-specific behavior that must
+# not ship to standalone users). Those files are exempt from the byte
+# comparison here; their drift is governed by the crossing checklist
+# (see ScanStudioCloseout/MULTIBATCH-CROSSING-20260807.md) instead.
+set -euo pipefail
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+VENDORED_DIRS="coolscanpy/src/coolscanpy"
+KNOWN_VENDORED_DIVERGENCE=(
+  "protocol/ls5000_single_pass/worker.py"
+  "protocol/ls5000_single_pass/roll_index.py"
+  "protocol/ls5000_single_pass/bundle.py"
+)
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+echo "fetching latest published coolscanpy from PyPI..."
+meta="$workdir/meta.json"
+curl --fail --silent --show-error --location \
+  https://pypi.org/pypi/coolscanpy/json > "$meta"
+
+pypi_version="$(python3 -c "import json;print(json.load(open('$meta'))['info']['version'])")"
+sdist_url="$(python3 - "$meta" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+for f in data["urls"]:
+    if f["packagetype"] == "sdist":
+        print(f["url"]); break
+else:
+    raise SystemExit("no sdist on the latest PyPI release")
+PY
+)"
+
+curl --fail --silent --show-error --location "$sdist_url" > "$workdir/sdist.tar.gz"
+tar -xzf "$workdir/sdist.tar.gz" -C "$workdir"
+published_src="$(find "$workdir" -type d -path '*/src/coolscanpy' | head -1)"
+if [ -z "$published_src" ]; then
+  echo "::error::coolscanpy PyPI sync gate: sdist layout unexpected (no src/coolscanpy)"
+  exit 1
+fi
+
+fail=0
+raw="$(diff -rq --exclude='__pycache__' --exclude='*.pyc' \
+  "$published_src" "$VENDORED_DIRS" 2>&1 || true)"
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  exempt=0
+  for known in "${KNOWN_VENDORED_DIVERGENCE[@]}"; do
+    case "$line" in *"$known"*) exempt=1 ;; esac
+  done
+  if [ "$exempt" = 0 ]; then
+    echo "::error::driver differs from the published PyPI package: $line"
+    fail=1
+  fi
+done <<EOF
+$raw
+EOF
+
+vendored_version="$(python3 -c "
+import tomllib
+print(tomllib.load(open('coolscanpy/pyproject.toml','rb'))['project']['version'])")"
+if [ "$vendored_version" != "$pypi_version" ]; then
+  echo "::error::coolscanpy version mismatch: vendored $vendored_version vs PyPI $pypi_version"
+  fail=1
+fi
+
+if [ "$fail" = 1 ]; then
+  echo
+  echo "coolscanpy PyPI sync gate FAILED: this release carries driver code"
+  echo "that standalone PyPI users would not have. Publish the matching"
+  echo "coolscanpy release from the canonical repo (rohanpandula/coolscanpy,"
+  echo "port/cross-platform) FIRST -- same round, same generation, no delta"
+  echo "-- then re-run this release. Deliberately ScanStudio-only files are"
+  echo "exempt and listed in this script."
+  exit 1
+fi
+
+echo "OK: vendored driver matches PyPI coolscanpy $pypi_version (exempt files aside)"


### PR DESCRIPTION
started as the wide-gap fix for #23 / #24; now carries the full feeding-recovery ladder. four steps, each one only appearing when the one before it can't help:

1. normal frame detection, unchanged. every roll that worked before behaves byte-for-byte identically -- replayed against every archived capture to prove it.

2. one automatic retry that accepts wider blank strips between frames (13-20 rows, about 3.5-5.3 mm). this is the #23/#24 fix: those strips have one gap just past the old limit plus faint gaps riding the contrast floor. anything found this way is flagged for review, capped at medium confidence, and can never auto-scan.

3. when detection still fails, the error now says WHY in plain words, computed from the film itself: 'this looks like half-frame film', 'the blank strips between your frames measure about 0.5 mm -- too narrow', 'the blank film is only slightly clearer than the frames -- could be fog or a dense base', 'one edge of the film window looks partly blocked -- check the holder seating'. the analyzer is structurally incapable of producing frames, so a wrong guess can never become a wrong crop -- and it stays silent rather than guessing (several review rounds tuned exactly when it is allowed to speak).

4. when the film really is something detection can't handle, the operator places the frames by hand: the failure card shows the whole captured strip, you drag boundary lines onto it, and those frames go through the normal approve-then-scan flow. the machine keeps every physical check it can still make: it resolves each line against the scanner's own position readings (using the same math the automatic path trusts, validated against every archived capture -- the automatic detector's own boundaries fed back through manual placement reproduce its answers exactly), refuses frames taller than the scanner's fixed 38.7 mm capture window instead of silently cutting them short, and refuses placements whose position data it can't verify.

the safety spine, unchanged everywhere: a refusal is always preferred to a wrong crop. nothing recovered, diagnosed, or hand-placed ever scans without the operator approving it, approvals are cryptographically tied to the exact placement they approved (a failed replacement can't inherit an old approval -- the session swap is transactional now), approving or scanning a frame you were never shown is refused, and 'use anyway' decisions die with the placement they were made for.

how it was checked: three independent adversarial review rounds plus a fourth full-diff pass. they found real problems -- the first manual-placement position check misread the scanner's normal position-table pattern as corruption and refused every real capture; a failed placement swap could leave the screen showing one session while the scanner held another; stale approvals could carry across placements -- all fixed and re-verified against the reviewers' own exploit reproductions, with regressions committed. the archived-capture acceptance test now ships in the suite so this class of synthetic-only blindness can't recur.

suites: driver 1638, bridge 320, engine 395+43, app 456, all green; mirror drift guard clean; canonical driver is d91ba5d on coolscanpy port/cross-platform.

not in this PR: the raw DNG / linear TIFF export (#41) is built and verified on its own branch, feat/dng-linear-export.