### PR TITLE
power-on preview fix + partial-frame marker forwarding

### DIFF
--- a/app/ScanStudio/engine/src/bin/mock_bridge.rs
+++ b/app/ScanStudio/engine/src/bin/mock_bridge.rs
@@ -439,6 +439,17 @@ fn main() {
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Lane C mock: exactly one designated slot reports `partial: true` so
+/// integration tests can assert the field survives the engine unmangled;
+/// every other slot omits it, like a real bridge on a fully-inside frame.
+/// Slot 3 -- the last of the mock's standard 1..3 preview trio -- is the
+/// natural edge frame.
+const MOCK_PARTIAL_SLOT: u32 = 3;
+
+fn mock_partial_for(slot: u32) -> Option<bool> {
+    (slot == MOCK_PARTIAL_SLOT).then_some(true)
+}
+
 fn handle_request(
     tx: &mpsc::Sender<String>,
     request: &BridgeRequest,
@@ -591,6 +602,7 @@ fn handle_request(
                     needs_approval: false,
                     warnings: vec![],
                     image_path: path.to_string_lossy().into_owned(),
+                    partial: mock_partial_for(params.slot),
                 },
             })
         }
@@ -625,6 +637,7 @@ fn handle_request(
                         needs_approval: true,
                         warnings: vec!["user-picked".to_string()],
                         image_path: path.to_string_lossy().into_owned(),
+                        partial: mock_partial_for(slot),
                     }
                 })
                 .collect();
@@ -886,6 +899,7 @@ fn spawn_roll_preview_worker(
                         // save error above) so the wire shape is never
                         // missing this required field.
                         image_path: path.to_string_lossy().into_owned(),
+                        partial: mock_partial_for(slot),
                     },
                 },
             );

--- a/app/ScanStudio/engine/src/bridge_protocol.rs
+++ b/app/ScanStudio/engine/src/bridge_protocol.rs
@@ -239,6 +239,11 @@ pub struct BridgeThumbnail {
     /// bridge writes for this slot's preview crop (BRIDGE.md "Types" note
     /// under `Thumbnail`) — a path, never image bytes on the wire.
     pub image_path: String,
+    /// Lane C, additive (BRIDGE.md): `true` only on a frame whose crop
+    /// overlaps the preview with >=90% of its height inside but not all of
+    /// it. Absent everywhere else; older bridges never send it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partial: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -797,6 +802,7 @@ mod tests {
                 "possible-double-exposure".to_string(),
             ],
             image_path: "/tmp/slot-0007.tif".to_string(),
+            partial: None,
         };
         let value = serde_json::to_value(&thumbnail).unwrap();
         assert_eq!(value["needsApproval"], json!(true));
@@ -1031,6 +1037,7 @@ mod tests {
                     needs_approval: true,
                     warnings: vec!["user-picked".to_string()],
                     image_path: "/tmp/stub-manual/slot-0001.tif".to_string(),
+                    partial: None,
                 },
                 BridgeThumbnail {
                     slot: 2,
@@ -1039,6 +1046,7 @@ mod tests {
                     needs_approval: true,
                     warnings: vec!["user-picked".to_string()],
                     image_path: "/tmp/stub-manual/slot-0002.tif".to_string(),
+                    partial: None,
                 },
             ],
             snaps: vec![BridgeBoundarySnap {
@@ -1100,5 +1108,36 @@ mod tests {
             json!({"rows": [100, 300, 500]})
         );
         round_trip(&params);
+    }
+
+    #[test]
+    fn bridge_thumbnail_partial_round_trips_and_defaults_absent() {
+        let with_partial = BridgeThumbnail {
+            slot: 39,
+            boundary_rows: (10, 800),
+            spacing_offset: 0,
+            needs_approval: true,
+            warnings: vec![],
+            image_path: "/tmp/t.tif".to_string(),
+            partial: Some(true),
+        };
+        let value = serde_json::to_value(&with_partial).unwrap();
+        assert_eq!(value["partial"], serde_json::json!(true));
+        round_trip(&with_partial);
+
+        let without: BridgeThumbnail = serde_json::from_value(serde_json::json!({
+            "slot": 1,
+            "boundaryRows": [10, 800],
+            "spacingOffset": 0,
+            "needsApproval": false,
+            "warnings": [],
+            "imagePath": "/tmp/t.tif",
+        }))
+        .unwrap();
+        assert_eq!(without.partial, None);
+        assert!(serde_json::to_value(&without)
+            .unwrap()
+            .get("partial")
+            .is_none());
     }
 }

--- a/app/ScanStudio/engine/src/protocol.rs
+++ b/app/ScanStudio/engine/src/protocol.rs
@@ -352,6 +352,11 @@ pub struct Thumbnail {
     /// Omitted by the simulator and older real backends.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spacing_offset: Option<i64>,
+    /// Lane C, additive: `true` only on a frame whose crop overlaps the
+    /// preview with >=90% of its height inside but not all of it. Forwarded
+    /// verbatim from the bridge; omitted whenever the bridge omits it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partial: Option<bool>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub needs_approval: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -920,6 +925,7 @@ mod tests {
             image_path: None,
             boundary_rows: None,
             spacing_offset: None,
+            partial: None,
             needs_approval: false,
             warnings: vec![],
         };
@@ -1191,6 +1197,7 @@ mod tests {
                     image_path: Some("/tmp/manual/slot-0001.tif".to_string()),
                     boundary_rows: Some((100, 300)),
                     spacing_offset: Some(0),
+                    partial: None,
                     needs_approval: true,
                     warnings: vec!["user-picked".to_string()],
                 },

--- a/app/ScanStudio/engine/src/real_backend.rs
+++ b/app/ScanStudio/engine/src/real_backend.rs
@@ -1819,6 +1819,7 @@ impl RealLs5000 {
             image_path: Some(result.thumbnail.image_path),
             boundary_rows: Some(result.thumbnail.boundary_rows),
             spacing_offset: Some(result.thumbnail.spacing_offset),
+            partial: result.thumbnail.partial,
             needs_approval: result.thumbnail.needs_approval,
             warnings: result.thumbnail.warnings,
         })
@@ -1899,6 +1900,7 @@ impl RealLs5000 {
                     image_path: Some(thumbnail.image_path),
                     boundary_rows: Some(thumbnail.boundary_rows),
                     spacing_offset: Some(thumbnail.spacing_offset),
+                    partial: thumbnail.partial,
                     needs_approval: thumbnail.needs_approval,
                     warnings: thumbnail.warnings,
                 },
@@ -2188,6 +2190,7 @@ impl ScannerBackend for RealLs5000 {
                                     image_path: Some(bridge_thumbnail.image_path.clone()),
                                     boundary_rows: Some(bridge_thumbnail.boundary_rows),
                                     spacing_offset: Some(bridge_thumbnail.spacing_offset),
+                                    partial: bridge_thumbnail.partial,
                                     needs_approval: bridge_thumbnail.needs_approval,
                                     warnings: bridge_thumbnail.warnings.clone(),
                                 };

--- a/app/ScanStudio/engine/src/sim.rs
+++ b/app/ScanStudio/engine/src/sim.rs
@@ -58,6 +58,9 @@ pub fn thumbnail_for(device_id: &str, frame_index: u32) -> Thumbnail {
         image_path: None,
         boundary_rows: None,
         spacing_offset: None,
+        // The simulator has no preview raster for a frame to run off the
+        // edge of; simulated frames are never partial.
+        partial: None,
         needs_approval: false,
         warnings: vec![],
     }

--- a/app/ScanStudio/engine/tests/end_to_end_real_backend.rs
+++ b/app/ScanStudio/engine/tests/end_to_end_real_backend.rs
@@ -4369,3 +4369,47 @@ fn scan_start_rejects_a_frame_the_completed_preview_never_returned() {
     let _ = reader_handle.join();
     let _ = std::fs::remove_dir_all(output_directory);
 }
+
+#[test]
+fn partial_frame_marker_survives_bridge_to_engine_wire() {
+    // Lane C: the bridge marks a frame `partial: true` when its crop runs
+    // off the preview edge. The engine used to drop the field silently
+    // (BridgeThumbnail had no such field, serde discarded it); this pins
+    // the whole path: mock bridge -> engine -> public wire. The mock's
+    // designated partial slot is 39 (outside the standard 1..3 preview
+    // trio, so no other test's thumbnail expectations change).
+    let (mut child, mut stdin, rx, reader_handle) =
+        spawn_connected_engine_with_bridge_env("e2e-partial-marker", &[]);
+
+    send(
+        &mut stdin,
+        3,
+        "scanner.acquireThumbnails",
+        json!({"frames": [1, 2, 3], "operationId": "partial-preview"}),
+    );
+    assert!(recv_response_for(&rx, 3, |_| {}).get("error").is_none());
+    let events = drain_until(&rx, Duration::from_secs(5), |event| {
+        event["event"] == "scanner.thumbnail" && event["payload"]["frameIndex"] == 1
+    });
+    let thumbnail_event = events.last().expect("slot 1 thumbnail event");
+    assert!(
+        thumbnail_event["payload"]["thumbnail"].get("partial").is_none(),
+        "an ordinary fully-inside frame must not carry the marker: {thumbnail_event}"
+    );
+
+    let events = drain_until(&rx, Duration::from_secs(5), |event| {
+        event["event"] == "scanner.thumbnail" && event["payload"]["frameIndex"] == 3
+    });
+    let partial_event = events.last().expect("slot 3 thumbnail event");
+    assert_eq!(
+        partial_event["payload"]["thumbnail"]["partial"],
+        json!(true),
+        "the mock's designated partial slot must reach the public wire intact: {partial_event}"
+    );
+
+    send(&mut stdin, 5, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 5, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}

--- a/coolscanpy/CHANGELOG.md
+++ b/coolscanpy/CHANGELOG.md
@@ -20,6 +20,26 @@ bridge delivery, and derivative rendering. The timing survives CoolscanPy,
 bridge, engine, manifest, and app boundaries. Legacy receipts remain valid and
 show their absent timing as not recorded rather than inventing a value.
 
+A failed roll preview can no longer strand its capture worker holding the
+scanner's USB claim. `Roll.preview()` spawns the `--preview-and-hold` child,
+and when the completed traversal's evidence was then refused parent-side
+(journal validation, index decode, topology mismatch, or a raising progress
+callback), the raise left the child parked at its hold boundary waiting for
+a decision — so a caller that exited on that raise orphaned a worker that
+kept the libusb device claim, failing every subsequent `coolscanpy.open`
+with `USBError` errno 13 for the hold wait's remaining half-hour timeout.
+Observed live 2026-08-08 (attempt preview-g7w8t49z): the parent died on
+`IndexDecodeError: index row framing mismatch at usable row 5317` and the
+worker PID had to be killed by hand. Every preview-failure exit now tears
+the held child down fail-closed before the exception escapes: a release
+decision is published first (a healthy child releases the unit cleanly and
+exits 0 — the live incident's child would have), then a bounded wait, then
+terminate, then kill. The adapter's own internal refusals ride the same
+ladder, including the no-rendezvous case that was previously left running
+by design. An unclean teardown preserves the attempts directory as evidence,
+and the propagating exception is annotated with exactly what happened to
+the child.
+
 Whole-roll preview now keeps a content-supported leading frame when an
 otherwise valid feed places its fitted start exactly one 97-dpi preview row
 before the captured raster. The thumbnail is clamped to row zero, its

--- a/coolscanpy/src/coolscanpy/_roll.py
+++ b/coolscanpy/src/coolscanpy/_roll.py
@@ -562,6 +562,14 @@ class Roll:
         or by a prior ``scan_many()``/``scan()`` that completed without
         ``eject_after`` -- releasing it cleanly before starting the fresh
         transport read, exactly like an explicit :meth:`release` would.
+
+        A ``preview()`` that raises never leaves the reservation held: the
+        capture child a failed preview would otherwise strand at its hold
+        boundary is told to release -- and terminated, then killed, if it
+        will not -- before the exception propagates, so a caller that dies
+        on the raise cannot leak a worker holding the scanner's USB claim.
+        The next ``scan_many()``/``scan()`` after a failed preview starts a
+        fresh reservation.
         """
 
         with self._state_condition:
@@ -578,6 +586,7 @@ class Roll:
             self._preview_thread_id = threading.get_ident()
 
         io_acquired = False
+        held: HeldPreviewSession | None = None
         try:
             self._device._acquire_io_lock("roll preview")
             io_acquired = True
@@ -609,17 +618,19 @@ class Roll:
             except CaptureStopped as error:
                 raise SafeStopRequested(str(error)) from error
             # Track a live held child the moment the adapter hands it back,
-            # before any interpretation of what it produced. Everything below
-            # can raise, and a raise must leave close()/release()/a retried
-            # preview() a handle to tell the still-alive child to let go of its
-            # reservation. Assigning only after validation succeeded (the
-            # previous behavior) orphaned a live child -- still blocked in
-            # wait_for_hold_decision, still holding the scanner -- whenever
-            # build_roll_preview_session refused the journal. An unusable
-            # session is the opposite case (the child exited before the hold
-            # boundary and was already reaped -- see HeldPreviewSession.usable)
-            # and is deliberately not stored, preserving that docstring's
-            # "preview() never stores an unusable session" invariant.
+            # before any interpretation of what it produced. On the success
+            # path this is the reservation scan_many()/scan() resumes without
+            # a refeed; on any raise below it is what the failure handler at
+            # the bottom of this method tears down, fail-closed, before the
+            # exception escapes. Assigning only after validation succeeded
+            # (the original behavior) orphaned a live child -- still blocked
+            # in wait_for_hold_decision, still holding the scanner --
+            # whenever build_roll_preview_session refused the journal. An
+            # unusable session is the opposite case (the child exited before
+            # the hold boundary and was already reaped -- see
+            # HeldPreviewSession.usable) and is deliberately not stored,
+            # preserving that docstring's "preview() never stores an unusable
+            # session" invariant.
             if held.usable:
                 self._held_session = held
             attempt = held.preview_attempt
@@ -696,6 +707,32 @@ class Roll:
                 for slot in session.slots
                 if wanted is None or slot.slot_id in wanted
             ]
+        except BaseException as error:
+            # A raise leaving preview() may be the last thing this process
+            # ever runs: the caller can die on it without reaching close()
+            # or release() (live failure 2026-08-08, attempt
+            # preview-g7w8t49z -- the parent exited on IndexDecodeError
+            # "index row framing mismatch" and the parked child kept the
+            # libusb device claim, failing every subsequent open with
+            # USBError errno 13 until it was killed by hand). So a failed
+            # preview never relies on a later call: its held child is torn
+            # down here, fail-closed, before the exception escapes --
+            # release decision, bounded wait, then terminate/kill (see
+            # CaptureProcessAdapter.teardown_held_session). An unusable
+            # session's child already exited and was reaped inside
+            # begin_held_preview; a raise before the adapter handed
+            # anything back has nothing to tear down.
+            if held is not None:
+                if self._held_session is held:
+                    self._held_session = None
+                if held.usable and not self._ensure_adapter().teardown_held_session(
+                    held, error=error
+                ):
+                    self._preserve_evidence(
+                        "held preview child did not end cleanly after the "
+                        f"failed preview: {error}"
+                    )
+            raise
         finally:
             if io_acquired:
                 self._device._release_io_lock()

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -40,7 +40,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "ee4320ac7f71f42db57d6a7a8c1c103226635f1214fb9f4a6271c8ef2ff0d812",
+    "roll_index.py": "d444d40f0bfb66e63ccf5467b6b153036eeac63c37c7b34b8d44bbc78dbfe2fa",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -31,7 +31,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     # Resealed 2026-08-07 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, Rung 4
     # scan-side wiring): both files gained CaptureBatchRequest/LiveBatchJob's
     # additive manual_boundary_rows field plus its batch-job.json plumbing.
-    "capture_process.py": "31485687011afad5dcf3470d72da26bc090ec43398518c7c9b85c42841fc97ef",
+    "capture_process.py": "6208a95b23bba84ee0903a07a0d583a9840c5332cbdc60f38a4b574a050d24e2",
     "worker.py": "f625057c5619c9ddf94d7e233c6ac9d2a86e300c1a8b1bd8d7f5f03d0eac8c24",
     "manual_frames.py": "f30f0003e081c3a98610d5700d7e6b6ee4d182b9d5228932f3304f1307d4815f",
     "usb_backend.py": "afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62",

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
@@ -1542,11 +1542,22 @@ class ProcessRunner(Protocol):
 
 
 class RunningBatchProcess(Protocol):
-    """The non-signalled subset of ``subprocess.Popen`` used by the adapter."""
+    """The subset of ``subprocess.Popen`` used by the adapter.
+
+    ``terminate()``/``kill()`` exist for exactly one caller -- the
+    fail-closed teardown of a held child whose preview this parent has
+    already refused (``_release_unreturnable_held_child``) -- and stay
+    unused everywhere else: a healthy capture child is never signalled
+    mid-attempt, it is always waited out (``_wait_for_batch_exit``).
+    """
 
     def poll(self) -> int | None: ...
 
     def wait(self, timeout: float | None = None) -> int: ...
+
+    def terminate(self) -> None: ...
+
+    def kill(self) -> None: ...
 
 
 class BatchProcessSpawner(Protocol):
@@ -1594,7 +1605,12 @@ def _spawn_batch_subprocess(
     stdout: Any,
     stderr: Any,
 ) -> RunningBatchProcess:
-    """Start one isolated child without exposing any signal/kill seam."""
+    """Start one isolated child in its own session.
+
+    ``start_new_session`` keeps an application-level SIGINT/SIGTERM from
+    reaching the scanner child implicitly; the returned handle's own
+    ``terminate()``/``kill()`` remain reserved for the failed-preview
+    teardown (see ``RunningBatchProcess``)."""
 
     return subprocess.Popen(
         list(argv),
@@ -1820,6 +1836,7 @@ class CaptureProcessAdapter:
         manifest_payload: bytes | None = None,
         batch_spawner: BatchProcessSpawner = _spawn_batch_subprocess,
         batch_poll_seconds: float = 0.1,
+        held_teardown_wait_seconds: float = 5.0,
     ) -> None:
         if not _is_sha256(expected_worker_sha256):
             raise ValueError("expected worker SHA-256 is not a lowercase digest")
@@ -1860,6 +1877,9 @@ class CaptureProcessAdapter:
             raise ValueError("batch_poll_seconds cannot be negative")
         self._batch_spawner = batch_spawner
         self._batch_poll_seconds = float(batch_poll_seconds)
+        if held_teardown_wait_seconds < 0:
+            raise ValueError("held_teardown_wait_seconds cannot be negative")
+        self._held_teardown_wait_seconds = float(held_teardown_wait_seconds)
         self._stop_requested = threading.Event()
         self._stop_gate = threading.Lock()
         self._attempt_lock = threading.Lock()
@@ -2276,9 +2296,9 @@ class CaptureProcessAdapter:
         ``begin_held_preview``'s do -- the child is alive, parked at a hold
         boundary, holding the reservation -- and raises instead of returning
         the only handle that could release it. So, exactly like
-        ``begin_held_preview``, the child is best-effort released on the way
-        out (``_release_unreturnable_held_child``); without that, a refused
-        journal orphaned a live child on the scanner until
+        ``begin_held_preview``, the child is torn down fail-closed on the
+        way out (``_release_unreturnable_held_child``); without that, a
+        refused journal orphaned a live child on the scanner until
         ``wait_for_hold_decision``'s own half-hour timeout expired.
         """
 
@@ -2501,8 +2521,9 @@ class CaptureProcessAdapter:
 
         Raising and returning a session are the only two outcomes, and a
         raise never leaves a child holding: if this call refuses a child
-        that already reached the hold boundary, it best-effort releases and
-        reaps that child on the way out (see
+        that already reached the hold boundary, it tears that child down
+        fail-closed on the way out -- release decision first, then a
+        bounded wait, then terminate/kill (see
         ``_release_unreturnable_held_child``).  It has to happen here --
         the caller is being handed an exception instead of the session, so
         it has no handle to release anything with.
@@ -2626,8 +2647,9 @@ class CaptureProcessAdapter:
                 # reservation -- and this call is about to raise instead of
                 # returning the only handle that could ever release it.
                 # Nothing downstream can clean that up (Roll.preview()'s own
-                # orphan fix needs a returned session to track), so the
-                # release belongs here, before the raise leaves this method.
+                # failure teardown needs a returned session to act on), so
+                # the teardown belongs here, before the raise leaves this
+                # method.
                 self._release_unreturnable_held_child(
                     process,
                     hold_ack_path=hold_ack_path,
@@ -2857,25 +2879,34 @@ class CaptureProcessAdapter:
         hold_ack_path: Path | None,
         hold_session_id: Any,
         error: BaseException,
-    ) -> None:
-        """Best-effort release and reap of a child parked at a hold boundary
-        that this adapter can no longer hand back.
+    ) -> bool:
+        """Fail-closed teardown of a child parked at a hold boundary that
+        this adapter can no longer hand back (or that the caller has already
+        refused).
 
-        Shared by both refusal paths that leave a live child holding the
-        reservation with nothing returned to release it with:
-        ``begin_held_preview`` refusing the original preview/hold journal,
-        and ``_resolve_held_after_batch`` refusing a CONTINUE_HOLD round's
-        own held-after-batch journal.  Both raise instead of returning a
-        session, so neither caller has a handle afterwards.
+        Shared by every preview-failure exit that would otherwise strand a
+        live child holding the reservation: ``begin_held_preview`` refusing
+        the original preview/hold journal, ``_resolve_held_after_batch``
+        refusing a CONTINUE_HOLD round's own held-after-batch journal, and
+        ``teardown_held_session`` (``Roll.preview()``'s own failure path,
+        where the session was returned but its evidence was then refused).
+        All of them are propagating ``error`` -- and the propagating parent
+        may well be about to die with it, taking every later chance to
+        release the child along (live failure 2026-08-08, attempt
+        preview-g7w8t49z: the parent exited on an ``IndexDecodeError`` and
+        the parked child kept the libusb device claim, failing every
+        subsequent open with ``USBError`` errno 13 for
+        ``wait_for_hold_decision``'s remaining half-hour timeout).
 
-        Mirrors ``_release_held_session_locked`` -- publish a release
-        decision, then wait the child out rather than signalling or
-        abandoning it -- but deliberately never raises and never validates
-        the release receipt.  ``error`` is the refusal already on its way
-        out and must stay the exception the caller sees; what happened here
-        is recorded on it as a note instead of replacing it.  A best-effort
-        release that quietly fails is still strictly better than leaving the
-        child alive and holding the scanner with no handle anywhere.
+        So, unlike ``_release_held_session_locked`` -- the operator-facing
+        path, which waits indefinitely for a validated release receipt --
+        this teardown is bounded and always ends with the child gone:
+        publish a release decision (the cooperative unblock the worker
+        releases the unit cleanly for), give the child
+        ``held_teardown_wait_seconds`` to act on it, then ``terminate()``,
+        wait the same bound again, then ``kill()``.  Never raises; ``error``
+        stays the exception the caller sees, with what happened here
+        recorded on it as a note.
 
         ``hold_session_id`` is the validated id when the caller got that
         far, and whatever the child itself published (possibly ``None``)
@@ -2883,65 +2914,85 @@ class CaptureProcessAdapter:
         not accepted by the worker -- it fails the wait closed as a
         ``SynchronizedProtocolError``, whose synchronized-cleanup path does
         still release the unit -- so publishing it unblocks a child that
-        would otherwise sit on the reservation until
-        ``wait_for_hold_decision``'s own half-hour timeout expired.
-        ``hold_ack_path`` is ``None`` only when the refused journal did not
-        name a usable rendezvous at all, which is the one case where there
-        is no way to address the child; that is recorded rather than
-        guessed at.
+        would otherwise sit on the reservation.  ``hold_ack_path`` is
+        ``None`` only when the refused journal did not name a usable
+        rendezvous at all; that child cannot be told anything and goes
+        straight to the terminate/kill ladder.
 
-        The child is waited out only once it has actually been unblocked --
-        either it was already gone, or a decision it will act on is now
-        published. ``_wait_for_batch_exit`` deliberately never gives up, so
-        waiting on a child still parked in ``wait_for_hold_decision`` with
-        no decision to read would block this thread for that wait's full
-        half-hour timeout rather than letting the refusal out.
+        Returns ``True`` when the child ended on its own (already gone, or
+        exited after taking the release decision) -- ``False`` when it had
+        to be signalled or could not be confirmed dead, which callers
+        should treat as evidence-preserving.
         """
 
         told = "reached the hold boundary"
-        unblocked = False
         try:
-            if process.poll() is None:
-                if hold_ack_path is None:
-                    told = (
-                        "could not be told to release (its journal named no "
-                        "usable hold rendezvous)"
-                    )
-                else:
-                    try:
-                        self._publish_hold_ack_at(
-                            hold_ack_path,
-                            hold_session_id=hold_session_id,
-                            action="release",
-                        )
-                        told = "was told to release"
-                        unblocked = True
-                    except FileExistsError:
-                        told = "already had a hold decision published"
-                        unblocked = True
-                    except BaseException as publish_error:
-                        told = f"could not be told to release ({publish_error})"
-            else:
-                told = "was already gone"
-                unblocked = True
-            if not unblocked:
-                error.add_note(
-                    f"held preview child {told}; it was left running rather "
-                    "than waited on, and the scanner reservation must be "
-                    "assumed still held until it times out"
+            if process.poll() is not None:
+                returncode, wait_error = self._wait_for_batch_exit(process)
+                note = f"held preview child was already gone and exited {returncode}"
+                if wait_error is not None:
+                    note += f" (reap deferred {wait_error!r})"
+                error.add_note(note)
+                return True
+            if hold_ack_path is None:
+                told = (
+                    "could not be told to release (its journal named no "
+                    "usable hold rendezvous)"
                 )
-                return
-            returncode, wait_error = self._wait_for_batch_exit(process)
+            else:
+                try:
+                    self._publish_hold_ack_at(
+                        hold_ack_path,
+                        hold_session_id=hold_session_id,
+                        action="release",
+                    )
+                    told = "was told to release"
+                except FileExistsError:
+                    told = "already had a hold decision published"
+                except BaseException as publish_error:
+                    told = f"could not be told to release ({publish_error})"
+            returncode = self._wait_for_exit_bounded(process)
+            if returncode is not None:
+                error.add_note(f"held preview child {told} and exited {returncode}")
+                return True
+            wait = self._held_teardown_wait_seconds
+            try:
+                process.terminate()
+            except BaseException:
+                # A child that vanished between poll() and the signal shows
+                # up as an exit code on the next bounded wait; anything else
+                # still has the kill rung below.
+                pass
+            returncode = self._wait_for_exit_bounded(process)
+            if returncode is not None:
+                error.add_note(
+                    f"held preview child {told}, did not exit within {wait:g}s, "
+                    f"and was terminated (exit {returncode})"
+                )
+                return False
+            try:
+                process.kill()
+            except BaseException:
+                pass
+            returncode = self._wait_for_exit_bounded(process)
         except BaseException as cleanup_error:
             error.add_note(
                 f"held preview child {told} but could not be let go cleanly "
                 f"({cleanup_error}); assume the scanner reservation is still held"
             )
-            return
-        note = f"held preview child {told} and exited {returncode}"
-        if wait_error is not None:
-            note += f" (reap deferred {wait_error!r})"
-        error.add_note(note)
+            return False
+        if returncode is not None:
+            error.add_note(
+                f"held preview child {told}, survived terminate, and was "
+                f"killed (exit {returncode})"
+            )
+            return False
+        error.add_note(
+            f"held preview child {told} and could not be confirmed dead even "
+            "after terminate and kill; assume the scanner reservation and its "
+            "USB device claim are still held"
+        )
+        return False
 
     def _rejected_hold_session_id(self, paths: AttemptPaths) -> Any:
         """Read back whatever the held child called its hold session, for a
@@ -3231,6 +3282,32 @@ class CaptureProcessAdapter:
                 )
         return journal
 
+    def teardown_held_session(
+        self,
+        held: HeldPreviewSession,
+        *,
+        error: BaseException,
+    ) -> bool:
+        """Fail-closed teardown of a held session whose completed preview
+        evidence the caller has refused.
+
+        ``Roll.preview()`` calls this on every failure exit after
+        ``begin_held_preview`` returned a usable session: the raise about to
+        propagate may be the last thing the parent process does, so the
+        still-parked child cannot be left for a ``close()``/``release()``
+        that may never come.  Bounded and never raises -- see
+        ``_release_unreturnable_held_child`` for the release-then-terminate-
+        then-kill ladder and the return value's meaning.
+        """
+
+        with self._attempt_lock:
+            return self._release_unreturnable_held_child(
+                held.process,
+                hold_ack_path=held.hold_ack_path,
+                hold_session_id=held.hold_session_id,
+                error=error,
+            )
+
     def _wait_for_batch_exit(
         self,
         process: RunningBatchProcess,
@@ -3252,6 +3329,23 @@ class CaptureProcessAdapter:
                     return returncode, deferred
                 if self._batch_poll_seconds:
                     time.sleep(self._batch_poll_seconds)
+
+    def _wait_for_exit_bounded(self, process: RunningBatchProcess) -> int | None:
+        """Poll for exit like ``_wait_for_held_preview_ready`` does, but give
+        up after ``held_teardown_wait_seconds`` instead of never: the one
+        caller (``_release_unreturnable_held_child``) escalates on ``None``
+        rather than blocking a failure exit behind an uncooperative child."""
+
+        deadline = time.monotonic() + self._held_teardown_wait_seconds
+        while True:
+            returncode = process.poll()
+            if returncode is not None:
+                return returncode
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            if self._batch_poll_seconds:
+                time.sleep(min(self._batch_poll_seconds, remaining))
 
     def run_attempt(self, request: CaptureRequest) -> CaptureAttemptResult:
         """Run and validate one worker attempt synchronously."""

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -546,20 +546,41 @@ def _validate_full_index_rows(rows: np.ndarray, usable_rows: int) -> dict:
         parity: rows[parity, INDEX_RGB_WORDS_PER_ROW:].copy()
         for parity in range(min(2, len(rows)))
     }
+    housekeeping_suffix_start: int | None = None
+    final_housekeeping = dict(parity_housekeeping)
     for parity, expected in parity_housekeeping.items():
         actual = prefix[parity::2, INDEX_RGB_WORDS_PER_ROW:]
         if len(actual) == 0:
             continue
         matches = np.all(actual == expected, axis=1)
-        if not bool(matches.all()):
-            local = int(np.flatnonzero(~matches)[0])
-            row = parity + 2 * local
-            raise IndexDecodeError(f"index row framing mismatch at usable row {row}")
+        if bool(matches.all()):
+            continue
+        local = int(np.flatnonzero(~matches)[0])
+        row = parity + 2 * local
+        # Power-on housekeeping collapse (first live observation 2026-08-08,
+        # attempt preview-g7w8t49z, the first preview after a scanner power
+        # cycle; same per-power-on precedent class as the fine-scan padding
+        # dialects). Partway through the capture -- observed just past the
+        # film's trailing edge -- the odd parity's housekeeping record
+        # collapses into the OTHER parity's own record and stays there.
+        # Accepted only in exactly that shape, fail-closed on everything
+        # else: at most one transition per parity, and the entire remainder
+        # must byte-equal the other parity's template from this same
+        # capture -- self-referential, no magic constants, so arbitrary
+        # corruption (which cannot reproduce the other parity's exact
+        # 224-word record) still refuses with today's message.
+        other = parity_housekeeping.get(1 - parity)
+        suffix = actual[local:]
+        if other is not None and bool(np.all(suffix == other)):
+            housekeeping_suffix_start = row
+            final_housekeeping[parity] = other.copy()
+            continue
+        raise IndexDecodeError(f"index row framing mismatch at usable row {row}")
 
     padding = rows[usable_rows:]
     padding_record_type = None
     if len(padding):
-        expected_housekeeping = parity_housekeeping[usable_rows % 2]
+        expected_housekeeping = final_housekeeping[usable_rows % 2]
         first = padding[0]
         if bool(np.any(first[:INDEX_RGB_WORDS_PER_ROW])) or not np.array_equal(
             first[INDEX_RGB_WORDS_PER_ROW:], expected_housekeeping
@@ -587,6 +608,9 @@ def _validate_full_index_rows(rows: np.ndarray, usable_rows: int) -> dict:
             if np.array_equal(parity_housekeeping[1], canonical_sync)
             else "stable-observed"
         ),
+        # Additive: absent (None) on every capture without the power-on
+        # housekeeping collapse; the first affected usable row otherwise.
+        "housekeeping_suffix_start": housekeeping_suffix_start,
     }
 
 

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
@@ -2914,6 +2914,19 @@ class FakeHeldBatchProcess:
 
         self._returncode = returncode
 
+    def terminate(self) -> None:
+        """SIGTERM from the failed-preview teardown ladder. The real
+        worker installs no handler, so a parked child dies to it."""
+
+        self.events.append("terminate")
+        if self._returncode is None:
+            self._returncode = -15
+
+    def kill(self) -> None:
+        self.events.append("kill")
+        if self._returncode is None:
+            self._returncode = -9
+
     def poll(self) -> int | None:
         if self._returncode is not None:
             return self._returncode
@@ -3214,6 +3227,7 @@ def _held_spawner(
     children: list[FakeHeldBatchProcess] | None = None,
     journal_overrides: dict[str, Any] | None = None,
     held_after_batch_journal_overrides: dict[str, Any] | None = None,
+    child_class: type[FakeHeldBatchProcess] = FakeHeldBatchProcess,
 ):
     def spawn(
         argv: Sequence[str],
@@ -3225,7 +3239,7 @@ def _held_spawner(
         del cwd, stdout, stderr
         spawn_calls.append(tuple(argv))
         hold_job_path = Path(_argument(argv, "--hold-job"))
-        child = FakeHeldBatchProcess(
+        child = child_class(
             output_path=Path(_argument(argv, "--output")),
             journal_path=Path(_argument(argv, "--journal")),
             hold_job_path=hold_job_path,
@@ -3249,6 +3263,8 @@ def _held_adapter(
     children: list[FakeHeldBatchProcess] | None = None,
     journal_overrides: dict[str, Any] | None = None,
     held_after_batch_journal_overrides: dict[str, Any] | None = None,
+    child_class: type[FakeHeldBatchProcess] = FakeHeldBatchProcess,
+    held_teardown_wait_seconds: float = 5.0,
 ) -> capture.CaptureProcessAdapter:
     return capture.CaptureProcessAdapter(
         worker_path=binding.worker,
@@ -3263,8 +3279,10 @@ def _held_adapter(
             held_after_batch_journal_overrides=(
                 held_after_batch_journal_overrides
             ),
+            child_class=child_class,
         ),
         batch_poll_seconds=0,
+        held_teardown_wait_seconds=held_teardown_wait_seconds,
     )
 
 
@@ -3672,6 +3690,9 @@ def test_refused_held_after_batch_journal_releases_the_child_instead_of_orphanin
         spawn_calls,
         children=children,
         held_after_batch_journal_overrides=overrides,
+        # The no-rendezvous case cannot publish a decision, so its child
+        # rides the teardown ladder's bounded waits; keep them short.
+        held_teardown_wait_seconds=0.05,
     )
     held = adapter.begin_held_preview(
         capture.CaptureRequest(mode=capture.CaptureMode.PREVIEW)
@@ -3705,11 +3726,145 @@ def test_refused_held_after_batch_journal_releases_the_child_instead_of_orphanin
         assert any("exited 0" in note for note in notes), notes
     else:
         # No rendezvous to publish a decision at, so the child cannot be
-        # unblocked -- and must therefore not be waited on either, or the
-        # refusal would sit here for wait_for_hold_decision's own half-hour
-        # timeout instead of reaching the caller.
+        # told to release -- which the fail-closed ladder answers by
+        # signalling it instead of leaving it holding the scanner for
+        # wait_for_hold_decision's own half-hour timeout (the pre-teardown
+        # behavior, and exactly the 2026-08-08 orphaned-worker leak).
+        assert child.poll() is not None, (
+            "an unaddressable child must still end dead, not orphaned"
+        )
+        assert "terminate" in child.events, child.events
         assert any("no usable hold rendezvous" in note for note in notes), notes
-        assert any("left running rather than waited on" in note for note in notes), notes
+        assert any("was terminated" in note for note in notes), notes
+
+
+class _AckIgnoringHeldProcess(FakeHeldBatchProcess):
+    """A child wedged past cooperation: parked while holding the
+    reservation but never consuming the release decision (e.g. blocked
+    mid-USB transfer rather than in ``wait_for_hold_decision``'s poll
+    loop). SIGTERM still lands, exactly as it does on the real worker,
+    which installs no handler."""
+
+    def poll(self) -> int | None:
+        return self._returncode
+
+
+class _TermIgnoringHeldProcess(_AckIgnoringHeldProcess):
+    """A child that survives SIGTERM too (e.g. uninterruptible in a USB
+    ioctl); only SIGKILL ends it."""
+
+    def terminate(self) -> None:
+        self.events.append("terminate")
+
+
+def _teardown_held(
+    tmp_path: Path,
+    binding: Binding,
+    *,
+    child_class: type[FakeHeldBatchProcess] = FakeHeldBatchProcess,
+) -> tuple[FakeHeldBatchProcess, capture.CaptureProcessError, bool]:
+    """Begin a held preview, then tear it down the way ``Roll.preview()``'s
+    failure exit does, returning (child, error-with-notes, clean)."""
+
+    spawn_calls: list[tuple[str, ...]] = []
+    children: list[FakeHeldBatchProcess] = []
+    adapter = _held_adapter(
+        tmp_path,
+        binding,
+        spawn_calls,
+        children=children,
+        child_class=child_class,
+        held_teardown_wait_seconds=0.05,
+    )
+    held = adapter.begin_held_preview(
+        capture.CaptureRequest(mode=capture.CaptureMode.PREVIEW)
+    )
+    error = capture.CaptureProcessError("synthetic preview evidence refusal")
+    clean = adapter.teardown_held_session(held, error=error)
+    assert len(children) == 1
+    return children[0], error, clean
+
+
+def test_teardown_held_session_releases_a_cooperative_child(
+    tmp_path: Path, binding: Binding
+) -> None:
+    """Roll.preview()'s failure exit for the common case -- the live
+    2026-08-08 orphan was a perfectly healthy child whose parent simply
+    died without telling it anything: one release decision, the child
+    releases the unit and exits 0, no signal anywhere near it."""
+
+    child, error, clean = _teardown_held(tmp_path, binding)
+
+    assert clean is True
+    assert child.poll() == 0
+    assert child.events[-1] == "hold-ack-release", child.events
+    assert "terminate" not in child.events and "kill" not in child.events
+    notes = getattr(error, "__notes__", [])
+    assert any("was told to release and exited 0" in note for note in notes), notes
+    receipt = json.loads(child.journal_path.read_text(encoding="utf-8"))
+    assert receipt["hold_outcome"] == "released"
+    assert receipt["unit_released"] is True
+
+
+def test_teardown_held_session_terminates_a_child_that_ignores_the_release(
+    tmp_path: Path, binding: Binding
+) -> None:
+    child, error, clean = _teardown_held(
+        tmp_path, binding, child_class=_AckIgnoringHeldProcess
+    )
+
+    assert clean is False
+    assert child.poll() == -15
+    assert "terminate" in child.events, child.events
+    assert "kill" not in child.events, child.events
+    notes = getattr(error, "__notes__", [])
+    assert any("did not exit within" in note for note in notes), notes
+    assert any("was terminated (exit -15)" in note for note in notes), notes
+
+
+def test_teardown_held_session_kills_a_child_that_survives_terminate(
+    tmp_path: Path, binding: Binding
+) -> None:
+    child, error, clean = _teardown_held(
+        tmp_path, binding, child_class=_TermIgnoringHeldProcess
+    )
+
+    assert clean is False
+    assert child.poll() == -9
+    assert child.events[-2:] == ["terminate", "kill"], child.events
+    notes = getattr(error, "__notes__", [])
+    assert any("survived terminate" in note for note in notes), notes
+    assert any("killed (exit -9)" in note for note in notes), notes
+
+
+def test_teardown_held_session_reaps_an_already_dead_child(
+    tmp_path: Path, binding: Binding
+) -> None:
+    spawn_calls: list[tuple[str, ...]] = []
+    children: list[FakeHeldBatchProcess] = []
+    adapter = _held_adapter(
+        tmp_path,
+        binding,
+        spawn_calls,
+        children=children,
+        held_teardown_wait_seconds=0.05,
+    )
+    held = adapter.begin_held_preview(
+        capture.CaptureRequest(mode=capture.CaptureMode.PREVIEW)
+    )
+    children[0].die(returncode=3)
+    error = capture.CaptureProcessError("synthetic preview evidence refusal")
+
+    assert adapter.teardown_held_session(held, error=error) is True
+
+    notes = getattr(error, "__notes__", [])
+    assert any(
+        "was already gone and exited 3" in note for note in notes
+    ), notes
+    assert "terminate" not in children[0].events
+    assert "hold-ack-release" not in children[0].events, (
+        "a dead child gets no decision published"
+    )
 
 
 def test_batch_result_density_accessors_survive_the_held_preview_port(

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_multibatch_per_feed_live_shape.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_multibatch_per_feed_live_shape.py
@@ -298,6 +298,15 @@ class _RealWorkerChild:
             raise TimeoutError("real worker child did not exit")
         return self._returncode
 
+    def terminate(self) -> None:
+        """A thread cannot be signalled; the failed-preview teardown ladder
+        treats an ignored terminate exactly like a wedged child, which is
+        the honest stand-in behavior (this suite never exercises it -- a
+        parked real worker takes the ladder's release decision first)."""
+
+    def kill(self) -> None:
+        """See terminate()."""
+
 
 class _DeviceDouble:
     """The handful of private hooks ``Roll`` uses on its owning Device.

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -1718,3 +1718,77 @@ def test_manual_placement_accepts_every_archived_automatic_boundary_set() -> Non
             "boundary -- expected <= 5.0 (this codebase's own leading-"
             "anchor wobble allowance)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Power-on housekeeping collapse (first observed 2026-08-08, the first
+# preview after a scanner power cycle): partway through the capture the odd
+# parity's housekeeping record collapses into the even parity's record and
+# stays there. Accepted in exactly that shape only.
+
+
+def _collapse_odd_housekeeping(stream: bytes, from_row: int) -> bytes:
+    rows = np.frombuffer(stream, dtype=">u2").copy().reshape(-1, roll.INDEX_ROW_WORDS)
+    even_record = rows[0, roll.INDEX_RGB_WORDS_PER_ROW :].copy()
+    for row in range(from_row, len(rows)):
+        if row % 2 == 1:
+            rows[row, roll.INDEX_RGB_WORDS_PER_ROW :] = even_record
+    return rows.astype(">u2", copy=False).tobytes()
+
+
+def test_power_on_housekeeping_collapse_suffix_is_accepted() -> None:
+    rgb = np.arange(20 * 96 * 3, dtype=np.uint16).reshape(20, 96, 3)
+    stream = _collapse_odd_housekeeping(_encode_index(rgb), from_row=13)
+    geometry = roll.IndexGeometry(97, 4000, 41, 3946, 20, 96, 20, 2048, len(stream))
+
+    decoded, known, report = roll.decode_full_index_bytes(stream, geometry)
+
+    np.testing.assert_array_equal(decoded, rgb)
+    assert known.all()
+    assert report["housekeeping_suffix_start"] == 13
+    assert report["odd_housekeeping"] == "canonical-aa55-counter"
+
+
+def test_power_on_collapse_to_garbage_still_refuses() -> None:
+    rgb = np.arange(20 * 96 * 3, dtype=np.uint16).reshape(20, 96, 3)
+    rows = (
+        np.frombuffer(_encode_index(rgb), dtype=">u2")
+        .copy()
+        .reshape(-1, roll.INDEX_ROW_WORDS)
+    )
+    for row in range(13, len(rows), 2):  # odd rows only: not the even record
+        rows[row, roll.INDEX_RGB_WORDS_PER_ROW :] = 0x1234
+    stream = rows.astype(">u2", copy=False).tobytes()
+    geometry = roll.IndexGeometry(97, 4000, 41, 3946, 20, 96, 20, 2048, len(stream))
+
+    with pytest.raises(roll.IndexDecodeError, match="framing mismatch at usable row 13"):
+        roll.decode_full_index_bytes(stream, geometry)
+
+
+def test_power_on_collapse_with_reversion_still_refuses() -> None:
+    """One transition only: collapse then back to canonical must refuse."""
+
+    rgb = np.arange(24 * 96 * 3, dtype=np.uint16).reshape(24, 96, 3)
+    stream = _collapse_odd_housekeeping(_encode_index(rgb), from_row=13)
+    rows = np.frombuffer(stream, dtype=">u2").copy().reshape(-1, roll.INDEX_ROW_WORDS)
+    canonical = np.frombuffer(_encode_index(rgb), dtype=">u2").reshape(
+        -1, roll.INDEX_ROW_WORDS
+    )
+    rows[21, roll.INDEX_RGB_WORDS_PER_ROW :] = canonical[
+        21, roll.INDEX_RGB_WORDS_PER_ROW :
+    ]
+    stream = rows.astype(">u2", copy=False).tobytes()
+    geometry = roll.IndexGeometry(97, 4000, 41, 3946, 24, 96, 24, 2048, len(stream))
+
+    with pytest.raises(roll.IndexDecodeError, match="framing mismatch"):
+        roll.decode_full_index_bytes(stream, geometry)
+
+
+def test_healthy_captures_report_no_housekeeping_suffix() -> None:
+    rgb = np.arange(20 * 96 * 3, dtype=np.uint16).reshape(20, 96, 3)
+    stream = _encode_index(rgb)
+    geometry = roll.IndexGeometry(97, 4000, 41, 3946, 20, 96, 20, 2048, len(stream))
+
+    _decoded, _known, report = roll.decode_full_index_bytes(stream, geometry)
+
+    assert report["housekeeping_suffix_start"] is None

--- a/coolscanpy/tests/test_facade.py
+++ b/coolscanpy/tests/test_facade.py
@@ -406,6 +406,26 @@ def _encode_index(rgb16: np.ndarray) -> bytes:
     return blocks.astype(">u2", copy=False).tobytes()
 
 
+def _corrupt_index_framing(preview: bytes, row: int) -> bytes:
+    """Overwrite one housekeeping word of ``row``'s record in an encoded
+    index stream, upstream of every hash: ``_FakeHeldWorkerProcess`` computes
+    its journal sha256s and density evidence over the returned bytes (the
+    corruption happened "on the wire", not after publication), so every
+    artifact validation passes and only ``decode_full_index_bytes``'s
+    parity-framing repetition check refuses -- ``IndexDecodeError: index row
+    framing mismatch at usable row {row}``, the exact live 2026-08-08
+    preview-g7w8t49z failure shape.  ``row`` must be odd: in
+    ``_encode_index``'s block layout the AA55 trailer that framing
+    validation exact-matches belongs to the odd row's record."""
+
+    if row % 2 != 1:
+        raise ValueError("corrupt an odd row: that parity carries the AA55 trailer")
+    offset = (row // 2) * roll_index.INDEX_BLOCK_WORDS * 2 + 800 * 2
+    corrupted = bytearray(preview)
+    corrupted[offset : offset + 2] = (0x0BAD).to_bytes(2, "big")
+    return bytes(corrupted)
+
+
 def _synthetic_index(*, height: int = 6_104) -> np.ndarray:
     """40 textured cells separated by clear-film gaps (adapted from
     tests/roll/test_ls5000_roll_session.py's ``_synthetic_index``)."""
@@ -1308,6 +1328,11 @@ class _FakeHeldWorkerProcess:
     expected_usb_address: int | None = None
     preview_started: threading.Event | None = None
     preview_release: threading.Event | None = None
+    # Odd preview row whose housekeeping record gets corrupted at encode
+    # time (see _corrupt_index_framing): every downstream hash and density
+    # artifact stays self-consistent, so the refusal surfaces exactly where
+    # the live 2026-08-08 failure did -- decode_full_index_bytes.
+    corrupt_framing_at_row: int | None = None
     hold_session_id: str = field(default_factory=lambda: secrets.token_hex(16))
     _delegate: Any = field(default=None, init=False, repr=False)
     _returncode: int | None = field(default=None, init=False)
@@ -1331,6 +1356,8 @@ class _FakeHeldWorkerProcess:
             self.preview_release.wait(timeout=5)
         rgb = _synthetic_index()
         preview = _encode_index(rgb)
+        if self.corrupt_framing_at_row is not None:
+            preview = _corrupt_index_framing(preview, self.corrupt_framing_at_row)
         table = _transport_table(len(rgb))
         directory = self.journal_path.parent
         preview_path = directory / "capture-preview.bin"
@@ -1462,6 +1489,19 @@ class _FakeHeldWorkerProcess:
 
         self._returncode = returncode
 
+    def terminate(self) -> None:
+        """SIGTERM from the failed-preview teardown ladder. The real worker
+        installs no handler, so a parked child dies to it."""
+
+        self.events.append("terminate")
+        if self._returncode is None:
+            self._returncode = -15
+
+    def kill(self) -> None:
+        self.events.append("kill")
+        if self._returncode is None:
+            self._returncode = -9
+
     def poll(self) -> int | None:
         # Checked first, ahead of any delegate/reset dispatch below: die()
         # simulates the child being gone *right now*, regardless of
@@ -1568,6 +1608,7 @@ def _held_worker_process(
     delegate_factory: Callable[[Path, Path], Any],
     preview_started: threading.Event | None = None,
     preview_release: threading.Event | None = None,
+    corrupt_framing_at_row: int | None = None,
 ) -> _FakeHeldWorkerProcess:
     hold_job_path = Path(_arg(argv, "--hold-job"))
     return _FakeHeldWorkerProcess(
@@ -1578,6 +1619,7 @@ def _held_worker_process(
         worker_sha256=_sha256(_FAKE_WORKER_SOURCE),
         events=events,
         delegate_factory=delegate_factory,
+        corrupt_framing_at_row=corrupt_framing_at_row,
         expected_usb_bus=(
             int(_arg(argv, "--expected-usb-bus"))
             if "--expected-usb-bus" in argv
@@ -2876,17 +2918,47 @@ def _corrupting_spawner(events: list[str], *, corrupt_first_previews: int = 1):
     return spawn
 
 
+def _framing_corrupting_spawner(events: list[str], *, row: int):
+    """Held-preview children whose index stream carries a parity-framing
+    corruption at ``row`` (see ``_corrupt_index_framing``): every hash and
+    density artifact is computed over the corrupted bytes, so
+    ``begin_held_preview`` accepts the journal (it never decodes the
+    stream), the child parks at the hold boundary, and
+    ``build_roll_preview_session``'s ``decode_full_index_bytes`` is what
+    refuses -- the exact live 2026-08-08 preview-g7w8t49z failure shape."""
+
+    def make_batch_process(job_path: Path, session_journal_path: Path):
+        raise AssertionError(
+            "a preview refused at decode must never resume into a batch"
+        )
+
+    def spawn(argv: Sequence[str], *, cwd: Path, stdout: object, stderr: object):
+        del cwd, stdout, stderr
+        assert "--preview-and-hold" in argv
+        return _held_worker_process(
+            argv,
+            events,
+            delegate_factory=make_batch_process,
+            corrupt_framing_at_row=row,
+        )
+
+    return spawn
+
+
 class TestRollPreviewFailureCleanup:
-    def test_refused_preview_journal_still_releases_the_held_child_on_exit(
+    def test_refused_preview_journal_tears_down_the_held_child_in_preview_itself(
         self, fake_service_factory, tmp_path: Path
     ) -> None:
-        """The 2026-07-24 orphaned-hold defect: preview()'s transport read
-        completes and the child pauses at the hold boundary, then
-        build_roll_preview_session refuses the journal. The held session
-        must already be tracked at that point, so context exit -> close()
-        finds it and tells the still-alive child to release -- previously
-        the child was orphaned holding the scanner's reservation, and the
-        refused journal was deleted with the attempts directory."""
+        """The 2026-07-24 orphaned-hold defect, at its current, stronger
+        contract: preview()'s transport read completes and the child pauses
+        at the hold boundary, then build_roll_preview_session refuses the
+        journal. Tracking the held session for close() to release (the
+        original fix) was not enough -- a parent that dies on the raise
+        never calls close() (live 2026-08-08: the orphan kept the libusb
+        device claim, failing every subsequent open with USBError errno 13)
+        -- so the failing preview() call itself must release and reap the
+        child before its raise escapes, and a close() that does run later
+        must find nothing left to release."""
 
         from coolscanpy.roll.preview_session import RollSessionIntegrityError
 
@@ -2899,12 +2971,25 @@ class TestRollPreviewFailureCleanup:
             with pytest.raises(
                 RollSessionIntegrityError, match="disk_bytes"
             ) as excinfo:
-                with roll:
-                    roll.preview()
+                roll.preview()
 
+            # No close() has run yet: the failing preview() call already
+            # told the child to release and reaped it.
             assert events == ["preview-hold-ready", "hold-ack-release"], (
-                "close() must release the held child a refused preview "
-                "left at the hold boundary, not orphan it"
+                "the failed preview() itself must release the held child "
+                "it left at the hold boundary, not defer to a close() that "
+                "a dying parent never reaches"
+            )
+            assert roll._held_session is None
+            notes = getattr(excinfo.value, "__notes__", [])
+            assert any(
+                "was told to release and exited 0" in note for note in notes
+            ), notes
+
+            roll.close()
+            assert events == ["preview-hold-ready", "hold-ack-release"], (
+                "close() must not publish a second release for a child the "
+                "failed preview already tore down"
             )
             attempts_root = tmp_path / "attempts"
             assert attempts_root.exists(), (
@@ -2912,9 +2997,66 @@ class TestRollPreviewFailureCleanup:
                 "not delete it"
             )
             note = f"preview capture evidence preserved at {attempts_root}"
-            assert note in getattr(excinfo.value, "__notes__", [])
+            assert note in notes
         finally:
             dev.close()
+
+    def test_decode_refusal_reaps_the_held_child_with_no_close_at_all(
+        self, fake_service_factory, tmp_path: Path
+    ) -> None:
+        """Live failure 2026-08-08 ~09:29, attempt preview-g7w8t49z: preview()
+        raised IndexDecodeError "index row framing mismatch at usable row
+        5317" after the --preview-and-hold child was already parked at its
+        hold boundary, and the parent's failure path exited without
+        terminating it. The orphaned worker kept the libusb device claim,
+        so every subsequent coolscanpy.open failed with USBError errno 13
+        until the PID was killed by hand. Reproduced through the real
+        validation path with the same corruption shape (one odd row's
+        housekeeping record breaking parity-framing repetition at row
+        5317): every hash and density artifact is self-consistent, so
+        decode_full_index_bytes is what refuses -- and the child must be
+        dead before that raise ever escapes preview()."""
+
+        events: list[str] = []
+        processes: list[Any] = []
+        dev = _open_device(fake_service_factory)
+        roll, _worker = _make_roll(
+            tmp_path,
+            dev,
+            batch_spawner=_counting_spawner(
+                events, processes, _framing_corrupting_spawner(events, row=5_317)
+            ),
+        )
+        try:
+            with pytest.raises(
+                roll_index.IndexDecodeError,
+                match="index row framing mismatch at usable row 5317",
+            ) as excinfo:
+                roll.preview()
+
+            assert len(processes) == 1
+            child = processes[0]
+            assert child.poll() == 0, (
+                "the held child must already be released and reaped when "
+                "preview() raises -- the parent may never run another line"
+            )
+            assert events == ["preview-hold-ready", "hold-ack-release"], (
+                "a cooperative child is released, never signalled"
+            )
+            assert roll._held_session is None
+            notes = getattr(excinfo.value, "__notes__", [])
+            assert any(
+                "was told to release and exited 0" in note for note in notes
+            ), notes
+            assert (tmp_path / "attempts").exists(), (
+                "the refused index stream is forensic evidence"
+            )
+        finally:
+            roll.close()
+            dev.close()
+        assert events == ["preview-hold-ready", "hold-ack-release"], (
+            "close() after the teardown must be a no-op for the held child"
+        )
 
     def test_clean_close_still_removes_the_attempts_directory(
         self, fake_service_factory, tmp_path: Path

--- a/ports/tauri/vendor/coolscanpy/CHANGELOG.md
+++ b/ports/tauri/vendor/coolscanpy/CHANGELOG.md
@@ -20,6 +20,26 @@ bridge delivery, and derivative rendering. The timing survives CoolscanPy,
 bridge, engine, manifest, and app boundaries. Legacy receipts remain valid and
 show their absent timing as not recorded rather than inventing a value.
 
+A failed roll preview can no longer strand its capture worker holding the
+scanner's USB claim. `Roll.preview()` spawns the `--preview-and-hold` child,
+and when the completed traversal's evidence was then refused parent-side
+(journal validation, index decode, topology mismatch, or a raising progress
+callback), the raise left the child parked at its hold boundary waiting for
+a decision — so a caller that exited on that raise orphaned a worker that
+kept the libusb device claim, failing every subsequent `coolscanpy.open`
+with `USBError` errno 13 for the hold wait's remaining half-hour timeout.
+Observed live 2026-08-08 (attempt preview-g7w8t49z): the parent died on
+`IndexDecodeError: index row framing mismatch at usable row 5317` and the
+worker PID had to be killed by hand. Every preview-failure exit now tears
+the held child down fail-closed before the exception escapes: a release
+decision is published first (a healthy child releases the unit cleanly and
+exits 0 — the live incident's child would have), then a bounded wait, then
+terminate, then kill. The adapter's own internal refusals ride the same
+ladder, including the no-rendezvous case that was previously left running
+by design. An unclean teardown preserves the attempts directory as evidence,
+and the propagating exception is annotated with exactly what happened to
+the child.
+
 Whole-roll preview now keeps a content-supported leading frame when an
 otherwise valid feed places its fitted start exactly one 97-dpi preview row
 before the captured raster. The thumbnail is clamped to row zero, its

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/_roll.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/_roll.py
@@ -562,6 +562,14 @@ class Roll:
         or by a prior ``scan_many()``/``scan()`` that completed without
         ``eject_after`` -- releasing it cleanly before starting the fresh
         transport read, exactly like an explicit :meth:`release` would.
+
+        A ``preview()`` that raises never leaves the reservation held: the
+        capture child a failed preview would otherwise strand at its hold
+        boundary is told to release -- and terminated, then killed, if it
+        will not -- before the exception propagates, so a caller that dies
+        on the raise cannot leak a worker holding the scanner's USB claim.
+        The next ``scan_many()``/``scan()`` after a failed preview starts a
+        fresh reservation.
         """
 
         with self._state_condition:
@@ -578,6 +586,7 @@ class Roll:
             self._preview_thread_id = threading.get_ident()
 
         io_acquired = False
+        held: HeldPreviewSession | None = None
         try:
             self._device._acquire_io_lock("roll preview")
             io_acquired = True
@@ -609,17 +618,19 @@ class Roll:
             except CaptureStopped as error:
                 raise SafeStopRequested(str(error)) from error
             # Track a live held child the moment the adapter hands it back,
-            # before any interpretation of what it produced. Everything below
-            # can raise, and a raise must leave close()/release()/a retried
-            # preview() a handle to tell the still-alive child to let go of its
-            # reservation. Assigning only after validation succeeded (the
-            # previous behavior) orphaned a live child -- still blocked in
-            # wait_for_hold_decision, still holding the scanner -- whenever
-            # build_roll_preview_session refused the journal. An unusable
-            # session is the opposite case (the child exited before the hold
-            # boundary and was already reaped -- see HeldPreviewSession.usable)
-            # and is deliberately not stored, preserving that docstring's
-            # "preview() never stores an unusable session" invariant.
+            # before any interpretation of what it produced. On the success
+            # path this is the reservation scan_many()/scan() resumes without
+            # a refeed; on any raise below it is what the failure handler at
+            # the bottom of this method tears down, fail-closed, before the
+            # exception escapes. Assigning only after validation succeeded
+            # (the original behavior) orphaned a live child -- still blocked
+            # in wait_for_hold_decision, still holding the scanner --
+            # whenever build_roll_preview_session refused the journal. An
+            # unusable session is the opposite case (the child exited before
+            # the hold boundary and was already reaped -- see
+            # HeldPreviewSession.usable) and is deliberately not stored,
+            # preserving that docstring's "preview() never stores an unusable
+            # session" invariant.
             if held.usable:
                 self._held_session = held
             attempt = held.preview_attempt
@@ -696,6 +707,32 @@ class Roll:
                 for slot in session.slots
                 if wanted is None or slot.slot_id in wanted
             ]
+        except BaseException as error:
+            # A raise leaving preview() may be the last thing this process
+            # ever runs: the caller can die on it without reaching close()
+            # or release() (live failure 2026-08-08, attempt
+            # preview-g7w8t49z -- the parent exited on IndexDecodeError
+            # "index row framing mismatch" and the parked child kept the
+            # libusb device claim, failing every subsequent open with
+            # USBError errno 13 until it was killed by hand). So a failed
+            # preview never relies on a later call: its held child is torn
+            # down here, fail-closed, before the exception escapes --
+            # release decision, bounded wait, then terminate/kill (see
+            # CaptureProcessAdapter.teardown_held_session). An unusable
+            # session's child already exited and was reaped inside
+            # begin_held_preview; a raise before the adapter handed
+            # anything back has nothing to tear down.
+            if held is not None:
+                if self._held_session is held:
+                    self._held_session = None
+                if held.usable and not self._ensure_adapter().teardown_held_session(
+                    held, error=error
+                ):
+                    self._preserve_evidence(
+                        "held preview child did not end cleanly after the "
+                        f"failed preview: {error}"
+                    )
+            raise
         finally:
             if io_acquired:
                 self._device._release_io_lock()

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -37,7 +37,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "ee4320ac7f71f42db57d6a7a8c1c103226635f1214fb9f4a6271c8ef2ff0d812",
+    "roll_index.py": "d444d40f0bfb66e63ccf5467b6b153036eeac63c37c7b34b8d44bbc78dbfe2fa",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -28,7 +28,7 @@ CANONICAL_MANIFEST_FILENAME = "replay-first-rgbi4-manifest.json"
 # density-source cap-0x10d/f03 exposures, the proven 97-dpi reservation-preview
 # evidence, runtime arithmetic gate, and exact per-frame ownership receipt.
 CAPTURE_BUNDLE_COMPONENT_SHA256 = {
-    "capture_process.py": "31485687011afad5dcf3470d72da26bc090ec43398518c7c9b85c42841fc97ef",
+    "capture_process.py": "6208a95b23bba84ee0903a07a0d583a9840c5332cbdc60f38a4b574a050d24e2",
     "worker.py": "f625057c5619c9ddf94d7e233c6ac9d2a86e300c1a8b1bd8d7f5f03d0eac8c24",
     "manual_frames.py": "f30f0003e081c3a98610d5700d7e6b6ee4d182b9d5228932f3304f1307d4815f",
     "usb_backend.py": "77499a606dc48049521d2fd0359a0405cb55525242843d61165b642c78841208",

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
@@ -1542,11 +1542,22 @@ class ProcessRunner(Protocol):
 
 
 class RunningBatchProcess(Protocol):
-    """The non-signalled subset of ``subprocess.Popen`` used by the adapter."""
+    """The subset of ``subprocess.Popen`` used by the adapter.
+
+    ``terminate()``/``kill()`` exist for exactly one caller -- the
+    fail-closed teardown of a held child whose preview this parent has
+    already refused (``_release_unreturnable_held_child``) -- and stay
+    unused everywhere else: a healthy capture child is never signalled
+    mid-attempt, it is always waited out (``_wait_for_batch_exit``).
+    """
 
     def poll(self) -> int | None: ...
 
     def wait(self, timeout: float | None = None) -> int: ...
+
+    def terminate(self) -> None: ...
+
+    def kill(self) -> None: ...
 
 
 class BatchProcessSpawner(Protocol):
@@ -1594,7 +1605,12 @@ def _spawn_batch_subprocess(
     stdout: Any,
     stderr: Any,
 ) -> RunningBatchProcess:
-    """Start one isolated child without exposing any signal/kill seam."""
+    """Start one isolated child in its own session.
+
+    ``start_new_session`` keeps an application-level SIGINT/SIGTERM from
+    reaching the scanner child implicitly; the returned handle's own
+    ``terminate()``/``kill()`` remain reserved for the failed-preview
+    teardown (see ``RunningBatchProcess``)."""
 
     return subprocess.Popen(
         list(argv),
@@ -1820,6 +1836,7 @@ class CaptureProcessAdapter:
         manifest_payload: bytes | None = None,
         batch_spawner: BatchProcessSpawner = _spawn_batch_subprocess,
         batch_poll_seconds: float = 0.1,
+        held_teardown_wait_seconds: float = 5.0,
     ) -> None:
         if not _is_sha256(expected_worker_sha256):
             raise ValueError("expected worker SHA-256 is not a lowercase digest")
@@ -1860,6 +1877,9 @@ class CaptureProcessAdapter:
             raise ValueError("batch_poll_seconds cannot be negative")
         self._batch_spawner = batch_spawner
         self._batch_poll_seconds = float(batch_poll_seconds)
+        if held_teardown_wait_seconds < 0:
+            raise ValueError("held_teardown_wait_seconds cannot be negative")
+        self._held_teardown_wait_seconds = float(held_teardown_wait_seconds)
         self._stop_requested = threading.Event()
         self._stop_gate = threading.Lock()
         self._attempt_lock = threading.Lock()
@@ -2276,9 +2296,9 @@ class CaptureProcessAdapter:
         ``begin_held_preview``'s do -- the child is alive, parked at a hold
         boundary, holding the reservation -- and raises instead of returning
         the only handle that could release it. So, exactly like
-        ``begin_held_preview``, the child is best-effort released on the way
-        out (``_release_unreturnable_held_child``); without that, a refused
-        journal orphaned a live child on the scanner until
+        ``begin_held_preview``, the child is torn down fail-closed on the
+        way out (``_release_unreturnable_held_child``); without that, a
+        refused journal orphaned a live child on the scanner until
         ``wait_for_hold_decision``'s own half-hour timeout expired.
         """
 
@@ -2501,8 +2521,9 @@ class CaptureProcessAdapter:
 
         Raising and returning a session are the only two outcomes, and a
         raise never leaves a child holding: if this call refuses a child
-        that already reached the hold boundary, it best-effort releases and
-        reaps that child on the way out (see
+        that already reached the hold boundary, it tears that child down
+        fail-closed on the way out -- release decision first, then a
+        bounded wait, then terminate/kill (see
         ``_release_unreturnable_held_child``).  It has to happen here --
         the caller is being handed an exception instead of the session, so
         it has no handle to release anything with.
@@ -2626,8 +2647,9 @@ class CaptureProcessAdapter:
                 # reservation -- and this call is about to raise instead of
                 # returning the only handle that could ever release it.
                 # Nothing downstream can clean that up (Roll.preview()'s own
-                # orphan fix needs a returned session to track), so the
-                # release belongs here, before the raise leaves this method.
+                # failure teardown needs a returned session to act on), so
+                # the teardown belongs here, before the raise leaves this
+                # method.
                 self._release_unreturnable_held_child(
                     process,
                     hold_ack_path=hold_ack_path,
@@ -2857,25 +2879,34 @@ class CaptureProcessAdapter:
         hold_ack_path: Path | None,
         hold_session_id: Any,
         error: BaseException,
-    ) -> None:
-        """Best-effort release and reap of a child parked at a hold boundary
-        that this adapter can no longer hand back.
+    ) -> bool:
+        """Fail-closed teardown of a child parked at a hold boundary that
+        this adapter can no longer hand back (or that the caller has already
+        refused).
 
-        Shared by both refusal paths that leave a live child holding the
-        reservation with nothing returned to release it with:
-        ``begin_held_preview`` refusing the original preview/hold journal,
-        and ``_resolve_held_after_batch`` refusing a CONTINUE_HOLD round's
-        own held-after-batch journal.  Both raise instead of returning a
-        session, so neither caller has a handle afterwards.
+        Shared by every preview-failure exit that would otherwise strand a
+        live child holding the reservation: ``begin_held_preview`` refusing
+        the original preview/hold journal, ``_resolve_held_after_batch``
+        refusing a CONTINUE_HOLD round's own held-after-batch journal, and
+        ``teardown_held_session`` (``Roll.preview()``'s own failure path,
+        where the session was returned but its evidence was then refused).
+        All of them are propagating ``error`` -- and the propagating parent
+        may well be about to die with it, taking every later chance to
+        release the child along (live failure 2026-08-08, attempt
+        preview-g7w8t49z: the parent exited on an ``IndexDecodeError`` and
+        the parked child kept the libusb device claim, failing every
+        subsequent open with ``USBError`` errno 13 for
+        ``wait_for_hold_decision``'s remaining half-hour timeout).
 
-        Mirrors ``_release_held_session_locked`` -- publish a release
-        decision, then wait the child out rather than signalling or
-        abandoning it -- but deliberately never raises and never validates
-        the release receipt.  ``error`` is the refusal already on its way
-        out and must stay the exception the caller sees; what happened here
-        is recorded on it as a note instead of replacing it.  A best-effort
-        release that quietly fails is still strictly better than leaving the
-        child alive and holding the scanner with no handle anywhere.
+        So, unlike ``_release_held_session_locked`` -- the operator-facing
+        path, which waits indefinitely for a validated release receipt --
+        this teardown is bounded and always ends with the child gone:
+        publish a release decision (the cooperative unblock the worker
+        releases the unit cleanly for), give the child
+        ``held_teardown_wait_seconds`` to act on it, then ``terminate()``,
+        wait the same bound again, then ``kill()``.  Never raises; ``error``
+        stays the exception the caller sees, with what happened here
+        recorded on it as a note.
 
         ``hold_session_id`` is the validated id when the caller got that
         far, and whatever the child itself published (possibly ``None``)
@@ -2883,65 +2914,85 @@ class CaptureProcessAdapter:
         not accepted by the worker -- it fails the wait closed as a
         ``SynchronizedProtocolError``, whose synchronized-cleanup path does
         still release the unit -- so publishing it unblocks a child that
-        would otherwise sit on the reservation until
-        ``wait_for_hold_decision``'s own half-hour timeout expired.
-        ``hold_ack_path`` is ``None`` only when the refused journal did not
-        name a usable rendezvous at all, which is the one case where there
-        is no way to address the child; that is recorded rather than
-        guessed at.
+        would otherwise sit on the reservation.  ``hold_ack_path`` is
+        ``None`` only when the refused journal did not name a usable
+        rendezvous at all; that child cannot be told anything and goes
+        straight to the terminate/kill ladder.
 
-        The child is waited out only once it has actually been unblocked --
-        either it was already gone, or a decision it will act on is now
-        published. ``_wait_for_batch_exit`` deliberately never gives up, so
-        waiting on a child still parked in ``wait_for_hold_decision`` with
-        no decision to read would block this thread for that wait's full
-        half-hour timeout rather than letting the refusal out.
+        Returns ``True`` when the child ended on its own (already gone, or
+        exited after taking the release decision) -- ``False`` when it had
+        to be signalled or could not be confirmed dead, which callers
+        should treat as evidence-preserving.
         """
 
         told = "reached the hold boundary"
-        unblocked = False
         try:
-            if process.poll() is None:
-                if hold_ack_path is None:
-                    told = (
-                        "could not be told to release (its journal named no "
-                        "usable hold rendezvous)"
-                    )
-                else:
-                    try:
-                        self._publish_hold_ack_at(
-                            hold_ack_path,
-                            hold_session_id=hold_session_id,
-                            action="release",
-                        )
-                        told = "was told to release"
-                        unblocked = True
-                    except FileExistsError:
-                        told = "already had a hold decision published"
-                        unblocked = True
-                    except BaseException as publish_error:
-                        told = f"could not be told to release ({publish_error})"
-            else:
-                told = "was already gone"
-                unblocked = True
-            if not unblocked:
-                error.add_note(
-                    f"held preview child {told}; it was left running rather "
-                    "than waited on, and the scanner reservation must be "
-                    "assumed still held until it times out"
+            if process.poll() is not None:
+                returncode, wait_error = self._wait_for_batch_exit(process)
+                note = f"held preview child was already gone and exited {returncode}"
+                if wait_error is not None:
+                    note += f" (reap deferred {wait_error!r})"
+                error.add_note(note)
+                return True
+            if hold_ack_path is None:
+                told = (
+                    "could not be told to release (its journal named no "
+                    "usable hold rendezvous)"
                 )
-                return
-            returncode, wait_error = self._wait_for_batch_exit(process)
+            else:
+                try:
+                    self._publish_hold_ack_at(
+                        hold_ack_path,
+                        hold_session_id=hold_session_id,
+                        action="release",
+                    )
+                    told = "was told to release"
+                except FileExistsError:
+                    told = "already had a hold decision published"
+                except BaseException as publish_error:
+                    told = f"could not be told to release ({publish_error})"
+            returncode = self._wait_for_exit_bounded(process)
+            if returncode is not None:
+                error.add_note(f"held preview child {told} and exited {returncode}")
+                return True
+            wait = self._held_teardown_wait_seconds
+            try:
+                process.terminate()
+            except BaseException:
+                # A child that vanished between poll() and the signal shows
+                # up as an exit code on the next bounded wait; anything else
+                # still has the kill rung below.
+                pass
+            returncode = self._wait_for_exit_bounded(process)
+            if returncode is not None:
+                error.add_note(
+                    f"held preview child {told}, did not exit within {wait:g}s, "
+                    f"and was terminated (exit {returncode})"
+                )
+                return False
+            try:
+                process.kill()
+            except BaseException:
+                pass
+            returncode = self._wait_for_exit_bounded(process)
         except BaseException as cleanup_error:
             error.add_note(
                 f"held preview child {told} but could not be let go cleanly "
                 f"({cleanup_error}); assume the scanner reservation is still held"
             )
-            return
-        note = f"held preview child {told} and exited {returncode}"
-        if wait_error is not None:
-            note += f" (reap deferred {wait_error!r})"
-        error.add_note(note)
+            return False
+        if returncode is not None:
+            error.add_note(
+                f"held preview child {told}, survived terminate, and was "
+                f"killed (exit {returncode})"
+            )
+            return False
+        error.add_note(
+            f"held preview child {told} and could not be confirmed dead even "
+            "after terminate and kill; assume the scanner reservation and its "
+            "USB device claim are still held"
+        )
+        return False
 
     def _rejected_hold_session_id(self, paths: AttemptPaths) -> Any:
         """Read back whatever the held child called its hold session, for a
@@ -3231,6 +3282,32 @@ class CaptureProcessAdapter:
                 )
         return journal
 
+    def teardown_held_session(
+        self,
+        held: HeldPreviewSession,
+        *,
+        error: BaseException,
+    ) -> bool:
+        """Fail-closed teardown of a held session whose completed preview
+        evidence the caller has refused.
+
+        ``Roll.preview()`` calls this on every failure exit after
+        ``begin_held_preview`` returned a usable session: the raise about to
+        propagate may be the last thing the parent process does, so the
+        still-parked child cannot be left for a ``close()``/``release()``
+        that may never come.  Bounded and never raises -- see
+        ``_release_unreturnable_held_child`` for the release-then-terminate-
+        then-kill ladder and the return value's meaning.
+        """
+
+        with self._attempt_lock:
+            return self._release_unreturnable_held_child(
+                held.process,
+                hold_ack_path=held.hold_ack_path,
+                hold_session_id=held.hold_session_id,
+                error=error,
+            )
+
     def _wait_for_batch_exit(
         self,
         process: RunningBatchProcess,
@@ -3252,6 +3329,23 @@ class CaptureProcessAdapter:
                     return returncode, deferred
                 if self._batch_poll_seconds:
                     time.sleep(self._batch_poll_seconds)
+
+    def _wait_for_exit_bounded(self, process: RunningBatchProcess) -> int | None:
+        """Poll for exit like ``_wait_for_held_preview_ready`` does, but give
+        up after ``held_teardown_wait_seconds`` instead of never: the one
+        caller (``_release_unreturnable_held_child``) escalates on ``None``
+        rather than blocking a failure exit behind an uncooperative child."""
+
+        deadline = time.monotonic() + self._held_teardown_wait_seconds
+        while True:
+            returncode = process.poll()
+            if returncode is not None:
+                return returncode
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            if self._batch_poll_seconds:
+                time.sleep(min(self._batch_poll_seconds, remaining))
 
     def run_attempt(self, request: CaptureRequest) -> CaptureAttemptResult:
         """Run and validate one worker attempt synchronously."""

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -546,20 +546,41 @@ def _validate_full_index_rows(rows: np.ndarray, usable_rows: int) -> dict:
         parity: rows[parity, INDEX_RGB_WORDS_PER_ROW:].copy()
         for parity in range(min(2, len(rows)))
     }
+    housekeeping_suffix_start: int | None = None
+    final_housekeeping = dict(parity_housekeeping)
     for parity, expected in parity_housekeeping.items():
         actual = prefix[parity::2, INDEX_RGB_WORDS_PER_ROW:]
         if len(actual) == 0:
             continue
         matches = np.all(actual == expected, axis=1)
-        if not bool(matches.all()):
-            local = int(np.flatnonzero(~matches)[0])
-            row = parity + 2 * local
-            raise IndexDecodeError(f"index row framing mismatch at usable row {row}")
+        if bool(matches.all()):
+            continue
+        local = int(np.flatnonzero(~matches)[0])
+        row = parity + 2 * local
+        # Power-on housekeeping collapse (first live observation 2026-08-08,
+        # attempt preview-g7w8t49z, the first preview after a scanner power
+        # cycle; same per-power-on precedent class as the fine-scan padding
+        # dialects). Partway through the capture -- observed just past the
+        # film's trailing edge -- the odd parity's housekeeping record
+        # collapses into the OTHER parity's own record and stays there.
+        # Accepted only in exactly that shape, fail-closed on everything
+        # else: at most one transition per parity, and the entire remainder
+        # must byte-equal the other parity's template from this same
+        # capture -- self-referential, no magic constants, so arbitrary
+        # corruption (which cannot reproduce the other parity's exact
+        # 224-word record) still refuses with today's message.
+        other = parity_housekeeping.get(1 - parity)
+        suffix = actual[local:]
+        if other is not None and bool(np.all(suffix == other)):
+            housekeeping_suffix_start = row
+            final_housekeeping[parity] = other.copy()
+            continue
+        raise IndexDecodeError(f"index row framing mismatch at usable row {row}")
 
     padding = rows[usable_rows:]
     padding_record_type = None
     if len(padding):
-        expected_housekeeping = parity_housekeeping[usable_rows % 2]
+        expected_housekeeping = final_housekeeping[usable_rows % 2]
         first = padding[0]
         if bool(np.any(first[:INDEX_RGB_WORDS_PER_ROW])) or not np.array_equal(
             first[INDEX_RGB_WORDS_PER_ROW:], expected_housekeeping
@@ -587,6 +608,9 @@ def _validate_full_index_rows(rows: np.ndarray, usable_rows: int) -> dict:
             if np.array_equal(parity_housekeeping[1], canonical_sync)
             else "stable-observed"
         ),
+        # Additive: absent (None) on every capture without the power-on
+        # housekeeping collapse; the first affected usable row otherwise.
+        "housekeeping_suffix_start": housekeeping_suffix_start,
     }
 
 

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_capture_process.py
@@ -2914,6 +2914,19 @@ class FakeHeldBatchProcess:
 
         self._returncode = returncode
 
+    def terminate(self) -> None:
+        """SIGTERM from the failed-preview teardown ladder. The real
+        worker installs no handler, so a parked child dies to it."""
+
+        self.events.append("terminate")
+        if self._returncode is None:
+            self._returncode = -15
+
+    def kill(self) -> None:
+        self.events.append("kill")
+        if self._returncode is None:
+            self._returncode = -9
+
     def poll(self) -> int | None:
         if self._returncode is not None:
             return self._returncode
@@ -3214,6 +3227,7 @@ def _held_spawner(
     children: list[FakeHeldBatchProcess] | None = None,
     journal_overrides: dict[str, Any] | None = None,
     held_after_batch_journal_overrides: dict[str, Any] | None = None,
+    child_class: type[FakeHeldBatchProcess] = FakeHeldBatchProcess,
 ):
     def spawn(
         argv: Sequence[str],
@@ -3225,7 +3239,7 @@ def _held_spawner(
         del cwd, stdout, stderr
         spawn_calls.append(tuple(argv))
         hold_job_path = Path(_argument(argv, "--hold-job"))
-        child = FakeHeldBatchProcess(
+        child = child_class(
             output_path=Path(_argument(argv, "--output")),
             journal_path=Path(_argument(argv, "--journal")),
             hold_job_path=hold_job_path,
@@ -3249,6 +3263,8 @@ def _held_adapter(
     children: list[FakeHeldBatchProcess] | None = None,
     journal_overrides: dict[str, Any] | None = None,
     held_after_batch_journal_overrides: dict[str, Any] | None = None,
+    child_class: type[FakeHeldBatchProcess] = FakeHeldBatchProcess,
+    held_teardown_wait_seconds: float = 5.0,
 ) -> capture.CaptureProcessAdapter:
     return capture.CaptureProcessAdapter(
         worker_path=binding.worker,
@@ -3263,8 +3279,10 @@ def _held_adapter(
             held_after_batch_journal_overrides=(
                 held_after_batch_journal_overrides
             ),
+            child_class=child_class,
         ),
         batch_poll_seconds=0,
+        held_teardown_wait_seconds=held_teardown_wait_seconds,
     )
 
 
@@ -3672,6 +3690,9 @@ def test_refused_held_after_batch_journal_releases_the_child_instead_of_orphanin
         spawn_calls,
         children=children,
         held_after_batch_journal_overrides=overrides,
+        # The no-rendezvous case cannot publish a decision, so its child
+        # rides the teardown ladder's bounded waits; keep them short.
+        held_teardown_wait_seconds=0.05,
     )
     held = adapter.begin_held_preview(
         capture.CaptureRequest(mode=capture.CaptureMode.PREVIEW)
@@ -3705,11 +3726,145 @@ def test_refused_held_after_batch_journal_releases_the_child_instead_of_orphanin
         assert any("exited 0" in note for note in notes), notes
     else:
         # No rendezvous to publish a decision at, so the child cannot be
-        # unblocked -- and must therefore not be waited on either, or the
-        # refusal would sit here for wait_for_hold_decision's own half-hour
-        # timeout instead of reaching the caller.
+        # told to release -- which the fail-closed ladder answers by
+        # signalling it instead of leaving it holding the scanner for
+        # wait_for_hold_decision's own half-hour timeout (the pre-teardown
+        # behavior, and exactly the 2026-08-08 orphaned-worker leak).
+        assert child.poll() is not None, (
+            "an unaddressable child must still end dead, not orphaned"
+        )
+        assert "terminate" in child.events, child.events
         assert any("no usable hold rendezvous" in note for note in notes), notes
-        assert any("left running rather than waited on" in note for note in notes), notes
+        assert any("was terminated" in note for note in notes), notes
+
+
+class _AckIgnoringHeldProcess(FakeHeldBatchProcess):
+    """A child wedged past cooperation: parked while holding the
+    reservation but never consuming the release decision (e.g. blocked
+    mid-USB transfer rather than in ``wait_for_hold_decision``'s poll
+    loop). SIGTERM still lands, exactly as it does on the real worker,
+    which installs no handler."""
+
+    def poll(self) -> int | None:
+        return self._returncode
+
+
+class _TermIgnoringHeldProcess(_AckIgnoringHeldProcess):
+    """A child that survives SIGTERM too (e.g. uninterruptible in a USB
+    ioctl); only SIGKILL ends it."""
+
+    def terminate(self) -> None:
+        self.events.append("terminate")
+
+
+def _teardown_held(
+    tmp_path: Path,
+    binding: Binding,
+    *,
+    child_class: type[FakeHeldBatchProcess] = FakeHeldBatchProcess,
+) -> tuple[FakeHeldBatchProcess, capture.CaptureProcessError, bool]:
+    """Begin a held preview, then tear it down the way ``Roll.preview()``'s
+    failure exit does, returning (child, error-with-notes, clean)."""
+
+    spawn_calls: list[tuple[str, ...]] = []
+    children: list[FakeHeldBatchProcess] = []
+    adapter = _held_adapter(
+        tmp_path,
+        binding,
+        spawn_calls,
+        children=children,
+        child_class=child_class,
+        held_teardown_wait_seconds=0.05,
+    )
+    held = adapter.begin_held_preview(
+        capture.CaptureRequest(mode=capture.CaptureMode.PREVIEW)
+    )
+    error = capture.CaptureProcessError("synthetic preview evidence refusal")
+    clean = adapter.teardown_held_session(held, error=error)
+    assert len(children) == 1
+    return children[0], error, clean
+
+
+def test_teardown_held_session_releases_a_cooperative_child(
+    tmp_path: Path, binding: Binding
+) -> None:
+    """Roll.preview()'s failure exit for the common case -- the live
+    2026-08-08 orphan was a perfectly healthy child whose parent simply
+    died without telling it anything: one release decision, the child
+    releases the unit and exits 0, no signal anywhere near it."""
+
+    child, error, clean = _teardown_held(tmp_path, binding)
+
+    assert clean is True
+    assert child.poll() == 0
+    assert child.events[-1] == "hold-ack-release", child.events
+    assert "terminate" not in child.events and "kill" not in child.events
+    notes = getattr(error, "__notes__", [])
+    assert any("was told to release and exited 0" in note for note in notes), notes
+    receipt = json.loads(child.journal_path.read_text(encoding="utf-8"))
+    assert receipt["hold_outcome"] == "released"
+    assert receipt["unit_released"] is True
+
+
+def test_teardown_held_session_terminates_a_child_that_ignores_the_release(
+    tmp_path: Path, binding: Binding
+) -> None:
+    child, error, clean = _teardown_held(
+        tmp_path, binding, child_class=_AckIgnoringHeldProcess
+    )
+
+    assert clean is False
+    assert child.poll() == -15
+    assert "terminate" in child.events, child.events
+    assert "kill" not in child.events, child.events
+    notes = getattr(error, "__notes__", [])
+    assert any("did not exit within" in note for note in notes), notes
+    assert any("was terminated (exit -15)" in note for note in notes), notes
+
+
+def test_teardown_held_session_kills_a_child_that_survives_terminate(
+    tmp_path: Path, binding: Binding
+) -> None:
+    child, error, clean = _teardown_held(
+        tmp_path, binding, child_class=_TermIgnoringHeldProcess
+    )
+
+    assert clean is False
+    assert child.poll() == -9
+    assert child.events[-2:] == ["terminate", "kill"], child.events
+    notes = getattr(error, "__notes__", [])
+    assert any("survived terminate" in note for note in notes), notes
+    assert any("killed (exit -9)" in note for note in notes), notes
+
+
+def test_teardown_held_session_reaps_an_already_dead_child(
+    tmp_path: Path, binding: Binding
+) -> None:
+    spawn_calls: list[tuple[str, ...]] = []
+    children: list[FakeHeldBatchProcess] = []
+    adapter = _held_adapter(
+        tmp_path,
+        binding,
+        spawn_calls,
+        children=children,
+        held_teardown_wait_seconds=0.05,
+    )
+    held = adapter.begin_held_preview(
+        capture.CaptureRequest(mode=capture.CaptureMode.PREVIEW)
+    )
+    children[0].die(returncode=3)
+    error = capture.CaptureProcessError("synthetic preview evidence refusal")
+
+    assert adapter.teardown_held_session(held, error=error) is True
+
+    notes = getattr(error, "__notes__", [])
+    assert any(
+        "was already gone and exited 3" in note for note in notes
+    ), notes
+    assert "terminate" not in children[0].events
+    assert "hold-ack-release" not in children[0].events, (
+        "a dead child gets no decision published"
+    )
 
 
 def test_batch_result_density_accessors_survive_the_held_preview_port(

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_multibatch_per_feed_live_shape.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_multibatch_per_feed_live_shape.py
@@ -298,6 +298,15 @@ class _RealWorkerChild:
             raise TimeoutError("real worker child did not exit")
         return self._returncode
 
+    def terminate(self) -> None:
+        """A thread cannot be signalled; the failed-preview teardown ladder
+        treats an ignored terminate exactly like a wedged child, which is
+        the honest stand-in behavior (this suite never exercises it -- a
+        parked real worker takes the ladder's release decision first)."""
+
+    def kill(self) -> None:
+        """See terminate()."""
+
 
 class _DeviceDouble:
     """The handful of private hooks ``Roll`` uses on its owning Device.

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -1718,3 +1718,77 @@ def test_manual_placement_accepts_every_archived_automatic_boundary_set() -> Non
             "boundary -- expected <= 5.0 (this codebase's own leading-"
             "anchor wobble allowance)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Power-on housekeeping collapse (first observed 2026-08-08, the first
+# preview after a scanner power cycle): partway through the capture the odd
+# parity's housekeeping record collapses into the even parity's record and
+# stays there. Accepted in exactly that shape only.
+
+
+def _collapse_odd_housekeeping(stream: bytes, from_row: int) -> bytes:
+    rows = np.frombuffer(stream, dtype=">u2").copy().reshape(-1, roll.INDEX_ROW_WORDS)
+    even_record = rows[0, roll.INDEX_RGB_WORDS_PER_ROW :].copy()
+    for row in range(from_row, len(rows)):
+        if row % 2 == 1:
+            rows[row, roll.INDEX_RGB_WORDS_PER_ROW :] = even_record
+    return rows.astype(">u2", copy=False).tobytes()
+
+
+def test_power_on_housekeeping_collapse_suffix_is_accepted() -> None:
+    rgb = np.arange(20 * 96 * 3, dtype=np.uint16).reshape(20, 96, 3)
+    stream = _collapse_odd_housekeeping(_encode_index(rgb), from_row=13)
+    geometry = roll.IndexGeometry(97, 4000, 41, 3946, 20, 96, 20, 2048, len(stream))
+
+    decoded, known, report = roll.decode_full_index_bytes(stream, geometry)
+
+    np.testing.assert_array_equal(decoded, rgb)
+    assert known.all()
+    assert report["housekeeping_suffix_start"] == 13
+    assert report["odd_housekeeping"] == "canonical-aa55-counter"
+
+
+def test_power_on_collapse_to_garbage_still_refuses() -> None:
+    rgb = np.arange(20 * 96 * 3, dtype=np.uint16).reshape(20, 96, 3)
+    rows = (
+        np.frombuffer(_encode_index(rgb), dtype=">u2")
+        .copy()
+        .reshape(-1, roll.INDEX_ROW_WORDS)
+    )
+    for row in range(13, len(rows), 2):  # odd rows only: not the even record
+        rows[row, roll.INDEX_RGB_WORDS_PER_ROW :] = 0x1234
+    stream = rows.astype(">u2", copy=False).tobytes()
+    geometry = roll.IndexGeometry(97, 4000, 41, 3946, 20, 96, 20, 2048, len(stream))
+
+    with pytest.raises(roll.IndexDecodeError, match="framing mismatch at usable row 13"):
+        roll.decode_full_index_bytes(stream, geometry)
+
+
+def test_power_on_collapse_with_reversion_still_refuses() -> None:
+    """One transition only: collapse then back to canonical must refuse."""
+
+    rgb = np.arange(24 * 96 * 3, dtype=np.uint16).reshape(24, 96, 3)
+    stream = _collapse_odd_housekeeping(_encode_index(rgb), from_row=13)
+    rows = np.frombuffer(stream, dtype=">u2").copy().reshape(-1, roll.INDEX_ROW_WORDS)
+    canonical = np.frombuffer(_encode_index(rgb), dtype=">u2").reshape(
+        -1, roll.INDEX_ROW_WORDS
+    )
+    rows[21, roll.INDEX_RGB_WORDS_PER_ROW :] = canonical[
+        21, roll.INDEX_RGB_WORDS_PER_ROW :
+    ]
+    stream = rows.astype(">u2", copy=False).tobytes()
+    geometry = roll.IndexGeometry(97, 4000, 41, 3946, 24, 96, 24, 2048, len(stream))
+
+    with pytest.raises(roll.IndexDecodeError, match="framing mismatch"):
+        roll.decode_full_index_bytes(stream, geometry)
+
+
+def test_healthy_captures_report_no_housekeeping_suffix() -> None:
+    rgb = np.arange(20 * 96 * 3, dtype=np.uint16).reshape(20, 96, 3)
+    stream = _encode_index(rgb)
+    geometry = roll.IndexGeometry(97, 4000, 41, 3946, 20, 96, 20, 2048, len(stream))
+
+    _decoded, _known, report = roll.decode_full_index_bytes(stream, geometry)
+
+    assert report["housekeeping_suffix_start"] is None

--- a/ports/tauri/vendor/coolscanpy/tests/test_facade.py
+++ b/ports/tauri/vendor/coolscanpy/tests/test_facade.py
@@ -406,6 +406,26 @@ def _encode_index(rgb16: np.ndarray) -> bytes:
     return blocks.astype(">u2", copy=False).tobytes()
 
 
+def _corrupt_index_framing(preview: bytes, row: int) -> bytes:
+    """Overwrite one housekeeping word of ``row``'s record in an encoded
+    index stream, upstream of every hash: ``_FakeHeldWorkerProcess`` computes
+    its journal sha256s and density evidence over the returned bytes (the
+    corruption happened "on the wire", not after publication), so every
+    artifact validation passes and only ``decode_full_index_bytes``'s
+    parity-framing repetition check refuses -- ``IndexDecodeError: index row
+    framing mismatch at usable row {row}``, the exact live 2026-08-08
+    preview-g7w8t49z failure shape.  ``row`` must be odd: in
+    ``_encode_index``'s block layout the AA55 trailer that framing
+    validation exact-matches belongs to the odd row's record."""
+
+    if row % 2 != 1:
+        raise ValueError("corrupt an odd row: that parity carries the AA55 trailer")
+    offset = (row // 2) * roll_index.INDEX_BLOCK_WORDS * 2 + 800 * 2
+    corrupted = bytearray(preview)
+    corrupted[offset : offset + 2] = (0x0BAD).to_bytes(2, "big")
+    return bytes(corrupted)
+
+
 def _synthetic_index(*, height: int = 6_104) -> np.ndarray:
     """40 textured cells separated by clear-film gaps (adapted from
     tests/roll/test_ls5000_roll_session.py's ``_synthetic_index``)."""
@@ -1308,6 +1328,11 @@ class _FakeHeldWorkerProcess:
     expected_usb_address: int | None = None
     preview_started: threading.Event | None = None
     preview_release: threading.Event | None = None
+    # Odd preview row whose housekeeping record gets corrupted at encode
+    # time (see _corrupt_index_framing): every downstream hash and density
+    # artifact stays self-consistent, so the refusal surfaces exactly where
+    # the live 2026-08-08 failure did -- decode_full_index_bytes.
+    corrupt_framing_at_row: int | None = None
     hold_session_id: str = field(default_factory=lambda: secrets.token_hex(16))
     _delegate: Any = field(default=None, init=False, repr=False)
     _returncode: int | None = field(default=None, init=False)
@@ -1331,6 +1356,8 @@ class _FakeHeldWorkerProcess:
             self.preview_release.wait(timeout=5)
         rgb = _synthetic_index()
         preview = _encode_index(rgb)
+        if self.corrupt_framing_at_row is not None:
+            preview = _corrupt_index_framing(preview, self.corrupt_framing_at_row)
         table = _transport_table(len(rgb))
         directory = self.journal_path.parent
         preview_path = directory / "capture-preview.bin"
@@ -1462,6 +1489,19 @@ class _FakeHeldWorkerProcess:
 
         self._returncode = returncode
 
+    def terminate(self) -> None:
+        """SIGTERM from the failed-preview teardown ladder. The real worker
+        installs no handler, so a parked child dies to it."""
+
+        self.events.append("terminate")
+        if self._returncode is None:
+            self._returncode = -15
+
+    def kill(self) -> None:
+        self.events.append("kill")
+        if self._returncode is None:
+            self._returncode = -9
+
     def poll(self) -> int | None:
         # Checked first, ahead of any delegate/reset dispatch below: die()
         # simulates the child being gone *right now*, regardless of
@@ -1568,6 +1608,7 @@ def _held_worker_process(
     delegate_factory: Callable[[Path, Path], Any],
     preview_started: threading.Event | None = None,
     preview_release: threading.Event | None = None,
+    corrupt_framing_at_row: int | None = None,
 ) -> _FakeHeldWorkerProcess:
     hold_job_path = Path(_arg(argv, "--hold-job"))
     return _FakeHeldWorkerProcess(
@@ -1578,6 +1619,7 @@ def _held_worker_process(
         worker_sha256=_sha256(_FAKE_WORKER_SOURCE),
         events=events,
         delegate_factory=delegate_factory,
+        corrupt_framing_at_row=corrupt_framing_at_row,
         expected_usb_bus=(
             int(_arg(argv, "--expected-usb-bus"))
             if "--expected-usb-bus" in argv
@@ -2876,17 +2918,47 @@ def _corrupting_spawner(events: list[str], *, corrupt_first_previews: int = 1):
     return spawn
 
 
+def _framing_corrupting_spawner(events: list[str], *, row: int):
+    """Held-preview children whose index stream carries a parity-framing
+    corruption at ``row`` (see ``_corrupt_index_framing``): every hash and
+    density artifact is computed over the corrupted bytes, so
+    ``begin_held_preview`` accepts the journal (it never decodes the
+    stream), the child parks at the hold boundary, and
+    ``build_roll_preview_session``'s ``decode_full_index_bytes`` is what
+    refuses -- the exact live 2026-08-08 preview-g7w8t49z failure shape."""
+
+    def make_batch_process(job_path: Path, session_journal_path: Path):
+        raise AssertionError(
+            "a preview refused at decode must never resume into a batch"
+        )
+
+    def spawn(argv: Sequence[str], *, cwd: Path, stdout: object, stderr: object):
+        del cwd, stdout, stderr
+        assert "--preview-and-hold" in argv
+        return _held_worker_process(
+            argv,
+            events,
+            delegate_factory=make_batch_process,
+            corrupt_framing_at_row=row,
+        )
+
+    return spawn
+
+
 class TestRollPreviewFailureCleanup:
-    def test_refused_preview_journal_still_releases_the_held_child_on_exit(
+    def test_refused_preview_journal_tears_down_the_held_child_in_preview_itself(
         self, fake_service_factory, tmp_path: Path
     ) -> None:
-        """The 2026-07-24 orphaned-hold defect: preview()'s transport read
-        completes and the child pauses at the hold boundary, then
-        build_roll_preview_session refuses the journal. The held session
-        must already be tracked at that point, so context exit -> close()
-        finds it and tells the still-alive child to release -- previously
-        the child was orphaned holding the scanner's reservation, and the
-        refused journal was deleted with the attempts directory."""
+        """The 2026-07-24 orphaned-hold defect, at its current, stronger
+        contract: preview()'s transport read completes and the child pauses
+        at the hold boundary, then build_roll_preview_session refuses the
+        journal. Tracking the held session for close() to release (the
+        original fix) was not enough -- a parent that dies on the raise
+        never calls close() (live 2026-08-08: the orphan kept the libusb
+        device claim, failing every subsequent open with USBError errno 13)
+        -- so the failing preview() call itself must release and reap the
+        child before its raise escapes, and a close() that does run later
+        must find nothing left to release."""
 
         from coolscanpy.roll.preview_session import RollSessionIntegrityError
 
@@ -2899,12 +2971,25 @@ class TestRollPreviewFailureCleanup:
             with pytest.raises(
                 RollSessionIntegrityError, match="disk_bytes"
             ) as excinfo:
-                with roll:
-                    roll.preview()
+                roll.preview()
 
+            # No close() has run yet: the failing preview() call already
+            # told the child to release and reaped it.
             assert events == ["preview-hold-ready", "hold-ack-release"], (
-                "close() must release the held child a refused preview "
-                "left at the hold boundary, not orphan it"
+                "the failed preview() itself must release the held child "
+                "it left at the hold boundary, not defer to a close() that "
+                "a dying parent never reaches"
+            )
+            assert roll._held_session is None
+            notes = getattr(excinfo.value, "__notes__", [])
+            assert any(
+                "was told to release and exited 0" in note for note in notes
+            ), notes
+
+            roll.close()
+            assert events == ["preview-hold-ready", "hold-ack-release"], (
+                "close() must not publish a second release for a child the "
+                "failed preview already tore down"
             )
             attempts_root = tmp_path / "attempts"
             assert attempts_root.exists(), (
@@ -2912,9 +2997,66 @@ class TestRollPreviewFailureCleanup:
                 "not delete it"
             )
             note = f"preview capture evidence preserved at {attempts_root}"
-            assert note in getattr(excinfo.value, "__notes__", [])
+            assert note in notes
         finally:
             dev.close()
+
+    def test_decode_refusal_reaps_the_held_child_with_no_close_at_all(
+        self, fake_service_factory, tmp_path: Path
+    ) -> None:
+        """Live failure 2026-08-08 ~09:29, attempt preview-g7w8t49z: preview()
+        raised IndexDecodeError "index row framing mismatch at usable row
+        5317" after the --preview-and-hold child was already parked at its
+        hold boundary, and the parent's failure path exited without
+        terminating it. The orphaned worker kept the libusb device claim,
+        so every subsequent coolscanpy.open failed with USBError errno 13
+        until the PID was killed by hand. Reproduced through the real
+        validation path with the same corruption shape (one odd row's
+        housekeeping record breaking parity-framing repetition at row
+        5317): every hash and density artifact is self-consistent, so
+        decode_full_index_bytes is what refuses -- and the child must be
+        dead before that raise ever escapes preview()."""
+
+        events: list[str] = []
+        processes: list[Any] = []
+        dev = _open_device(fake_service_factory)
+        roll, _worker = _make_roll(
+            tmp_path,
+            dev,
+            batch_spawner=_counting_spawner(
+                events, processes, _framing_corrupting_spawner(events, row=5_317)
+            ),
+        )
+        try:
+            with pytest.raises(
+                roll_index.IndexDecodeError,
+                match="index row framing mismatch at usable row 5317",
+            ) as excinfo:
+                roll.preview()
+
+            assert len(processes) == 1
+            child = processes[0]
+            assert child.poll() == 0, (
+                "the held child must already be released and reaped when "
+                "preview() raises -- the parent may never run another line"
+            )
+            assert events == ["preview-hold-ready", "hold-ack-release"], (
+                "a cooperative child is released, never signalled"
+            )
+            assert roll._held_session is None
+            notes = getattr(excinfo.value, "__notes__", [])
+            assert any(
+                "was told to release and exited 0" in note for note in notes
+            ), notes
+            assert (tmp_path / "attempts").exists(), (
+                "the refused index stream is forensic evidence"
+            )
+        finally:
+            roll.close()
+            dev.close()
+        assert events == ["preview-hold-ready", "hold-ack-release"], (
+            "close() after the teardown must be a no-op for the held child"
+        )
 
     def test_clean_close_still_removes_the_attempts_directory(
         self, fake_service_factory, tmp_path: Path

--- a/ports/tauri/vendor/engine/src/bin/mock_bridge.rs
+++ b/ports/tauri/vendor/engine/src/bin/mock_bridge.rs
@@ -439,6 +439,17 @@ fn main() {
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Lane C mock: exactly one designated slot reports `partial: true` so
+/// integration tests can assert the field survives the engine unmangled;
+/// every other slot omits it, like a real bridge on a fully-inside frame.
+/// Slot 3 -- the last of the mock's standard 1..3 preview trio -- is the
+/// natural edge frame.
+const MOCK_PARTIAL_SLOT: u32 = 3;
+
+fn mock_partial_for(slot: u32) -> Option<bool> {
+    (slot == MOCK_PARTIAL_SLOT).then_some(true)
+}
+
 fn handle_request(
     tx: &mpsc::Sender<String>,
     request: &BridgeRequest,
@@ -591,6 +602,7 @@ fn handle_request(
                     needs_approval: false,
                     warnings: vec![],
                     image_path: path.to_string_lossy().into_owned(),
+                    partial: mock_partial_for(params.slot),
                 },
             })
         }
@@ -625,6 +637,7 @@ fn handle_request(
                         needs_approval: true,
                         warnings: vec!["user-picked".to_string()],
                         image_path: path.to_string_lossy().into_owned(),
+                        partial: mock_partial_for(slot),
                     }
                 })
                 .collect();
@@ -886,6 +899,7 @@ fn spawn_roll_preview_worker(
                         // save error above) so the wire shape is never
                         // missing this required field.
                         image_path: path.to_string_lossy().into_owned(),
+                        partial: mock_partial_for(slot),
                     },
                 },
             );

--- a/ports/tauri/vendor/engine/src/bridge_protocol.rs
+++ b/ports/tauri/vendor/engine/src/bridge_protocol.rs
@@ -239,6 +239,11 @@ pub struct BridgeThumbnail {
     /// bridge writes for this slot's preview crop (BRIDGE.md "Types" note
     /// under `Thumbnail`) — a path, never image bytes on the wire.
     pub image_path: String,
+    /// Lane C, additive (BRIDGE.md): `true` only on a frame whose crop
+    /// overlaps the preview with >=90% of its height inside but not all of
+    /// it. Absent everywhere else; older bridges never send it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partial: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -797,6 +802,7 @@ mod tests {
                 "possible-double-exposure".to_string(),
             ],
             image_path: "/tmp/slot-0007.tif".to_string(),
+            partial: None,
         };
         let value = serde_json::to_value(&thumbnail).unwrap();
         assert_eq!(value["needsApproval"], json!(true));
@@ -1031,6 +1037,7 @@ mod tests {
                     needs_approval: true,
                     warnings: vec!["user-picked".to_string()],
                     image_path: "/tmp/stub-manual/slot-0001.tif".to_string(),
+                    partial: None,
                 },
                 BridgeThumbnail {
                     slot: 2,
@@ -1039,6 +1046,7 @@ mod tests {
                     needs_approval: true,
                     warnings: vec!["user-picked".to_string()],
                     image_path: "/tmp/stub-manual/slot-0002.tif".to_string(),
+                    partial: None,
                 },
             ],
             snaps: vec![BridgeBoundarySnap {
@@ -1100,5 +1108,36 @@ mod tests {
             json!({"rows": [100, 300, 500]})
         );
         round_trip(&params);
+    }
+
+    #[test]
+    fn bridge_thumbnail_partial_round_trips_and_defaults_absent() {
+        let with_partial = BridgeThumbnail {
+            slot: 39,
+            boundary_rows: (10, 800),
+            spacing_offset: 0,
+            needs_approval: true,
+            warnings: vec![],
+            image_path: "/tmp/t.tif".to_string(),
+            partial: Some(true),
+        };
+        let value = serde_json::to_value(&with_partial).unwrap();
+        assert_eq!(value["partial"], serde_json::json!(true));
+        round_trip(&with_partial);
+
+        let without: BridgeThumbnail = serde_json::from_value(serde_json::json!({
+            "slot": 1,
+            "boundaryRows": [10, 800],
+            "spacingOffset": 0,
+            "needsApproval": false,
+            "warnings": [],
+            "imagePath": "/tmp/t.tif",
+        }))
+        .unwrap();
+        assert_eq!(without.partial, None);
+        assert!(serde_json::to_value(&without)
+            .unwrap()
+            .get("partial")
+            .is_none());
     }
 }

--- a/ports/tauri/vendor/engine/src/protocol.rs
+++ b/ports/tauri/vendor/engine/src/protocol.rs
@@ -352,6 +352,11 @@ pub struct Thumbnail {
     /// Omitted by the simulator and older real backends.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spacing_offset: Option<i64>,
+    /// Lane C, additive: `true` only on a frame whose crop overlaps the
+    /// preview with >=90% of its height inside but not all of it. Forwarded
+    /// verbatim from the bridge; omitted whenever the bridge omits it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partial: Option<bool>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub needs_approval: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -920,6 +925,7 @@ mod tests {
             image_path: None,
             boundary_rows: None,
             spacing_offset: None,
+            partial: None,
             needs_approval: false,
             warnings: vec![],
         };
@@ -1191,6 +1197,7 @@ mod tests {
                     image_path: Some("/tmp/manual/slot-0001.tif".to_string()),
                     boundary_rows: Some((100, 300)),
                     spacing_offset: Some(0),
+                    partial: None,
                     needs_approval: true,
                     warnings: vec!["user-picked".to_string()],
                 },

--- a/ports/tauri/vendor/engine/src/real_backend.rs
+++ b/ports/tauri/vendor/engine/src/real_backend.rs
@@ -1851,6 +1851,7 @@ impl RealLs5000 {
             image_path: Some(result.thumbnail.image_path),
             boundary_rows: Some(result.thumbnail.boundary_rows),
             spacing_offset: Some(result.thumbnail.spacing_offset),
+            partial: result.thumbnail.partial,
             needs_approval: result.thumbnail.needs_approval,
             warnings: result.thumbnail.warnings,
         })
@@ -1931,6 +1932,7 @@ impl RealLs5000 {
                     image_path: Some(thumbnail.image_path),
                     boundary_rows: Some(thumbnail.boundary_rows),
                     spacing_offset: Some(thumbnail.spacing_offset),
+                    partial: thumbnail.partial,
                     needs_approval: thumbnail.needs_approval,
                     warnings: thumbnail.warnings,
                 },
@@ -2220,6 +2222,7 @@ impl ScannerBackend for RealLs5000 {
                                     image_path: Some(bridge_thumbnail.image_path.clone()),
                                     boundary_rows: Some(bridge_thumbnail.boundary_rows),
                                     spacing_offset: Some(bridge_thumbnail.spacing_offset),
+                                    partial: bridge_thumbnail.partial,
                                     needs_approval: bridge_thumbnail.needs_approval,
                                     warnings: bridge_thumbnail.warnings.clone(),
                                 };

--- a/ports/tauri/vendor/engine/src/sim.rs
+++ b/ports/tauri/vendor/engine/src/sim.rs
@@ -58,6 +58,9 @@ pub fn thumbnail_for(device_id: &str, frame_index: u32) -> Thumbnail {
         image_path: None,
         boundary_rows: None,
         spacing_offset: None,
+        // The simulator has no preview raster for a frame to run off the
+        // edge of; simulated frames are never partial.
+        partial: None,
         needs_approval: false,
         warnings: vec![],
     }

--- a/ports/tauri/vendor/engine/tests/end_to_end_real_backend.rs
+++ b/ports/tauri/vendor/engine/tests/end_to_end_real_backend.rs
@@ -4369,3 +4369,47 @@ fn scan_start_rejects_a_frame_the_completed_preview_never_returned() {
     let _ = reader_handle.join();
     let _ = std::fs::remove_dir_all(output_directory);
 }
+
+#[test]
+fn partial_frame_marker_survives_bridge_to_engine_wire() {
+    // Lane C: the bridge marks a frame `partial: true` when its crop runs
+    // off the preview edge. The engine used to drop the field silently
+    // (BridgeThumbnail had no such field, serde discarded it); this pins
+    // the whole path: mock bridge -> engine -> public wire. The mock's
+    // designated partial slot is 39 (outside the standard 1..3 preview
+    // trio, so no other test's thumbnail expectations change).
+    let (mut child, mut stdin, rx, reader_handle) =
+        spawn_connected_engine_with_bridge_env("e2e-partial-marker", &[]);
+
+    send(
+        &mut stdin,
+        3,
+        "scanner.acquireThumbnails",
+        json!({"frames": [1, 2, 3], "operationId": "partial-preview"}),
+    );
+    assert!(recv_response_for(&rx, 3, |_| {}).get("error").is_none());
+    let events = drain_until(&rx, Duration::from_secs(5), |event| {
+        event["event"] == "scanner.thumbnail" && event["payload"]["frameIndex"] == 1
+    });
+    let thumbnail_event = events.last().expect("slot 1 thumbnail event");
+    assert!(
+        thumbnail_event["payload"]["thumbnail"].get("partial").is_none(),
+        "an ordinary fully-inside frame must not carry the marker: {thumbnail_event}"
+    );
+
+    let events = drain_until(&rx, Duration::from_secs(5), |event| {
+        event["event"] == "scanner.thumbnail" && event["payload"]["frameIndex"] == 3
+    });
+    let partial_event = events.last().expect("slot 3 thumbnail event");
+    assert_eq!(
+        partial_event["payload"]["thumbnail"]["partial"],
+        json!(true),
+        "the mock's designated partial slot must reach the public wire intact: {partial_event}"
+    );
+
+    send(&mut stdin, 5, "engine.shutdown", json!({}));
+    assert!(recv_response_for(&rx, 5, |_| {}).get("error").is_none());
+    let exit = wait_for_exit_bounded(&mut child, Duration::from_secs(10));
+    assert!(exit.success(), "engine did not exit 0: {exit:?}");
+    let _ = reader_handle.join();
+}


### PR DESCRIPTION
two follow-ups found after #45 merged, both validated live today.

the power-on fix: the first preview after switching the scanner on can fail with 'index row framing mismatch' -- discovered this morning on real hardware. after a cold start, partway through the capture (right past the film's end) the scanner's odd-row bookkeeping record collapses into the even-row record and stays there. same family as the power-on padding behaviors found earlier this week, striking the preview stream this time. the validator now accepts exactly that shape and nothing else: one transition at most, and the remainder must byte-match the same capture's own other-parity record -- corruption still refuses with the same message. proven live: the exact failing capture now previews at high confidence with the same geometry as the same roll's warm preview, and a frame scanned clean through the production path right after. replayed against every archived capture: byte-identical results everywhere.

the partial-frame marker: the bridge has always been able to mark a frame 'partial' (its crop runs off the edge of the preview -- common near a roll's start or end), and the app already knows how to show it, but the engine in the middle never modeled the field, so it was silently dropped for every frame. now forwarded end to end, with a test pinning bridge -> engine -> app wire. purely additive; frames that aren't partial look byte-identical.

suites: driver 1641, engine 523, app 456, drift guard clean. driver canonical is 6368a9d on coolscanpy port/cross-platform.