### PR TITLE
driver 0.2.1: refuse the parity-swap misframe

### DIFF
--- a/bridge/uv.lock
+++ b/bridge/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/coolscanpy/pyproject.toml
+++ b/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.2.0"
+version = "0.2.1"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/coolscanpy/src/coolscanpy/_roll.py
+++ b/coolscanpy/src/coolscanpy/_roll.py
@@ -725,7 +725,11 @@ class Roll:
             if held is not None:
                 if self._held_session is held:
                     self._held_session = None
-                if held.usable and not self._ensure_adapter().teardown_held_session(
+                # The already-resolved adapter local, never _ensure_adapter():
+                # re-resolving inside this handler could itself raise and
+                # replace the propagating exception while skipping teardown
+                # (post-release adversarial review 2026-08-08, T2).
+                if held.usable and not adapter.teardown_held_session(
                     held, error=error
                 ):
                     self._preserve_evidence(

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -40,7 +40,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "d444d40f0bfb66e63ccf5467b6b153036eeac63c37c7b34b8d44bbc78dbfe2fa",
+    "roll_index.py": "ae64e28a5d7e442cc368995b47c60ea1097f95f272fff558e93c7fc50800a5ef",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -548,14 +548,18 @@ def _validate_full_index_rows(rows: np.ndarray, usable_rows: int) -> dict:
     }
     housekeeping_suffix_start: int | None = None
     final_housekeeping = dict(parity_housekeeping)
+    parity_is_stable = {}
+    parity_first_bad = {}
     for parity, expected in parity_housekeeping.items():
         actual = prefix[parity::2, INDEX_RGB_WORDS_PER_ROW:]
-        if len(actual) == 0:
+        matches = np.all(actual == expected, axis=1) if len(actual) else np.ones(0, bool)
+        parity_is_stable[parity] = bool(matches.all())
+        if not parity_is_stable[parity]:
+            parity_first_bad[parity] = int(np.flatnonzero(~matches)[0])
+    for parity, expected in parity_housekeeping.items():
+        if parity_is_stable.get(parity, True):
             continue
-        matches = np.all(actual == expected, axis=1)
-        if bool(matches.all()):
-            continue
-        local = int(np.flatnonzero(~matches)[0])
+        local = parity_first_bad[parity]
         row = parity + 2 * local
         # Power-on housekeeping collapse (first live observation 2026-08-08,
         # attempt preview-g7w8t49z, the first preview after a scanner power
@@ -564,14 +568,23 @@ def _validate_full_index_rows(rows: np.ndarray, usable_rows: int) -> dict:
         # film's trailing edge -- the odd parity's housekeeping record
         # collapses into the OTHER parity's own record and stays there.
         # Accepted only in exactly that shape, fail-closed on everything
-        # else: at most one transition per parity, and the entire remainder
-        # must byte-equal the other parity's template from this same
-        # capture -- self-referential, no magic constants, so arbitrary
-        # corruption (which cannot reproduce the other parity's exact
-        # 224-word record) still refuses with today's message.
+        # else: EXACTLY ONE parity may transition, the entire remainder must
+        # byte-equal the other parity's template from this same capture, and
+        # the other parity must itself be stable across every usable row.
+        # The two-sided version of this pattern -- both parities swapping at
+        # one point -- is precisely what a one-row slip in the device's row
+        # generator produces (every later row lands on the opposite parity),
+        # and accepting it would silently misframe every frame after the
+        # slip by one index row (2026-08-08 post-release adversarial review,
+        # C2). One-sided-only keeps the live power-on shape and restores the
+        # pre-change refusal for the slip signature.
         other = parity_housekeeping.get(1 - parity)
-        suffix = actual[local:]
-        if other is not None and bool(np.all(suffix == other)):
+        suffix = prefix[parity::2, INDEX_RGB_WORDS_PER_ROW:][local:]
+        if (
+            other is not None
+            and parity_is_stable.get(1 - parity, False)
+            and bool(np.all(suffix == other))
+        ):
             housekeeping_suffix_start = row
             final_housekeeping[parity] = other.copy()
             continue

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -1792,3 +1792,30 @@ def test_healthy_captures_report_no_housekeeping_suffix() -> None:
     _decoded, _known, report = roll.decode_full_index_bytes(stream, geometry)
 
     assert report["housekeeping_suffix_start"] is None
+
+
+def test_two_sided_parity_swap_is_refused_as_a_framing_slip() -> None:
+    """Post-release adversarial review 2026-08-08, C2: BOTH parities
+    swapping onto each other's record at one point is the signature of a
+    one-row slip in the device's row generator -- every subsequent row
+    lands on the opposite parity, displacing all later frames by one index
+    row. The one-sided power-on collapse stays accepted; the two-sided
+    swap must refuse exactly as it did before the collapse acceptance."""
+
+    rgb = np.arange(20 * 96 * 3, dtype=np.uint16).reshape(20, 96, 3)
+    rows = (
+        np.frombuffer(_encode_index(rgb), dtype=">u2")
+        .copy()
+        .reshape(-1, roll.INDEX_ROW_WORDS)
+    )
+    even_record = rows[0, roll.INDEX_RGB_WORDS_PER_ROW :].copy()
+    odd_record = rows[1, roll.INDEX_RGB_WORDS_PER_ROW :].copy()
+    for row in range(13, len(rows)):
+        rows[row, roll.INDEX_RGB_WORDS_PER_ROW :] = (
+            odd_record if row % 2 == 0 else even_record
+        )
+    stream = rows.astype(">u2", copy=False).tobytes()
+    geometry = roll.IndexGeometry(97, 4000, 41, 3946, 20, 96, 20, 2048, len(stream))
+
+    with pytest.raises(roll.IndexDecodeError, match="framing mismatch"):
+        roll.decode_full_index_bytes(stream, geometry)

--- a/coolscanpy/uv.lock
+++ b/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/coolscanpy/pyproject.toml
+++ b/ports/tauri/vendor/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.2.0"
+version = "0.2.1"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/__init__.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/__init__.py
@@ -18,7 +18,7 @@ except Exception:  # pragma: no cover - only when the package isn't installed
     # Linux preview packages run directly from CorrespondingSource, where
     # distribution metadata is intentionally absent. Keep this fallback
     # aligned with pyproject.toml for accurate startup provenance.
-    __version__ = "0.2.0"
+    __version__ = "0.2.1"
 
 from coolscanpy._device import Device, get_devices, open
 from coolscanpy._roll import Roll

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/_roll.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/_roll.py
@@ -725,7 +725,11 @@ class Roll:
             if held is not None:
                 if self._held_session is held:
                     self._held_session = None
-                if held.usable and not self._ensure_adapter().teardown_held_session(
+                # The already-resolved adapter local, never _ensure_adapter():
+                # re-resolving inside this handler could itself raise and
+                # replace the propagating exception while skipping teardown
+                # (post-release adversarial review 2026-08-08, T2).
+                if held.usable and not adapter.teardown_held_session(
                     held, error=error
                 ):
                     self._preserve_evidence(

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -37,7 +37,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "d444d40f0bfb66e63ccf5467b6b153036eeac63c37c7b34b8d44bbc78dbfe2fa",
+    "roll_index.py": "ae64e28a5d7e442cc368995b47c60ea1097f95f272fff558e93c7fc50800a5ef",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -548,14 +548,18 @@ def _validate_full_index_rows(rows: np.ndarray, usable_rows: int) -> dict:
     }
     housekeeping_suffix_start: int | None = None
     final_housekeeping = dict(parity_housekeeping)
+    parity_is_stable = {}
+    parity_first_bad = {}
     for parity, expected in parity_housekeeping.items():
         actual = prefix[parity::2, INDEX_RGB_WORDS_PER_ROW:]
-        if len(actual) == 0:
+        matches = np.all(actual == expected, axis=1) if len(actual) else np.ones(0, bool)
+        parity_is_stable[parity] = bool(matches.all())
+        if not parity_is_stable[parity]:
+            parity_first_bad[parity] = int(np.flatnonzero(~matches)[0])
+    for parity, expected in parity_housekeeping.items():
+        if parity_is_stable.get(parity, True):
             continue
-        matches = np.all(actual == expected, axis=1)
-        if bool(matches.all()):
-            continue
-        local = int(np.flatnonzero(~matches)[0])
+        local = parity_first_bad[parity]
         row = parity + 2 * local
         # Power-on housekeeping collapse (first live observation 2026-08-08,
         # attempt preview-g7w8t49z, the first preview after a scanner power
@@ -564,14 +568,23 @@ def _validate_full_index_rows(rows: np.ndarray, usable_rows: int) -> dict:
         # film's trailing edge -- the odd parity's housekeeping record
         # collapses into the OTHER parity's own record and stays there.
         # Accepted only in exactly that shape, fail-closed on everything
-        # else: at most one transition per parity, and the entire remainder
-        # must byte-equal the other parity's template from this same
-        # capture -- self-referential, no magic constants, so arbitrary
-        # corruption (which cannot reproduce the other parity's exact
-        # 224-word record) still refuses with today's message.
+        # else: EXACTLY ONE parity may transition, the entire remainder must
+        # byte-equal the other parity's template from this same capture, and
+        # the other parity must itself be stable across every usable row.
+        # The two-sided version of this pattern -- both parities swapping at
+        # one point -- is precisely what a one-row slip in the device's row
+        # generator produces (every later row lands on the opposite parity),
+        # and accepting it would silently misframe every frame after the
+        # slip by one index row (2026-08-08 post-release adversarial review,
+        # C2). One-sided-only keeps the live power-on shape and restores the
+        # pre-change refusal for the slip signature.
         other = parity_housekeeping.get(1 - parity)
-        suffix = actual[local:]
-        if other is not None and bool(np.all(suffix == other)):
+        suffix = prefix[parity::2, INDEX_RGB_WORDS_PER_ROW:][local:]
+        if (
+            other is not None
+            and parity_is_stable.get(1 - parity, False)
+            and bool(np.all(suffix == other))
+        ):
             housekeeping_suffix_start = row
             final_housekeeping[parity] = other.copy()
             continue

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -1792,3 +1792,30 @@ def test_healthy_captures_report_no_housekeeping_suffix() -> None:
     _decoded, _known, report = roll.decode_full_index_bytes(stream, geometry)
 
     assert report["housekeeping_suffix_start"] is None
+
+
+def test_two_sided_parity_swap_is_refused_as_a_framing_slip() -> None:
+    """Post-release adversarial review 2026-08-08, C2: BOTH parities
+    swapping onto each other's record at one point is the signature of a
+    one-row slip in the device's row generator -- every subsequent row
+    lands on the opposite parity, displacing all later frames by one index
+    row. The one-sided power-on collapse stays accepted; the two-sided
+    swap must refuse exactly as it did before the collapse acceptance."""
+
+    rgb = np.arange(20 * 96 * 3, dtype=np.uint16).reshape(20, 96, 3)
+    rows = (
+        np.frombuffer(_encode_index(rgb), dtype=">u2")
+        .copy()
+        .reshape(-1, roll.INDEX_ROW_WORDS)
+    )
+    even_record = rows[0, roll.INDEX_RGB_WORDS_PER_ROW :].copy()
+    odd_record = rows[1, roll.INDEX_RGB_WORDS_PER_ROW :].copy()
+    for row in range(13, len(rows)):
+        rows[row, roll.INDEX_RGB_WORDS_PER_ROW :] = (
+            odd_record if row % 2 == 0 else even_record
+        )
+    stream = rows.astype(">u2", copy=False).tobytes()
+    geometry = roll.IndexGeometry(97, 4000, 41, 3946, 20, 96, 20, 2048, len(stream))
+
+    with pytest.raises(roll.IndexDecodeError, match="framing mismatch"):
+        roll.decode_full_index_bytes(stream, geometry)

--- a/ports/tauri/vendor/coolscanpy/uv.lock
+++ b/ports/tauri/vendor/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/scanstudio-bridge/uv.lock
+++ b/ports/tauri/vendor/scanstudio-bridge/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },


### PR DESCRIPTION
post-release adversarial review of the 0.2.0 power-on fix found a hole: the acceptance checked each parity independently, so BOTH parities swapping onto each other's records at one point -- which is what a one-row slip in the scanner's internal row generator looks like -- passed validation and silently shifted every later frame by one preview row. that is the wrong-crop class this project treats as worse than any refusal.

the acceptance is now one-sided only: exactly one parity may collapse onto the other's record, and the other must hold steady for the whole capture. the reviewer's slip construction refuses with the same message it did before 0.2.0 and ships as a permanent regression test; the real power-on capture from this morning still decodes end-to-end (high confidence, 37 slots). also folds in a small hardening to the preview-failure teardown from the same review.

driver 0.2.1 is on PyPI; versions, bundle pins, and lockfiles synced in lockstep. v0.5.0-beta.2 tags after this merges, superseding beta.1.