### PR TITLE
Release v0.6.0-beta.1: driver 0.3.0 version sync

### DIFF
--- a/app/ScanStudio/Tests/ScanStudioKitTests/FixtureDecodingTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/FixtureDecodingTests.swift
@@ -114,6 +114,18 @@ struct FixtureDecodingTests {
         #expect(back.autoCrop)
         #expect(back.rawExport.fileFormat == .linearTiff)
         #expect(back.rawExport.tiffInfrared == .sidecar)
+
+        let both = OutputRecipe(
+            archive: decoded.archive,
+            rawExport: enabled.rawExport,
+            positive: decoded.positive,
+            preview: decoded.preview,
+            autoCrop: true,
+            c41Render: C41RenderRecipe(target: .noritsuLs600)
+        )
+        let bothBack = try JSONDecoder().decode(OutputRecipe.self, from: JSONEncoder().encode(both))
+        #expect(bothBack.rawExport.tiffInfrared == .sidecar, "raw export survives alongside a c41 style")
+        #expect(bothBack.c41Render.target == .noritsuLs600, "c41 style survives alongside raw export")
     }
 
     @Test("08: scan.progress event decodes")

--- a/bridge/uv.lock
+++ b/bridge/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/coolscanpy/pyproject.toml
+++ b/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.2.1"
+version = "0.3.0"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/coolscanpy/uv.lock
+++ b/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/coolscanpy/pyproject.toml
+++ b/ports/tauri/vendor/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.2.1"
+version = "0.3.0"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/__init__.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/__init__.py
@@ -18,7 +18,7 @@ except Exception:  # pragma: no cover - only when the package isn't installed
     # Linux preview packages run directly from CorrespondingSource, where
     # distribution metadata is intentionally absent. Keep this fallback
     # aligned with pyproject.toml for accurate startup provenance.
-    __version__ = "0.2.1"
+    __version__ = "0.3.0"
 
 from coolscanpy._device import Device, get_devices, open
 from coolscanpy._roll import Roll

--- a/ports/tauri/vendor/coolscanpy/uv.lock
+++ b/ports/tauri/vendor/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/scanstudio-bridge/uv.lock
+++ b/ports/tauri/vendor/scanstudio-bridge/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },


### PR DESCRIPTION
Bumps the bundled coolscanpy driver to 0.3.0 -- the version published to PyPI today with the raw negative export writers -- and regenerates every lockfile that pins it. The PyPI lockstep gate passes locally against the published sdist. Once this merges, main is ready to tag v0.6.0-beta.1.