### PR TITLE
Release v0.7.0-beta.1: driver 0.4.0 version sync

### DIFF
--- a/bridge/uv.lock
+++ b/bridge/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/coolscanpy/CHANGELOG.md
+++ b/coolscanpy/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.0 - 2026-08-09
+
 - macOS SCSI transport for FireWire Coolscans (`coolscanpy.transport.macos_scsi`):
   pure-ctypes SCSITaskLib client targeting the ASFireWire DriverKit stack, with
   device discovery, identity, a motion-free probe CLI, and the 1 MB per-task

--- a/coolscanpy/pyproject.toml
+++ b/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.3.0"
+version = "0.4.0"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/coolscanpy/uv.lock
+++ b/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/coolscanpy/CHANGELOG.md
+++ b/ports/tauri/vendor/coolscanpy/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.0 - 2026-08-09
+
 - macOS SCSI transport for FireWire Coolscans (`coolscanpy.transport.macos_scsi`):
   pure-ctypes SCSITaskLib client targeting the ASFireWire DriverKit stack, with
   device discovery, identity, a motion-free probe CLI, and the 1 MB per-task

--- a/ports/tauri/vendor/coolscanpy/pyproject.toml
+++ b/ports/tauri/vendor/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.3.0"
+version = "0.4.0"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/__init__.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/__init__.py
@@ -18,7 +18,7 @@ except Exception:  # pragma: no cover - only when the package isn't installed
     # Linux preview packages run directly from CorrespondingSource, where
     # distribution metadata is intentionally absent. Keep this fallback
     # aligned with pyproject.toml for accurate startup provenance.
-    __version__ = "0.3.0"
+    __version__ = "0.4.0"
 
 from coolscanpy._device import Device, get_devices, open
 from coolscanpy._roll import Roll

--- a/ports/tauri/vendor/coolscanpy/uv.lock
+++ b/ports/tauri/vendor/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/scanstudio-bridge/uv.lock
+++ b/ports/tauri/vendor/scanstudio-bridge/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },


### PR DESCRIPTION
Bumps the bundled coolscanpy driver to 0.4.0 -- published to PyPI today with the macOS FireWire SCSI transport -- and regenerates every lockfile that pins it. The sha256-pinned PyPI lockstep gate passes locally against the published sdist. Once this merges, main is ready to tag v0.7.0-beta.1.