### PR TITLE
docs: cross-reference the nkscan v0.3.0 rewrite in FIREWIRE.md

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -42,11 +42,14 @@ operation failure, never a simulated successful connection.
 
 CoolscanPy's USB discovery recognizes Nikon Coolscan units by vendor/product id.
 The PID-to-model mapping (LS-40 `04b0:4000`, LS-50 `04b0:4001`, LS-5000
-`04b0:4002`) is referenced from the `nkscan` project by activexray, licensed
-Apache-2.0, at commit `87a1724886f8262e7791731ca055aa00ad6632fb`
-(`src/scanners/ls40.rs`, `src/scanners/ls50/mod.rs`, `src/scanners/ls5000/mod.rs`;
-`src/devices.rs` round-trip tests). This is a reference to the USB identity
-facts only; no `nkscan` source code is vendored.
+`04b0:4002`) is referenced from the `nkscan` project by activexray,
+dual-licensed MIT OR Apache-2.0, at commit
+`87a1724886f8262e7791731ca055aa00ad6632fb` (`src/scanners/ls40.rs`,
+`src/scanners/ls50/mod.rs`, `src/scanners/ls5000/mod.rs`;
+`src/devices.rs` round-trip tests), and re-verified at tag `v0.3.0`,
+where the table lives in `src/protocol/model.rs` with the same ids.
+This is a reference to the USB identity facts only; no `nkscan` source
+code is vendored.
 
 ## ASFireWire behavioral reference (FireWire Coolscans)
 

--- a/coolscanpy/FIREWIRE.md
+++ b/coolscanpy/FIREWIRE.md
@@ -29,14 +29,67 @@ block, and releases the device. It never moves film.
 ## What deliberately does not work yet
 
 Scanning. coolscanpy's single-pass protocol layer is validated against
-the LS-5000's USB dialect, byte-for-byte, on real captures. Whether the
-FireWire models answer the same command vocabulary is an open question
-that only real hardware can settle -- guessing would produce silently
-wrong scans, which is worse than refusing. The probe output above is
-exactly the evidence that question needs: if you have a FireWire
-Coolscan running through ASFireWire, please run it and paste the output
-into [ScanStudio issue #28](https://github.com/rohanpandula/ScanStudio/issues/28),
+the LS-5000's USB dialect, byte-for-byte, on real captures. The command
+vocabulary itself is settled -- Nikon's own interface specifications
+describe one protocol for the LS-5000 and LS-9000, and the nkscan
+project has driven a real LS-9000 with it (next section) -- but
+everything between a vocabulary and a correct scan through ASFireWire
+is not: SBP-2 status and sense behavior, transfer chunking under the
+1 MB task ceiling, frame geometry on the medium-format holders.
+Guessing at those would produce silently wrong scans, which is worse
+than refusing. The probe output above is exactly the evidence this
+needs: if you have a FireWire Coolscan running through ASFireWire,
+please run it and paste the output into
+[ScanStudio issue #28](https://github.com/rohanpandula/ScanStudio/issues/28),
 the coordination thread for these models.
+
+## What the nkscan v0.3.0 rewrite establishes
+
+[nkscan](https://github.com/activexray/nkscan) is the independent
+open-source Coolscan driver this project coordinates with rather than
+duplicates (the engineering thread in issue #28). Its v0.3.0 release
+(2026-08-09, tag `v0.3.0`) is a ground-up rewrite against Nikon's own
+interface specifications, and it changes what is known about the
+FireWire models:
+
+- Nikon's official wire-protocol documents for the LS-5000 (USB) and
+  LS-9000 (IEEE 1394/SBP-2) are published in nkscan's `docs/`
+  directory. Compared side by side they describe one command protocol,
+  with fields in the same bit and byte positions on both units;
+  per-model differences are advertised by the scanner through
+  capability pages, not baked into per-model dialects. v0.3.0 is built
+  on that finding and carries no per-model scanner modules at all.
+- Its command set is a superset of the vocabulary coolscanpy validated
+  byte-for-byte on the LS-5000. Common to both implementations:
+  TEST UNIT READY, INQUIRY, MODE SELECT, RESERVE UNIT, SCAN,
+  SET WINDOW, GET WINDOW, READ, SEND, and Nikon's SET PARAMETER /
+  GET PARAMETER / EXECUTE (E0h/E1h/C1h). nkscan additionally issues
+  RELEASE UNIT, MODE SENSE, SEND DIAGNOSTIC, and ABORT (C0h).
+- What is genuinely different on the FireWire units, per its transport
+  and scan layers: SBP-2 can answer BUSY and RESERVATION CONFLICT,
+  statuses the USB wrapper never carries; sense data arrives in
+  per-transport shapes; the LS-8000/9000's three-line CCD needs a
+  row-response correction the single-line units do not; and some
+  holders publish frame rectangles without lengths, so framing works
+  from a whole-strip thumbnail.
+- Hardware validation is complementary: nkscan has run against a real
+  LS-9000 (with the 869S holder); every LS-5000 row in its support
+  matrix is marked theoretical. coolscanpy is the exact reverse.
+- Its transports are Linux `sg`, Windows `scsiscan.sys`, and
+  cross-platform USB. There is no macOS FireWire transport, and its
+  README defers Mac FireWire support -- ASFireWire remains the only
+  macOS path to these scanners, so this file's plan stands.
+- The rewrite removed nkscan's Python bindings, marked temporary in
+  its changelog; the `nkscan` package on PyPI is still the pre-rewrite
+  0.2.0. The surface a future binding would wrap is its `Transport`
+  trait -- execute one CDB with a data phase and a timeout, get
+  status, sense, and bytes transferred back -- the open/claim plus
+  read/write shape a protocol layer sits on the same way the USB lane
+  here sits on libusb.
+
+The USB identity facts credited in `THIRD_PARTY_NOTICES.md` were
+re-verified at v0.3.0: the table moved from `src/devices.rs` to
+`src/protocol/model.rs` and the vendor/product ids are unchanged.
 
 ## Requirements and honest limits
 
@@ -53,5 +106,6 @@ the coordination thread for these models.
   exclusive access fails with a named error -- close the other client
   first.
 - On Linux, none of this is needed: the kernel's own `firewire-sbp2`
-  exposes the same scanners as SCSI devices, and the long-term plan for
-  FireWire units remains Linux-first (issue #16 discussion).
+  exposes the same scanners as SCSI devices, nkscan drives a real
+  LS-9000 that way today, and the long-term plan for FireWire units
+  remains Linux-first (issue #16 discussion).

--- a/coolscanpy/src/coolscanpy/_device.py
+++ b/coolscanpy/src/coolscanpy/_device.py
@@ -78,6 +78,8 @@ _USB_FALLBACK_ID_PREFIX = "usb"
 # from memory: LS-40 = 0x4000 (Coolscan IV), LS-50 = 0x4001 (Coolscan V),
 # LS-5000 = 0x4002 (Coolscan 5000 ED). FireWire models (LS-8000/9000/4000)
 # expose no USB ids and are found by SCSI only, so they are out of scope here.
+# Re-verified at tag v0.3.0 (2026-08-09): the table moved to
+# src/protocol/model.rs; the ids are unchanged.
 # Of which only the LS-5000 (0x4002) is driven; the other models are listed
 # by discovery as recognized-but-unsupported (labeled, never connectable).
 _NIKON_COOLSCAN_USB_MODELS: dict[int, dict[int, str]] = {

--- a/ports/tauri/vendor/coolscanpy/FIREWIRE.md
+++ b/ports/tauri/vendor/coolscanpy/FIREWIRE.md
@@ -29,14 +29,67 @@ block, and releases the device. It never moves film.
 ## What deliberately does not work yet
 
 Scanning. coolscanpy's single-pass protocol layer is validated against
-the LS-5000's USB dialect, byte-for-byte, on real captures. Whether the
-FireWire models answer the same command vocabulary is an open question
-that only real hardware can settle -- guessing would produce silently
-wrong scans, which is worse than refusing. The probe output above is
-exactly the evidence that question needs: if you have a FireWire
-Coolscan running through ASFireWire, please run it and paste the output
-into [ScanStudio issue #28](https://github.com/rohanpandula/ScanStudio/issues/28),
+the LS-5000's USB dialect, byte-for-byte, on real captures. The command
+vocabulary itself is settled -- Nikon's own interface specifications
+describe one protocol for the LS-5000 and LS-9000, and the nkscan
+project has driven a real LS-9000 with it (next section) -- but
+everything between a vocabulary and a correct scan through ASFireWire
+is not: SBP-2 status and sense behavior, transfer chunking under the
+1 MB task ceiling, frame geometry on the medium-format holders.
+Guessing at those would produce silently wrong scans, which is worse
+than refusing. The probe output above is exactly the evidence this
+needs: if you have a FireWire Coolscan running through ASFireWire,
+please run it and paste the output into
+[ScanStudio issue #28](https://github.com/rohanpandula/ScanStudio/issues/28),
 the coordination thread for these models.
+
+## What the nkscan v0.3.0 rewrite establishes
+
+[nkscan](https://github.com/activexray/nkscan) is the independent
+open-source Coolscan driver this project coordinates with rather than
+duplicates (the engineering thread in issue #28). Its v0.3.0 release
+(2026-08-09, tag `v0.3.0`) is a ground-up rewrite against Nikon's own
+interface specifications, and it changes what is known about the
+FireWire models:
+
+- Nikon's official wire-protocol documents for the LS-5000 (USB) and
+  LS-9000 (IEEE 1394/SBP-2) are published in nkscan's `docs/`
+  directory. Compared side by side they describe one command protocol,
+  with fields in the same bit and byte positions on both units;
+  per-model differences are advertised by the scanner through
+  capability pages, not baked into per-model dialects. v0.3.0 is built
+  on that finding and carries no per-model scanner modules at all.
+- Its command set is a superset of the vocabulary coolscanpy validated
+  byte-for-byte on the LS-5000. Common to both implementations:
+  TEST UNIT READY, INQUIRY, MODE SELECT, RESERVE UNIT, SCAN,
+  SET WINDOW, GET WINDOW, READ, SEND, and Nikon's SET PARAMETER /
+  GET PARAMETER / EXECUTE (E0h/E1h/C1h). nkscan additionally issues
+  RELEASE UNIT, MODE SENSE, SEND DIAGNOSTIC, and ABORT (C0h).
+- What is genuinely different on the FireWire units, per its transport
+  and scan layers: SBP-2 can answer BUSY and RESERVATION CONFLICT,
+  statuses the USB wrapper never carries; sense data arrives in
+  per-transport shapes; the LS-8000/9000's three-line CCD needs a
+  row-response correction the single-line units do not; and some
+  holders publish frame rectangles without lengths, so framing works
+  from a whole-strip thumbnail.
+- Hardware validation is complementary: nkscan has run against a real
+  LS-9000 (with the 869S holder); every LS-5000 row in its support
+  matrix is marked theoretical. coolscanpy is the exact reverse.
+- Its transports are Linux `sg`, Windows `scsiscan.sys`, and
+  cross-platform USB. There is no macOS FireWire transport, and its
+  README defers Mac FireWire support -- ASFireWire remains the only
+  macOS path to these scanners, so this file's plan stands.
+- The rewrite removed nkscan's Python bindings, marked temporary in
+  its changelog; the `nkscan` package on PyPI is still the pre-rewrite
+  0.2.0. The surface a future binding would wrap is its `Transport`
+  trait -- execute one CDB with a data phase and a timeout, get
+  status, sense, and bytes transferred back -- the open/claim plus
+  read/write shape a protocol layer sits on the same way the USB lane
+  here sits on libusb.
+
+The USB identity facts credited in `THIRD_PARTY_NOTICES.md` were
+re-verified at v0.3.0: the table moved from `src/devices.rs` to
+`src/protocol/model.rs` and the vendor/product ids are unchanged.
 
 ## Requirements and honest limits
 
@@ -53,5 +106,6 @@ the coordination thread for these models.
   exclusive access fails with a named error -- close the other client
   first.
 - On Linux, none of this is needed: the kernel's own `firewire-sbp2`
-  exposes the same scanners as SCSI devices, and the long-term plan for
-  FireWire units remains Linux-first (issue #16 discussion).
+  exposes the same scanners as SCSI devices, nkscan drives a real
+  LS-9000 that way today, and the long-term plan for FireWire units
+  remains Linux-first (issue #16 discussion).

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/_device.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/_device.py
@@ -78,6 +78,8 @@ _USB_FALLBACK_ID_PREFIX = "usb"
 # from memory: LS-40 = 0x4000 (Coolscan IV), LS-50 = 0x4001 (Coolscan V),
 # LS-5000 = 0x4002 (Coolscan 5000 ED). FireWire models (LS-8000/9000/4000)
 # expose no USB ids and are found by SCSI only, so they are out of scope here.
+# Re-verified at tag v0.3.0 (2026-08-09): the table moved to
+# src/protocol/model.rs; the ids are unchanged.
 # Of which only the LS-5000 (0x4002) is driven; the other models are listed
 # by discovery as recognized-but-unsupported (labeled, never connectable).
 _NIKON_COOLSCAN_USB_MODELS: dict[int, dict[int, str]] = {


### PR DESCRIPTION
nkscan shipped v0.3.0 today: a ground-up rewrite built against Nikon's official LS-5000 and LS-9000 interface specifications, which it now publishes in its `docs/` tree. Their side-by-side finding — one command protocol, same bit and byte positions, per-model differences advertised through capability pages — settles the command-vocabulary question FIREWIRE.md has carried since it was written, and narrows what only real hardware can still answer to SBP-2 transport discipline and holder frame geometry.

What this records:

- The shared command set: every opcode in coolscanpy's byte-validated LS-5000 allowlist appears in nkscan's unified vocabulary (TEST UNIT READY, INQUIRY, MODE SELECT, RESERVE UNIT, SCAN, SET WINDOW, GET WINDOW, READ, SEND, SET PARAMETER/GET PARAMETER/EXECUTE). nkscan additionally issues RELEASE UNIT, MODE SENSE, SEND DIAGNOSTIC, and ABORT.
- The FireWire-only realities their layers encode: SBP-2 BUSY / RESERVATION CONFLICT statuses, per-transport sense shapes, three-line CCD row-response correction on the LS-8000/9000, thumbnail-based framing for holders that publish rectangles without lengths.
- Complementary hardware coverage: their support matrix has a real LS-9000 run (869S holder) and all-theoretical LS-5000 rows — the exact reverse of ours.
- No macOS FireWire transport upstream (Linux `sg`, Windows `scsiscan.sys`, cross-platform USB), so ASFireWire remains the only macOS path and this file's plan stands.
- The rewrite removed the Python bindings for now (changelog marks them temporary; PyPI `nkscan` is still pre-rewrite 0.2.0). The doc names their `Transport` trait as the open/claim + read/write surface a future binding would wrap — the shape the #28 thread asked for.

Also in this PR:

- USB identity facts re-verified at tag `v0.3.0`: the table moved from `src/devices.rs` to `src/protocol/model.rs`; LS-40 `0x4000`, LS-50 `0x4001`, LS-5000 `0x4002` unchanged. `_device.py` comments note the re-verification.
- THIRD_PARTY_NOTICES corrected to nkscan's actual dual license, MIT OR Apache-2.0 — verified in upstream `Cargo.toml` at both our pinned commit and the tag. Posture unchanged: identity facts only, no code vendored.
- Both `ports/tauri/vendor` mirrors updated byte-identically; `scripts/check_ports_vendor_sync.sh` passes locally.

Docs and comments only — no behavior change.