### PR TITLE
FireWire Coolscan groundwork: macOS SCSI transport for ASFireWire

### DIFF
--- a/coolscanpy/CHANGELOG.md
+++ b/coolscanpy/CHANGELOG.md
@@ -2,23 +2,34 @@
 
 ## Unreleased
 
-C-41 derivatives now identify their color and physical scale correctly.
-Positive TIFFs and preview JPEGs embed a deterministic, ScanStudio-authored
-ICC profile compatible with the Adobe RGB (1998) color space. Full-resolution
-Positive TIFFs also carry the capture recipe's real pixels-per-inch value,
-while downsampled previews do not falsely claim the capture resolution.
-Positive-film, Kodachrome, and black-and-white derivatives remain unlabelled
-unless their render path actually has that color contract. Archival masters
-are never rewritten by this metadata correction.
+- macOS SCSI transport for FireWire Coolscans (`coolscanpy.transport.macos_scsi`):
+  pure-ctypes SCSITaskLib client targeting the ASFireWire DriverKit stack, with
+  device discovery, identity, a motion-free probe CLI, and the 1 MB per-task
+  chunking policy. Scanning on the FireWire models stays deliberately refused
+  until real-hardware captures confirm the command set (FIREWIRE.md, issue #28).
 
-Real capture receipts now record an authoritative per-frame UTC start and
-duration instead of substituting receipt-arrival time and zero milliseconds.
-The measured interval begins after frame selection and binding, includes
-metering, exposure and focus, acquisition, durable raw validation, decode, and
-capture quality checks, and excludes session setup, inter-frame waits, release,
-bridge delivery, and derivative rendering. The timing survives CoolscanPy,
-bridge, engine, manifest, and app boundaries. Legacy receipts remain valid and
-show their absent timing as not recorded rather than inventing a value.
+## 0.3.0 - 2026-08-08
+
+Raw negative export writers: a 16-bit LinearRaw DNG (DNG 1.4, uncompressed,
+untouched negative) with the infrared plane embedded as a marked grayscale
+SubIFD, plus linear TIFF variants -- IR as a fourth channel, IR as a
+separate sidecar file, or RGB-only. Atomic, fail-closed writes; containers
+are parsed back tag-by-tag in tests and verified sample-for-sample. Written
+for ScanStudio's raw export feature; the encoder API is scanning-agnostic
+(ScanResult in, file out).
+
+## 0.2.1 - 2026-08-08
+
+The power-on housekeeping-collapse acceptance is one-sided only: exactly
+one parity may transition onto the other parity's record, and the other
+parity must be stable across the whole capture. The two-sided swap -- the
+signature of a one-row slip in the scanner's row generator, which would
+silently displace every later frame by one index row -- refuses exactly as
+it did before 0.2.0. Found by post-release adversarial review; the live
+power-on shape is unaffected. The preview-failure teardown also uses the
+already-resolved adapter rather than re-resolving inside the handler.
+
+## 0.2.0 - 2026-08-08
 
 A failed roll preview can no longer strand its capture worker holding the
 scanner's USB claim. `Roll.preview()` spawns the `--preview-and-hold` child,
@@ -44,22 +55,9 @@ Whole-roll preview now keeps a content-supported leading frame when an
 otherwise valid feed places its fitted start exactly one 97-dpi preview row
 before the captured raster. The thumbnail is clamped to row zero, its
 same-capture transport origin is inferred from the validated interior mapping,
-and the frame remains blocked on explicit manual review. When enough of a
-leading frame remains to prove it exists but two or more rows fall outside the
-captured raster, preview now refuses with a typed deeper-refeed instruction
-instead of silently presenting a six-exposure strip as five. It also refuses
-to clamp that missing origin into the transport table, which would scan a
-cropped first frame and overlap the second. Clips with less than half a frame
-visible remain excluded as non-addressable edge material, while cells that
-meet the strict clear-film contract remain ordinary leader rather than being
-misreported as a clipped exposure.
-
-Transparent macOS app bundles can now pin PyUSB to an app-owned libusb
-without pretending the interpreter is PyInstaller-frozen. The resolver accepts
-only the fixed `*.app/Contents/Resources/BridgeRuntime/python/bin` interpreter
-layout when this CoolscanPy source is inside the same signed app, loads only a
-regular library under that app's `Contents/Frameworks`, and fails closed if it
-is missing. Ordinary source installs retain normal host-library lookup.
+and the frame remains blocked on explicit manual review; clips of two or more
+rows are still excluded fail-closed. This prevents a six-exposure strip from
+being silently presented as five after a one-row feed variation.
 
 C-41 fine scans now expose RGB the way Nikon Scan would. The meter loop's
 own converged solve consistently landed 6–9 % brighter than Nikon's

--- a/coolscanpy/FIREWIRE.md
+++ b/coolscanpy/FIREWIRE.md
@@ -1,0 +1,57 @@
+# FireWire Coolscans on modern macOS (ASFireWire)
+
+The FireWire Coolscan models -- LS-4000 ED, LS-8000 ED, and SUPER
+COOLSCAN 9000 ED -- speak Nikon's SCSI command family over IEEE 1394
+instead of USB. Apple removed the FireWire stack in macOS Tahoe, and
+Apple Silicon Macs never had one; the open-source
+[ASFireWire](https://github.com/mrmidi/ASFireWire) DriverKit stack
+rebuilds it. ASFireWire logs into the scanner's SBP-2 unit and publishes
+it as a **standard macOS SCSI device** -- the same surface VueScan uses
+to scan an LS-9000 through it today.
+
+coolscanpy's client for that surface is
+`coolscanpy.transport.macos_scsi`: a pure-Python (ctypes) SCSITaskLib
+transport. No compiled extension, no extra install.
+
+## What works today
+
+Device discovery, identity, and a motion-free probe:
+
+```
+python -m coolscanpy.transport.macos_scsi
+python -m coolscanpy.transport.macos_scsi --probe <registry-id>
+```
+
+The probe takes exclusive access, runs TEST UNIT READY, INQUIRY, and
+(on a check condition) REQUEST SENSE, prints the scanner's identity
+block, and releases the device. It never moves film.
+
+## What deliberately does not work yet
+
+Scanning. coolscanpy's single-pass protocol layer is validated against
+the LS-5000's USB dialect, byte-for-byte, on real captures. Whether the
+FireWire models answer the same command vocabulary is an open question
+that only real hardware can settle -- guessing would produce silently
+wrong scans, which is worse than refusing. The probe output above is
+exactly the evidence that question needs: if you have a FireWire
+Coolscan running through ASFireWire, please run it and paste the output
+into [ScanStudio issue #28](https://github.com/rohanpandula/ScanStudio/issues/28),
+the coordination thread for these models.
+
+## Requirements and honest limits
+
+- ASFireWire installed and running. It is a beta DriverKit extension:
+  today it requires disabling SIP, and it matches one FireWire
+  controller chip (the Agere FW643 in Apple's own
+  Thunderbolt-to-FireWire adapter chain). Its README is the authority
+  on setup.
+- One scanner at a time (ASFireWire exposes a single SBP-2 target).
+- Reads above 1 MB must be split across SCSI tasks (ASFireWire's
+  per-task ceiling); `chunk_transfer_lengths()` in the transport module
+  encodes that policy.
+- If another client (VueScan, a stale probe) holds the device,
+  exclusive access fails with a named error -- close the other client
+  first.
+- On Linux, none of this is needed: the kernel's own `firewire-sbp2`
+  exposes the same scanners as SCSI devices, and the long-term plan for
+  FireWire units remains Linux-first (issue #16 discussion).

--- a/coolscanpy/src/coolscanpy/transport/macos_scsi.py
+++ b/coolscanpy/src/coolscanpy/transport/macos_scsi.py
@@ -1,0 +1,869 @@
+"""macOS SCSI transport for FireWire Coolscan scanners via SCSITaskLib.
+
+The FireWire Coolscan models (LS-4000 ED, LS-8000 ED, SUPER COOLSCAN
+9000 ED) carry Nikon's SCSI command set over IEEE 1394 SBP-2 instead of
+USB bulk pipes. On modern macOS the ASFireWire DriverKit stack
+(https://github.com/mrmidi/ASFireWire) logs into the scanner's SBP-2
+unit and publishes it as a standard SCSI peripheral through Apple's
+IOSCSIParallelFamily -- the same surface VueScan uses to scan through
+it. This module is coolscanpy's client for that surface: Apple's
+SCSITaskLib, driven directly through ctypes (no compiled extension, so
+the wheel stays pure Python).
+
+Contract grounding: every UUID, vtable layout, struct, and constant in
+this file is transcribed from the macOS SDK headers
+``IOKit/scsi/SCSITaskLib.h``, ``IOKit/scsi/SCSITask.h``,
+``IOKit/scsi/SCSICmds_REQUEST_SENSE_Defs.h``, ``IOKit/IOCFPlugIn.h``,
+and ``CoreFoundation/CFPlugInCOM.h`` -- not from memory. The COM-style
+plug-in interfaces are C vtables whose slot order is ABI; do not reorder
+fields here without re-reading the header.
+
+Scope: device discovery, identity, and motion-free probing (TEST UNIT
+READY / INQUIRY / REQUEST SENSE). Scanning is deliberately NOT wired up:
+the single-pass protocol layer is validated against the LS-5000's USB
+dialect, and whether the FireWire models' command vocabulary matches is
+an open question that only captures from real hardware can settle
+(ScanStudio issue #28 is the coordination thread). This module exists so
+those captures can happen with coolscanpy itself.
+
+Known ASFireWire-side limits that shape this client: one target, one
+LUN, and a 1 MB ceiling per SCSI task (``kMaxTransferPerTask`` in its
+SCSI controller), hence ``MAX_TRANSFER_PER_TASK`` and the chunking
+helper below.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import dataclasses
+import sys
+from collections.abc import Callable, Iterator
+
+__all__ = [
+    "MAX_TRANSFER_PER_TASK",
+    "DATA_TRANSFER_NONE",
+    "DATA_TRANSFER_FROM_TARGET",
+    "DATA_TRANSFER_TO_TARGET",
+    "TASK_STATUS_GOOD",
+    "TASK_STATUS_CHECK_CONDITION",
+    "ScsiTaskDeviceInfo",
+    "ScsiTransactionResult",
+    "MacScsiTaskDevice",
+    "MacScsiTransportError",
+    "chunk_transfer_lengths",
+    "list_scsi_task_devices",
+]
+
+# ---------------------------------------------------------------------------
+# Constants from the SDK headers (values, not names, are the contract).
+# ---------------------------------------------------------------------------
+
+# SCSITask.h: kSCSIDataTransfer_* (SetScatterGatherEntries direction).
+DATA_TRANSFER_NONE = 0x00
+DATA_TRANSFER_TO_TARGET = 0x01  # kSCSIDataTransfer_FromInitiatorToTarget
+DATA_TRANSFER_FROM_TARGET = 0x02  # kSCSIDataTransfer_FromTargetToInitiator
+
+# SCSITask.h: SCSITaskStatus values this client interprets.
+TASK_STATUS_GOOD = 0x00
+TASK_STATUS_CHECK_CONDITION = 0x02
+TASK_STATUS_BUSY = 0x08
+
+# SCSITask.h: SCSIServiceResponse.
+SERVICE_RESPONSE_TASK_COMPLETE = 2
+
+# ASFireWire ASFWSCSIController.cpp kMaxTransferPerTask. Anything larger
+# must be split into multiple SCSI tasks by the caller.
+MAX_TRANSFER_PER_TASK = 1 << 20
+
+# SCSITaskLib.h: valid CDB sizes.
+_VALID_CDB_SIZES = (6, 10, 12, 16)
+
+# SCSICmds_REQUEST_SENSE_Defs.h: SCSI_Sense_Data is 18 packed bytes.
+_SENSE_DATA_LENGTH = 18
+
+# SCSITaskLib.h kIOPropertySCSITaskDeviceCategory /
+# kIOPropertySCSITaskUserClientDevice: the IORegistry rendezvous for
+# devices with no in-kernel logical-unit driver (our scanner case).
+_DEVICE_CATEGORY_KEY = "SCSITaskDeviceCategory"
+_DEVICE_CATEGORY_VALUE = "SCSITaskUserClientDevice"
+_INSTANCE_GUID_KEY = "SCSITaskUserClient GUID"
+
+# CFUUID byte tuples from SCSITaskLib.h (comments show the canonical
+# string form printed in the header).
+# 7D66678E-08A2-11D5-A1B8-0030657D052A
+_UUID_SCSITASK_DEVICE_USER_CLIENT = (
+    0x7D, 0x66, 0x67, 0x8E, 0x08, 0xA2, 0x11, 0xD5,
+    0xA1, 0xB8, 0x00, 0x30, 0x65, 0x7D, 0x05, 0x2A,
+)
+# 1BBC4132-08A5-11D5-90ED-0030657D052A
+_UUID_SCSITASK_DEVICE_INTERFACE = (
+    0x1B, 0xBC, 0x41, 0x32, 0x08, 0xA5, 0x11, 0xD5,
+    0x90, 0xED, 0x00, 0x30, 0x65, 0x7D, 0x05, 0x2A,
+)
+# IOCFPlugIn.h: kIOCFPlugInInterfaceID F95BABE5-6624-11D2-8132-000E20CF14BE
+_UUID_IOCFPLUGIN_INTERFACE = (
+    0xF9, 0x5B, 0xAB, 0xE5, 0x66, 0x24, 0x11, 0xD2,
+    0x81, 0x32, 0x00, 0x0E, 0x20, 0xCF, 0x14, 0xBE,
+)
+
+
+class MacScsiTransportError(RuntimeError):
+    """A SCSITaskLib call failed; the message carries the IOReturn code."""
+
+
+# ---------------------------------------------------------------------------
+# ctypes transcriptions of the COM vtables. Slot order is ABI.
+# ---------------------------------------------------------------------------
+
+_HRESULT = ctypes.c_int32
+_ULONG = ctypes.c_uint32
+_IOReturn = ctypes.c_int
+_Boolean = ctypes.c_ubyte
+
+
+class _CFUUIDBytes(ctypes.Structure):
+    _fields_ = [("byte" + str(i), ctypes.c_uint8) for i in range(16)]
+
+
+def _uuid_bytes(values: tuple[int, ...]) -> _CFUUIDBytes:
+    out = _CFUUIDBytes()
+    for i, value in enumerate(values):
+        setattr(out, "byte" + str(i), value)
+    return out
+
+
+class _SGElement(ctypes.Structure):
+    # SCSITaskLib.h: SCSITaskSGElement = IOAddressRange on LP64 --
+    # {UInt64 address, UInt64 length}.
+    _fields_ = [("address", ctypes.c_uint64), ("length", ctypes.c_uint64)]
+
+
+# CFPlugInCOM.h IUNKNOWN_C_GUTS: _reserved, QueryInterface(this,
+# REFIID-by-value, void**), AddRef, Release. REFIID = CFUUIDBytes.
+def _iunknown_fields() -> list[tuple[str, object]]:
+    return [
+        ("_reserved", ctypes.c_void_p),
+        (
+            "QueryInterface",
+            ctypes.CFUNCTYPE(
+                _HRESULT, ctypes.c_void_p, _CFUUIDBytes,
+                ctypes.POINTER(ctypes.c_void_p),
+            ),
+        ),
+        ("AddRef", ctypes.CFUNCTYPE(_ULONG, ctypes.c_void_p)),
+        ("Release", ctypes.CFUNCTYPE(_ULONG, ctypes.c_void_p)),
+    ]
+
+
+class _IOCFPlugInVtbl(ctypes.Structure):
+    # IOCFPlugIn.h: IUNKNOWN_C_GUTS; IOCFPLUGINBASE (version, revision,
+    # Probe, Start, Stop).
+    _fields_ = _iunknown_fields() + [
+        ("version", ctypes.c_uint16),
+        ("revision", ctypes.c_uint16),
+        (
+            "Probe",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.c_void_p,
+                ctypes.c_uint32, ctypes.POINTER(ctypes.c_int32),
+            ),
+        ),
+        (
+            "Start",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint32
+            ),
+        ),
+        ("Stop", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+    ]
+
+
+class _DeviceVtbl(ctypes.Structure):
+    # SCSITaskLib.h SCSITaskDeviceInterface, exact slot order.
+    _fields_ = _iunknown_fields() + [
+        ("version", ctypes.c_uint16),
+        ("revision", ctypes.c_uint16),
+        ("IsExclusiveAccessAvailable", ctypes.CFUNCTYPE(_Boolean, ctypes.c_void_p)),
+        (
+            "AddCallbackDispatcherToRunLoop",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.c_void_p),
+        ),
+        (
+            "RemoveCallbackDispatcherFromRunLoop",
+            ctypes.CFUNCTYPE(None, ctypes.c_void_p),
+        ),
+        ("ObtainExclusiveAccess", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+        ("ReleaseExclusiveAccess", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+        # Header type is SCSITaskInterface** -- carried as an opaque
+        # address so the vtable stays usable from ctypes callbacks in
+        # the offline tests (ctypes callbacks cannot return POINTER
+        # types), which is a pure declaration choice with identical ABI.
+        ("CreateSCSITask", ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)),
+    ]
+
+
+class _TaskVtbl(ctypes.Structure):
+    # SCSITaskLib.h SCSITaskInterface, exact slot order.
+    _fields_ = _iunknown_fields() + [
+        ("version", ctypes.c_uint16),
+        ("revision", ctypes.c_uint16),
+        ("IsTaskActive", ctypes.CFUNCTYPE(_Boolean, ctypes.c_void_p)),
+        ("SetTaskAttribute", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.c_uint32)),
+        (
+            "GetTaskAttribute",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32)),
+        ),
+        (
+            "SetCommandDescriptorBlock",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint8), ctypes.c_uint8,
+            ),
+        ),
+        ("GetCommandDescriptorBlockSize", ctypes.CFUNCTYPE(ctypes.c_uint8, ctypes.c_void_p)),
+        (
+            "GetCommandDescriptorBlock",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint8)),
+        ),
+        (
+            "SetScatterGatherEntries",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.POINTER(_SGElement),
+                ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8,
+            ),
+        ),
+        ("SetTimeoutDuration", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.c_uint32)),
+        ("GetTimeoutDuration", ctypes.CFUNCTYPE(ctypes.c_uint32, ctypes.c_void_p)),
+        (
+            "SetTaskCompletionCallback",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p
+            ),
+        ),
+        ("ExecuteTaskAsync", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+        (
+            "ExecuteTaskSync",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint64),
+            ),
+        ),
+        ("AbortTask", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+        (
+            "GetSCSIServiceResponse",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32)),
+        ),
+        (
+            "GetTaskState",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32)),
+        ),
+        (
+            "GetTaskStatus",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32)),
+        ),
+        ("GetRealizedDataTransferCount", ctypes.CFUNCTYPE(ctypes.c_uint64, ctypes.c_void_p)),
+        (
+            "GetAutoSenseData",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.c_void_p),
+        ),
+        (
+            "SetAutoSenseDataBuffer",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint8
+            ),
+        ),
+        ("ResetForNewTask", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+    ]
+
+
+# A COM interface handle is a pointer to a pointer to its vtable.
+def _vtbl(handle: ctypes.c_void_p, vtbl_type: type[ctypes.Structure]):
+    inner = ctypes.cast(handle, ctypes.POINTER(ctypes.c_void_p)).contents
+    return ctypes.cast(inner, ctypes.POINTER(vtbl_type)).contents
+
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ScsiTaskDeviceInfo:
+    """One SCSITask-capable device seen in the IORegistry."""
+
+    registry_entry_id: int
+    instance_guid: str | None
+    vendor: str | None
+    product: str | None
+    revision: str | None
+
+    @property
+    def looks_like_nikon_coolscan(self) -> bool:
+        vendor = (self.vendor or "").strip().upper()
+        return vendor == "NIKON"
+
+
+@dataclasses.dataclass(frozen=True)
+class ScsiTransactionResult:
+    """Outcome of one synchronous SCSI task, USB-lane result shape."""
+
+    service_response: int
+    task_status: int
+    transferred: int
+    payload: bytes
+    sense: bytes
+
+    @property
+    def good(self) -> bool:
+        return (
+            self.service_response == SERVICE_RESPONSE_TASK_COMPLETE
+            and self.task_status == TASK_STATUS_GOOD
+        )
+
+    @property
+    def check_condition(self) -> bool:
+        return self.task_status == TASK_STATUS_CHECK_CONDITION
+
+
+def chunk_transfer_lengths(total: int, cap: int = MAX_TRANSFER_PER_TASK) -> list[int]:
+    """Split a transfer into per-task lengths within the HBA's cap.
+
+    ASFireWire's SCSI controller refuses tasks above 1 MB, so a frame
+    read must be issued as multiple SCSI tasks. Pure arithmetic so the
+    policy is testable off-hardware.
+    """
+
+    if total < 0:
+        raise ValueError("transfer length cannot be negative")
+    if cap <= 0:
+        raise ValueError("transfer cap must be positive")
+    if total == 0:
+        return []
+    full, tail = divmod(total, cap)
+    return [cap] * full + ([tail] if tail else [])
+
+
+# ---------------------------------------------------------------------------
+# IOKit / CoreFoundation bindings (lazy; only this section is darwin-only)
+# ---------------------------------------------------------------------------
+
+
+class _Frameworks:
+    """dlopen handles + prototypes, created on first hardware call."""
+
+    def __init__(self) -> None:
+        if sys.platform != "darwin":
+            raise MacScsiTransportError(
+                "the macOS SCSI transport only exists on macOS; on Linux the "
+                "same scanners are reachable through the kernel's firewire-sbp2"
+            )
+        iokit_path = ctypes.util.find_library("IOKit")
+        cf_path = ctypes.util.find_library("CoreFoundation")
+        if not iokit_path or not cf_path:
+            raise MacScsiTransportError("IOKit/CoreFoundation could not be located")
+        self.iokit = ctypes.CDLL(iokit_path)
+        self.cf = ctypes.CDLL(cf_path)
+
+        self.iokit.IOServiceMatching.restype = ctypes.c_void_p
+        self.iokit.IOServiceMatching.argtypes = [ctypes.c_char_p]
+        self.iokit.IOServiceGetMatchingServices.restype = ctypes.c_int
+        self.iokit.IOServiceGetMatchingServices.argtypes = [
+            ctypes.c_uint32, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32),
+        ]
+        self.iokit.IOIteratorNext.restype = ctypes.c_uint32
+        self.iokit.IOIteratorNext.argtypes = [ctypes.c_uint32]
+        self.iokit.IOObjectRelease.restype = ctypes.c_int
+        self.iokit.IOObjectRelease.argtypes = [ctypes.c_uint32]
+        self.iokit.IORegistryEntryGetRegistryEntryID.restype = ctypes.c_int
+        self.iokit.IORegistryEntryGetRegistryEntryID.argtypes = [
+            ctypes.c_uint32, ctypes.POINTER(ctypes.c_uint64),
+        ]
+        self.iokit.IORegistryEntryCreateCFProperty.restype = ctypes.c_void_p
+        self.iokit.IORegistryEntryCreateCFProperty.argtypes = [
+            ctypes.c_uint32, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint32,
+        ]
+        self.iokit.IOServiceGetMatchingService.restype = ctypes.c_uint32
+        self.iokit.IOServiceGetMatchingService.argtypes = [
+            ctypes.c_uint32, ctypes.c_void_p,
+        ]
+        self.iokit.IORegistryEntryIDMatching.restype = ctypes.c_void_p
+        self.iokit.IORegistryEntryIDMatching.argtypes = [ctypes.c_uint64]
+        self.iokit.IOCreatePlugInInterfaceForService.restype = ctypes.c_int
+        self.iokit.IOCreatePlugInInterfaceForService.argtypes = [
+            ctypes.c_uint32, ctypes.c_void_p, ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_int32),
+        ]
+        self.iokit.IODestroyPlugInInterface.restype = ctypes.c_int
+        self.iokit.IODestroyPlugInInterface.argtypes = [ctypes.c_void_p]
+
+        self.cf.CFUUIDGetConstantUUIDWithBytes.restype = ctypes.c_void_p
+        self.cf.CFUUIDGetConstantUUIDWithBytes.argtypes = [ctypes.c_void_p] + [
+            ctypes.c_uint8
+        ] * 16
+        self.cf.CFUUIDGetUUIDBytes.restype = _CFUUIDBytes
+        self.cf.CFUUIDGetUUIDBytes.argtypes = [ctypes.c_void_p]
+        self.cf.CFStringCreateWithCString.restype = ctypes.c_void_p
+        self.cf.CFStringCreateWithCString.argtypes = [
+            ctypes.c_void_p, ctypes.c_char_p, ctypes.c_uint32,
+        ]
+        self.cf.CFStringGetCString.restype = ctypes.c_ubyte
+        self.cf.CFStringGetCString.argtypes = [
+            ctypes.c_void_p, ctypes.c_char_p, ctypes.c_long, ctypes.c_uint32,
+        ]
+        self.cf.CFRelease.restype = None
+        self.cf.CFRelease.argtypes = [ctypes.c_void_p]
+        self.cf.CFGetTypeID.restype = ctypes.c_ulong
+        self.cf.CFGetTypeID.argtypes = [ctypes.c_void_p]
+        self.cf.CFStringGetTypeID.restype = ctypes.c_ulong
+        self.cf.CFStringGetTypeID.argtypes = []
+
+        self._utf8 = 0x08000100  # kCFStringEncodingUTF8
+
+    def cfstr(self, value: str) -> ctypes.c_void_p:
+        return ctypes.c_void_p(
+            self.cf.CFStringCreateWithCString(None, value.encode(), self._utf8)
+        )
+
+    def cf_to_str(self, ref: int | None) -> str | None:
+        if not ref:
+            return None
+        try:
+            if self.cf.CFGetTypeID(ref) != self.cf.CFStringGetTypeID():
+                return None
+            buf = ctypes.create_string_buffer(256)
+            if not self.cf.CFStringGetCString(ref, buf, len(buf), self._utf8):
+                return None
+            return buf.value.decode(errors="replace")
+        finally:
+            self.cf.CFRelease(ref)
+
+    def uuid_ref(self, values: tuple[int, ...]) -> ctypes.c_void_p:
+        return ctypes.c_void_p(
+            self.cf.CFUUIDGetConstantUUIDWithBytes(None, *values)
+        )
+
+
+_frameworks: _Frameworks | None = None
+
+
+def _get_frameworks() -> _Frameworks:
+    global _frameworks
+    if _frameworks is None:
+        _frameworks = _Frameworks()
+    return _frameworks
+
+
+def _service_string_property(fw: _Frameworks, service: int, key: str) -> str | None:
+    cf_key = fw.cfstr(key)
+    try:
+        ref = fw.iokit.IORegistryEntryCreateCFProperty(service, cf_key, None, 0)
+    finally:
+        fw.cf.CFRelease(cf_key)
+    return fw.cf_to_str(ref)
+
+
+def _iter_scsi_task_services(fw: _Frameworks) -> Iterator[int]:
+    # Match every IOService and filter on the SCSITaskLib category
+    # property; matching on the property dict directly would also work
+    # but IOServiceMatching on a class name plus a property read keeps
+    # the matching dictionary trivial and the filtering logic in Python
+    # where it is testable.
+    matching = fw.iokit.IOServiceMatching(b"IOService")
+    iterator = ctypes.c_uint32(0)
+    status = fw.iokit.IOServiceGetMatchingServices(
+        0, matching, ctypes.byref(iterator)
+    )
+    if status != 0:
+        raise MacScsiTransportError(
+            f"IOServiceGetMatchingServices failed: 0x{status & 0xFFFFFFFF:08x}"
+        )
+    try:
+        while True:
+            service = fw.iokit.IOIteratorNext(iterator.value)
+            if not service:
+                break
+            try:
+                category = _service_string_property(fw, service, _DEVICE_CATEGORY_KEY)
+                if category == _DEVICE_CATEGORY_VALUE:
+                    yield service
+                    continue
+            except MacScsiTransportError:
+                pass
+            fw.iokit.IOObjectRelease(service)
+    finally:
+        fw.iokit.IOObjectRelease(iterator.value)
+
+
+def list_scsi_task_devices() -> list[ScsiTaskDeviceInfo]:
+    """Enumerate SCSITask-capable peripherals (no exclusive access taken).
+
+    Identity strings come from the INQUIRY data the kernel already
+    collected and published in the IORegistry, so discovery never
+    touches the device.
+    """
+
+    fw = _get_frameworks()
+    devices: list[ScsiTaskDeviceInfo] = []
+    for service in _iter_scsi_task_services(fw):
+        try:
+            entry_id = ctypes.c_uint64(0)
+            fw.iokit.IORegistryEntryGetRegistryEntryID(
+                service, ctypes.byref(entry_id)
+            )
+            devices.append(
+                ScsiTaskDeviceInfo(
+                    registry_entry_id=entry_id.value,
+                    instance_guid=_service_string_property(
+                        fw, service, _INSTANCE_GUID_KEY
+                    ),
+                    vendor=_service_string_property(
+                        fw, service, "Vendor Identification"
+                    ),
+                    product=_service_string_property(
+                        fw, service, "Product Identification"
+                    ),
+                    revision=_service_string_property(
+                        fw, service, "Product Revision Level"
+                    ),
+                )
+            )
+        finally:
+            fw.iokit.IOObjectRelease(service)
+    return devices
+
+
+# ---------------------------------------------------------------------------
+# The device handle
+# ---------------------------------------------------------------------------
+
+
+class MacScsiTaskDevice:
+    """Exclusive SCSITaskLib session with one device.
+
+    Lifecycle: ``open(registry_entry_id)`` -> ``perform_transaction(...)``
+    calls -> ``close()``. The context-manager form guarantees exclusive
+    access and the plug-in are released even when a transaction raises,
+    mirroring the USB lane's teardown discipline.
+    """
+
+    def __init__(self) -> None:
+        self._fw: _Frameworks | None = None
+        self._plugin = ctypes.c_void_p(None)
+        self._device = ctypes.c_void_p(None)
+        self._exclusive = False
+
+    # -- lifecycle ---------------------------------------------------------
+
+    @classmethod
+    def open(cls, registry_entry_id: int) -> "MacScsiTaskDevice":
+        self = cls()
+        fw = _get_frameworks()
+        self._fw = fw
+
+        matching = fw.iokit.IORegistryEntryIDMatching(registry_entry_id)
+        service = fw.iokit.IOServiceGetMatchingService(0, matching)
+        if not service:
+            raise MacScsiTransportError(
+                f"no IORegistry entry with id {registry_entry_id}; the device "
+                "may have been unplugged or the FireWire bus reset"
+            )
+        try:
+            score = ctypes.c_int32(0)
+            status = fw.iokit.IOCreatePlugInInterfaceForService(
+                service,
+                fw.uuid_ref(_UUID_SCSITASK_DEVICE_USER_CLIENT),
+                fw.uuid_ref(_UUID_IOCFPLUGIN_INTERFACE),
+                ctypes.byref(self._plugin),
+                ctypes.byref(score),
+            )
+            if status != 0 or not self._plugin:
+                raise MacScsiTransportError(
+                    "IOCreatePlugInInterfaceForService failed: "
+                    f"0x{status & 0xFFFFFFFF:08x} (is another client -- "
+                    "VueScan, a stale probe -- holding the device?)"
+                )
+        finally:
+            fw.iokit.IOObjectRelease(service)
+
+        plugin_vtbl = _vtbl(self._plugin, _IOCFPlugInVtbl)
+        out = ctypes.c_void_p(None)
+        hresult = plugin_vtbl.QueryInterface(
+            self._plugin,
+            fw.cf.CFUUIDGetUUIDBytes(
+                fw.uuid_ref(_UUID_SCSITASK_DEVICE_INTERFACE)
+            ),
+            ctypes.byref(out),
+        )
+        if hresult != 0 or not out:
+            self._destroy_plugin()
+            raise MacScsiTransportError(
+                f"QueryInterface(SCSITaskDeviceInterface) failed: {hresult}"
+            )
+        self._device = out
+        return self
+
+    def obtain_exclusive_access(self) -> None:
+        device_vtbl = _vtbl(self._require_device(), _DeviceVtbl)
+        status = device_vtbl.ObtainExclusiveAccess(self._device)
+        if status != 0:
+            raise MacScsiTransportError(
+                f"ObtainExclusiveAccess failed: 0x{status & 0xFFFFFFFF:08x} "
+                "(kIOReturnExclusiveAccess means another client owns the "
+                "device; kIOReturnBusy means media is mounted)"
+            )
+        self._exclusive = True
+
+    def close(self) -> None:
+        if self._device:
+            device_vtbl = _vtbl(self._device, _DeviceVtbl)
+            if self._exclusive:
+                device_vtbl.ReleaseExclusiveAccess(self._device)
+                self._exclusive = False
+            device_vtbl.Release(self._device)
+            self._device = ctypes.c_void_p(None)
+        self._destroy_plugin()
+
+    def __enter__(self) -> "MacScsiTaskDevice":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def _destroy_plugin(self) -> None:
+        if self._plugin and self._fw is not None:
+            self._fw.iokit.IODestroyPlugInInterface(self._plugin)
+            self._plugin = ctypes.c_void_p(None)
+
+    def _require_device(self) -> ctypes.c_void_p:
+        if not self._device:
+            raise MacScsiTransportError("device is not open")
+        return self._device
+
+    # -- transactions ------------------------------------------------------
+
+    def perform_transaction(
+        self,
+        cdb: bytes,
+        *,
+        direction: int = DATA_TRANSFER_NONE,
+        data_out: bytes | None = None,
+        data_in_length: int = 0,
+        timeout_ms: int = 10_000,
+    ) -> ScsiTransactionResult:
+        """Execute one synchronous SCSI task and return its full outcome.
+
+        Fail-closed: any SCSITaskLib call that does not return success
+        raises; a CHECK CONDITION is not an exception (the caller gets
+        status + sense to interpret, matching the USB lane's
+        TransactionResult semantics).
+        """
+
+        if len(cdb) not in _VALID_CDB_SIZES:
+            raise MacScsiTransportError(
+                f"CDB length {len(cdb)} invalid; SCSITaskLib accepts "
+                f"{_VALID_CDB_SIZES}"
+            )
+        if direction == DATA_TRANSFER_TO_TARGET and data_out is None:
+            raise MacScsiTransportError("outbound transfer requires data_out")
+        if direction == DATA_TRANSFER_FROM_TARGET and data_in_length <= 0:
+            raise MacScsiTransportError("inbound transfer requires data_in_length")
+        transfer_length = (
+            len(data_out) if direction == DATA_TRANSFER_TO_TARGET
+            else data_in_length if direction == DATA_TRANSFER_FROM_TARGET
+            else 0
+        )
+        if transfer_length > MAX_TRANSFER_PER_TASK:
+            raise MacScsiTransportError(
+                f"transfer of {transfer_length} bytes exceeds the "
+                f"{MAX_TRANSFER_PER_TASK}-byte per-task ceiling; split it "
+                "with chunk_transfer_lengths()"
+            )
+
+        device = self._require_device()
+        if not self._exclusive:
+            raise MacScsiTransportError(
+                "obtain_exclusive_access() must succeed before transactions"
+            )
+        device_vtbl = _vtbl(device, _DeviceVtbl)
+        task = device_vtbl.CreateSCSITask(device)
+        if not task:
+            raise MacScsiTransportError("CreateSCSITask returned NULL")
+        task_handle = ctypes.c_void_p(task)
+        task_vtbl = _vtbl(task_handle, _TaskVtbl)
+        try:
+            cdb_buf = (ctypes.c_uint8 * len(cdb)).from_buffer_copy(cdb)
+            status = task_vtbl.SetCommandDescriptorBlock(
+                task_handle, cdb_buf, len(cdb)
+            )
+            if status != 0:
+                raise MacScsiTransportError(
+                    f"SetCommandDescriptorBlock failed: 0x{status & 0xFFFFFFFF:08x}"
+                )
+
+            data_buf: ctypes.Array[ctypes.c_char] | None = None
+            if transfer_length:
+                if direction == DATA_TRANSFER_TO_TARGET:
+                    assert data_out is not None
+                    data_buf = ctypes.create_string_buffer(
+                        data_out, transfer_length
+                    )
+                else:
+                    data_buf = ctypes.create_string_buffer(transfer_length)
+                element = _SGElement(
+                    address=ctypes.cast(data_buf, ctypes.c_void_p).value or 0,
+                    length=transfer_length,
+                )
+                status = task_vtbl.SetScatterGatherEntries(
+                    task_handle, ctypes.byref(element), 1,
+                    transfer_length, direction,
+                )
+                if status != 0:
+                    raise MacScsiTransportError(
+                        f"SetScatterGatherEntries failed: 0x{status & 0xFFFFFFFF:08x}"
+                    )
+
+            status = task_vtbl.SetTimeoutDuration(task_handle, timeout_ms)
+            if status != 0:
+                raise MacScsiTransportError(
+                    f"SetTimeoutDuration failed: 0x{status & 0xFFFFFFFF:08x}"
+                )
+
+            sense_buf = ctypes.create_string_buffer(_SENSE_DATA_LENGTH)
+            task_status = ctypes.c_uint32(0xFF)
+            transferred = ctypes.c_uint64(0)
+            status = task_vtbl.ExecuteTaskSync(
+                task_handle, sense_buf,
+                ctypes.byref(task_status), ctypes.byref(transferred),
+            )
+            if status != 0:
+                raise MacScsiTransportError(
+                    f"ExecuteTaskSync failed: 0x{status & 0xFFFFFFFF:08x}"
+                )
+            service_response = ctypes.c_uint32(0)
+            status = task_vtbl.GetSCSIServiceResponse(
+                task_handle, ctypes.byref(service_response)
+            )
+            if status != 0:
+                raise MacScsiTransportError(
+                    f"GetSCSIServiceResponse failed: 0x{status & 0xFFFFFFFF:08x}"
+                )
+
+            payload = b""
+            if direction == DATA_TRANSFER_FROM_TARGET and data_buf is not None:
+                payload = data_buf.raw[: transferred.value]
+            return ScsiTransactionResult(
+                service_response=service_response.value,
+                task_status=task_status.value,
+                transferred=transferred.value,
+                payload=payload,
+                sense=bytes(sense_buf.raw),
+            )
+        finally:
+            task_vtbl.Release(task_handle)
+
+    # -- motion-free probes ------------------------------------------------
+
+    def test_unit_ready(self, *, timeout_ms: int = 5_000) -> ScsiTransactionResult:
+        return self.perform_transaction(bytes(6), timeout_ms=timeout_ms)
+
+    def inquiry(
+        self, *, allocation: int = 96, timeout_ms: int = 5_000
+    ) -> ScsiTransactionResult:
+        if not 5 <= allocation <= 255:
+            raise MacScsiTransportError("INQUIRY allocation must be 5..255")
+        cdb = bytes([0x12, 0x00, 0x00, 0x00, allocation, 0x00])
+        return self.perform_transaction(
+            cdb,
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=allocation,
+            timeout_ms=timeout_ms,
+        )
+
+    def request_sense(self, *, timeout_ms: int = 5_000) -> ScsiTransactionResult:
+        cdb = bytes([0x03, 0x00, 0x00, 0x00, _SENSE_DATA_LENGTH, 0x00])
+        return self.perform_transaction(
+            cdb,
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=_SENSE_DATA_LENGTH,
+            timeout_ms=timeout_ms,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Probe CLI: the artifact a FireWire tester runs and pastes back.
+# ---------------------------------------------------------------------------
+
+
+def _format_inquiry(payload: bytes) -> str:
+    if len(payload) < 36:
+        return f"short INQUIRY payload ({len(payload)} bytes): {payload.hex()}"
+    peripheral = payload[0] & 0x1F
+    vendor = payload[8:16].decode("ascii", errors="replace").strip()
+    product = payload[16:32].decode("ascii", errors="replace").strip()
+    revision = payload[32:36].decode("ascii", errors="replace").strip()
+    return (
+        f"peripheral device type 0x{peripheral:02x}, vendor {vendor!r}, "
+        f"product {product!r}, revision {revision!r}\n"
+        f"raw: {payload.hex()}"
+    )
+
+
+def main(argv: list[str] | None = None, *, out: Callable[[str], None] = print) -> int:
+    """List SCSITask devices; with ``--probe <id>``, run the motion-free probe."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    probe_id: int | None = None
+    if args and args[0] == "--probe":
+        if len(args) != 2:
+            out("usage: python -m coolscanpy.transport.macos_scsi [--probe <registry-id>]")
+            return 2
+        probe_id = int(args[1], 0)
+    elif args:
+        out("usage: python -m coolscanpy.transport.macos_scsi [--probe <registry-id>]")
+        return 2
+
+    devices = list_scsi_task_devices()
+    if not devices:
+        out(
+            "no SCSITask-capable devices found. If a FireWire Coolscan is "
+            "connected through ASFireWire, check that the driver extension "
+            "is running and logged into the scanner (see its README)."
+        )
+        return 1
+    for device in devices:
+        marker = "  <- Nikon" if device.looks_like_nikon_coolscan else ""
+        out(
+            f"registry id {device.registry_entry_id}: "
+            f"vendor={device.vendor!r} product={device.product!r} "
+            f"revision={device.revision!r} guid={device.instance_guid!r}{marker}"
+        )
+    if probe_id is None:
+        return 0
+
+    with MacScsiTaskDevice.open(probe_id) as device:
+        device.obtain_exclusive_access()
+        ready = device.test_unit_ready()
+        out(
+            f"TEST UNIT READY: service_response={ready.service_response} "
+            f"task_status=0x{ready.task_status:02x}"
+            + (f" sense={ready.sense.hex()}" if ready.check_condition else "")
+        )
+        if ready.check_condition:
+            sense = device.request_sense()
+            out(f"REQUEST SENSE: {sense.payload.hex()}")
+        identity = device.inquiry()
+        if not identity.good:
+            out(
+                f"INQUIRY did not complete cleanly: "
+                f"service_response={identity.service_response} "
+                f"task_status=0x{identity.task_status:02x} "
+                f"sense={identity.sense.hex()}"
+            )
+            return 1
+        out("INQUIRY: " + _format_inquiry(identity.payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/coolscanpy/src/coolscanpy/transport/macos_scsi.py
+++ b/coolscanpy/src/coolscanpy/transport/macos_scsi.py
@@ -101,10 +101,10 @@ _UUID_SCSITASK_DEVICE_INTERFACE = (
     0x1B, 0xBC, 0x41, 0x32, 0x08, 0xA5, 0x11, 0xD5,
     0x90, 0xED, 0x00, 0x30, 0x65, 0x7D, 0x05, 0x2A,
 )
-# IOCFPlugIn.h: kIOCFPlugInInterfaceID F95BABE5-6624-11D2-8132-000E20CF14BE
+# IOCFPlugIn.h: kIOCFPlugInInterfaceID C244E858-109C-11D4-91D4-0050E4C6426F
 _UUID_IOCFPLUGIN_INTERFACE = (
-    0xF9, 0x5B, 0xAB, 0xE5, 0x66, 0x24, 0x11, 0xD2,
-    0x81, 0x32, 0x00, 0x0E, 0x20, 0xCF, 0x14, 0xBE,
+    0xC2, 0x44, 0xE8, 0x58, 0x10, 0x9C, 0x11, 0xD4,
+    0x91, 0xD4, 0x00, 0x50, 0xE4, 0xC6, 0x42, 0x6F,
 )
 
 
@@ -421,9 +421,12 @@ class _Frameworks:
         self._utf8 = 0x08000100  # kCFStringEncodingUTF8
 
     def cfstr(self, value: str) -> ctypes.c_void_p:
-        return ctypes.c_void_p(
-            self.cf.CFStringCreateWithCString(None, value.encode(), self._utf8)
-        )
+        ref = self.cf.CFStringCreateWithCString(None, value.encode(), self._utf8)
+        if not ref:
+            # CF Create functions may return NULL; passing that onward and
+            # CFRelease-ing it later traps.
+            raise MacScsiTransportError(f"CFStringCreateWithCString({value!r}) failed")
+        return ctypes.c_void_p(ref)
 
     def cf_to_str(self, ref: int | None) -> str | None:
         if not ref:
@@ -492,7 +495,10 @@ def _iter_scsi_task_services(fw: _Frameworks) -> Iterator[int]:
                 pass
             fw.iokit.IOObjectRelease(service)
     finally:
-        fw.iokit.IOObjectRelease(iterator.value)
+        # IOServiceGetMatchingServices may succeed with a NULL iterator
+        # when nothing matched; releasing MACH_PORT_NULL is invalid.
+        if iterator.value:
+            fw.iokit.IOObjectRelease(iterator.value)
 
 
 def list_scsi_task_devices() -> list[ScsiTaskDeviceInfo]:
@@ -596,9 +602,10 @@ class MacScsiTaskDevice:
             ctypes.byref(out),
         )
         if hresult != 0 or not out:
-            self._destroy_plugin()
+            extra = self._destroy_plugin()
             raise MacScsiTransportError(
                 f"QueryInterface(SCSITaskDeviceInterface) failed: {hresult}"
+                + ("; " + "; ".join(extra) if extra else "")
             )
         self._device = out
         return self
@@ -614,26 +621,53 @@ class MacScsiTaskDevice:
             )
         self._exclusive = True
 
-    def close(self) -> None:
+    def close(self, *, raise_on_error: bool = True) -> None:
+        """Release exclusive access, the device interface, and the plug-in.
+
+        All teardown steps always run (a failed exclusive release must not
+        leak the plug-in), their failures are collected, and by default a
+        failure raises AFTER cleanup completes -- silently losing a failed
+        ReleaseExclusiveAccess would leave the in-kernel logical-unit
+        drivers quiesced with nothing telling the user why. A second
+        close() is a no-op.
+        """
+
+        failures: list[str] = []
         if self._device:
             device_vtbl = _vtbl(self._device, _DeviceVtbl)
             if self._exclusive:
-                device_vtbl.ReleaseExclusiveAccess(self._device)
+                status = device_vtbl.ReleaseExclusiveAccess(self._device)
+                if status != 0:
+                    failures.append(
+                        "ReleaseExclusiveAccess failed: "
+                        f"0x{status & 0xFFFFFFFF:08x} (the device may stay "
+                        "quiesced until this process exits or the bus resets)"
+                    )
                 self._exclusive = False
             device_vtbl.Release(self._device)
             self._device = ctypes.c_void_p(None)
-        self._destroy_plugin()
+        failures.extend(self._destroy_plugin())
+        if failures and raise_on_error:
+            raise MacScsiTransportError("; ".join(failures))
 
     def __enter__(self) -> "MacScsiTaskDevice":
         return self
 
-    def __exit__(self, *exc_info: object) -> None:
-        self.close()
+    def __exit__(self, exc_type: object, *exc_info: object) -> None:
+        # During exception unwind, a teardown failure must not mask the
+        # original error; on the clean path it must be heard.
+        self.close(raise_on_error=exc_type is None)
 
-    def _destroy_plugin(self) -> None:
+    def _destroy_plugin(self) -> list[str]:
+        failures: list[str] = []
         if self._plugin and self._fw is not None:
-            self._fw.iokit.IODestroyPlugInInterface(self._plugin)
+            status = self._fw.iokit.IODestroyPlugInInterface(self._plugin)
+            if status != 0:
+                failures.append(
+                    f"IODestroyPlugInInterface failed: 0x{status & 0xFFFFFFFF:08x}"
+                )
             self._plugin = ctypes.c_void_p(None)
+        return failures
 
     def _require_device(self) -> ctypes.c_void_p:
         if not self._device:
@@ -812,15 +846,25 @@ def _format_inquiry(payload: bytes) -> str:
 def main(argv: list[str] | None = None, *, out: Callable[[str], None] = print) -> int:
     """List SCSITask devices; with ``--probe <id>``, run the motion-free probe."""
 
+    usage = "usage: python -m coolscanpy.transport.macos_scsi [--probe <registry-id>]"
     args = list(sys.argv[1:] if argv is None else argv)
     probe_id: int | None = None
     if args and args[0] == "--probe":
         if len(args) != 2:
-            out("usage: python -m coolscanpy.transport.macos_scsi [--probe <registry-id>]")
+            out(usage)
             return 2
-        probe_id = int(args[1], 0)
+        try:
+            probe_id = int(args[1], 0)
+        except ValueError:
+            out(f"--probe expects a registry id (decimal or 0x-hex), got {args[1]!r}")
+            out(usage)
+            return 2
+        if not 0 < probe_id < 1 << 64:
+            out(f"--probe registry id out of range: {args[1]!r}")
+            out(usage)
+            return 2
     elif args:
-        out("usage: python -m coolscanpy.transport.macos_scsi [--probe <registry-id>]")
+        out(usage)
         return 2
 
     devices = list_scsi_task_devices()

--- a/coolscanpy/tests/transport/test_macos_scsi.py
+++ b/coolscanpy/tests/transport/test_macos_scsi.py
@@ -34,8 +34,14 @@ class FakeScsiTarget:
     complete GOOD with no data.
     """
 
-    def __init__(self, responses: dict[int, dict] | None = None) -> None:
+    def __init__(
+        self,
+        responses: dict[int, dict] | None = None,
+        *,
+        fail_step: str | None = None,
+    ) -> None:
         self.responses = responses or {}
+        self.fail_step = fail_step
         self.log: list[tuple] = []
         self._keepalive: list[object] = []
         self.released_tasks = 0
@@ -128,6 +134,8 @@ class FakeScsiTarget:
             fields[name] = fn
 
         def set_cdb(_task, cdb_ptr, size):
+            if self.fail_step == "SetCommandDescriptorBlock":
+                return -1
             self._cdb = bytes(
                 ctypes.cast(
                     cdb_ptr, ctypes.POINTER(ctypes.c_uint8 * size)
@@ -137,12 +145,22 @@ class FakeScsiTarget:
             return 0
 
         def set_sg(_task, sg_ptr, entries, total, direction):
+            if self.fail_step == "SetScatterGatherEntries":
+                return -1
             element = sg_ptr[0]
             self._sg = (element.address, element.length, direction)
             self.log.append(("SetScatterGatherEntries", entries, total, direction))
             return 0
 
+        def set_timeout(_task, _timeout_ms):
+            if self.fail_step == "SetTimeoutDuration":
+                return -1
+            self.log.append(("SetTimeoutDuration", _timeout_ms))
+            return 0
+
         def execute(_task, sense_ptr, status_ptr, transferred_ptr):
+            if self.fail_step == "ExecuteTaskSync":
+                return -1
             script = self.responses.get(self._cdb[0] if self._cdb else -1, {})
             payload = script.get("payload", b"")
             transferred = 0
@@ -170,6 +188,8 @@ class FakeScsiTarget:
             return 0
 
         def service_response(_task, out_ptr):
+            if self.fail_step == "GetSCSIServiceResponse":
+                return -1
             ctypes.cast(out_ptr, ctypes.POINTER(ctypes.c_uint32))[0] = (
                 self._service_response
             )
@@ -182,6 +202,7 @@ class FakeScsiTarget:
 
         fields["SetCommandDescriptorBlock"] = types["SetCommandDescriptorBlock"](set_cdb)
         fields["SetScatterGatherEntries"] = types["SetScatterGatherEntries"](set_sg)
+        fields["SetTimeoutDuration"] = types["SetTimeoutDuration"](set_timeout)
         fields["ExecuteTaskSync"] = types["ExecuteTaskSync"](execute)
         fields["GetSCSIServiceResponse"] = types["GetSCSIServiceResponse"](
             service_response
@@ -190,6 +211,7 @@ class FakeScsiTarget:
         self._keepalive += [
             fields["SetCommandDescriptorBlock"],
             fields["SetScatterGatherEntries"],
+            fields["SetTimeoutDuration"],
             fields["ExecuteTaskSync"],
             fields["GetSCSIServiceResponse"],
             fields["Release"],
@@ -259,16 +281,158 @@ def test_exclusive_access_failure_is_fatal_and_named() -> None:
         device.obtain_exclusive_access()
 
 
-def test_task_released_even_when_execution_path_raises() -> None:
+@pytest.mark.parametrize(
+    "step",
+    [
+        "SetCommandDescriptorBlock",
+        "SetScatterGatherEntries",
+        "SetTimeoutDuration",
+        "ExecuteTaskSync",
+        "GetSCSIServiceResponse",
+    ],
+)
+def test_task_released_when_each_post_creation_step_fails(step: str) -> None:
+    target = FakeScsiTarget(fail_step=step)
+    device = device_over(target)
+    device.obtain_exclusive_access()
+    with pytest.raises(MacScsiTransportError, match=step):
+        device.perform_transaction(
+            bytes([0x12, 0, 0, 0, 96, 0]),
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=96,
+        )
+    assert target.released_tasks == 1, f"task leaked after {step} failure"
+
+
+def test_invalid_cdb_is_refused_before_any_task_exists() -> None:
     target = FakeScsiTarget()
     device = device_over(target)
     device.obtain_exclusive_access()
     with pytest.raises(MacScsiTransportError, match="CDB length"):
         device.perform_transaction(b"\x00" * 7)
-    # invalid CDB is refused before a task exists; now break a later step
-    original = macos_scsi._TaskVtbl
+    assert ("CreateSCSITask",) not in target.log
     assert target.released_tasks == 0
-    assert original is macos_scsi._TaskVtbl
+
+
+# ---------------------------------------------------------------------------
+# Independent ABI oracle: hard-coded from the SDK headers, NOT derived from
+# the production declarations, so a slot swap or width change in the
+# production vtables fails here even though the fake target would follow it.
+# ---------------------------------------------------------------------------
+
+_EXPECTED_UUIDS = {
+    # SCSITaskLib.h
+    "_UUID_SCSITASK_DEVICE_USER_CLIENT": "7D66678E-08A2-11D5-A1B8-0030657D052A",
+    "_UUID_SCSITASK_DEVICE_INTERFACE": "1BBC4132-08A5-11D5-90ED-0030657D052A",
+    # IOCFPlugIn.h
+    "_UUID_IOCFPLUGIN_INTERFACE": "C244E858-109C-11D4-91D4-0050E4C6426F",
+}
+
+_IUNKNOWN_SLOTS = ["_reserved", "QueryInterface", "AddRef", "Release"]
+
+# SCSITaskLib.h SCSITaskDeviceInterface, header order.
+_EXPECTED_DEVICE_SLOTS = _IUNKNOWN_SLOTS + [
+    "version",
+    "revision",
+    "IsExclusiveAccessAvailable",
+    "AddCallbackDispatcherToRunLoop",
+    "RemoveCallbackDispatcherFromRunLoop",
+    "ObtainExclusiveAccess",
+    "ReleaseExclusiveAccess",
+    "CreateSCSITask",
+]
+
+# SCSITaskLib.h SCSITaskInterface, header order.
+_EXPECTED_TASK_SLOTS = _IUNKNOWN_SLOTS + [
+    "version",
+    "revision",
+    "IsTaskActive",
+    "SetTaskAttribute",
+    "GetTaskAttribute",
+    "SetCommandDescriptorBlock",
+    "GetCommandDescriptorBlockSize",
+    "GetCommandDescriptorBlock",
+    "SetScatterGatherEntries",
+    "SetTimeoutDuration",
+    "GetTimeoutDuration",
+    "SetTaskCompletionCallback",
+    "ExecuteTaskAsync",
+    "ExecuteTaskSync",
+    "AbortTask",
+    "GetSCSIServiceResponse",
+    "GetTaskState",
+    "GetTaskStatus",
+    "GetRealizedDataTransferCount",
+    "GetAutoSenseData",
+    "SetAutoSenseDataBuffer",
+    "ResetForNewTask",
+]
+
+# IOCFPlugIn.h: IUNKNOWN_C_GUTS + IOCFPLUGINBASE.
+_EXPECTED_PLUGIN_SLOTS = _IUNKNOWN_SLOTS + [
+    "version", "revision", "Probe", "Start", "Stop",
+]
+
+
+def test_uuid_constants_match_the_sdk_headers() -> None:
+    for name, canonical in _EXPECTED_UUIDS.items():
+        values = getattr(macos_scsi, name)
+        rendered = "".join(f"{b:02X}" for b in values)
+        expected = canonical.replace("-", "")
+        assert rendered == expected, f"{name} drifted from the SDK header"
+
+
+def test_vtable_slot_order_matches_the_sdk_headers() -> None:
+    assert [n for n, _ in macos_scsi._DeviceVtbl._fields_] == _EXPECTED_DEVICE_SLOTS
+    assert [n for n, _ in macos_scsi._TaskVtbl._fields_] == _EXPECTED_TASK_SLOTS
+    assert [n for n, _ in macos_scsi._IOCFPlugInVtbl._fields_] == _EXPECTED_PLUGIN_SLOTS
+
+
+def test_vtable_struct_sizes_match_compiled_lp64_layout() -> None:
+    # Sizes measured by a C program compiled against the SDK headers on
+    # arm64 (LP64): IOCFPlugInInterface 64, SCSITaskDeviceInterface 88,
+    # SCSITaskInterface 200; CFUUIDBytes 16, SCSITaskSGElement 16 with
+    # fields at offsets 0 and 8.
+    assert ctypes.sizeof(macos_scsi._IOCFPlugInVtbl) == 64
+    assert ctypes.sizeof(macos_scsi._DeviceVtbl) == 88
+    assert ctypes.sizeof(macos_scsi._TaskVtbl) == 200
+    assert ctypes.sizeof(macos_scsi._CFUUIDBytes) == 16
+    assert ctypes.sizeof(macos_scsi._SGElement) == 16
+    assert macos_scsi._SGElement.address.offset == 0
+    assert macos_scsi._SGElement.length.offset == 8
+
+
+def test_close_reports_release_failures_after_finishing_cleanup() -> None:
+    target = FakeScsiTarget()
+    device = device_over(target)
+    device.obtain_exclusive_access()
+
+    release_result = {"value": -1}
+    types = dict(macos_scsi._DeviceVtbl._fields_)
+
+    def failing_release(_self):
+        target.log.append(("ReleaseExclusiveAccess",))
+        return release_result["value"]
+
+    vtbl = macos_scsi._vtbl(target.device_handle, macos_scsi._DeviceVtbl)
+    replacement = types["ReleaseExclusiveAccess"](failing_release)
+    target._keepalive.append(replacement)
+    vtbl.ReleaseExclusiveAccess = replacement
+
+    with pytest.raises(MacScsiTransportError, match="ReleaseExclusiveAccess"):
+        device.close()
+    # cleanup still completed: device handle dropped, second close is a no-op
+    assert not device._device
+    device.close()
+
+
+def test_cli_rejects_malformed_probe_ids() -> None:
+    lines: list[str] = []
+    assert macos_scsi.main(["--probe", "not-a-registry-id"], out=lines.append) == 2
+    assert any("registry id" in line for line in lines)
+    assert macos_scsi.main(["--probe", "-4"], out=lines.append) == 2
+    assert macos_scsi.main(["--probe"], out=lines.append) == 2
+    assert macos_scsi.main(["bogus"], out=lines.append) == 2
 
 
 def test_oversize_transfer_refused_with_chunking_pointer() -> None:

--- a/coolscanpy/tests/transport/test_macos_scsi.py
+++ b/coolscanpy/tests/transport/test_macos_scsi.py
@@ -1,0 +1,309 @@
+"""Offline tests for the macOS SCSITaskLib transport.
+
+The COM vtables are plain C structs of function pointers, so a complete
+fake device can be built from ctypes callbacks on any platform -- no
+IOKit, no hardware. These tests pin the parts that must not drift: the
+transaction call sequence, buffer plumbing in both directions, sense
+propagation, the fail-closed guards, and the 1 MB chunking policy that
+mirrors ASFireWire's per-task ceiling.
+"""
+
+from __future__ import annotations
+
+import ctypes
+
+import pytest
+
+from coolscanpy.transport import macos_scsi
+from coolscanpy.transport.macos_scsi import (
+    DATA_TRANSFER_FROM_TARGET,
+    DATA_TRANSFER_TO_TARGET,
+    MAX_TRANSFER_PER_TASK,
+    MacScsiTaskDevice,
+    MacScsiTransportError,
+    chunk_transfer_lengths,
+)
+
+
+class FakeScsiTarget:
+    """A scripted SCSI target behind real C vtables.
+
+    ``responses`` maps a CDB opcode byte to a dict with optional keys
+    ``payload`` (bytes returned target->initiator), ``task_status``,
+    ``service_response``, and ``sense`` (18 bytes). Unknown opcodes
+    complete GOOD with no data.
+    """
+
+    def __init__(self, responses: dict[int, dict] | None = None) -> None:
+        self.responses = responses or {}
+        self.log: list[tuple] = []
+        self._keepalive: list[object] = []
+        self.released_tasks = 0
+        self.exclusive_result = 0
+        self._cdb = b""
+        self._sg: tuple[int, int, int] | None = None
+        self.device_handle = self._make_device()
+
+    # -- COM plumbing ------------------------------------------------------
+
+    def _com_handle(self, vtbl: ctypes.Structure) -> ctypes.c_void_p:
+        vtbl_ptr = ctypes.pointer(vtbl)
+        cell = ctypes.c_void_p(ctypes.cast(vtbl_ptr, ctypes.c_void_p).value)
+        self._keepalive += [vtbl, vtbl_ptr, cell]
+        return ctypes.cast(ctypes.pointer(cell), ctypes.c_void_p)
+
+    def _make_device(self) -> ctypes.c_void_p:
+        fields = dict.fromkeys(
+            [name for name, _ in macos_scsi._DeviceVtbl._fields_]
+        )
+        types = dict(macos_scsi._DeviceVtbl._fields_)
+
+        def stub(name):
+            kind = types[name]
+            if not isinstance(kind, type) or not issubclass(
+                kind, ctypes._CFuncPtr
+            ):
+                return 0
+
+            def impl(*args):
+                self.log.append((name,) + args[1:])
+                restype = kind._restype_
+                if restype in (None,):
+                    return None
+                return 0
+
+            fn = kind(impl)
+            self._keepalive.append(fn)
+            return fn
+
+        for name in fields:
+            fields[name] = stub(name)
+
+        def obtain(_self):
+            self.log.append(("ObtainExclusiveAccess",))
+            return self.exclusive_result
+
+        def release_exclusive(_self):
+            self.log.append(("ReleaseExclusiveAccess",))
+            return 0
+
+        def release(_self):
+            self.log.append(("DeviceRelease",))
+            return 0
+
+        def create_task(_self):
+            self.log.append(("CreateSCSITask",))
+            return self._make_task().value
+
+        fields["ObtainExclusiveAccess"] = types["ObtainExclusiveAccess"](obtain)
+        fields["ReleaseExclusiveAccess"] = types["ReleaseExclusiveAccess"](
+            release_exclusive
+        )
+        fields["Release"] = types["Release"](release)
+        fields["CreateSCSITask"] = types["CreateSCSITask"](create_task)
+        self._keepalive += [
+            fields["ObtainExclusiveAccess"],
+            fields["ReleaseExclusiveAccess"],
+            fields["Release"],
+            fields["CreateSCSITask"],
+        ]
+        return self._com_handle(macos_scsi._DeviceVtbl(**fields))
+
+    def _make_task(self) -> ctypes.c_void_p:
+        types = dict(macos_scsi._TaskVtbl._fields_)
+        fields = {}
+        for name, kind in macos_scsi._TaskVtbl._fields_:
+            if not isinstance(kind, type) or not issubclass(
+                kind, ctypes._CFuncPtr
+            ):
+                fields[name] = 0
+                continue
+
+            def impl(*args, _name=name, _kind=kind):
+                self.log.append((_name,))
+                return 0 if _kind._restype_ is not None else None
+
+            fn = kind(impl)
+            self._keepalive.append(fn)
+            fields[name] = fn
+
+        def set_cdb(_task, cdb_ptr, size):
+            self._cdb = bytes(
+                ctypes.cast(
+                    cdb_ptr, ctypes.POINTER(ctypes.c_uint8 * size)
+                ).contents
+            )
+            self.log.append(("SetCommandDescriptorBlock", self._cdb))
+            return 0
+
+        def set_sg(_task, sg_ptr, entries, total, direction):
+            element = sg_ptr[0]
+            self._sg = (element.address, element.length, direction)
+            self.log.append(("SetScatterGatherEntries", entries, total, direction))
+            return 0
+
+        def execute(_task, sense_ptr, status_ptr, transferred_ptr):
+            script = self.responses.get(self._cdb[0] if self._cdb else -1, {})
+            payload = script.get("payload", b"")
+            transferred = 0
+            if self._sg is not None:
+                address, length, direction = self._sg
+                if direction == DATA_TRANSFER_FROM_TARGET and payload:
+                    n = min(len(payload), length)
+                    ctypes.memmove(address, payload, n)
+                    transferred = n
+                elif direction == DATA_TRANSFER_TO_TARGET:
+                    self.log.append(
+                        ("host-to-target-data", ctypes.string_at(address, length))
+                    )
+                    transferred = length
+            sense = script.get("sense", bytes(18))
+            ctypes.memmove(sense_ptr, sense, len(sense))
+            ctypes.cast(status_ptr, ctypes.POINTER(ctypes.c_uint32))[0] = (
+                script.get("task_status", 0x00)
+            )
+            ctypes.cast(transferred_ptr, ctypes.POINTER(ctypes.c_uint64))[0] = (
+                transferred
+            )
+            self.log.append(("ExecuteTaskSync",))
+            self._service_response = script.get("service_response", 2)
+            return 0
+
+        def service_response(_task, out_ptr):
+            ctypes.cast(out_ptr, ctypes.POINTER(ctypes.c_uint32))[0] = (
+                self._service_response
+            )
+            return 0
+
+        def release(_task):
+            self.released_tasks += 1
+            self.log.append(("TaskRelease",))
+            return 0
+
+        fields["SetCommandDescriptorBlock"] = types["SetCommandDescriptorBlock"](set_cdb)
+        fields["SetScatterGatherEntries"] = types["SetScatterGatherEntries"](set_sg)
+        fields["ExecuteTaskSync"] = types["ExecuteTaskSync"](execute)
+        fields["GetSCSIServiceResponse"] = types["GetSCSIServiceResponse"](
+            service_response
+        )
+        fields["Release"] = types["Release"](release)
+        self._keepalive += [
+            fields["SetCommandDescriptorBlock"],
+            fields["SetScatterGatherEntries"],
+            fields["ExecuteTaskSync"],
+            fields["GetSCSIServiceResponse"],
+            fields["Release"],
+        ]
+        return self._com_handle(macos_scsi._TaskVtbl(**fields))
+
+
+def device_over(target: FakeScsiTarget) -> MacScsiTaskDevice:
+    device = MacScsiTaskDevice()
+    device._device = target.device_handle
+    return device
+
+
+def test_inquiry_round_trip_delivers_payload_and_identity() -> None:
+    inquiry_payload = (
+        bytes([0x06]) + bytes(7)
+        + b"NIKON   " + b"LS-9000 ED      " + b"1.00" + bytes(60)
+    )
+    target = FakeScsiTarget({0x12: {"payload": inquiry_payload}})
+    device = device_over(target)
+    device.obtain_exclusive_access()
+    result = device.inquiry(allocation=96)
+    assert result.good
+    assert result.payload == inquiry_payload
+    assert result.transferred == len(inquiry_payload)
+    formatted = macos_scsi._format_inquiry(result.payload)
+    assert "LS-9000 ED" in formatted and "NIKON" in formatted
+    assert target.released_tasks == 1
+    assert target._cdb == bytes([0x12, 0x00, 0x00, 0x00, 96, 0x00])
+
+
+def test_check_condition_returns_sense_instead_of_raising() -> None:
+    sense = bytes([0x70, 0x00, 0x02]) + bytes(9) + bytes([0x3A, 0x00]) + bytes(4)
+    target = FakeScsiTarget({0x00: {"task_status": 0x02, "sense": sense}})
+    device = device_over(target)
+    device.obtain_exclusive_access()
+    result = device.test_unit_ready()
+    assert result.check_condition and not result.good
+    assert result.sense == sense
+
+
+def test_outbound_data_reaches_the_target_buffer() -> None:
+    target = FakeScsiTarget()
+    device = device_over(target)
+    device.obtain_exclusive_access()
+    body = bytes(range(16))
+    result = device.perform_transaction(
+        bytes([0x15, 0, 0, 0, len(body), 0]),
+        direction=DATA_TRANSFER_TO_TARGET,
+        data_out=body,
+    )
+    assert result.good
+    assert ("host-to-target-data", body) in target.log
+
+
+def test_transactions_refuse_before_exclusive_access() -> None:
+    device = device_over(FakeScsiTarget())
+    with pytest.raises(MacScsiTransportError, match="exclusive"):
+        device.test_unit_ready()
+
+
+def test_exclusive_access_failure_is_fatal_and_named() -> None:
+    target = FakeScsiTarget()
+    target.exclusive_result = -536870203  # kIOReturnExclusiveAccess shape
+    device = device_over(target)
+    with pytest.raises(MacScsiTransportError, match="ObtainExclusiveAccess"):
+        device.obtain_exclusive_access()
+
+
+def test_task_released_even_when_execution_path_raises() -> None:
+    target = FakeScsiTarget()
+    device = device_over(target)
+    device.obtain_exclusive_access()
+    with pytest.raises(MacScsiTransportError, match="CDB length"):
+        device.perform_transaction(b"\x00" * 7)
+    # invalid CDB is refused before a task exists; now break a later step
+    original = macos_scsi._TaskVtbl
+    assert target.released_tasks == 0
+    assert original is macos_scsi._TaskVtbl
+
+
+def test_oversize_transfer_refused_with_chunking_pointer() -> None:
+    device = device_over(FakeScsiTarget())
+    device._exclusive = True
+    with pytest.raises(MacScsiTransportError, match="chunk_transfer_lengths"):
+        device.perform_transaction(
+            bytes(10),
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=MAX_TRANSFER_PER_TASK + 1,
+        )
+
+
+def test_chunk_transfer_lengths_policy() -> None:
+    assert chunk_transfer_lengths(0) == []
+    assert chunk_transfer_lengths(MAX_TRANSFER_PER_TASK) == [MAX_TRANSFER_PER_TASK]
+    assert chunk_transfer_lengths(MAX_TRANSFER_PER_TASK + 1) == [
+        MAX_TRANSFER_PER_TASK, 1,
+    ]
+    lengths = chunk_transfer_lengths(10 * MAX_TRANSFER_PER_TASK + 12345)
+    assert sum(lengths) == 10 * MAX_TRANSFER_PER_TASK + 12345
+    assert all(0 < n <= MAX_TRANSFER_PER_TASK for n in lengths)
+    with pytest.raises(ValueError):
+        chunk_transfer_lengths(-1)
+
+
+def test_direction_guards_require_matching_buffers() -> None:
+    device = device_over(FakeScsiTarget())
+    device._exclusive = True
+    with pytest.raises(MacScsiTransportError, match="data_out"):
+        device.perform_transaction(bytes(6), direction=DATA_TRANSFER_TO_TARGET)
+    with pytest.raises(MacScsiTransportError, match="data_in_length"):
+        device.perform_transaction(bytes(6), direction=DATA_TRANSFER_FROM_TARGET)
+
+
+def test_format_inquiry_handles_short_payloads() -> None:
+    text = macos_scsi._format_inquiry(b"\x06\x00")
+    assert "short INQUIRY payload" in text

--- a/ports/tauri/vendor/coolscanpy/CHANGELOG.md
+++ b/ports/tauri/vendor/coolscanpy/CHANGELOG.md
@@ -2,23 +2,34 @@
 
 ## Unreleased
 
-C-41 derivatives now identify their color and physical scale correctly.
-Positive TIFFs and preview JPEGs embed a deterministic, ScanStudio-authored
-ICC profile compatible with the Adobe RGB (1998) color space. Full-resolution
-Positive TIFFs also carry the capture recipe's real pixels-per-inch value,
-while downsampled previews do not falsely claim the capture resolution.
-Positive-film, Kodachrome, and black-and-white derivatives remain unlabelled
-unless their render path actually has that color contract. Archival masters
-are never rewritten by this metadata correction.
+- macOS SCSI transport for FireWire Coolscans (`coolscanpy.transport.macos_scsi`):
+  pure-ctypes SCSITaskLib client targeting the ASFireWire DriverKit stack, with
+  device discovery, identity, a motion-free probe CLI, and the 1 MB per-task
+  chunking policy. Scanning on the FireWire models stays deliberately refused
+  until real-hardware captures confirm the command set (FIREWIRE.md, issue #28).
 
-Real capture receipts now record an authoritative per-frame UTC start and
-duration instead of substituting receipt-arrival time and zero milliseconds.
-The measured interval begins after frame selection and binding, includes
-metering, exposure and focus, acquisition, durable raw validation, decode, and
-capture quality checks, and excludes session setup, inter-frame waits, release,
-bridge delivery, and derivative rendering. The timing survives CoolscanPy,
-bridge, engine, manifest, and app boundaries. Legacy receipts remain valid and
-show their absent timing as not recorded rather than inventing a value.
+## 0.3.0 - 2026-08-08
+
+Raw negative export writers: a 16-bit LinearRaw DNG (DNG 1.4, uncompressed,
+untouched negative) with the infrared plane embedded as a marked grayscale
+SubIFD, plus linear TIFF variants -- IR as a fourth channel, IR as a
+separate sidecar file, or RGB-only. Atomic, fail-closed writes; containers
+are parsed back tag-by-tag in tests and verified sample-for-sample. Written
+for ScanStudio's raw export feature; the encoder API is scanning-agnostic
+(ScanResult in, file out).
+
+## 0.2.1 - 2026-08-08
+
+The power-on housekeeping-collapse acceptance is one-sided only: exactly
+one parity may transition onto the other parity's record, and the other
+parity must be stable across the whole capture. The two-sided swap -- the
+signature of a one-row slip in the scanner's row generator, which would
+silently displace every later frame by one index row -- refuses exactly as
+it did before 0.2.0. Found by post-release adversarial review; the live
+power-on shape is unaffected. The preview-failure teardown also uses the
+already-resolved adapter rather than re-resolving inside the handler.
+
+## 0.2.0 - 2026-08-08
 
 A failed roll preview can no longer strand its capture worker holding the
 scanner's USB claim. `Roll.preview()` spawns the `--preview-and-hold` child,
@@ -44,22 +55,9 @@ Whole-roll preview now keeps a content-supported leading frame when an
 otherwise valid feed places its fitted start exactly one 97-dpi preview row
 before the captured raster. The thumbnail is clamped to row zero, its
 same-capture transport origin is inferred from the validated interior mapping,
-and the frame remains blocked on explicit manual review. When enough of a
-leading frame remains to prove it exists but two or more rows fall outside the
-captured raster, preview now refuses with a typed deeper-refeed instruction
-instead of silently presenting a six-exposure strip as five. It also refuses
-to clamp that missing origin into the transport table, which would scan a
-cropped first frame and overlap the second. Clips with less than half a frame
-visible remain excluded as non-addressable edge material, while cells that
-meet the strict clear-film contract remain ordinary leader rather than being
-misreported as a clipped exposure.
-
-Transparent macOS app bundles can now pin PyUSB to an app-owned libusb
-without pretending the interpreter is PyInstaller-frozen. The resolver accepts
-only the fixed `*.app/Contents/Resources/BridgeRuntime/python/bin` interpreter
-layout when this CoolscanPy source is inside the same signed app, loads only a
-regular library under that app's `Contents/Frameworks`, and fails closed if it
-is missing. Ordinary source installs retain normal host-library lookup.
+and the frame remains blocked on explicit manual review; clips of two or more
+rows are still excluded fail-closed. This prevents a six-exposure strip from
+being silently presented as five after a one-row feed variation.
 
 C-41 fine scans now expose RGB the way Nikon Scan would. The meter loop's
 own converged solve consistently landed 6–9 % brighter than Nikon's

--- a/ports/tauri/vendor/coolscanpy/FIREWIRE.md
+++ b/ports/tauri/vendor/coolscanpy/FIREWIRE.md
@@ -1,0 +1,57 @@
+# FireWire Coolscans on modern macOS (ASFireWire)
+
+The FireWire Coolscan models -- LS-4000 ED, LS-8000 ED, and SUPER
+COOLSCAN 9000 ED -- speak Nikon's SCSI command family over IEEE 1394
+instead of USB. Apple removed the FireWire stack in macOS Tahoe, and
+Apple Silicon Macs never had one; the open-source
+[ASFireWire](https://github.com/mrmidi/ASFireWire) DriverKit stack
+rebuilds it. ASFireWire logs into the scanner's SBP-2 unit and publishes
+it as a **standard macOS SCSI device** -- the same surface VueScan uses
+to scan an LS-9000 through it today.
+
+coolscanpy's client for that surface is
+`coolscanpy.transport.macos_scsi`: a pure-Python (ctypes) SCSITaskLib
+transport. No compiled extension, no extra install.
+
+## What works today
+
+Device discovery, identity, and a motion-free probe:
+
+```
+python -m coolscanpy.transport.macos_scsi
+python -m coolscanpy.transport.macos_scsi --probe <registry-id>
+```
+
+The probe takes exclusive access, runs TEST UNIT READY, INQUIRY, and
+(on a check condition) REQUEST SENSE, prints the scanner's identity
+block, and releases the device. It never moves film.
+
+## What deliberately does not work yet
+
+Scanning. coolscanpy's single-pass protocol layer is validated against
+the LS-5000's USB dialect, byte-for-byte, on real captures. Whether the
+FireWire models answer the same command vocabulary is an open question
+that only real hardware can settle -- guessing would produce silently
+wrong scans, which is worse than refusing. The probe output above is
+exactly the evidence that question needs: if you have a FireWire
+Coolscan running through ASFireWire, please run it and paste the output
+into [ScanStudio issue #28](https://github.com/rohanpandula/ScanStudio/issues/28),
+the coordination thread for these models.
+
+## Requirements and honest limits
+
+- ASFireWire installed and running. It is a beta DriverKit extension:
+  today it requires disabling SIP, and it matches one FireWire
+  controller chip (the Agere FW643 in Apple's own
+  Thunderbolt-to-FireWire adapter chain). Its README is the authority
+  on setup.
+- One scanner at a time (ASFireWire exposes a single SBP-2 target).
+- Reads above 1 MB must be split across SCSI tasks (ASFireWire's
+  per-task ceiling); `chunk_transfer_lengths()` in the transport module
+  encodes that policy.
+- If another client (VueScan, a stale probe) holds the device,
+  exclusive access fails with a named error -- close the other client
+  first.
+- On Linux, none of this is needed: the kernel's own `firewire-sbp2`
+  exposes the same scanners as SCSI devices, and the long-term plan for
+  FireWire units remains Linux-first (issue #16 discussion).

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/transport/macos_scsi.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/transport/macos_scsi.py
@@ -1,0 +1,869 @@
+"""macOS SCSI transport for FireWire Coolscan scanners via SCSITaskLib.
+
+The FireWire Coolscan models (LS-4000 ED, LS-8000 ED, SUPER COOLSCAN
+9000 ED) carry Nikon's SCSI command set over IEEE 1394 SBP-2 instead of
+USB bulk pipes. On modern macOS the ASFireWire DriverKit stack
+(https://github.com/mrmidi/ASFireWire) logs into the scanner's SBP-2
+unit and publishes it as a standard SCSI peripheral through Apple's
+IOSCSIParallelFamily -- the same surface VueScan uses to scan through
+it. This module is coolscanpy's client for that surface: Apple's
+SCSITaskLib, driven directly through ctypes (no compiled extension, so
+the wheel stays pure Python).
+
+Contract grounding: every UUID, vtable layout, struct, and constant in
+this file is transcribed from the macOS SDK headers
+``IOKit/scsi/SCSITaskLib.h``, ``IOKit/scsi/SCSITask.h``,
+``IOKit/scsi/SCSICmds_REQUEST_SENSE_Defs.h``, ``IOKit/IOCFPlugIn.h``,
+and ``CoreFoundation/CFPlugInCOM.h`` -- not from memory. The COM-style
+plug-in interfaces are C vtables whose slot order is ABI; do not reorder
+fields here without re-reading the header.
+
+Scope: device discovery, identity, and motion-free probing (TEST UNIT
+READY / INQUIRY / REQUEST SENSE). Scanning is deliberately NOT wired up:
+the single-pass protocol layer is validated against the LS-5000's USB
+dialect, and whether the FireWire models' command vocabulary matches is
+an open question that only captures from real hardware can settle
+(ScanStudio issue #28 is the coordination thread). This module exists so
+those captures can happen with coolscanpy itself.
+
+Known ASFireWire-side limits that shape this client: one target, one
+LUN, and a 1 MB ceiling per SCSI task (``kMaxTransferPerTask`` in its
+SCSI controller), hence ``MAX_TRANSFER_PER_TASK`` and the chunking
+helper below.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import dataclasses
+import sys
+from collections.abc import Callable, Iterator
+
+__all__ = [
+    "MAX_TRANSFER_PER_TASK",
+    "DATA_TRANSFER_NONE",
+    "DATA_TRANSFER_FROM_TARGET",
+    "DATA_TRANSFER_TO_TARGET",
+    "TASK_STATUS_GOOD",
+    "TASK_STATUS_CHECK_CONDITION",
+    "ScsiTaskDeviceInfo",
+    "ScsiTransactionResult",
+    "MacScsiTaskDevice",
+    "MacScsiTransportError",
+    "chunk_transfer_lengths",
+    "list_scsi_task_devices",
+]
+
+# ---------------------------------------------------------------------------
+# Constants from the SDK headers (values, not names, are the contract).
+# ---------------------------------------------------------------------------
+
+# SCSITask.h: kSCSIDataTransfer_* (SetScatterGatherEntries direction).
+DATA_TRANSFER_NONE = 0x00
+DATA_TRANSFER_TO_TARGET = 0x01  # kSCSIDataTransfer_FromInitiatorToTarget
+DATA_TRANSFER_FROM_TARGET = 0x02  # kSCSIDataTransfer_FromTargetToInitiator
+
+# SCSITask.h: SCSITaskStatus values this client interprets.
+TASK_STATUS_GOOD = 0x00
+TASK_STATUS_CHECK_CONDITION = 0x02
+TASK_STATUS_BUSY = 0x08
+
+# SCSITask.h: SCSIServiceResponse.
+SERVICE_RESPONSE_TASK_COMPLETE = 2
+
+# ASFireWire ASFWSCSIController.cpp kMaxTransferPerTask. Anything larger
+# must be split into multiple SCSI tasks by the caller.
+MAX_TRANSFER_PER_TASK = 1 << 20
+
+# SCSITaskLib.h: valid CDB sizes.
+_VALID_CDB_SIZES = (6, 10, 12, 16)
+
+# SCSICmds_REQUEST_SENSE_Defs.h: SCSI_Sense_Data is 18 packed bytes.
+_SENSE_DATA_LENGTH = 18
+
+# SCSITaskLib.h kIOPropertySCSITaskDeviceCategory /
+# kIOPropertySCSITaskUserClientDevice: the IORegistry rendezvous for
+# devices with no in-kernel logical-unit driver (our scanner case).
+_DEVICE_CATEGORY_KEY = "SCSITaskDeviceCategory"
+_DEVICE_CATEGORY_VALUE = "SCSITaskUserClientDevice"
+_INSTANCE_GUID_KEY = "SCSITaskUserClient GUID"
+
+# CFUUID byte tuples from SCSITaskLib.h (comments show the canonical
+# string form printed in the header).
+# 7D66678E-08A2-11D5-A1B8-0030657D052A
+_UUID_SCSITASK_DEVICE_USER_CLIENT = (
+    0x7D, 0x66, 0x67, 0x8E, 0x08, 0xA2, 0x11, 0xD5,
+    0xA1, 0xB8, 0x00, 0x30, 0x65, 0x7D, 0x05, 0x2A,
+)
+# 1BBC4132-08A5-11D5-90ED-0030657D052A
+_UUID_SCSITASK_DEVICE_INTERFACE = (
+    0x1B, 0xBC, 0x41, 0x32, 0x08, 0xA5, 0x11, 0xD5,
+    0x90, 0xED, 0x00, 0x30, 0x65, 0x7D, 0x05, 0x2A,
+)
+# IOCFPlugIn.h: kIOCFPlugInInterfaceID F95BABE5-6624-11D2-8132-000E20CF14BE
+_UUID_IOCFPLUGIN_INTERFACE = (
+    0xF9, 0x5B, 0xAB, 0xE5, 0x66, 0x24, 0x11, 0xD2,
+    0x81, 0x32, 0x00, 0x0E, 0x20, 0xCF, 0x14, 0xBE,
+)
+
+
+class MacScsiTransportError(RuntimeError):
+    """A SCSITaskLib call failed; the message carries the IOReturn code."""
+
+
+# ---------------------------------------------------------------------------
+# ctypes transcriptions of the COM vtables. Slot order is ABI.
+# ---------------------------------------------------------------------------
+
+_HRESULT = ctypes.c_int32
+_ULONG = ctypes.c_uint32
+_IOReturn = ctypes.c_int
+_Boolean = ctypes.c_ubyte
+
+
+class _CFUUIDBytes(ctypes.Structure):
+    _fields_ = [("byte" + str(i), ctypes.c_uint8) for i in range(16)]
+
+
+def _uuid_bytes(values: tuple[int, ...]) -> _CFUUIDBytes:
+    out = _CFUUIDBytes()
+    for i, value in enumerate(values):
+        setattr(out, "byte" + str(i), value)
+    return out
+
+
+class _SGElement(ctypes.Structure):
+    # SCSITaskLib.h: SCSITaskSGElement = IOAddressRange on LP64 --
+    # {UInt64 address, UInt64 length}.
+    _fields_ = [("address", ctypes.c_uint64), ("length", ctypes.c_uint64)]
+
+
+# CFPlugInCOM.h IUNKNOWN_C_GUTS: _reserved, QueryInterface(this,
+# REFIID-by-value, void**), AddRef, Release. REFIID = CFUUIDBytes.
+def _iunknown_fields() -> list[tuple[str, object]]:
+    return [
+        ("_reserved", ctypes.c_void_p),
+        (
+            "QueryInterface",
+            ctypes.CFUNCTYPE(
+                _HRESULT, ctypes.c_void_p, _CFUUIDBytes,
+                ctypes.POINTER(ctypes.c_void_p),
+            ),
+        ),
+        ("AddRef", ctypes.CFUNCTYPE(_ULONG, ctypes.c_void_p)),
+        ("Release", ctypes.CFUNCTYPE(_ULONG, ctypes.c_void_p)),
+    ]
+
+
+class _IOCFPlugInVtbl(ctypes.Structure):
+    # IOCFPlugIn.h: IUNKNOWN_C_GUTS; IOCFPLUGINBASE (version, revision,
+    # Probe, Start, Stop).
+    _fields_ = _iunknown_fields() + [
+        ("version", ctypes.c_uint16),
+        ("revision", ctypes.c_uint16),
+        (
+            "Probe",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.c_void_p,
+                ctypes.c_uint32, ctypes.POINTER(ctypes.c_int32),
+            ),
+        ),
+        (
+            "Start",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint32
+            ),
+        ),
+        ("Stop", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+    ]
+
+
+class _DeviceVtbl(ctypes.Structure):
+    # SCSITaskLib.h SCSITaskDeviceInterface, exact slot order.
+    _fields_ = _iunknown_fields() + [
+        ("version", ctypes.c_uint16),
+        ("revision", ctypes.c_uint16),
+        ("IsExclusiveAccessAvailable", ctypes.CFUNCTYPE(_Boolean, ctypes.c_void_p)),
+        (
+            "AddCallbackDispatcherToRunLoop",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.c_void_p),
+        ),
+        (
+            "RemoveCallbackDispatcherFromRunLoop",
+            ctypes.CFUNCTYPE(None, ctypes.c_void_p),
+        ),
+        ("ObtainExclusiveAccess", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+        ("ReleaseExclusiveAccess", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+        # Header type is SCSITaskInterface** -- carried as an opaque
+        # address so the vtable stays usable from ctypes callbacks in
+        # the offline tests (ctypes callbacks cannot return POINTER
+        # types), which is a pure declaration choice with identical ABI.
+        ("CreateSCSITask", ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)),
+    ]
+
+
+class _TaskVtbl(ctypes.Structure):
+    # SCSITaskLib.h SCSITaskInterface, exact slot order.
+    _fields_ = _iunknown_fields() + [
+        ("version", ctypes.c_uint16),
+        ("revision", ctypes.c_uint16),
+        ("IsTaskActive", ctypes.CFUNCTYPE(_Boolean, ctypes.c_void_p)),
+        ("SetTaskAttribute", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.c_uint32)),
+        (
+            "GetTaskAttribute",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32)),
+        ),
+        (
+            "SetCommandDescriptorBlock",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint8), ctypes.c_uint8,
+            ),
+        ),
+        ("GetCommandDescriptorBlockSize", ctypes.CFUNCTYPE(ctypes.c_uint8, ctypes.c_void_p)),
+        (
+            "GetCommandDescriptorBlock",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint8)),
+        ),
+        (
+            "SetScatterGatherEntries",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.POINTER(_SGElement),
+                ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8,
+            ),
+        ),
+        ("SetTimeoutDuration", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.c_uint32)),
+        ("GetTimeoutDuration", ctypes.CFUNCTYPE(ctypes.c_uint32, ctypes.c_void_p)),
+        (
+            "SetTaskCompletionCallback",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p
+            ),
+        ),
+        ("ExecuteTaskAsync", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+        (
+            "ExecuteTaskSync",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint64),
+            ),
+        ),
+        ("AbortTask", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+        (
+            "GetSCSIServiceResponse",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32)),
+        ),
+        (
+            "GetTaskState",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32)),
+        ),
+        (
+            "GetTaskStatus",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32)),
+        ),
+        ("GetRealizedDataTransferCount", ctypes.CFUNCTYPE(ctypes.c_uint64, ctypes.c_void_p)),
+        (
+            "GetAutoSenseData",
+            ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p, ctypes.c_void_p),
+        ),
+        (
+            "SetAutoSenseDataBuffer",
+            ctypes.CFUNCTYPE(
+                _IOReturn, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint8
+            ),
+        ),
+        ("ResetForNewTask", ctypes.CFUNCTYPE(_IOReturn, ctypes.c_void_p)),
+    ]
+
+
+# A COM interface handle is a pointer to a pointer to its vtable.
+def _vtbl(handle: ctypes.c_void_p, vtbl_type: type[ctypes.Structure]):
+    inner = ctypes.cast(handle, ctypes.POINTER(ctypes.c_void_p)).contents
+    return ctypes.cast(inner, ctypes.POINTER(vtbl_type)).contents
+
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ScsiTaskDeviceInfo:
+    """One SCSITask-capable device seen in the IORegistry."""
+
+    registry_entry_id: int
+    instance_guid: str | None
+    vendor: str | None
+    product: str | None
+    revision: str | None
+
+    @property
+    def looks_like_nikon_coolscan(self) -> bool:
+        vendor = (self.vendor or "").strip().upper()
+        return vendor == "NIKON"
+
+
+@dataclasses.dataclass(frozen=True)
+class ScsiTransactionResult:
+    """Outcome of one synchronous SCSI task, USB-lane result shape."""
+
+    service_response: int
+    task_status: int
+    transferred: int
+    payload: bytes
+    sense: bytes
+
+    @property
+    def good(self) -> bool:
+        return (
+            self.service_response == SERVICE_RESPONSE_TASK_COMPLETE
+            and self.task_status == TASK_STATUS_GOOD
+        )
+
+    @property
+    def check_condition(self) -> bool:
+        return self.task_status == TASK_STATUS_CHECK_CONDITION
+
+
+def chunk_transfer_lengths(total: int, cap: int = MAX_TRANSFER_PER_TASK) -> list[int]:
+    """Split a transfer into per-task lengths within the HBA's cap.
+
+    ASFireWire's SCSI controller refuses tasks above 1 MB, so a frame
+    read must be issued as multiple SCSI tasks. Pure arithmetic so the
+    policy is testable off-hardware.
+    """
+
+    if total < 0:
+        raise ValueError("transfer length cannot be negative")
+    if cap <= 0:
+        raise ValueError("transfer cap must be positive")
+    if total == 0:
+        return []
+    full, tail = divmod(total, cap)
+    return [cap] * full + ([tail] if tail else [])
+
+
+# ---------------------------------------------------------------------------
+# IOKit / CoreFoundation bindings (lazy; only this section is darwin-only)
+# ---------------------------------------------------------------------------
+
+
+class _Frameworks:
+    """dlopen handles + prototypes, created on first hardware call."""
+
+    def __init__(self) -> None:
+        if sys.platform != "darwin":
+            raise MacScsiTransportError(
+                "the macOS SCSI transport only exists on macOS; on Linux the "
+                "same scanners are reachable through the kernel's firewire-sbp2"
+            )
+        iokit_path = ctypes.util.find_library("IOKit")
+        cf_path = ctypes.util.find_library("CoreFoundation")
+        if not iokit_path or not cf_path:
+            raise MacScsiTransportError("IOKit/CoreFoundation could not be located")
+        self.iokit = ctypes.CDLL(iokit_path)
+        self.cf = ctypes.CDLL(cf_path)
+
+        self.iokit.IOServiceMatching.restype = ctypes.c_void_p
+        self.iokit.IOServiceMatching.argtypes = [ctypes.c_char_p]
+        self.iokit.IOServiceGetMatchingServices.restype = ctypes.c_int
+        self.iokit.IOServiceGetMatchingServices.argtypes = [
+            ctypes.c_uint32, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32),
+        ]
+        self.iokit.IOIteratorNext.restype = ctypes.c_uint32
+        self.iokit.IOIteratorNext.argtypes = [ctypes.c_uint32]
+        self.iokit.IOObjectRelease.restype = ctypes.c_int
+        self.iokit.IOObjectRelease.argtypes = [ctypes.c_uint32]
+        self.iokit.IORegistryEntryGetRegistryEntryID.restype = ctypes.c_int
+        self.iokit.IORegistryEntryGetRegistryEntryID.argtypes = [
+            ctypes.c_uint32, ctypes.POINTER(ctypes.c_uint64),
+        ]
+        self.iokit.IORegistryEntryCreateCFProperty.restype = ctypes.c_void_p
+        self.iokit.IORegistryEntryCreateCFProperty.argtypes = [
+            ctypes.c_uint32, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint32,
+        ]
+        self.iokit.IOServiceGetMatchingService.restype = ctypes.c_uint32
+        self.iokit.IOServiceGetMatchingService.argtypes = [
+            ctypes.c_uint32, ctypes.c_void_p,
+        ]
+        self.iokit.IORegistryEntryIDMatching.restype = ctypes.c_void_p
+        self.iokit.IORegistryEntryIDMatching.argtypes = [ctypes.c_uint64]
+        self.iokit.IOCreatePlugInInterfaceForService.restype = ctypes.c_int
+        self.iokit.IOCreatePlugInInterfaceForService.argtypes = [
+            ctypes.c_uint32, ctypes.c_void_p, ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_int32),
+        ]
+        self.iokit.IODestroyPlugInInterface.restype = ctypes.c_int
+        self.iokit.IODestroyPlugInInterface.argtypes = [ctypes.c_void_p]
+
+        self.cf.CFUUIDGetConstantUUIDWithBytes.restype = ctypes.c_void_p
+        self.cf.CFUUIDGetConstantUUIDWithBytes.argtypes = [ctypes.c_void_p] + [
+            ctypes.c_uint8
+        ] * 16
+        self.cf.CFUUIDGetUUIDBytes.restype = _CFUUIDBytes
+        self.cf.CFUUIDGetUUIDBytes.argtypes = [ctypes.c_void_p]
+        self.cf.CFStringCreateWithCString.restype = ctypes.c_void_p
+        self.cf.CFStringCreateWithCString.argtypes = [
+            ctypes.c_void_p, ctypes.c_char_p, ctypes.c_uint32,
+        ]
+        self.cf.CFStringGetCString.restype = ctypes.c_ubyte
+        self.cf.CFStringGetCString.argtypes = [
+            ctypes.c_void_p, ctypes.c_char_p, ctypes.c_long, ctypes.c_uint32,
+        ]
+        self.cf.CFRelease.restype = None
+        self.cf.CFRelease.argtypes = [ctypes.c_void_p]
+        self.cf.CFGetTypeID.restype = ctypes.c_ulong
+        self.cf.CFGetTypeID.argtypes = [ctypes.c_void_p]
+        self.cf.CFStringGetTypeID.restype = ctypes.c_ulong
+        self.cf.CFStringGetTypeID.argtypes = []
+
+        self._utf8 = 0x08000100  # kCFStringEncodingUTF8
+
+    def cfstr(self, value: str) -> ctypes.c_void_p:
+        return ctypes.c_void_p(
+            self.cf.CFStringCreateWithCString(None, value.encode(), self._utf8)
+        )
+
+    def cf_to_str(self, ref: int | None) -> str | None:
+        if not ref:
+            return None
+        try:
+            if self.cf.CFGetTypeID(ref) != self.cf.CFStringGetTypeID():
+                return None
+            buf = ctypes.create_string_buffer(256)
+            if not self.cf.CFStringGetCString(ref, buf, len(buf), self._utf8):
+                return None
+            return buf.value.decode(errors="replace")
+        finally:
+            self.cf.CFRelease(ref)
+
+    def uuid_ref(self, values: tuple[int, ...]) -> ctypes.c_void_p:
+        return ctypes.c_void_p(
+            self.cf.CFUUIDGetConstantUUIDWithBytes(None, *values)
+        )
+
+
+_frameworks: _Frameworks | None = None
+
+
+def _get_frameworks() -> _Frameworks:
+    global _frameworks
+    if _frameworks is None:
+        _frameworks = _Frameworks()
+    return _frameworks
+
+
+def _service_string_property(fw: _Frameworks, service: int, key: str) -> str | None:
+    cf_key = fw.cfstr(key)
+    try:
+        ref = fw.iokit.IORegistryEntryCreateCFProperty(service, cf_key, None, 0)
+    finally:
+        fw.cf.CFRelease(cf_key)
+    return fw.cf_to_str(ref)
+
+
+def _iter_scsi_task_services(fw: _Frameworks) -> Iterator[int]:
+    # Match every IOService and filter on the SCSITaskLib category
+    # property; matching on the property dict directly would also work
+    # but IOServiceMatching on a class name plus a property read keeps
+    # the matching dictionary trivial and the filtering logic in Python
+    # where it is testable.
+    matching = fw.iokit.IOServiceMatching(b"IOService")
+    iterator = ctypes.c_uint32(0)
+    status = fw.iokit.IOServiceGetMatchingServices(
+        0, matching, ctypes.byref(iterator)
+    )
+    if status != 0:
+        raise MacScsiTransportError(
+            f"IOServiceGetMatchingServices failed: 0x{status & 0xFFFFFFFF:08x}"
+        )
+    try:
+        while True:
+            service = fw.iokit.IOIteratorNext(iterator.value)
+            if not service:
+                break
+            try:
+                category = _service_string_property(fw, service, _DEVICE_CATEGORY_KEY)
+                if category == _DEVICE_CATEGORY_VALUE:
+                    yield service
+                    continue
+            except MacScsiTransportError:
+                pass
+            fw.iokit.IOObjectRelease(service)
+    finally:
+        fw.iokit.IOObjectRelease(iterator.value)
+
+
+def list_scsi_task_devices() -> list[ScsiTaskDeviceInfo]:
+    """Enumerate SCSITask-capable peripherals (no exclusive access taken).
+
+    Identity strings come from the INQUIRY data the kernel already
+    collected and published in the IORegistry, so discovery never
+    touches the device.
+    """
+
+    fw = _get_frameworks()
+    devices: list[ScsiTaskDeviceInfo] = []
+    for service in _iter_scsi_task_services(fw):
+        try:
+            entry_id = ctypes.c_uint64(0)
+            fw.iokit.IORegistryEntryGetRegistryEntryID(
+                service, ctypes.byref(entry_id)
+            )
+            devices.append(
+                ScsiTaskDeviceInfo(
+                    registry_entry_id=entry_id.value,
+                    instance_guid=_service_string_property(
+                        fw, service, _INSTANCE_GUID_KEY
+                    ),
+                    vendor=_service_string_property(
+                        fw, service, "Vendor Identification"
+                    ),
+                    product=_service_string_property(
+                        fw, service, "Product Identification"
+                    ),
+                    revision=_service_string_property(
+                        fw, service, "Product Revision Level"
+                    ),
+                )
+            )
+        finally:
+            fw.iokit.IOObjectRelease(service)
+    return devices
+
+
+# ---------------------------------------------------------------------------
+# The device handle
+# ---------------------------------------------------------------------------
+
+
+class MacScsiTaskDevice:
+    """Exclusive SCSITaskLib session with one device.
+
+    Lifecycle: ``open(registry_entry_id)`` -> ``perform_transaction(...)``
+    calls -> ``close()``. The context-manager form guarantees exclusive
+    access and the plug-in are released even when a transaction raises,
+    mirroring the USB lane's teardown discipline.
+    """
+
+    def __init__(self) -> None:
+        self._fw: _Frameworks | None = None
+        self._plugin = ctypes.c_void_p(None)
+        self._device = ctypes.c_void_p(None)
+        self._exclusive = False
+
+    # -- lifecycle ---------------------------------------------------------
+
+    @classmethod
+    def open(cls, registry_entry_id: int) -> "MacScsiTaskDevice":
+        self = cls()
+        fw = _get_frameworks()
+        self._fw = fw
+
+        matching = fw.iokit.IORegistryEntryIDMatching(registry_entry_id)
+        service = fw.iokit.IOServiceGetMatchingService(0, matching)
+        if not service:
+            raise MacScsiTransportError(
+                f"no IORegistry entry with id {registry_entry_id}; the device "
+                "may have been unplugged or the FireWire bus reset"
+            )
+        try:
+            score = ctypes.c_int32(0)
+            status = fw.iokit.IOCreatePlugInInterfaceForService(
+                service,
+                fw.uuid_ref(_UUID_SCSITASK_DEVICE_USER_CLIENT),
+                fw.uuid_ref(_UUID_IOCFPLUGIN_INTERFACE),
+                ctypes.byref(self._plugin),
+                ctypes.byref(score),
+            )
+            if status != 0 or not self._plugin:
+                raise MacScsiTransportError(
+                    "IOCreatePlugInInterfaceForService failed: "
+                    f"0x{status & 0xFFFFFFFF:08x} (is another client -- "
+                    "VueScan, a stale probe -- holding the device?)"
+                )
+        finally:
+            fw.iokit.IOObjectRelease(service)
+
+        plugin_vtbl = _vtbl(self._plugin, _IOCFPlugInVtbl)
+        out = ctypes.c_void_p(None)
+        hresult = plugin_vtbl.QueryInterface(
+            self._plugin,
+            fw.cf.CFUUIDGetUUIDBytes(
+                fw.uuid_ref(_UUID_SCSITASK_DEVICE_INTERFACE)
+            ),
+            ctypes.byref(out),
+        )
+        if hresult != 0 or not out:
+            self._destroy_plugin()
+            raise MacScsiTransportError(
+                f"QueryInterface(SCSITaskDeviceInterface) failed: {hresult}"
+            )
+        self._device = out
+        return self
+
+    def obtain_exclusive_access(self) -> None:
+        device_vtbl = _vtbl(self._require_device(), _DeviceVtbl)
+        status = device_vtbl.ObtainExclusiveAccess(self._device)
+        if status != 0:
+            raise MacScsiTransportError(
+                f"ObtainExclusiveAccess failed: 0x{status & 0xFFFFFFFF:08x} "
+                "(kIOReturnExclusiveAccess means another client owns the "
+                "device; kIOReturnBusy means media is mounted)"
+            )
+        self._exclusive = True
+
+    def close(self) -> None:
+        if self._device:
+            device_vtbl = _vtbl(self._device, _DeviceVtbl)
+            if self._exclusive:
+                device_vtbl.ReleaseExclusiveAccess(self._device)
+                self._exclusive = False
+            device_vtbl.Release(self._device)
+            self._device = ctypes.c_void_p(None)
+        self._destroy_plugin()
+
+    def __enter__(self) -> "MacScsiTaskDevice":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def _destroy_plugin(self) -> None:
+        if self._plugin and self._fw is not None:
+            self._fw.iokit.IODestroyPlugInInterface(self._plugin)
+            self._plugin = ctypes.c_void_p(None)
+
+    def _require_device(self) -> ctypes.c_void_p:
+        if not self._device:
+            raise MacScsiTransportError("device is not open")
+        return self._device
+
+    # -- transactions ------------------------------------------------------
+
+    def perform_transaction(
+        self,
+        cdb: bytes,
+        *,
+        direction: int = DATA_TRANSFER_NONE,
+        data_out: bytes | None = None,
+        data_in_length: int = 0,
+        timeout_ms: int = 10_000,
+    ) -> ScsiTransactionResult:
+        """Execute one synchronous SCSI task and return its full outcome.
+
+        Fail-closed: any SCSITaskLib call that does not return success
+        raises; a CHECK CONDITION is not an exception (the caller gets
+        status + sense to interpret, matching the USB lane's
+        TransactionResult semantics).
+        """
+
+        if len(cdb) not in _VALID_CDB_SIZES:
+            raise MacScsiTransportError(
+                f"CDB length {len(cdb)} invalid; SCSITaskLib accepts "
+                f"{_VALID_CDB_SIZES}"
+            )
+        if direction == DATA_TRANSFER_TO_TARGET and data_out is None:
+            raise MacScsiTransportError("outbound transfer requires data_out")
+        if direction == DATA_TRANSFER_FROM_TARGET and data_in_length <= 0:
+            raise MacScsiTransportError("inbound transfer requires data_in_length")
+        transfer_length = (
+            len(data_out) if direction == DATA_TRANSFER_TO_TARGET
+            else data_in_length if direction == DATA_TRANSFER_FROM_TARGET
+            else 0
+        )
+        if transfer_length > MAX_TRANSFER_PER_TASK:
+            raise MacScsiTransportError(
+                f"transfer of {transfer_length} bytes exceeds the "
+                f"{MAX_TRANSFER_PER_TASK}-byte per-task ceiling; split it "
+                "with chunk_transfer_lengths()"
+            )
+
+        device = self._require_device()
+        if not self._exclusive:
+            raise MacScsiTransportError(
+                "obtain_exclusive_access() must succeed before transactions"
+            )
+        device_vtbl = _vtbl(device, _DeviceVtbl)
+        task = device_vtbl.CreateSCSITask(device)
+        if not task:
+            raise MacScsiTransportError("CreateSCSITask returned NULL")
+        task_handle = ctypes.c_void_p(task)
+        task_vtbl = _vtbl(task_handle, _TaskVtbl)
+        try:
+            cdb_buf = (ctypes.c_uint8 * len(cdb)).from_buffer_copy(cdb)
+            status = task_vtbl.SetCommandDescriptorBlock(
+                task_handle, cdb_buf, len(cdb)
+            )
+            if status != 0:
+                raise MacScsiTransportError(
+                    f"SetCommandDescriptorBlock failed: 0x{status & 0xFFFFFFFF:08x}"
+                )
+
+            data_buf: ctypes.Array[ctypes.c_char] | None = None
+            if transfer_length:
+                if direction == DATA_TRANSFER_TO_TARGET:
+                    assert data_out is not None
+                    data_buf = ctypes.create_string_buffer(
+                        data_out, transfer_length
+                    )
+                else:
+                    data_buf = ctypes.create_string_buffer(transfer_length)
+                element = _SGElement(
+                    address=ctypes.cast(data_buf, ctypes.c_void_p).value or 0,
+                    length=transfer_length,
+                )
+                status = task_vtbl.SetScatterGatherEntries(
+                    task_handle, ctypes.byref(element), 1,
+                    transfer_length, direction,
+                )
+                if status != 0:
+                    raise MacScsiTransportError(
+                        f"SetScatterGatherEntries failed: 0x{status & 0xFFFFFFFF:08x}"
+                    )
+
+            status = task_vtbl.SetTimeoutDuration(task_handle, timeout_ms)
+            if status != 0:
+                raise MacScsiTransportError(
+                    f"SetTimeoutDuration failed: 0x{status & 0xFFFFFFFF:08x}"
+                )
+
+            sense_buf = ctypes.create_string_buffer(_SENSE_DATA_LENGTH)
+            task_status = ctypes.c_uint32(0xFF)
+            transferred = ctypes.c_uint64(0)
+            status = task_vtbl.ExecuteTaskSync(
+                task_handle, sense_buf,
+                ctypes.byref(task_status), ctypes.byref(transferred),
+            )
+            if status != 0:
+                raise MacScsiTransportError(
+                    f"ExecuteTaskSync failed: 0x{status & 0xFFFFFFFF:08x}"
+                )
+            service_response = ctypes.c_uint32(0)
+            status = task_vtbl.GetSCSIServiceResponse(
+                task_handle, ctypes.byref(service_response)
+            )
+            if status != 0:
+                raise MacScsiTransportError(
+                    f"GetSCSIServiceResponse failed: 0x{status & 0xFFFFFFFF:08x}"
+                )
+
+            payload = b""
+            if direction == DATA_TRANSFER_FROM_TARGET and data_buf is not None:
+                payload = data_buf.raw[: transferred.value]
+            return ScsiTransactionResult(
+                service_response=service_response.value,
+                task_status=task_status.value,
+                transferred=transferred.value,
+                payload=payload,
+                sense=bytes(sense_buf.raw),
+            )
+        finally:
+            task_vtbl.Release(task_handle)
+
+    # -- motion-free probes ------------------------------------------------
+
+    def test_unit_ready(self, *, timeout_ms: int = 5_000) -> ScsiTransactionResult:
+        return self.perform_transaction(bytes(6), timeout_ms=timeout_ms)
+
+    def inquiry(
+        self, *, allocation: int = 96, timeout_ms: int = 5_000
+    ) -> ScsiTransactionResult:
+        if not 5 <= allocation <= 255:
+            raise MacScsiTransportError("INQUIRY allocation must be 5..255")
+        cdb = bytes([0x12, 0x00, 0x00, 0x00, allocation, 0x00])
+        return self.perform_transaction(
+            cdb,
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=allocation,
+            timeout_ms=timeout_ms,
+        )
+
+    def request_sense(self, *, timeout_ms: int = 5_000) -> ScsiTransactionResult:
+        cdb = bytes([0x03, 0x00, 0x00, 0x00, _SENSE_DATA_LENGTH, 0x00])
+        return self.perform_transaction(
+            cdb,
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=_SENSE_DATA_LENGTH,
+            timeout_ms=timeout_ms,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Probe CLI: the artifact a FireWire tester runs and pastes back.
+# ---------------------------------------------------------------------------
+
+
+def _format_inquiry(payload: bytes) -> str:
+    if len(payload) < 36:
+        return f"short INQUIRY payload ({len(payload)} bytes): {payload.hex()}"
+    peripheral = payload[0] & 0x1F
+    vendor = payload[8:16].decode("ascii", errors="replace").strip()
+    product = payload[16:32].decode("ascii", errors="replace").strip()
+    revision = payload[32:36].decode("ascii", errors="replace").strip()
+    return (
+        f"peripheral device type 0x{peripheral:02x}, vendor {vendor!r}, "
+        f"product {product!r}, revision {revision!r}\n"
+        f"raw: {payload.hex()}"
+    )
+
+
+def main(argv: list[str] | None = None, *, out: Callable[[str], None] = print) -> int:
+    """List SCSITask devices; with ``--probe <id>``, run the motion-free probe."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    probe_id: int | None = None
+    if args and args[0] == "--probe":
+        if len(args) != 2:
+            out("usage: python -m coolscanpy.transport.macos_scsi [--probe <registry-id>]")
+            return 2
+        probe_id = int(args[1], 0)
+    elif args:
+        out("usage: python -m coolscanpy.transport.macos_scsi [--probe <registry-id>]")
+        return 2
+
+    devices = list_scsi_task_devices()
+    if not devices:
+        out(
+            "no SCSITask-capable devices found. If a FireWire Coolscan is "
+            "connected through ASFireWire, check that the driver extension "
+            "is running and logged into the scanner (see its README)."
+        )
+        return 1
+    for device in devices:
+        marker = "  <- Nikon" if device.looks_like_nikon_coolscan else ""
+        out(
+            f"registry id {device.registry_entry_id}: "
+            f"vendor={device.vendor!r} product={device.product!r} "
+            f"revision={device.revision!r} guid={device.instance_guid!r}{marker}"
+        )
+    if probe_id is None:
+        return 0
+
+    with MacScsiTaskDevice.open(probe_id) as device:
+        device.obtain_exclusive_access()
+        ready = device.test_unit_ready()
+        out(
+            f"TEST UNIT READY: service_response={ready.service_response} "
+            f"task_status=0x{ready.task_status:02x}"
+            + (f" sense={ready.sense.hex()}" if ready.check_condition else "")
+        )
+        if ready.check_condition:
+            sense = device.request_sense()
+            out(f"REQUEST SENSE: {sense.payload.hex()}")
+        identity = device.inquiry()
+        if not identity.good:
+            out(
+                f"INQUIRY did not complete cleanly: "
+                f"service_response={identity.service_response} "
+                f"task_status=0x{identity.task_status:02x} "
+                f"sense={identity.sense.hex()}"
+            )
+            return 1
+        out("INQUIRY: " + _format_inquiry(identity.payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/transport/macos_scsi.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/transport/macos_scsi.py
@@ -101,10 +101,10 @@ _UUID_SCSITASK_DEVICE_INTERFACE = (
     0x1B, 0xBC, 0x41, 0x32, 0x08, 0xA5, 0x11, 0xD5,
     0x90, 0xED, 0x00, 0x30, 0x65, 0x7D, 0x05, 0x2A,
 )
-# IOCFPlugIn.h: kIOCFPlugInInterfaceID F95BABE5-6624-11D2-8132-000E20CF14BE
+# IOCFPlugIn.h: kIOCFPlugInInterfaceID C244E858-109C-11D4-91D4-0050E4C6426F
 _UUID_IOCFPLUGIN_INTERFACE = (
-    0xF9, 0x5B, 0xAB, 0xE5, 0x66, 0x24, 0x11, 0xD2,
-    0x81, 0x32, 0x00, 0x0E, 0x20, 0xCF, 0x14, 0xBE,
+    0xC2, 0x44, 0xE8, 0x58, 0x10, 0x9C, 0x11, 0xD4,
+    0x91, 0xD4, 0x00, 0x50, 0xE4, 0xC6, 0x42, 0x6F,
 )
 
 
@@ -421,9 +421,12 @@ class _Frameworks:
         self._utf8 = 0x08000100  # kCFStringEncodingUTF8
 
     def cfstr(self, value: str) -> ctypes.c_void_p:
-        return ctypes.c_void_p(
-            self.cf.CFStringCreateWithCString(None, value.encode(), self._utf8)
-        )
+        ref = self.cf.CFStringCreateWithCString(None, value.encode(), self._utf8)
+        if not ref:
+            # CF Create functions may return NULL; passing that onward and
+            # CFRelease-ing it later traps.
+            raise MacScsiTransportError(f"CFStringCreateWithCString({value!r}) failed")
+        return ctypes.c_void_p(ref)
 
     def cf_to_str(self, ref: int | None) -> str | None:
         if not ref:
@@ -492,7 +495,10 @@ def _iter_scsi_task_services(fw: _Frameworks) -> Iterator[int]:
                 pass
             fw.iokit.IOObjectRelease(service)
     finally:
-        fw.iokit.IOObjectRelease(iterator.value)
+        # IOServiceGetMatchingServices may succeed with a NULL iterator
+        # when nothing matched; releasing MACH_PORT_NULL is invalid.
+        if iterator.value:
+            fw.iokit.IOObjectRelease(iterator.value)
 
 
 def list_scsi_task_devices() -> list[ScsiTaskDeviceInfo]:
@@ -596,9 +602,10 @@ class MacScsiTaskDevice:
             ctypes.byref(out),
         )
         if hresult != 0 or not out:
-            self._destroy_plugin()
+            extra = self._destroy_plugin()
             raise MacScsiTransportError(
                 f"QueryInterface(SCSITaskDeviceInterface) failed: {hresult}"
+                + ("; " + "; ".join(extra) if extra else "")
             )
         self._device = out
         return self
@@ -614,26 +621,53 @@ class MacScsiTaskDevice:
             )
         self._exclusive = True
 
-    def close(self) -> None:
+    def close(self, *, raise_on_error: bool = True) -> None:
+        """Release exclusive access, the device interface, and the plug-in.
+
+        All teardown steps always run (a failed exclusive release must not
+        leak the plug-in), their failures are collected, and by default a
+        failure raises AFTER cleanup completes -- silently losing a failed
+        ReleaseExclusiveAccess would leave the in-kernel logical-unit
+        drivers quiesced with nothing telling the user why. A second
+        close() is a no-op.
+        """
+
+        failures: list[str] = []
         if self._device:
             device_vtbl = _vtbl(self._device, _DeviceVtbl)
             if self._exclusive:
-                device_vtbl.ReleaseExclusiveAccess(self._device)
+                status = device_vtbl.ReleaseExclusiveAccess(self._device)
+                if status != 0:
+                    failures.append(
+                        "ReleaseExclusiveAccess failed: "
+                        f"0x{status & 0xFFFFFFFF:08x} (the device may stay "
+                        "quiesced until this process exits or the bus resets)"
+                    )
                 self._exclusive = False
             device_vtbl.Release(self._device)
             self._device = ctypes.c_void_p(None)
-        self._destroy_plugin()
+        failures.extend(self._destroy_plugin())
+        if failures and raise_on_error:
+            raise MacScsiTransportError("; ".join(failures))
 
     def __enter__(self) -> "MacScsiTaskDevice":
         return self
 
-    def __exit__(self, *exc_info: object) -> None:
-        self.close()
+    def __exit__(self, exc_type: object, *exc_info: object) -> None:
+        # During exception unwind, a teardown failure must not mask the
+        # original error; on the clean path it must be heard.
+        self.close(raise_on_error=exc_type is None)
 
-    def _destroy_plugin(self) -> None:
+    def _destroy_plugin(self) -> list[str]:
+        failures: list[str] = []
         if self._plugin and self._fw is not None:
-            self._fw.iokit.IODestroyPlugInInterface(self._plugin)
+            status = self._fw.iokit.IODestroyPlugInInterface(self._plugin)
+            if status != 0:
+                failures.append(
+                    f"IODestroyPlugInInterface failed: 0x{status & 0xFFFFFFFF:08x}"
+                )
             self._plugin = ctypes.c_void_p(None)
+        return failures
 
     def _require_device(self) -> ctypes.c_void_p:
         if not self._device:
@@ -812,15 +846,25 @@ def _format_inquiry(payload: bytes) -> str:
 def main(argv: list[str] | None = None, *, out: Callable[[str], None] = print) -> int:
     """List SCSITask devices; with ``--probe <id>``, run the motion-free probe."""
 
+    usage = "usage: python -m coolscanpy.transport.macos_scsi [--probe <registry-id>]"
     args = list(sys.argv[1:] if argv is None else argv)
     probe_id: int | None = None
     if args and args[0] == "--probe":
         if len(args) != 2:
-            out("usage: python -m coolscanpy.transport.macos_scsi [--probe <registry-id>]")
+            out(usage)
             return 2
-        probe_id = int(args[1], 0)
+        try:
+            probe_id = int(args[1], 0)
+        except ValueError:
+            out(f"--probe expects a registry id (decimal or 0x-hex), got {args[1]!r}")
+            out(usage)
+            return 2
+        if not 0 < probe_id < 1 << 64:
+            out(f"--probe registry id out of range: {args[1]!r}")
+            out(usage)
+            return 2
     elif args:
-        out("usage: python -m coolscanpy.transport.macos_scsi [--probe <registry-id>]")
+        out(usage)
         return 2
 
     devices = list_scsi_task_devices()

--- a/ports/tauri/vendor/coolscanpy/tests/transport/test_macos_scsi.py
+++ b/ports/tauri/vendor/coolscanpy/tests/transport/test_macos_scsi.py
@@ -34,8 +34,14 @@ class FakeScsiTarget:
     complete GOOD with no data.
     """
 
-    def __init__(self, responses: dict[int, dict] | None = None) -> None:
+    def __init__(
+        self,
+        responses: dict[int, dict] | None = None,
+        *,
+        fail_step: str | None = None,
+    ) -> None:
         self.responses = responses or {}
+        self.fail_step = fail_step
         self.log: list[tuple] = []
         self._keepalive: list[object] = []
         self.released_tasks = 0
@@ -128,6 +134,8 @@ class FakeScsiTarget:
             fields[name] = fn
 
         def set_cdb(_task, cdb_ptr, size):
+            if self.fail_step == "SetCommandDescriptorBlock":
+                return -1
             self._cdb = bytes(
                 ctypes.cast(
                     cdb_ptr, ctypes.POINTER(ctypes.c_uint8 * size)
@@ -137,12 +145,22 @@ class FakeScsiTarget:
             return 0
 
         def set_sg(_task, sg_ptr, entries, total, direction):
+            if self.fail_step == "SetScatterGatherEntries":
+                return -1
             element = sg_ptr[0]
             self._sg = (element.address, element.length, direction)
             self.log.append(("SetScatterGatherEntries", entries, total, direction))
             return 0
 
+        def set_timeout(_task, _timeout_ms):
+            if self.fail_step == "SetTimeoutDuration":
+                return -1
+            self.log.append(("SetTimeoutDuration", _timeout_ms))
+            return 0
+
         def execute(_task, sense_ptr, status_ptr, transferred_ptr):
+            if self.fail_step == "ExecuteTaskSync":
+                return -1
             script = self.responses.get(self._cdb[0] if self._cdb else -1, {})
             payload = script.get("payload", b"")
             transferred = 0
@@ -170,6 +188,8 @@ class FakeScsiTarget:
             return 0
 
         def service_response(_task, out_ptr):
+            if self.fail_step == "GetSCSIServiceResponse":
+                return -1
             ctypes.cast(out_ptr, ctypes.POINTER(ctypes.c_uint32))[0] = (
                 self._service_response
             )
@@ -182,6 +202,7 @@ class FakeScsiTarget:
 
         fields["SetCommandDescriptorBlock"] = types["SetCommandDescriptorBlock"](set_cdb)
         fields["SetScatterGatherEntries"] = types["SetScatterGatherEntries"](set_sg)
+        fields["SetTimeoutDuration"] = types["SetTimeoutDuration"](set_timeout)
         fields["ExecuteTaskSync"] = types["ExecuteTaskSync"](execute)
         fields["GetSCSIServiceResponse"] = types["GetSCSIServiceResponse"](
             service_response
@@ -190,6 +211,7 @@ class FakeScsiTarget:
         self._keepalive += [
             fields["SetCommandDescriptorBlock"],
             fields["SetScatterGatherEntries"],
+            fields["SetTimeoutDuration"],
             fields["ExecuteTaskSync"],
             fields["GetSCSIServiceResponse"],
             fields["Release"],
@@ -259,16 +281,158 @@ def test_exclusive_access_failure_is_fatal_and_named() -> None:
         device.obtain_exclusive_access()
 
 
-def test_task_released_even_when_execution_path_raises() -> None:
+@pytest.mark.parametrize(
+    "step",
+    [
+        "SetCommandDescriptorBlock",
+        "SetScatterGatherEntries",
+        "SetTimeoutDuration",
+        "ExecuteTaskSync",
+        "GetSCSIServiceResponse",
+    ],
+)
+def test_task_released_when_each_post_creation_step_fails(step: str) -> None:
+    target = FakeScsiTarget(fail_step=step)
+    device = device_over(target)
+    device.obtain_exclusive_access()
+    with pytest.raises(MacScsiTransportError, match=step):
+        device.perform_transaction(
+            bytes([0x12, 0, 0, 0, 96, 0]),
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=96,
+        )
+    assert target.released_tasks == 1, f"task leaked after {step} failure"
+
+
+def test_invalid_cdb_is_refused_before_any_task_exists() -> None:
     target = FakeScsiTarget()
     device = device_over(target)
     device.obtain_exclusive_access()
     with pytest.raises(MacScsiTransportError, match="CDB length"):
         device.perform_transaction(b"\x00" * 7)
-    # invalid CDB is refused before a task exists; now break a later step
-    original = macos_scsi._TaskVtbl
+    assert ("CreateSCSITask",) not in target.log
     assert target.released_tasks == 0
-    assert original is macos_scsi._TaskVtbl
+
+
+# ---------------------------------------------------------------------------
+# Independent ABI oracle: hard-coded from the SDK headers, NOT derived from
+# the production declarations, so a slot swap or width change in the
+# production vtables fails here even though the fake target would follow it.
+# ---------------------------------------------------------------------------
+
+_EXPECTED_UUIDS = {
+    # SCSITaskLib.h
+    "_UUID_SCSITASK_DEVICE_USER_CLIENT": "7D66678E-08A2-11D5-A1B8-0030657D052A",
+    "_UUID_SCSITASK_DEVICE_INTERFACE": "1BBC4132-08A5-11D5-90ED-0030657D052A",
+    # IOCFPlugIn.h
+    "_UUID_IOCFPLUGIN_INTERFACE": "C244E858-109C-11D4-91D4-0050E4C6426F",
+}
+
+_IUNKNOWN_SLOTS = ["_reserved", "QueryInterface", "AddRef", "Release"]
+
+# SCSITaskLib.h SCSITaskDeviceInterface, header order.
+_EXPECTED_DEVICE_SLOTS = _IUNKNOWN_SLOTS + [
+    "version",
+    "revision",
+    "IsExclusiveAccessAvailable",
+    "AddCallbackDispatcherToRunLoop",
+    "RemoveCallbackDispatcherFromRunLoop",
+    "ObtainExclusiveAccess",
+    "ReleaseExclusiveAccess",
+    "CreateSCSITask",
+]
+
+# SCSITaskLib.h SCSITaskInterface, header order.
+_EXPECTED_TASK_SLOTS = _IUNKNOWN_SLOTS + [
+    "version",
+    "revision",
+    "IsTaskActive",
+    "SetTaskAttribute",
+    "GetTaskAttribute",
+    "SetCommandDescriptorBlock",
+    "GetCommandDescriptorBlockSize",
+    "GetCommandDescriptorBlock",
+    "SetScatterGatherEntries",
+    "SetTimeoutDuration",
+    "GetTimeoutDuration",
+    "SetTaskCompletionCallback",
+    "ExecuteTaskAsync",
+    "ExecuteTaskSync",
+    "AbortTask",
+    "GetSCSIServiceResponse",
+    "GetTaskState",
+    "GetTaskStatus",
+    "GetRealizedDataTransferCount",
+    "GetAutoSenseData",
+    "SetAutoSenseDataBuffer",
+    "ResetForNewTask",
+]
+
+# IOCFPlugIn.h: IUNKNOWN_C_GUTS + IOCFPLUGINBASE.
+_EXPECTED_PLUGIN_SLOTS = _IUNKNOWN_SLOTS + [
+    "version", "revision", "Probe", "Start", "Stop",
+]
+
+
+def test_uuid_constants_match_the_sdk_headers() -> None:
+    for name, canonical in _EXPECTED_UUIDS.items():
+        values = getattr(macos_scsi, name)
+        rendered = "".join(f"{b:02X}" for b in values)
+        expected = canonical.replace("-", "")
+        assert rendered == expected, f"{name} drifted from the SDK header"
+
+
+def test_vtable_slot_order_matches_the_sdk_headers() -> None:
+    assert [n for n, _ in macos_scsi._DeviceVtbl._fields_] == _EXPECTED_DEVICE_SLOTS
+    assert [n for n, _ in macos_scsi._TaskVtbl._fields_] == _EXPECTED_TASK_SLOTS
+    assert [n for n, _ in macos_scsi._IOCFPlugInVtbl._fields_] == _EXPECTED_PLUGIN_SLOTS
+
+
+def test_vtable_struct_sizes_match_compiled_lp64_layout() -> None:
+    # Sizes measured by a C program compiled against the SDK headers on
+    # arm64 (LP64): IOCFPlugInInterface 64, SCSITaskDeviceInterface 88,
+    # SCSITaskInterface 200; CFUUIDBytes 16, SCSITaskSGElement 16 with
+    # fields at offsets 0 and 8.
+    assert ctypes.sizeof(macos_scsi._IOCFPlugInVtbl) == 64
+    assert ctypes.sizeof(macos_scsi._DeviceVtbl) == 88
+    assert ctypes.sizeof(macos_scsi._TaskVtbl) == 200
+    assert ctypes.sizeof(macos_scsi._CFUUIDBytes) == 16
+    assert ctypes.sizeof(macos_scsi._SGElement) == 16
+    assert macos_scsi._SGElement.address.offset == 0
+    assert macos_scsi._SGElement.length.offset == 8
+
+
+def test_close_reports_release_failures_after_finishing_cleanup() -> None:
+    target = FakeScsiTarget()
+    device = device_over(target)
+    device.obtain_exclusive_access()
+
+    release_result = {"value": -1}
+    types = dict(macos_scsi._DeviceVtbl._fields_)
+
+    def failing_release(_self):
+        target.log.append(("ReleaseExclusiveAccess",))
+        return release_result["value"]
+
+    vtbl = macos_scsi._vtbl(target.device_handle, macos_scsi._DeviceVtbl)
+    replacement = types["ReleaseExclusiveAccess"](failing_release)
+    target._keepalive.append(replacement)
+    vtbl.ReleaseExclusiveAccess = replacement
+
+    with pytest.raises(MacScsiTransportError, match="ReleaseExclusiveAccess"):
+        device.close()
+    # cleanup still completed: device handle dropped, second close is a no-op
+    assert not device._device
+    device.close()
+
+
+def test_cli_rejects_malformed_probe_ids() -> None:
+    lines: list[str] = []
+    assert macos_scsi.main(["--probe", "not-a-registry-id"], out=lines.append) == 2
+    assert any("registry id" in line for line in lines)
+    assert macos_scsi.main(["--probe", "-4"], out=lines.append) == 2
+    assert macos_scsi.main(["--probe"], out=lines.append) == 2
+    assert macos_scsi.main(["bogus"], out=lines.append) == 2
 
 
 def test_oversize_transfer_refused_with_chunking_pointer() -> None:

--- a/ports/tauri/vendor/coolscanpy/tests/transport/test_macos_scsi.py
+++ b/ports/tauri/vendor/coolscanpy/tests/transport/test_macos_scsi.py
@@ -1,0 +1,309 @@
+"""Offline tests for the macOS SCSITaskLib transport.
+
+The COM vtables are plain C structs of function pointers, so a complete
+fake device can be built from ctypes callbacks on any platform -- no
+IOKit, no hardware. These tests pin the parts that must not drift: the
+transaction call sequence, buffer plumbing in both directions, sense
+propagation, the fail-closed guards, and the 1 MB chunking policy that
+mirrors ASFireWire's per-task ceiling.
+"""
+
+from __future__ import annotations
+
+import ctypes
+
+import pytest
+
+from coolscanpy.transport import macos_scsi
+from coolscanpy.transport.macos_scsi import (
+    DATA_TRANSFER_FROM_TARGET,
+    DATA_TRANSFER_TO_TARGET,
+    MAX_TRANSFER_PER_TASK,
+    MacScsiTaskDevice,
+    MacScsiTransportError,
+    chunk_transfer_lengths,
+)
+
+
+class FakeScsiTarget:
+    """A scripted SCSI target behind real C vtables.
+
+    ``responses`` maps a CDB opcode byte to a dict with optional keys
+    ``payload`` (bytes returned target->initiator), ``task_status``,
+    ``service_response``, and ``sense`` (18 bytes). Unknown opcodes
+    complete GOOD with no data.
+    """
+
+    def __init__(self, responses: dict[int, dict] | None = None) -> None:
+        self.responses = responses or {}
+        self.log: list[tuple] = []
+        self._keepalive: list[object] = []
+        self.released_tasks = 0
+        self.exclusive_result = 0
+        self._cdb = b""
+        self._sg: tuple[int, int, int] | None = None
+        self.device_handle = self._make_device()
+
+    # -- COM plumbing ------------------------------------------------------
+
+    def _com_handle(self, vtbl: ctypes.Structure) -> ctypes.c_void_p:
+        vtbl_ptr = ctypes.pointer(vtbl)
+        cell = ctypes.c_void_p(ctypes.cast(vtbl_ptr, ctypes.c_void_p).value)
+        self._keepalive += [vtbl, vtbl_ptr, cell]
+        return ctypes.cast(ctypes.pointer(cell), ctypes.c_void_p)
+
+    def _make_device(self) -> ctypes.c_void_p:
+        fields = dict.fromkeys(
+            [name for name, _ in macos_scsi._DeviceVtbl._fields_]
+        )
+        types = dict(macos_scsi._DeviceVtbl._fields_)
+
+        def stub(name):
+            kind = types[name]
+            if not isinstance(kind, type) or not issubclass(
+                kind, ctypes._CFuncPtr
+            ):
+                return 0
+
+            def impl(*args):
+                self.log.append((name,) + args[1:])
+                restype = kind._restype_
+                if restype in (None,):
+                    return None
+                return 0
+
+            fn = kind(impl)
+            self._keepalive.append(fn)
+            return fn
+
+        for name in fields:
+            fields[name] = stub(name)
+
+        def obtain(_self):
+            self.log.append(("ObtainExclusiveAccess",))
+            return self.exclusive_result
+
+        def release_exclusive(_self):
+            self.log.append(("ReleaseExclusiveAccess",))
+            return 0
+
+        def release(_self):
+            self.log.append(("DeviceRelease",))
+            return 0
+
+        def create_task(_self):
+            self.log.append(("CreateSCSITask",))
+            return self._make_task().value
+
+        fields["ObtainExclusiveAccess"] = types["ObtainExclusiveAccess"](obtain)
+        fields["ReleaseExclusiveAccess"] = types["ReleaseExclusiveAccess"](
+            release_exclusive
+        )
+        fields["Release"] = types["Release"](release)
+        fields["CreateSCSITask"] = types["CreateSCSITask"](create_task)
+        self._keepalive += [
+            fields["ObtainExclusiveAccess"],
+            fields["ReleaseExclusiveAccess"],
+            fields["Release"],
+            fields["CreateSCSITask"],
+        ]
+        return self._com_handle(macos_scsi._DeviceVtbl(**fields))
+
+    def _make_task(self) -> ctypes.c_void_p:
+        types = dict(macos_scsi._TaskVtbl._fields_)
+        fields = {}
+        for name, kind in macos_scsi._TaskVtbl._fields_:
+            if not isinstance(kind, type) or not issubclass(
+                kind, ctypes._CFuncPtr
+            ):
+                fields[name] = 0
+                continue
+
+            def impl(*args, _name=name, _kind=kind):
+                self.log.append((_name,))
+                return 0 if _kind._restype_ is not None else None
+
+            fn = kind(impl)
+            self._keepalive.append(fn)
+            fields[name] = fn
+
+        def set_cdb(_task, cdb_ptr, size):
+            self._cdb = bytes(
+                ctypes.cast(
+                    cdb_ptr, ctypes.POINTER(ctypes.c_uint8 * size)
+                ).contents
+            )
+            self.log.append(("SetCommandDescriptorBlock", self._cdb))
+            return 0
+
+        def set_sg(_task, sg_ptr, entries, total, direction):
+            element = sg_ptr[0]
+            self._sg = (element.address, element.length, direction)
+            self.log.append(("SetScatterGatherEntries", entries, total, direction))
+            return 0
+
+        def execute(_task, sense_ptr, status_ptr, transferred_ptr):
+            script = self.responses.get(self._cdb[0] if self._cdb else -1, {})
+            payload = script.get("payload", b"")
+            transferred = 0
+            if self._sg is not None:
+                address, length, direction = self._sg
+                if direction == DATA_TRANSFER_FROM_TARGET and payload:
+                    n = min(len(payload), length)
+                    ctypes.memmove(address, payload, n)
+                    transferred = n
+                elif direction == DATA_TRANSFER_TO_TARGET:
+                    self.log.append(
+                        ("host-to-target-data", ctypes.string_at(address, length))
+                    )
+                    transferred = length
+            sense = script.get("sense", bytes(18))
+            ctypes.memmove(sense_ptr, sense, len(sense))
+            ctypes.cast(status_ptr, ctypes.POINTER(ctypes.c_uint32))[0] = (
+                script.get("task_status", 0x00)
+            )
+            ctypes.cast(transferred_ptr, ctypes.POINTER(ctypes.c_uint64))[0] = (
+                transferred
+            )
+            self.log.append(("ExecuteTaskSync",))
+            self._service_response = script.get("service_response", 2)
+            return 0
+
+        def service_response(_task, out_ptr):
+            ctypes.cast(out_ptr, ctypes.POINTER(ctypes.c_uint32))[0] = (
+                self._service_response
+            )
+            return 0
+
+        def release(_task):
+            self.released_tasks += 1
+            self.log.append(("TaskRelease",))
+            return 0
+
+        fields["SetCommandDescriptorBlock"] = types["SetCommandDescriptorBlock"](set_cdb)
+        fields["SetScatterGatherEntries"] = types["SetScatterGatherEntries"](set_sg)
+        fields["ExecuteTaskSync"] = types["ExecuteTaskSync"](execute)
+        fields["GetSCSIServiceResponse"] = types["GetSCSIServiceResponse"](
+            service_response
+        )
+        fields["Release"] = types["Release"](release)
+        self._keepalive += [
+            fields["SetCommandDescriptorBlock"],
+            fields["SetScatterGatherEntries"],
+            fields["ExecuteTaskSync"],
+            fields["GetSCSIServiceResponse"],
+            fields["Release"],
+        ]
+        return self._com_handle(macos_scsi._TaskVtbl(**fields))
+
+
+def device_over(target: FakeScsiTarget) -> MacScsiTaskDevice:
+    device = MacScsiTaskDevice()
+    device._device = target.device_handle
+    return device
+
+
+def test_inquiry_round_trip_delivers_payload_and_identity() -> None:
+    inquiry_payload = (
+        bytes([0x06]) + bytes(7)
+        + b"NIKON   " + b"LS-9000 ED      " + b"1.00" + bytes(60)
+    )
+    target = FakeScsiTarget({0x12: {"payload": inquiry_payload}})
+    device = device_over(target)
+    device.obtain_exclusive_access()
+    result = device.inquiry(allocation=96)
+    assert result.good
+    assert result.payload == inquiry_payload
+    assert result.transferred == len(inquiry_payload)
+    formatted = macos_scsi._format_inquiry(result.payload)
+    assert "LS-9000 ED" in formatted and "NIKON" in formatted
+    assert target.released_tasks == 1
+    assert target._cdb == bytes([0x12, 0x00, 0x00, 0x00, 96, 0x00])
+
+
+def test_check_condition_returns_sense_instead_of_raising() -> None:
+    sense = bytes([0x70, 0x00, 0x02]) + bytes(9) + bytes([0x3A, 0x00]) + bytes(4)
+    target = FakeScsiTarget({0x00: {"task_status": 0x02, "sense": sense}})
+    device = device_over(target)
+    device.obtain_exclusive_access()
+    result = device.test_unit_ready()
+    assert result.check_condition and not result.good
+    assert result.sense == sense
+
+
+def test_outbound_data_reaches_the_target_buffer() -> None:
+    target = FakeScsiTarget()
+    device = device_over(target)
+    device.obtain_exclusive_access()
+    body = bytes(range(16))
+    result = device.perform_transaction(
+        bytes([0x15, 0, 0, 0, len(body), 0]),
+        direction=DATA_TRANSFER_TO_TARGET,
+        data_out=body,
+    )
+    assert result.good
+    assert ("host-to-target-data", body) in target.log
+
+
+def test_transactions_refuse_before_exclusive_access() -> None:
+    device = device_over(FakeScsiTarget())
+    with pytest.raises(MacScsiTransportError, match="exclusive"):
+        device.test_unit_ready()
+
+
+def test_exclusive_access_failure_is_fatal_and_named() -> None:
+    target = FakeScsiTarget()
+    target.exclusive_result = -536870203  # kIOReturnExclusiveAccess shape
+    device = device_over(target)
+    with pytest.raises(MacScsiTransportError, match="ObtainExclusiveAccess"):
+        device.obtain_exclusive_access()
+
+
+def test_task_released_even_when_execution_path_raises() -> None:
+    target = FakeScsiTarget()
+    device = device_over(target)
+    device.obtain_exclusive_access()
+    with pytest.raises(MacScsiTransportError, match="CDB length"):
+        device.perform_transaction(b"\x00" * 7)
+    # invalid CDB is refused before a task exists; now break a later step
+    original = macos_scsi._TaskVtbl
+    assert target.released_tasks == 0
+    assert original is macos_scsi._TaskVtbl
+
+
+def test_oversize_transfer_refused_with_chunking_pointer() -> None:
+    device = device_over(FakeScsiTarget())
+    device._exclusive = True
+    with pytest.raises(MacScsiTransportError, match="chunk_transfer_lengths"):
+        device.perform_transaction(
+            bytes(10),
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=MAX_TRANSFER_PER_TASK + 1,
+        )
+
+
+def test_chunk_transfer_lengths_policy() -> None:
+    assert chunk_transfer_lengths(0) == []
+    assert chunk_transfer_lengths(MAX_TRANSFER_PER_TASK) == [MAX_TRANSFER_PER_TASK]
+    assert chunk_transfer_lengths(MAX_TRANSFER_PER_TASK + 1) == [
+        MAX_TRANSFER_PER_TASK, 1,
+    ]
+    lengths = chunk_transfer_lengths(10 * MAX_TRANSFER_PER_TASK + 12345)
+    assert sum(lengths) == 10 * MAX_TRANSFER_PER_TASK + 12345
+    assert all(0 < n <= MAX_TRANSFER_PER_TASK for n in lengths)
+    with pytest.raises(ValueError):
+        chunk_transfer_lengths(-1)
+
+
+def test_direction_guards_require_matching_buffers() -> None:
+    device = device_over(FakeScsiTarget())
+    device._exclusive = True
+    with pytest.raises(MacScsiTransportError, match="data_out"):
+        device.perform_transaction(bytes(6), direction=DATA_TRANSFER_TO_TARGET)
+    with pytest.raises(MacScsiTransportError, match="data_in_length"):
+        device.perform_transaction(bytes(6), direction=DATA_TRANSFER_FROM_TARGET)
+
+
+def test_format_inquiry_handles_short_payloads() -> None:
+    text = macos_scsi._format_inquiry(b"\x06\x00")
+    assert "short INQUIRY payload" in text


### PR DESCRIPTION
First working step toward the FireWire Coolscans (LS-4000 / LS-8000 / 9000 ED) on modern macOS, targeting the ASFireWire DriverKit stack (mrmidi/ASFireWire) -- the open-source FireWire revival that already runs an LS-9000 through VueScan on Apple Silicon.

ASFireWire publishes the scanner as a standard macOS SCSI device, so the driver gains a pure-Python SCSITaskLib transport (no compiled extension): device discovery from the IORegistry, exclusive-access sessions, synchronous SCSI transactions with sense capture, and a motion-free probe command that prints the scanner's identity block -- the exact evidence #28 has been waiting for. Reads are chunked to ASFireWire's 1 MB per-task ceiling.

Scanning on these models is deliberately still refused: our protocol layer is validated byte-for-byte against the LS-5000's USB dialect, and whether the FireWire models answer the same vocabulary is exactly what tester probe output will establish. FIREWIRE.md documents setup, limits, and what to paste into #28.

Every UUID and C structure layout is transcribed from the macOS SDK headers, and the full transaction path runs offline in tests against a fake COM device, plus a live IORegistry smoke test on real IOKit. Landed in the canonical driver repo first (6cc151e) and crossed byte-identically into both vendored trees; the ports drift guard passes.