### PR TITLE
feat(transport): Linux SG_IO probe lane for FireWire Coolscans

### DIFF
--- a/coolscanpy/FIREWIRE.md
+++ b/coolscanpy/FIREWIRE.md
@@ -11,15 +11,23 @@ to scan an LS-9000 through it today.
 
 coolscanpy's client for that surface is
 `coolscanpy.transport.macos_scsi`: a pure-Python (ctypes) SCSITaskLib
-transport. No compiled extension, no extra install.
+transport. No compiled extension, no extra install. On Linux the same
+role is played by `coolscanpy.transport.linux_sg`, a pure-Python client
+for the kernel's v3 `SG_IO` interface over the nodes `firewire-sbp2`
+publishes.
 
 ## What works today
 
-Device discovery, identity, and a motion-free probe:
+Device discovery, identity, and a motion-free probe, on either OS:
 
 ```
 python -m coolscanpy.transport.macos_scsi
 python -m coolscanpy.transport.macos_scsi --probe <registry-id>
+```
+
+```
+python -m coolscanpy.transport.linux_sg
+python -m coolscanpy.transport.linux_sg --probe /dev/sgN
 ```
 
 The probe takes exclusive access, runs TEST UNIT READY, INQUIRY, and
@@ -105,7 +113,9 @@ re-verified at v0.3.0: the table moved from `src/devices.rs` to
 - If another client (VueScan, a stale probe) holds the device,
   exclusive access fails with a named error -- close the other client
   first.
-- On Linux, none of this is needed: the kernel's own `firewire-sbp2`
-  exposes the same scanners as SCSI devices, nkscan drives a real
-  LS-9000 that way today, and the long-term plan for FireWire units
-  remains Linux-first (issue #16 discussion).
+- On Linux, none of the ASFireWire requirements apply: the kernel's own
+  `firewire-sbp2` exposes the same scanners as SCSI devices, nkscan
+  drives a real LS-9000 that way today, and the long-term plan for
+  FireWire units remains Linux-first (issue #16 discussion).
+  coolscanpy's probe runs there through `linux_sg` with no extra
+  install; the same paste-the-output ask in issue #28 applies.

--- a/coolscanpy/src/coolscanpy/transport/linux_sg.py
+++ b/coolscanpy/src/coolscanpy/transport/linux_sg.py
@@ -1,0 +1,549 @@
+"""Linux SCSI generic transport for FireWire Coolscan scanners via SG_IO.
+
+The FireWire Coolscan models (LS-4000 ED, LS-8000 ED, SUPER COOLSCAN
+9000 ED) carry Nikon's SCSI command set over IEEE 1394 SBP-2. On Linux
+the kernel's own ``firewire-sbp2`` driver logs into the scanner's SBP-2
+unit and publishes it as a standard SCSI device, which the ``sg`` driver
+exposes as a ``/dev/sg*`` character node. This module is coolscanpy's
+client for that surface: the v3 ``SG_IO`` ioctl, driven directly through
+``ctypes``/``fcntl`` (no compiled extension, so the wheel stays pure
+Python). It is the Linux twin of ``coolscanpy.transport.macos_scsi``,
+which reaches the same scanners through ASFireWire on macOS.
+
+Contract grounding: every struct field, offset, and constant in this
+file is transcribed from the kernel headers at tag v6.6 —
+``include/scsi/sg.h`` (``sg_io_hdr``, ``SG_IO``, ``SG_GET_VERSION_NUM``,
+``SG_DXFER_*``, ``SG_INFO_*``) and ``include/scsi/scsi_device.h``
+(``SCSI_SENSE_BUFFERSIZE``) — not from memory. ``sg_io_hdr`` carries
+pointers, so its LP64 layout (88 bytes, pad before ``usr_ptr``) is ABI;
+do not reorder fields here without re-reading the header.
+
+Scope: device discovery, identity, and motion-free probing (TEST UNIT
+READY / INQUIRY / REQUEST SENSE). Scanning is deliberately NOT wired up:
+the single-pass protocol layer is validated against the LS-5000's USB
+dialect, and driving the FireWire models further waits on captures from
+real hardware (ScanStudio issue #28 is the coordination thread). This
+module exists so those captures can happen with coolscanpy itself on
+Linux, the platform the FireWire track treats as primary.
+
+Transfer ceiling: ``MAX_TRANSFER_PER_IO`` mirrors the macOS lane's 1 MB
+per-task cap. On Linux that number is a policy choice, not a kernel
+constant — keeping both lanes on one ceiling lets a future protocol
+layer chunk identically on either transport (ASFireWire's 1 MB per-task
+limit is the binding constraint of the pair).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import dataclasses
+import errno
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+from coolscanpy.transport.macos_scsi import _format_inquiry, chunk_transfer_lengths
+
+__all__ = [
+    "MAX_TRANSFER_PER_IO",
+    "DATA_TRANSFER_NONE",
+    "DATA_TRANSFER_FROM_TARGET",
+    "DATA_TRANSFER_TO_TARGET",
+    "STATUS_GOOD",
+    "STATUS_CHECK_CONDITION",
+    "SgDeviceInfo",
+    "SgTransactionResult",
+    "LinuxSgDevice",
+    "LinuxSgTransportError",
+    "chunk_transfer_lengths",
+    "list_sg_devices",
+]
+
+# ---------------------------------------------------------------------------
+# Constants from include/scsi/sg.h @ v6.6 (values, not names, are the
+# contract).
+# ---------------------------------------------------------------------------
+
+# "#define SG_IO 0x2285   /* similar effect as write() followed by read() */"
+_SG_IO = 0x2285
+# "#define SG_GET_VERSION_NUM 0x2282 /* Example: version 2.1.34 yields 20134 */"
+_SG_GET_VERSION_NUM = 0x2282
+# The v3 sg_io_hdr interface exists from driver version 3.0.
+_SG_MIN_VERSION = 30000
+
+# sg.h SG_DXFER_* (dxfer_direction). The names mirror the macOS lane's
+# constants; the values are sg's own.
+DATA_TRANSFER_NONE = -1  # SG_DXFER_NONE
+DATA_TRANSFER_TO_TARGET = -2  # SG_DXFER_TO_DEV
+DATA_TRANSFER_FROM_TARGET = -3  # SG_DXFER_FROM_DEV
+
+# sg.h: "#define SG_INFO_OK_MASK 0x1" / "#define SG_INFO_OK 0x0".
+_SG_INFO_OK_MASK = 0x1
+_SG_INFO_OK = 0x0
+
+# sg_io_hdr.interface_id: "[i] 'S' for SCSI generic (required)".
+_INTERFACE_ID = ord("S")
+
+# SAM status bytes, as in the macOS lane and the USB lane.
+STATUS_GOOD = 0x00
+STATUS_CHECK_CONDITION = 0x02
+
+# include/scsi/scsi_device.h @ v6.6: "#define SCSI_SENSE_BUFFERSIZE 96" —
+# the most sense bytes the kernel will ever hold for one command, so the
+# most mx_sb_len can usefully request.
+_SENSE_BUFFER_SIZE = 96
+
+# Fixed-format sense payload requested by the explicit REQUEST SENSE probe,
+# matching the macOS lane's _SENSE_DATA_LENGTH.
+_REQUEST_SENSE_LENGTH = 18
+
+# Historical DRIVER_SENSE bit in driver_status: set alongside valid sense
+# data. Any other driver_status bit is treated as a transport fault.
+_DRIVER_SENSE = 0x08
+
+# Same per-transaction ceiling as macos_scsi.MAX_TRANSFER_PER_TASK; see the
+# module docstring for why the Linux lane adopts it as policy.
+MAX_TRANSFER_PER_IO = 1 << 20
+
+# Same accepted CDB sizes as the macOS lane's guard.
+_VALID_CDB_SIZES = (6, 10, 12, 16)
+
+_SYSFS_SCSI_GENERIC = "/sys/class/scsi_generic"
+_DEV_ROOT = "/dev"
+
+
+class LinuxSgTransportError(RuntimeError):
+    """An sg call failed; the message carries errno or the fault fields."""
+
+
+# ---------------------------------------------------------------------------
+# ctypes transcription of sg_io_hdr (include/scsi/sg.h @ v6.6). Field order
+# and types are ABI; the offline tests pin the LP64 offsets independently.
+# ---------------------------------------------------------------------------
+
+
+class _SgIoHdr(ctypes.Structure):
+    _fields_ = [
+        ("interface_id", ctypes.c_int),
+        ("dxfer_direction", ctypes.c_int),
+        ("cmd_len", ctypes.c_ubyte),
+        ("mx_sb_len", ctypes.c_ubyte),
+        ("iovec_count", ctypes.c_ushort),
+        ("dxfer_len", ctypes.c_uint),
+        ("dxferp", ctypes.c_void_p),
+        ("cmdp", ctypes.c_void_p),
+        ("sbp", ctypes.c_void_p),
+        ("timeout", ctypes.c_uint),
+        ("flags", ctypes.c_uint),
+        ("pack_id", ctypes.c_int),
+        ("usr_ptr", ctypes.c_void_p),
+        ("status", ctypes.c_ubyte),
+        ("masked_status", ctypes.c_ubyte),
+        ("msg_status", ctypes.c_ubyte),
+        ("sb_len_wr", ctypes.c_ubyte),
+        ("host_status", ctypes.c_ushort),
+        ("driver_status", ctypes.c_ushort),
+        ("resid", ctypes.c_int),
+        ("duration", ctypes.c_uint),
+        ("info", ctypes.c_uint),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Syscall seams. Tests replace these three names to build a scripted kernel;
+# production code never calls os.open/fcntl.ioctl through any other path.
+# ---------------------------------------------------------------------------
+
+
+def _open_node(path: str) -> int:
+    # O_EXCL on an sg node is the claim: it fails EBUSY while any other
+    # descriptor is open, and blocks later opens while ours is. O_NONBLOCK
+    # makes contention surface immediately instead of hanging.
+    return os.open(path, os.O_RDWR | os.O_EXCL | os.O_NONBLOCK)
+
+
+def _close_fd(fd: int) -> None:
+    os.close(fd)
+
+
+def _ioctl(fd: int, request: int, buffer: object) -> int:
+    # Imported here, not at module top: fcntl does not exist on Windows,
+    # and this module must stay importable everywhere (tests fake this
+    # seam; only real hardware calls reach it).
+    import fcntl
+
+    return fcntl.ioctl(fd, request, buffer)
+
+
+# ---------------------------------------------------------------------------
+# Discovery through sysfs: /sys/class/scsi_generic/sg*/device/{vendor,model,
+# rev,type} are fixed-width INQUIRY echoes published by the SCSI midlayer.
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class SgDeviceInfo:
+    """One sg-exposed SCSI device seen in sysfs."""
+
+    node: str
+    vendor: str | None
+    product: str | None
+    revision: str | None
+    scsi_type: int | None
+
+    @property
+    def looks_like_nikon_coolscan(self) -> bool:
+        vendor = (self.vendor or "").strip().upper()
+        return vendor == "NIKON"
+
+
+def _read_sysfs_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="ascii", errors="replace").strip() or None
+    except OSError:
+        return None
+
+
+def list_sg_devices(
+    *,
+    sysfs_root: str | None = None,
+    dev_root: str | None = None,
+) -> list[SgDeviceInfo]:
+    """Enumerate /dev/sg* nodes with their sysfs identity, sg-number order.
+
+    The roots resolve at call time (not at def time) so tests and callers
+    can point the module constants at a fake tree.
+    """
+
+    if sysfs_root is None:
+        sysfs_root = _SYSFS_SCSI_GENERIC
+    if dev_root is None:
+        dev_root = _DEV_ROOT
+    root = Path(sysfs_root)
+    try:
+        entries = [p for p in root.iterdir() if p.name.startswith("sg")]
+    except OSError:
+        return []
+
+    def sg_number(p: Path) -> int:
+        suffix = p.name[2:]
+        return int(suffix) if suffix.isdigit() else 1 << 31
+
+    devices: list[SgDeviceInfo] = []
+    for entry in sorted(entries, key=sg_number):
+        device_dir = entry / "device"
+        type_text = _read_sysfs_text(device_dir / "type")
+        devices.append(
+            SgDeviceInfo(
+                node=str(Path(dev_root) / entry.name),
+                vendor=_read_sysfs_text(device_dir / "vendor"),
+                product=_read_sysfs_text(device_dir / "model"),
+                revision=_read_sysfs_text(device_dir / "rev"),
+                scsi_type=int(type_text) if type_text and type_text.isdigit() else None,
+            )
+        )
+    return devices
+
+
+# ---------------------------------------------------------------------------
+# The device handle.
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class SgTransactionResult:
+    """Outcome of one synchronous SG_IO transaction, USB-lane result shape."""
+
+    status: int
+    host_status: int
+    driver_status: int
+    transferred: int
+    payload: bytes
+    sense: bytes
+
+    @property
+    def good(self) -> bool:
+        return (
+            self.status == STATUS_GOOD
+            and self.host_status == 0
+            and self.driver_status == 0
+        )
+
+    @property
+    def check_condition(self) -> bool:
+        return self.status == STATUS_CHECK_CONDITION
+
+
+class LinuxSgDevice:
+    """One exclusively-claimed /dev/sg node speaking the v3 SG_IO interface.
+
+    ``open()`` is the claim (O_EXCL), so unlike the macOS lane there is no
+    separate obtain-exclusive-access step; a node another client holds
+    raises the named contention error instead of returning a handle.
+    """
+
+    def __init__(self) -> None:
+        self._node: str = ""
+        self._fd: int | None = None
+
+    @classmethod
+    def open(cls, node: str) -> "LinuxSgDevice":
+        device = cls()
+        device._node = node
+        try:
+            fd = _open_node(node)
+        except OSError as error:
+            if error.errno == errno.EBUSY:
+                raise LinuxSgTransportError(
+                    f"{node} is held by another client (EBUSY). Close the "
+                    "other program using the scanner and retry."
+                ) from error
+            raise LinuxSgTransportError(
+                f"opening {node} failed: {error.strerror} "
+                f"(errno {error.errno})"
+            ) from error
+        device._fd = fd
+        try:
+            version = ctypes.c_int(0)
+            _ioctl(fd, _SG_GET_VERSION_NUM, version)
+            if version.value < _SG_MIN_VERSION:
+                raise LinuxSgTransportError(
+                    f"{node} answered sg driver version {version.value}, "
+                    f"below the v3 SG_IO minimum {_SG_MIN_VERSION}"
+                )
+        except OSError as error:
+            device.close(raise_on_error=False)
+            raise LinuxSgTransportError(
+                f"{node} did not answer SG_GET_VERSION_NUM: not an sg node? "
+                f"({error.strerror}, errno {error.errno})"
+            ) from error
+        except LinuxSgTransportError:
+            device.close(raise_on_error=False)
+            raise
+        return device
+
+    def close(self, *, raise_on_error: bool = True) -> None:
+        fd, self._fd = self._fd, None
+        if fd is None:
+            return
+        try:
+            _close_fd(fd)
+        except OSError as error:
+            if raise_on_error:
+                raise LinuxSgTransportError(
+                    f"closing {self._node} failed: {error.strerror} "
+                    f"(errno {error.errno})"
+                ) from error
+
+    def __enter__(self) -> "LinuxSgDevice":
+        return self
+
+    def __exit__(self, exc_type: object, *exc_info: object) -> None:
+        self.close(raise_on_error=exc_type is None)
+
+    def _require_fd(self) -> int:
+        if self._fd is None:
+            raise LinuxSgTransportError("device is not open")
+        return self._fd
+
+    def perform_transaction(
+        self,
+        cdb: bytes,
+        *,
+        direction: int = DATA_TRANSFER_NONE,
+        data_out: bytes | None = None,
+        data_in_length: int = 0,
+        timeout_ms: int = 10_000,
+    ) -> SgTransactionResult:
+        """Execute one synchronous SG_IO transaction and return its outcome.
+
+        Fail-closed, matching the macOS lane: syscall failures and
+        transport-level faults (nonzero host_status, driver_status bits
+        other than the sense marker) raise; a CHECK CONDITION is not an
+        exception — the caller gets status + sense to interpret.
+        """
+
+        if len(cdb) not in _VALID_CDB_SIZES:
+            raise LinuxSgTransportError(
+                f"CDB length {len(cdb)} invalid; this lane accepts "
+                f"{_VALID_CDB_SIZES}"
+            )
+        if direction == DATA_TRANSFER_TO_TARGET and data_out is None:
+            raise LinuxSgTransportError("outbound transfer requires data_out")
+        if direction == DATA_TRANSFER_FROM_TARGET and data_in_length <= 0:
+            raise LinuxSgTransportError("inbound transfer requires data_in_length")
+        if timeout_ms <= 0:
+            raise LinuxSgTransportError("timeout_ms must be positive")
+        transfer_length = (
+            len(data_out) if direction == DATA_TRANSFER_TO_TARGET
+            else data_in_length if direction == DATA_TRANSFER_FROM_TARGET
+            else 0
+        )
+        if transfer_length > MAX_TRANSFER_PER_IO:
+            raise LinuxSgTransportError(
+                f"transfer of {transfer_length} bytes exceeds the "
+                f"{MAX_TRANSFER_PER_IO}-byte per-transaction ceiling; split "
+                "it with chunk_transfer_lengths()"
+            )
+
+        fd = self._require_fd()
+        cdb_buf = ctypes.create_string_buffer(cdb, len(cdb))
+        sense_buf = ctypes.create_string_buffer(_SENSE_BUFFER_SIZE)
+        data_buf: ctypes.Array[ctypes.c_char] | None = None
+        if transfer_length:
+            if direction == DATA_TRANSFER_TO_TARGET:
+                assert data_out is not None
+                data_buf = ctypes.create_string_buffer(data_out, transfer_length)
+            else:
+                data_buf = ctypes.create_string_buffer(transfer_length)
+
+        hdr = _SgIoHdr()
+        hdr.interface_id = _INTERFACE_ID
+        hdr.dxfer_direction = direction
+        hdr.cmd_len = len(cdb)
+        hdr.mx_sb_len = _SENSE_BUFFER_SIZE
+        hdr.iovec_count = 0
+        hdr.dxfer_len = transfer_length
+        hdr.dxferp = ctypes.cast(data_buf, ctypes.c_void_p) if data_buf else None
+        hdr.cmdp = ctypes.cast(cdb_buf, ctypes.c_void_p)
+        hdr.sbp = ctypes.cast(sense_buf, ctypes.c_void_p)
+        hdr.timeout = timeout_ms
+        hdr.flags = 0
+        hdr.pack_id = 0
+        hdr.usr_ptr = None
+
+        while True:
+            try:
+                _ioctl(fd, _SG_IO, hdr)
+                break
+            except InterruptedError:
+                # sg.h documents EINTR handling for SG_IO as the caller's
+                # choice; retrying preserves the synchronous contract.
+                continue
+            except OSError as error:
+                raise LinuxSgTransportError(
+                    f"SG_IO failed on {self._node}: {error.strerror} "
+                    f"(errno {error.errno})"
+                ) from error
+
+        if hdr.host_status != 0:
+            raise LinuxSgTransportError(
+                f"host adapter fault on {self._node}: "
+                f"host_status=0x{hdr.host_status:04x} (see sg.h DID codes)"
+            )
+        if hdr.driver_status & ~_DRIVER_SENSE:
+            raise LinuxSgTransportError(
+                f"sg driver fault on {self._node}: "
+                f"driver_status=0x{hdr.driver_status:04x}"
+            )
+
+        transferred = max(0, transfer_length - hdr.resid)
+        payload = b""
+        if direction == DATA_TRANSFER_FROM_TARGET and data_buf is not None:
+            payload = data_buf.raw[:transferred]
+        return SgTransactionResult(
+            status=hdr.status,
+            host_status=hdr.host_status,
+            driver_status=hdr.driver_status,
+            transferred=transferred,
+            payload=payload,
+            sense=sense_buf.raw[: hdr.sb_len_wr],
+        )
+
+    # -- motion-free probes ------------------------------------------------
+
+    def test_unit_ready(self, *, timeout_ms: int = 5_000) -> SgTransactionResult:
+        return self.perform_transaction(bytes(6), timeout_ms=timeout_ms)
+
+    def inquiry(
+        self, *, allocation: int = 96, timeout_ms: int = 5_000
+    ) -> SgTransactionResult:
+        if not 5 <= allocation <= 255:
+            raise LinuxSgTransportError("INQUIRY allocation must be 5..255")
+        cdb = bytes([0x12, 0x00, 0x00, 0x00, allocation, 0x00])
+        return self.perform_transaction(
+            cdb,
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=allocation,
+            timeout_ms=timeout_ms,
+        )
+
+    def request_sense(self, *, timeout_ms: int = 5_000) -> SgTransactionResult:
+        cdb = bytes([0x03, 0x00, 0x00, 0x00, _REQUEST_SENSE_LENGTH, 0x00])
+        return self.perform_transaction(
+            cdb,
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=_REQUEST_SENSE_LENGTH,
+            timeout_ms=timeout_ms,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Probe CLI: the artifact a FireWire tester runs on Linux and pastes back.
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None, *, out: Callable[[str], None] = print) -> int:
+    """List sg devices; with ``--probe /dev/sgN``, run the motion-free probe."""
+
+    usage = "usage: python -m coolscanpy.transport.linux_sg [--probe /dev/sgN]"
+    args = list(sys.argv[1:] if argv is None else argv)
+    probe_node: str | None = None
+    if args and args[0] == "--probe":
+        if len(args) != 2:
+            out(usage)
+            return 2
+        probe_node = args[1]
+        if not probe_node.startswith("/dev/sg"):
+            out(f"--probe expects an sg node like /dev/sg1, got {probe_node!r}")
+            out(usage)
+            return 2
+    elif args:
+        out(usage)
+        return 2
+
+    devices = list_sg_devices()
+    if not devices:
+        out(
+            "no sg devices found. If a FireWire Coolscan is connected and "
+            "powered on, check that firewire-sbp2 and sg are loaded "
+            "(lsmod) and that the FireWire link shows the scanner "
+            "(dmesg | grep -i firewire)."
+        )
+        return 1
+    for device in devices:
+        marker = "  <- Nikon" if device.looks_like_nikon_coolscan else ""
+        out(
+            f"{device.node}: vendor={device.vendor!r} "
+            f"product={device.product!r} revision={device.revision!r} "
+            f"scsi_type={device.scsi_type}{marker}"
+        )
+    if probe_node is None:
+        return 0
+
+    with LinuxSgDevice.open(probe_node) as device:
+        ready = device.test_unit_ready()
+        out(
+            f"TEST UNIT READY: status=0x{ready.status:02x}"
+            + (f" sense={ready.sense.hex()}" if ready.check_condition else "")
+        )
+        if ready.check_condition:
+            sense = device.request_sense()
+            out(f"REQUEST SENSE: {sense.payload.hex()}")
+        identity = device.inquiry()
+        if not identity.good:
+            out(
+                f"INQUIRY did not complete cleanly: "
+                f"status=0x{identity.status:02x} "
+                f"host=0x{identity.host_status:04x} "
+                f"driver=0x{identity.driver_status:04x} "
+                f"sense={identity.sense.hex()}"
+            )
+            return 1
+        out("INQUIRY: " + _format_inquiry(identity.payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/coolscanpy/tests/transport/test_linux_sg.py
+++ b/coolscanpy/tests/transport/test_linux_sg.py
@@ -1,0 +1,431 @@
+"""Offline tests for the Linux SG_IO transport.
+
+The kernel boundary is three module seams (``_open_node``, ``_ioctl``,
+``_close_fd``), so a complete fake kernel can be scripted on any platform
+-- no Linux, no hardware. The fake parses the REAL ``sg_io_hdr`` buffer
+through ctypes, so the struct plumbing under test is the production
+layout, not a stand-in. Alongside the behavior tests, an independent ABI
+oracle pins the LP64 field offsets and header constants hand-derived
+from ``include/scsi/sg.h`` @ v6.6 -- deliberately NOT computed from the
+production struct, so a drifted declaration fails even though the fake
+would follow it.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+
+import pytest
+
+from coolscanpy.transport import linux_sg
+from coolscanpy.transport.linux_sg import (
+    DATA_TRANSFER_FROM_TARGET,
+    DATA_TRANSFER_TO_TARGET,
+    MAX_TRANSFER_PER_IO,
+    LinuxSgDevice,
+    LinuxSgTransportError,
+    SgDeviceInfo,
+    chunk_transfer_lengths,
+    list_sg_devices,
+)
+
+_SG_IO = 0x2285
+_SG_GET_VERSION_NUM = 0x2282
+
+
+class FakeSgKernel:
+    """A scripted sg node behind the module's three syscall seams.
+
+    ``responses`` maps a CDB opcode byte to a dict with optional keys
+    ``payload`` (bytes returned target->initiator), ``status``,
+    ``host_status``, ``driver_status``, and ``sense``. Unknown opcodes
+    complete GOOD with no data.
+    """
+
+    def __init__(
+        self,
+        responses: dict[int, dict] | None = None,
+        *,
+        version: int = 30536,
+        open_errno: int | None = None,
+        eintr_before_success: int = 0,
+    ) -> None:
+        self.responses = responses or {}
+        self.version = version
+        self.open_errno = open_errno
+        self.eintr_before_success = eintr_before_success
+        self.log: list[tuple] = []
+        self.open_flags: int | None = None
+        self.closed_fds: list[int] = []
+        self._next_fd = 7
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> "FakeSgKernel":
+        monkeypatch.setattr(linux_sg, "_open_node", self._open_node)
+        monkeypatch.setattr(linux_sg, "_ioctl", self._ioctl)
+        monkeypatch.setattr(linux_sg, "_close_fd", self._close_fd)
+        return self
+
+    # -- seams -------------------------------------------------------------
+
+    def _open_node(self, path: str) -> int:
+        self.log.append(("open", path))
+        if self.open_errno is not None:
+            raise OSError(self.open_errno, errno.errorcode[self.open_errno], path)
+        return self._next_fd
+
+    def _close_fd(self, fd: int) -> None:
+        self.log.append(("close", fd))
+        self.closed_fds.append(fd)
+
+    def _ioctl(self, fd: int, request: int, buffer: object) -> int:
+        if request == _SG_GET_VERSION_NUM:
+            self.log.append(("version", fd))
+            assert isinstance(buffer, ctypes.c_int)
+            buffer.value = self.version
+            return 0
+        assert request == _SG_IO, f"unexpected ioctl 0x{request:x}"
+        if self.eintr_before_success > 0:
+            self.eintr_before_success -= 1
+            self.log.append(("sg_io_eintr", fd))
+            raise InterruptedError(errno.EINTR, "Interrupted system call")
+        hdr = buffer
+        assert isinstance(hdr, linux_sg._SgIoHdr)
+        assert hdr.interface_id == ord("S")
+        assert hdr.iovec_count == 0
+        cdb = ctypes.string_at(hdr.cmdp, hdr.cmd_len)
+        self.log.append(("sg_io", fd, cdb, hdr.dxfer_direction, hdr.dxfer_len,
+                         hdr.timeout))
+        script = self.responses.get(cdb[0], {})
+        payload = script.get("payload", b"")
+        if payload:
+            assert hdr.dxfer_direction == linux_sg.DATA_TRANSFER_FROM_TARGET
+            n = min(len(payload), hdr.dxfer_len)
+            ctypes.memmove(hdr.dxferp, payload, n)
+            hdr.resid = hdr.dxfer_len - n
+        elif hdr.dxfer_direction == linux_sg.DATA_TRANSFER_TO_TARGET:
+            self.log.append(
+                ("received", ctypes.string_at(hdr.dxferp, hdr.dxfer_len))
+            )
+            hdr.resid = 0
+        else:
+            hdr.resid = hdr.dxfer_len
+        sense = script.get("sense", b"")
+        if sense:
+            ctypes.memmove(hdr.sbp, sense, min(len(sense), hdr.mx_sb_len))
+        hdr.sb_len_wr = min(len(sense), hdr.mx_sb_len)
+        hdr.status = script.get("status", 0x00)
+        hdr.host_status = script.get("host_status", 0)
+        hdr.driver_status = script.get("driver_status", 0)
+        return 0
+
+
+_INQUIRY_PAYLOAD = (
+    bytes([0x06, 0x00, 0x02, 0x02, 91]) + bytes(3)
+    + b"Nikon   " + b"LS-9000 ED      " + b"1.00"
+    + bytes(96 - 36)
+)
+
+
+# ---------------------------------------------------------------------------
+# Behavior through the real struct plumbing.
+# ---------------------------------------------------------------------------
+
+
+def test_inquiry_round_trip_delivers_payload_and_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = FakeSgKernel({0x12: {"payload": _INQUIRY_PAYLOAD}}).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        result = device.inquiry()
+    assert result.good
+    assert result.transferred == 96
+    assert result.payload[8:16] == b"Nikon   "
+    assert ("close", 7) in kernel.log
+
+
+def test_check_condition_returns_sense_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sense = bytes([0x70, 0, 0x02, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0x3A, 0x00, 0, 0, 0, 0])
+    FakeSgKernel({0x00: {"status": 0x02, "sense": sense}}).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        result = device.test_unit_ready()
+    assert not result.good
+    assert result.check_condition
+    assert result.sense == sense
+
+
+def test_outbound_data_reaches_the_kernel_buffer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = FakeSgKernel().install(monkeypatch)
+    body = bytes(range(16))
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        result = device.perform_transaction(
+            bytes([0x2A, 0, 0, 0, 0, 0, 0, 0, len(body), 0]),
+            direction=DATA_TRANSFER_TO_TARGET,
+            data_out=body,
+        )
+    assert result.good
+    assert ("received", body) in kernel.log
+
+
+def test_open_claim_maps_ebusy_to_named_contention_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeSgKernel(open_errno=errno.EBUSY).install(monkeypatch)
+    with pytest.raises(LinuxSgTransportError, match="held by another client"):
+        LinuxSgDevice.open("/dev/sg1")
+
+
+def test_open_uses_excl_nonblock_rdwr() -> None:
+    # The claim IS the open flags; pin them at the os level.
+    seen: dict[str, int] = {}
+
+    real_open = linux_sg.os.open
+
+    def spy(path: str, flags: int) -> int:
+        seen["flags"] = flags
+        raise OSError(errno.ENOENT, "spy stops before any real fd")
+
+    linux_sg.os.open = spy  # type: ignore[assignment]
+    try:
+        with pytest.raises(LinuxSgTransportError):
+            LinuxSgDevice.open("/dev/sg99")
+    finally:
+        linux_sg.os.open = real_open  # type: ignore[assignment]
+    import os as real_os
+
+    assert seen["flags"] == real_os.O_RDWR | real_os.O_EXCL | real_os.O_NONBLOCK
+
+
+def test_pre_v3_sg_driver_is_refused_and_fd_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = FakeSgKernel(version=20134).install(monkeypatch)
+    with pytest.raises(LinuxSgTransportError, match="below the v3"):
+        LinuxSgDevice.open("/dev/sg1")
+    assert kernel.closed_fds == [7]
+
+
+def test_eintr_during_sg_io_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    kernel = FakeSgKernel(
+        {0x12: {"payload": _INQUIRY_PAYLOAD}}, eintr_before_success=2
+    ).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        result = device.inquiry()
+    assert result.good
+    assert kernel.log.count(("sg_io_eintr", 7)) == 2
+
+
+def test_host_adapter_fault_raises_named_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeSgKernel({0x00: {"host_status": 0x07}}).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        with pytest.raises(LinuxSgTransportError, match="host adapter fault"):
+            device.test_unit_ready()
+
+
+def test_driver_sense_bit_is_tolerated_other_bits_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sense = bytes([0x70] + [0] * 17)
+    FakeSgKernel(
+        {0x00: {"status": 0x02, "driver_status": 0x08, "sense": sense}}
+    ).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        result = device.test_unit_ready()
+    assert result.check_condition
+
+    FakeSgKernel({0x00: {"driver_status": 0x06}}).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        with pytest.raises(LinuxSgTransportError, match="sg driver fault"):
+            device.test_unit_ready()
+
+
+def test_transactions_refuse_after_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeSgKernel().install(monkeypatch)
+    device = LinuxSgDevice.open("/dev/sg1")
+    device.close()
+    with pytest.raises(LinuxSgTransportError, match="not open"):
+        device.test_unit_ready()
+
+
+def test_invalid_cdb_is_refused_before_any_syscall(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = FakeSgKernel().install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        baseline = len(kernel.log)
+        with pytest.raises(LinuxSgTransportError, match="CDB length"):
+            device.perform_transaction(bytes(7))
+        assert len(kernel.log) == baseline
+
+
+def test_oversize_transfer_refused_with_chunking_pointer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeSgKernel().install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        with pytest.raises(LinuxSgTransportError, match="chunk_transfer_lengths"):
+            device.perform_transaction(
+                bytes([0x28, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                direction=DATA_TRANSFER_FROM_TARGET,
+                data_in_length=MAX_TRANSFER_PER_IO + 1,
+            )
+
+
+def test_direction_guards_require_matching_buffers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeSgKernel().install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        with pytest.raises(LinuxSgTransportError, match="requires data_out"):
+            device.perform_transaction(bytes(6), direction=DATA_TRANSFER_TO_TARGET)
+        with pytest.raises(LinuxSgTransportError, match="requires data_in_length"):
+            device.perform_transaction(bytes(6), direction=DATA_TRANSFER_FROM_TARGET)
+        with pytest.raises(LinuxSgTransportError, match="timeout_ms"):
+            device.test_unit_ready(timeout_ms=0)
+
+
+# ---------------------------------------------------------------------------
+# Discovery from a fake sysfs tree.
+# ---------------------------------------------------------------------------
+
+
+def test_list_sg_devices_reads_sysfs_identity(tmp_path) -> None:
+    for name, vendor, model, rev, scsi_type in (
+        ("sg0", "ATA     ", "Some Disk       ", "1.0 ", "0"),
+        ("sg2", "Nikon   ", "LS-9000 ED      ", "1.00", "6"),
+    ):
+        d = tmp_path / name / "device"
+        d.mkdir(parents=True)
+        (d / "vendor").write_text(vendor + "\n")
+        (d / "model").write_text(model + "\n")
+        (d / "rev").write_text(rev + "\n")
+        (d / "type").write_text(scsi_type + "\n")
+    (tmp_path / "sg1").mkdir()  # no device dir: fields all None
+
+    devices = list_sg_devices(sysfs_root=str(tmp_path), dev_root="/dev")
+    assert [d.node for d in devices] == ["/dev/sg0", "/dev/sg1", "/dev/sg2"]
+    nikon = devices[2]
+    assert nikon == SgDeviceInfo(
+        node="/dev/sg2",
+        vendor="Nikon",
+        product="LS-9000 ED",
+        revision="1.00",
+        scsi_type=6,
+    )
+    assert nikon.looks_like_nikon_coolscan
+    assert not devices[0].looks_like_nikon_coolscan
+    assert devices[1].vendor is None
+
+
+def test_list_sg_devices_missing_root_is_empty(tmp_path) -> None:
+    assert list_sg_devices(sysfs_root=str(tmp_path / "absent")) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_rejects_malformed_probe_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lines: list[str] = []
+    assert linux_sg.main(["--probe"], out=lines.append) == 2
+    assert linux_sg.main(["--probe", "sg1"], out=lines.append) == 2
+    assert linux_sg.main(["--frobnicate"], out=lines.append) == 2
+    assert any("usage:" in line for line in lines)
+
+
+def test_cli_probe_runs_the_motion_free_sequence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    d = tmp_path / "sg1" / "device"
+    d.mkdir(parents=True)
+    (d / "vendor").write_text("Nikon\n")
+    (d / "model").write_text("LS-9000 ED\n")
+    (d / "rev").write_text("1.00\n")
+    (d / "type").write_text("6\n")
+    monkeypatch.setattr(linux_sg, "_SYSFS_SCSI_GENERIC", str(tmp_path))
+    kernel = FakeSgKernel({0x12: {"payload": _INQUIRY_PAYLOAD}}).install(monkeypatch)
+
+    lines: list[str] = []
+    assert linux_sg.main(["--probe", "/dev/sg1"], out=lines.append) == 0
+    joined = "\n".join(lines)
+    assert "<- Nikon" in joined
+    assert "TEST UNIT READY: status=0x00" in joined
+    assert "product 'LS-9000 ED'" in joined
+    sg_io_cdbs = [entry[2][0] for entry in kernel.log if entry[0] == "sg_io"]
+    assert sg_io_cdbs == [0x00, 0x12]  # TUR then INQUIRY, nothing that moves film
+
+
+# ---------------------------------------------------------------------------
+# The independent ABI oracle: offsets and constants hand-derived from
+# include/scsi/sg.h @ v6.6 (LP64), NOT computed from the production struct.
+# ---------------------------------------------------------------------------
+
+_EXPECTED_LP64_OFFSETS = {
+    "interface_id": 0,
+    "dxfer_direction": 4,
+    "cmd_len": 8,
+    "mx_sb_len": 9,
+    "iovec_count": 10,
+    "dxfer_len": 12,
+    "dxferp": 16,
+    "cmdp": 24,
+    "sbp": 32,
+    "timeout": 40,
+    "flags": 44,
+    "pack_id": 48,
+    # 4 pad bytes: next field is a pointer needing 8-byte alignment.
+    "usr_ptr": 56,
+    "status": 64,
+    "masked_status": 65,
+    "msg_status": 66,
+    "sb_len_wr": 67,
+    "host_status": 68,
+    "driver_status": 70,
+    "resid": 72,
+    "duration": 76,
+    "info": 80,
+}
+
+
+def test_sg_io_hdr_matches_hand_derived_lp64_layout() -> None:
+    assert ctypes.sizeof(linux_sg._SgIoHdr) == 88
+    for name, expected in _EXPECTED_LP64_OFFSETS.items():
+        actual = getattr(linux_sg._SgIoHdr, name).offset
+        assert actual == expected, (
+            f"sg_io_hdr.{name} at offset {actual}, header derivation says "
+            f"{expected}"
+        )
+    assert [name for name, _ in linux_sg._SgIoHdr._fields_] == list(
+        _EXPECTED_LP64_OFFSETS
+    )
+
+
+def test_constants_match_the_kernel_headers() -> None:
+    # include/scsi/sg.h @ v6.6, values quoted in the module comments.
+    assert linux_sg._SG_IO == 0x2285
+    assert linux_sg._SG_GET_VERSION_NUM == 0x2282
+    assert linux_sg.DATA_TRANSFER_NONE == -1
+    assert linux_sg.DATA_TRANSFER_TO_TARGET == -2
+    assert linux_sg.DATA_TRANSFER_FROM_TARGET == -3
+    assert linux_sg._INTERFACE_ID == ord("S")
+    # include/scsi/scsi_device.h @ v6.6: SCSI_SENSE_BUFFERSIZE.
+    assert linux_sg._SENSE_BUFFER_SIZE == 96
+
+
+def test_transfer_ceiling_stays_in_lockstep_with_the_macos_lane() -> None:
+    from coolscanpy.transport.macos_scsi import MAX_TRANSFER_PER_TASK
+
+    assert MAX_TRANSFER_PER_IO == MAX_TRANSFER_PER_TASK
+    assert chunk_transfer_lengths(MAX_TRANSFER_PER_IO + 1) == [
+        MAX_TRANSFER_PER_IO,
+        1,
+    ]

--- a/ports/tauri/vendor/coolscanpy/FIREWIRE.md
+++ b/ports/tauri/vendor/coolscanpy/FIREWIRE.md
@@ -11,15 +11,23 @@ to scan an LS-9000 through it today.
 
 coolscanpy's client for that surface is
 `coolscanpy.transport.macos_scsi`: a pure-Python (ctypes) SCSITaskLib
-transport. No compiled extension, no extra install.
+transport. No compiled extension, no extra install. On Linux the same
+role is played by `coolscanpy.transport.linux_sg`, a pure-Python client
+for the kernel's v3 `SG_IO` interface over the nodes `firewire-sbp2`
+publishes.
 
 ## What works today
 
-Device discovery, identity, and a motion-free probe:
+Device discovery, identity, and a motion-free probe, on either OS:
 
 ```
 python -m coolscanpy.transport.macos_scsi
 python -m coolscanpy.transport.macos_scsi --probe <registry-id>
+```
+
+```
+python -m coolscanpy.transport.linux_sg
+python -m coolscanpy.transport.linux_sg --probe /dev/sgN
 ```
 
 The probe takes exclusive access, runs TEST UNIT READY, INQUIRY, and
@@ -105,7 +113,9 @@ re-verified at v0.3.0: the table moved from `src/devices.rs` to
 - If another client (VueScan, a stale probe) holds the device,
   exclusive access fails with a named error -- close the other client
   first.
-- On Linux, none of this is needed: the kernel's own `firewire-sbp2`
-  exposes the same scanners as SCSI devices, nkscan drives a real
-  LS-9000 that way today, and the long-term plan for FireWire units
-  remains Linux-first (issue #16 discussion).
+- On Linux, none of the ASFireWire requirements apply: the kernel's own
+  `firewire-sbp2` exposes the same scanners as SCSI devices, nkscan
+  drives a real LS-9000 that way today, and the long-term plan for
+  FireWire units remains Linux-first (issue #16 discussion).
+  coolscanpy's probe runs there through `linux_sg` with no extra
+  install; the same paste-the-output ask in issue #28 applies.

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/transport/linux_sg.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/transport/linux_sg.py
@@ -1,0 +1,549 @@
+"""Linux SCSI generic transport for FireWire Coolscan scanners via SG_IO.
+
+The FireWire Coolscan models (LS-4000 ED, LS-8000 ED, SUPER COOLSCAN
+9000 ED) carry Nikon's SCSI command set over IEEE 1394 SBP-2. On Linux
+the kernel's own ``firewire-sbp2`` driver logs into the scanner's SBP-2
+unit and publishes it as a standard SCSI device, which the ``sg`` driver
+exposes as a ``/dev/sg*`` character node. This module is coolscanpy's
+client for that surface: the v3 ``SG_IO`` ioctl, driven directly through
+``ctypes``/``fcntl`` (no compiled extension, so the wheel stays pure
+Python). It is the Linux twin of ``coolscanpy.transport.macos_scsi``,
+which reaches the same scanners through ASFireWire on macOS.
+
+Contract grounding: every struct field, offset, and constant in this
+file is transcribed from the kernel headers at tag v6.6 —
+``include/scsi/sg.h`` (``sg_io_hdr``, ``SG_IO``, ``SG_GET_VERSION_NUM``,
+``SG_DXFER_*``, ``SG_INFO_*``) and ``include/scsi/scsi_device.h``
+(``SCSI_SENSE_BUFFERSIZE``) — not from memory. ``sg_io_hdr`` carries
+pointers, so its LP64 layout (88 bytes, pad before ``usr_ptr``) is ABI;
+do not reorder fields here without re-reading the header.
+
+Scope: device discovery, identity, and motion-free probing (TEST UNIT
+READY / INQUIRY / REQUEST SENSE). Scanning is deliberately NOT wired up:
+the single-pass protocol layer is validated against the LS-5000's USB
+dialect, and driving the FireWire models further waits on captures from
+real hardware (ScanStudio issue #28 is the coordination thread). This
+module exists so those captures can happen with coolscanpy itself on
+Linux, the platform the FireWire track treats as primary.
+
+Transfer ceiling: ``MAX_TRANSFER_PER_IO`` mirrors the macOS lane's 1 MB
+per-task cap. On Linux that number is a policy choice, not a kernel
+constant — keeping both lanes on one ceiling lets a future protocol
+layer chunk identically on either transport (ASFireWire's 1 MB per-task
+limit is the binding constraint of the pair).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import dataclasses
+import errno
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+from coolscanpy.transport.macos_scsi import _format_inquiry, chunk_transfer_lengths
+
+__all__ = [
+    "MAX_TRANSFER_PER_IO",
+    "DATA_TRANSFER_NONE",
+    "DATA_TRANSFER_FROM_TARGET",
+    "DATA_TRANSFER_TO_TARGET",
+    "STATUS_GOOD",
+    "STATUS_CHECK_CONDITION",
+    "SgDeviceInfo",
+    "SgTransactionResult",
+    "LinuxSgDevice",
+    "LinuxSgTransportError",
+    "chunk_transfer_lengths",
+    "list_sg_devices",
+]
+
+# ---------------------------------------------------------------------------
+# Constants from include/scsi/sg.h @ v6.6 (values, not names, are the
+# contract).
+# ---------------------------------------------------------------------------
+
+# "#define SG_IO 0x2285   /* similar effect as write() followed by read() */"
+_SG_IO = 0x2285
+# "#define SG_GET_VERSION_NUM 0x2282 /* Example: version 2.1.34 yields 20134 */"
+_SG_GET_VERSION_NUM = 0x2282
+# The v3 sg_io_hdr interface exists from driver version 3.0.
+_SG_MIN_VERSION = 30000
+
+# sg.h SG_DXFER_* (dxfer_direction). The names mirror the macOS lane's
+# constants; the values are sg's own.
+DATA_TRANSFER_NONE = -1  # SG_DXFER_NONE
+DATA_TRANSFER_TO_TARGET = -2  # SG_DXFER_TO_DEV
+DATA_TRANSFER_FROM_TARGET = -3  # SG_DXFER_FROM_DEV
+
+# sg.h: "#define SG_INFO_OK_MASK 0x1" / "#define SG_INFO_OK 0x0".
+_SG_INFO_OK_MASK = 0x1
+_SG_INFO_OK = 0x0
+
+# sg_io_hdr.interface_id: "[i] 'S' for SCSI generic (required)".
+_INTERFACE_ID = ord("S")
+
+# SAM status bytes, as in the macOS lane and the USB lane.
+STATUS_GOOD = 0x00
+STATUS_CHECK_CONDITION = 0x02
+
+# include/scsi/scsi_device.h @ v6.6: "#define SCSI_SENSE_BUFFERSIZE 96" —
+# the most sense bytes the kernel will ever hold for one command, so the
+# most mx_sb_len can usefully request.
+_SENSE_BUFFER_SIZE = 96
+
+# Fixed-format sense payload requested by the explicit REQUEST SENSE probe,
+# matching the macOS lane's _SENSE_DATA_LENGTH.
+_REQUEST_SENSE_LENGTH = 18
+
+# Historical DRIVER_SENSE bit in driver_status: set alongside valid sense
+# data. Any other driver_status bit is treated as a transport fault.
+_DRIVER_SENSE = 0x08
+
+# Same per-transaction ceiling as macos_scsi.MAX_TRANSFER_PER_TASK; see the
+# module docstring for why the Linux lane adopts it as policy.
+MAX_TRANSFER_PER_IO = 1 << 20
+
+# Same accepted CDB sizes as the macOS lane's guard.
+_VALID_CDB_SIZES = (6, 10, 12, 16)
+
+_SYSFS_SCSI_GENERIC = "/sys/class/scsi_generic"
+_DEV_ROOT = "/dev"
+
+
+class LinuxSgTransportError(RuntimeError):
+    """An sg call failed; the message carries errno or the fault fields."""
+
+
+# ---------------------------------------------------------------------------
+# ctypes transcription of sg_io_hdr (include/scsi/sg.h @ v6.6). Field order
+# and types are ABI; the offline tests pin the LP64 offsets independently.
+# ---------------------------------------------------------------------------
+
+
+class _SgIoHdr(ctypes.Structure):
+    _fields_ = [
+        ("interface_id", ctypes.c_int),
+        ("dxfer_direction", ctypes.c_int),
+        ("cmd_len", ctypes.c_ubyte),
+        ("mx_sb_len", ctypes.c_ubyte),
+        ("iovec_count", ctypes.c_ushort),
+        ("dxfer_len", ctypes.c_uint),
+        ("dxferp", ctypes.c_void_p),
+        ("cmdp", ctypes.c_void_p),
+        ("sbp", ctypes.c_void_p),
+        ("timeout", ctypes.c_uint),
+        ("flags", ctypes.c_uint),
+        ("pack_id", ctypes.c_int),
+        ("usr_ptr", ctypes.c_void_p),
+        ("status", ctypes.c_ubyte),
+        ("masked_status", ctypes.c_ubyte),
+        ("msg_status", ctypes.c_ubyte),
+        ("sb_len_wr", ctypes.c_ubyte),
+        ("host_status", ctypes.c_ushort),
+        ("driver_status", ctypes.c_ushort),
+        ("resid", ctypes.c_int),
+        ("duration", ctypes.c_uint),
+        ("info", ctypes.c_uint),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Syscall seams. Tests replace these three names to build a scripted kernel;
+# production code never calls os.open/fcntl.ioctl through any other path.
+# ---------------------------------------------------------------------------
+
+
+def _open_node(path: str) -> int:
+    # O_EXCL on an sg node is the claim: it fails EBUSY while any other
+    # descriptor is open, and blocks later opens while ours is. O_NONBLOCK
+    # makes contention surface immediately instead of hanging.
+    return os.open(path, os.O_RDWR | os.O_EXCL | os.O_NONBLOCK)
+
+
+def _close_fd(fd: int) -> None:
+    os.close(fd)
+
+
+def _ioctl(fd: int, request: int, buffer: object) -> int:
+    # Imported here, not at module top: fcntl does not exist on Windows,
+    # and this module must stay importable everywhere (tests fake this
+    # seam; only real hardware calls reach it).
+    import fcntl
+
+    return fcntl.ioctl(fd, request, buffer)
+
+
+# ---------------------------------------------------------------------------
+# Discovery through sysfs: /sys/class/scsi_generic/sg*/device/{vendor,model,
+# rev,type} are fixed-width INQUIRY echoes published by the SCSI midlayer.
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class SgDeviceInfo:
+    """One sg-exposed SCSI device seen in sysfs."""
+
+    node: str
+    vendor: str | None
+    product: str | None
+    revision: str | None
+    scsi_type: int | None
+
+    @property
+    def looks_like_nikon_coolscan(self) -> bool:
+        vendor = (self.vendor or "").strip().upper()
+        return vendor == "NIKON"
+
+
+def _read_sysfs_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="ascii", errors="replace").strip() or None
+    except OSError:
+        return None
+
+
+def list_sg_devices(
+    *,
+    sysfs_root: str | None = None,
+    dev_root: str | None = None,
+) -> list[SgDeviceInfo]:
+    """Enumerate /dev/sg* nodes with their sysfs identity, sg-number order.
+
+    The roots resolve at call time (not at def time) so tests and callers
+    can point the module constants at a fake tree.
+    """
+
+    if sysfs_root is None:
+        sysfs_root = _SYSFS_SCSI_GENERIC
+    if dev_root is None:
+        dev_root = _DEV_ROOT
+    root = Path(sysfs_root)
+    try:
+        entries = [p for p in root.iterdir() if p.name.startswith("sg")]
+    except OSError:
+        return []
+
+    def sg_number(p: Path) -> int:
+        suffix = p.name[2:]
+        return int(suffix) if suffix.isdigit() else 1 << 31
+
+    devices: list[SgDeviceInfo] = []
+    for entry in sorted(entries, key=sg_number):
+        device_dir = entry / "device"
+        type_text = _read_sysfs_text(device_dir / "type")
+        devices.append(
+            SgDeviceInfo(
+                node=str(Path(dev_root) / entry.name),
+                vendor=_read_sysfs_text(device_dir / "vendor"),
+                product=_read_sysfs_text(device_dir / "model"),
+                revision=_read_sysfs_text(device_dir / "rev"),
+                scsi_type=int(type_text) if type_text and type_text.isdigit() else None,
+            )
+        )
+    return devices
+
+
+# ---------------------------------------------------------------------------
+# The device handle.
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class SgTransactionResult:
+    """Outcome of one synchronous SG_IO transaction, USB-lane result shape."""
+
+    status: int
+    host_status: int
+    driver_status: int
+    transferred: int
+    payload: bytes
+    sense: bytes
+
+    @property
+    def good(self) -> bool:
+        return (
+            self.status == STATUS_GOOD
+            and self.host_status == 0
+            and self.driver_status == 0
+        )
+
+    @property
+    def check_condition(self) -> bool:
+        return self.status == STATUS_CHECK_CONDITION
+
+
+class LinuxSgDevice:
+    """One exclusively-claimed /dev/sg node speaking the v3 SG_IO interface.
+
+    ``open()`` is the claim (O_EXCL), so unlike the macOS lane there is no
+    separate obtain-exclusive-access step; a node another client holds
+    raises the named contention error instead of returning a handle.
+    """
+
+    def __init__(self) -> None:
+        self._node: str = ""
+        self._fd: int | None = None
+
+    @classmethod
+    def open(cls, node: str) -> "LinuxSgDevice":
+        device = cls()
+        device._node = node
+        try:
+            fd = _open_node(node)
+        except OSError as error:
+            if error.errno == errno.EBUSY:
+                raise LinuxSgTransportError(
+                    f"{node} is held by another client (EBUSY). Close the "
+                    "other program using the scanner and retry."
+                ) from error
+            raise LinuxSgTransportError(
+                f"opening {node} failed: {error.strerror} "
+                f"(errno {error.errno})"
+            ) from error
+        device._fd = fd
+        try:
+            version = ctypes.c_int(0)
+            _ioctl(fd, _SG_GET_VERSION_NUM, version)
+            if version.value < _SG_MIN_VERSION:
+                raise LinuxSgTransportError(
+                    f"{node} answered sg driver version {version.value}, "
+                    f"below the v3 SG_IO minimum {_SG_MIN_VERSION}"
+                )
+        except OSError as error:
+            device.close(raise_on_error=False)
+            raise LinuxSgTransportError(
+                f"{node} did not answer SG_GET_VERSION_NUM: not an sg node? "
+                f"({error.strerror}, errno {error.errno})"
+            ) from error
+        except LinuxSgTransportError:
+            device.close(raise_on_error=False)
+            raise
+        return device
+
+    def close(self, *, raise_on_error: bool = True) -> None:
+        fd, self._fd = self._fd, None
+        if fd is None:
+            return
+        try:
+            _close_fd(fd)
+        except OSError as error:
+            if raise_on_error:
+                raise LinuxSgTransportError(
+                    f"closing {self._node} failed: {error.strerror} "
+                    f"(errno {error.errno})"
+                ) from error
+
+    def __enter__(self) -> "LinuxSgDevice":
+        return self
+
+    def __exit__(self, exc_type: object, *exc_info: object) -> None:
+        self.close(raise_on_error=exc_type is None)
+
+    def _require_fd(self) -> int:
+        if self._fd is None:
+            raise LinuxSgTransportError("device is not open")
+        return self._fd
+
+    def perform_transaction(
+        self,
+        cdb: bytes,
+        *,
+        direction: int = DATA_TRANSFER_NONE,
+        data_out: bytes | None = None,
+        data_in_length: int = 0,
+        timeout_ms: int = 10_000,
+    ) -> SgTransactionResult:
+        """Execute one synchronous SG_IO transaction and return its outcome.
+
+        Fail-closed, matching the macOS lane: syscall failures and
+        transport-level faults (nonzero host_status, driver_status bits
+        other than the sense marker) raise; a CHECK CONDITION is not an
+        exception — the caller gets status + sense to interpret.
+        """
+
+        if len(cdb) not in _VALID_CDB_SIZES:
+            raise LinuxSgTransportError(
+                f"CDB length {len(cdb)} invalid; this lane accepts "
+                f"{_VALID_CDB_SIZES}"
+            )
+        if direction == DATA_TRANSFER_TO_TARGET and data_out is None:
+            raise LinuxSgTransportError("outbound transfer requires data_out")
+        if direction == DATA_TRANSFER_FROM_TARGET and data_in_length <= 0:
+            raise LinuxSgTransportError("inbound transfer requires data_in_length")
+        if timeout_ms <= 0:
+            raise LinuxSgTransportError("timeout_ms must be positive")
+        transfer_length = (
+            len(data_out) if direction == DATA_TRANSFER_TO_TARGET
+            else data_in_length if direction == DATA_TRANSFER_FROM_TARGET
+            else 0
+        )
+        if transfer_length > MAX_TRANSFER_PER_IO:
+            raise LinuxSgTransportError(
+                f"transfer of {transfer_length} bytes exceeds the "
+                f"{MAX_TRANSFER_PER_IO}-byte per-transaction ceiling; split "
+                "it with chunk_transfer_lengths()"
+            )
+
+        fd = self._require_fd()
+        cdb_buf = ctypes.create_string_buffer(cdb, len(cdb))
+        sense_buf = ctypes.create_string_buffer(_SENSE_BUFFER_SIZE)
+        data_buf: ctypes.Array[ctypes.c_char] | None = None
+        if transfer_length:
+            if direction == DATA_TRANSFER_TO_TARGET:
+                assert data_out is not None
+                data_buf = ctypes.create_string_buffer(data_out, transfer_length)
+            else:
+                data_buf = ctypes.create_string_buffer(transfer_length)
+
+        hdr = _SgIoHdr()
+        hdr.interface_id = _INTERFACE_ID
+        hdr.dxfer_direction = direction
+        hdr.cmd_len = len(cdb)
+        hdr.mx_sb_len = _SENSE_BUFFER_SIZE
+        hdr.iovec_count = 0
+        hdr.dxfer_len = transfer_length
+        hdr.dxferp = ctypes.cast(data_buf, ctypes.c_void_p) if data_buf else None
+        hdr.cmdp = ctypes.cast(cdb_buf, ctypes.c_void_p)
+        hdr.sbp = ctypes.cast(sense_buf, ctypes.c_void_p)
+        hdr.timeout = timeout_ms
+        hdr.flags = 0
+        hdr.pack_id = 0
+        hdr.usr_ptr = None
+
+        while True:
+            try:
+                _ioctl(fd, _SG_IO, hdr)
+                break
+            except InterruptedError:
+                # sg.h documents EINTR handling for SG_IO as the caller's
+                # choice; retrying preserves the synchronous contract.
+                continue
+            except OSError as error:
+                raise LinuxSgTransportError(
+                    f"SG_IO failed on {self._node}: {error.strerror} "
+                    f"(errno {error.errno})"
+                ) from error
+
+        if hdr.host_status != 0:
+            raise LinuxSgTransportError(
+                f"host adapter fault on {self._node}: "
+                f"host_status=0x{hdr.host_status:04x} (see sg.h DID codes)"
+            )
+        if hdr.driver_status & ~_DRIVER_SENSE:
+            raise LinuxSgTransportError(
+                f"sg driver fault on {self._node}: "
+                f"driver_status=0x{hdr.driver_status:04x}"
+            )
+
+        transferred = max(0, transfer_length - hdr.resid)
+        payload = b""
+        if direction == DATA_TRANSFER_FROM_TARGET and data_buf is not None:
+            payload = data_buf.raw[:transferred]
+        return SgTransactionResult(
+            status=hdr.status,
+            host_status=hdr.host_status,
+            driver_status=hdr.driver_status,
+            transferred=transferred,
+            payload=payload,
+            sense=sense_buf.raw[: hdr.sb_len_wr],
+        )
+
+    # -- motion-free probes ------------------------------------------------
+
+    def test_unit_ready(self, *, timeout_ms: int = 5_000) -> SgTransactionResult:
+        return self.perform_transaction(bytes(6), timeout_ms=timeout_ms)
+
+    def inquiry(
+        self, *, allocation: int = 96, timeout_ms: int = 5_000
+    ) -> SgTransactionResult:
+        if not 5 <= allocation <= 255:
+            raise LinuxSgTransportError("INQUIRY allocation must be 5..255")
+        cdb = bytes([0x12, 0x00, 0x00, 0x00, allocation, 0x00])
+        return self.perform_transaction(
+            cdb,
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=allocation,
+            timeout_ms=timeout_ms,
+        )
+
+    def request_sense(self, *, timeout_ms: int = 5_000) -> SgTransactionResult:
+        cdb = bytes([0x03, 0x00, 0x00, 0x00, _REQUEST_SENSE_LENGTH, 0x00])
+        return self.perform_transaction(
+            cdb,
+            direction=DATA_TRANSFER_FROM_TARGET,
+            data_in_length=_REQUEST_SENSE_LENGTH,
+            timeout_ms=timeout_ms,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Probe CLI: the artifact a FireWire tester runs on Linux and pastes back.
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None, *, out: Callable[[str], None] = print) -> int:
+    """List sg devices; with ``--probe /dev/sgN``, run the motion-free probe."""
+
+    usage = "usage: python -m coolscanpy.transport.linux_sg [--probe /dev/sgN]"
+    args = list(sys.argv[1:] if argv is None else argv)
+    probe_node: str | None = None
+    if args and args[0] == "--probe":
+        if len(args) != 2:
+            out(usage)
+            return 2
+        probe_node = args[1]
+        if not probe_node.startswith("/dev/sg"):
+            out(f"--probe expects an sg node like /dev/sg1, got {probe_node!r}")
+            out(usage)
+            return 2
+    elif args:
+        out(usage)
+        return 2
+
+    devices = list_sg_devices()
+    if not devices:
+        out(
+            "no sg devices found. If a FireWire Coolscan is connected and "
+            "powered on, check that firewire-sbp2 and sg are loaded "
+            "(lsmod) and that the FireWire link shows the scanner "
+            "(dmesg | grep -i firewire)."
+        )
+        return 1
+    for device in devices:
+        marker = "  <- Nikon" if device.looks_like_nikon_coolscan else ""
+        out(
+            f"{device.node}: vendor={device.vendor!r} "
+            f"product={device.product!r} revision={device.revision!r} "
+            f"scsi_type={device.scsi_type}{marker}"
+        )
+    if probe_node is None:
+        return 0
+
+    with LinuxSgDevice.open(probe_node) as device:
+        ready = device.test_unit_ready()
+        out(
+            f"TEST UNIT READY: status=0x{ready.status:02x}"
+            + (f" sense={ready.sense.hex()}" if ready.check_condition else "")
+        )
+        if ready.check_condition:
+            sense = device.request_sense()
+            out(f"REQUEST SENSE: {sense.payload.hex()}")
+        identity = device.inquiry()
+        if not identity.good:
+            out(
+                f"INQUIRY did not complete cleanly: "
+                f"status=0x{identity.status:02x} "
+                f"host=0x{identity.host_status:04x} "
+                f"driver=0x{identity.driver_status:04x} "
+                f"sense={identity.sense.hex()}"
+            )
+            return 1
+        out("INQUIRY: " + _format_inquiry(identity.payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ports/tauri/vendor/coolscanpy/tests/transport/test_linux_sg.py
+++ b/ports/tauri/vendor/coolscanpy/tests/transport/test_linux_sg.py
@@ -1,0 +1,431 @@
+"""Offline tests for the Linux SG_IO transport.
+
+The kernel boundary is three module seams (``_open_node``, ``_ioctl``,
+``_close_fd``), so a complete fake kernel can be scripted on any platform
+-- no Linux, no hardware. The fake parses the REAL ``sg_io_hdr`` buffer
+through ctypes, so the struct plumbing under test is the production
+layout, not a stand-in. Alongside the behavior tests, an independent ABI
+oracle pins the LP64 field offsets and header constants hand-derived
+from ``include/scsi/sg.h`` @ v6.6 -- deliberately NOT computed from the
+production struct, so a drifted declaration fails even though the fake
+would follow it.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+
+import pytest
+
+from coolscanpy.transport import linux_sg
+from coolscanpy.transport.linux_sg import (
+    DATA_TRANSFER_FROM_TARGET,
+    DATA_TRANSFER_TO_TARGET,
+    MAX_TRANSFER_PER_IO,
+    LinuxSgDevice,
+    LinuxSgTransportError,
+    SgDeviceInfo,
+    chunk_transfer_lengths,
+    list_sg_devices,
+)
+
+_SG_IO = 0x2285
+_SG_GET_VERSION_NUM = 0x2282
+
+
+class FakeSgKernel:
+    """A scripted sg node behind the module's three syscall seams.
+
+    ``responses`` maps a CDB opcode byte to a dict with optional keys
+    ``payload`` (bytes returned target->initiator), ``status``,
+    ``host_status``, ``driver_status``, and ``sense``. Unknown opcodes
+    complete GOOD with no data.
+    """
+
+    def __init__(
+        self,
+        responses: dict[int, dict] | None = None,
+        *,
+        version: int = 30536,
+        open_errno: int | None = None,
+        eintr_before_success: int = 0,
+    ) -> None:
+        self.responses = responses or {}
+        self.version = version
+        self.open_errno = open_errno
+        self.eintr_before_success = eintr_before_success
+        self.log: list[tuple] = []
+        self.open_flags: int | None = None
+        self.closed_fds: list[int] = []
+        self._next_fd = 7
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> "FakeSgKernel":
+        monkeypatch.setattr(linux_sg, "_open_node", self._open_node)
+        monkeypatch.setattr(linux_sg, "_ioctl", self._ioctl)
+        monkeypatch.setattr(linux_sg, "_close_fd", self._close_fd)
+        return self
+
+    # -- seams -------------------------------------------------------------
+
+    def _open_node(self, path: str) -> int:
+        self.log.append(("open", path))
+        if self.open_errno is not None:
+            raise OSError(self.open_errno, errno.errorcode[self.open_errno], path)
+        return self._next_fd
+
+    def _close_fd(self, fd: int) -> None:
+        self.log.append(("close", fd))
+        self.closed_fds.append(fd)
+
+    def _ioctl(self, fd: int, request: int, buffer: object) -> int:
+        if request == _SG_GET_VERSION_NUM:
+            self.log.append(("version", fd))
+            assert isinstance(buffer, ctypes.c_int)
+            buffer.value = self.version
+            return 0
+        assert request == _SG_IO, f"unexpected ioctl 0x{request:x}"
+        if self.eintr_before_success > 0:
+            self.eintr_before_success -= 1
+            self.log.append(("sg_io_eintr", fd))
+            raise InterruptedError(errno.EINTR, "Interrupted system call")
+        hdr = buffer
+        assert isinstance(hdr, linux_sg._SgIoHdr)
+        assert hdr.interface_id == ord("S")
+        assert hdr.iovec_count == 0
+        cdb = ctypes.string_at(hdr.cmdp, hdr.cmd_len)
+        self.log.append(("sg_io", fd, cdb, hdr.dxfer_direction, hdr.dxfer_len,
+                         hdr.timeout))
+        script = self.responses.get(cdb[0], {})
+        payload = script.get("payload", b"")
+        if payload:
+            assert hdr.dxfer_direction == linux_sg.DATA_TRANSFER_FROM_TARGET
+            n = min(len(payload), hdr.dxfer_len)
+            ctypes.memmove(hdr.dxferp, payload, n)
+            hdr.resid = hdr.dxfer_len - n
+        elif hdr.dxfer_direction == linux_sg.DATA_TRANSFER_TO_TARGET:
+            self.log.append(
+                ("received", ctypes.string_at(hdr.dxferp, hdr.dxfer_len))
+            )
+            hdr.resid = 0
+        else:
+            hdr.resid = hdr.dxfer_len
+        sense = script.get("sense", b"")
+        if sense:
+            ctypes.memmove(hdr.sbp, sense, min(len(sense), hdr.mx_sb_len))
+        hdr.sb_len_wr = min(len(sense), hdr.mx_sb_len)
+        hdr.status = script.get("status", 0x00)
+        hdr.host_status = script.get("host_status", 0)
+        hdr.driver_status = script.get("driver_status", 0)
+        return 0
+
+
+_INQUIRY_PAYLOAD = (
+    bytes([0x06, 0x00, 0x02, 0x02, 91]) + bytes(3)
+    + b"Nikon   " + b"LS-9000 ED      " + b"1.00"
+    + bytes(96 - 36)
+)
+
+
+# ---------------------------------------------------------------------------
+# Behavior through the real struct plumbing.
+# ---------------------------------------------------------------------------
+
+
+def test_inquiry_round_trip_delivers_payload_and_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = FakeSgKernel({0x12: {"payload": _INQUIRY_PAYLOAD}}).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        result = device.inquiry()
+    assert result.good
+    assert result.transferred == 96
+    assert result.payload[8:16] == b"Nikon   "
+    assert ("close", 7) in kernel.log
+
+
+def test_check_condition_returns_sense_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sense = bytes([0x70, 0, 0x02, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0x3A, 0x00, 0, 0, 0, 0])
+    FakeSgKernel({0x00: {"status": 0x02, "sense": sense}}).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        result = device.test_unit_ready()
+    assert not result.good
+    assert result.check_condition
+    assert result.sense == sense
+
+
+def test_outbound_data_reaches_the_kernel_buffer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = FakeSgKernel().install(monkeypatch)
+    body = bytes(range(16))
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        result = device.perform_transaction(
+            bytes([0x2A, 0, 0, 0, 0, 0, 0, 0, len(body), 0]),
+            direction=DATA_TRANSFER_TO_TARGET,
+            data_out=body,
+        )
+    assert result.good
+    assert ("received", body) in kernel.log
+
+
+def test_open_claim_maps_ebusy_to_named_contention_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeSgKernel(open_errno=errno.EBUSY).install(monkeypatch)
+    with pytest.raises(LinuxSgTransportError, match="held by another client"):
+        LinuxSgDevice.open("/dev/sg1")
+
+
+def test_open_uses_excl_nonblock_rdwr() -> None:
+    # The claim IS the open flags; pin them at the os level.
+    seen: dict[str, int] = {}
+
+    real_open = linux_sg.os.open
+
+    def spy(path: str, flags: int) -> int:
+        seen["flags"] = flags
+        raise OSError(errno.ENOENT, "spy stops before any real fd")
+
+    linux_sg.os.open = spy  # type: ignore[assignment]
+    try:
+        with pytest.raises(LinuxSgTransportError):
+            LinuxSgDevice.open("/dev/sg99")
+    finally:
+        linux_sg.os.open = real_open  # type: ignore[assignment]
+    import os as real_os
+
+    assert seen["flags"] == real_os.O_RDWR | real_os.O_EXCL | real_os.O_NONBLOCK
+
+
+def test_pre_v3_sg_driver_is_refused_and_fd_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = FakeSgKernel(version=20134).install(monkeypatch)
+    with pytest.raises(LinuxSgTransportError, match="below the v3"):
+        LinuxSgDevice.open("/dev/sg1")
+    assert kernel.closed_fds == [7]
+
+
+def test_eintr_during_sg_io_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    kernel = FakeSgKernel(
+        {0x12: {"payload": _INQUIRY_PAYLOAD}}, eintr_before_success=2
+    ).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        result = device.inquiry()
+    assert result.good
+    assert kernel.log.count(("sg_io_eintr", 7)) == 2
+
+
+def test_host_adapter_fault_raises_named_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeSgKernel({0x00: {"host_status": 0x07}}).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        with pytest.raises(LinuxSgTransportError, match="host adapter fault"):
+            device.test_unit_ready()
+
+
+def test_driver_sense_bit_is_tolerated_other_bits_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sense = bytes([0x70] + [0] * 17)
+    FakeSgKernel(
+        {0x00: {"status": 0x02, "driver_status": 0x08, "sense": sense}}
+    ).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        result = device.test_unit_ready()
+    assert result.check_condition
+
+    FakeSgKernel({0x00: {"driver_status": 0x06}}).install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        with pytest.raises(LinuxSgTransportError, match="sg driver fault"):
+            device.test_unit_ready()
+
+
+def test_transactions_refuse_after_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeSgKernel().install(monkeypatch)
+    device = LinuxSgDevice.open("/dev/sg1")
+    device.close()
+    with pytest.raises(LinuxSgTransportError, match="not open"):
+        device.test_unit_ready()
+
+
+def test_invalid_cdb_is_refused_before_any_syscall(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = FakeSgKernel().install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        baseline = len(kernel.log)
+        with pytest.raises(LinuxSgTransportError, match="CDB length"):
+            device.perform_transaction(bytes(7))
+        assert len(kernel.log) == baseline
+
+
+def test_oversize_transfer_refused_with_chunking_pointer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeSgKernel().install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        with pytest.raises(LinuxSgTransportError, match="chunk_transfer_lengths"):
+            device.perform_transaction(
+                bytes([0x28, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                direction=DATA_TRANSFER_FROM_TARGET,
+                data_in_length=MAX_TRANSFER_PER_IO + 1,
+            )
+
+
+def test_direction_guards_require_matching_buffers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeSgKernel().install(monkeypatch)
+    with LinuxSgDevice.open("/dev/sg1") as device:
+        with pytest.raises(LinuxSgTransportError, match="requires data_out"):
+            device.perform_transaction(bytes(6), direction=DATA_TRANSFER_TO_TARGET)
+        with pytest.raises(LinuxSgTransportError, match="requires data_in_length"):
+            device.perform_transaction(bytes(6), direction=DATA_TRANSFER_FROM_TARGET)
+        with pytest.raises(LinuxSgTransportError, match="timeout_ms"):
+            device.test_unit_ready(timeout_ms=0)
+
+
+# ---------------------------------------------------------------------------
+# Discovery from a fake sysfs tree.
+# ---------------------------------------------------------------------------
+
+
+def test_list_sg_devices_reads_sysfs_identity(tmp_path) -> None:
+    for name, vendor, model, rev, scsi_type in (
+        ("sg0", "ATA     ", "Some Disk       ", "1.0 ", "0"),
+        ("sg2", "Nikon   ", "LS-9000 ED      ", "1.00", "6"),
+    ):
+        d = tmp_path / name / "device"
+        d.mkdir(parents=True)
+        (d / "vendor").write_text(vendor + "\n")
+        (d / "model").write_text(model + "\n")
+        (d / "rev").write_text(rev + "\n")
+        (d / "type").write_text(scsi_type + "\n")
+    (tmp_path / "sg1").mkdir()  # no device dir: fields all None
+
+    devices = list_sg_devices(sysfs_root=str(tmp_path), dev_root="/dev")
+    assert [d.node for d in devices] == ["/dev/sg0", "/dev/sg1", "/dev/sg2"]
+    nikon = devices[2]
+    assert nikon == SgDeviceInfo(
+        node="/dev/sg2",
+        vendor="Nikon",
+        product="LS-9000 ED",
+        revision="1.00",
+        scsi_type=6,
+    )
+    assert nikon.looks_like_nikon_coolscan
+    assert not devices[0].looks_like_nikon_coolscan
+    assert devices[1].vendor is None
+
+
+def test_list_sg_devices_missing_root_is_empty(tmp_path) -> None:
+    assert list_sg_devices(sysfs_root=str(tmp_path / "absent")) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_rejects_malformed_probe_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lines: list[str] = []
+    assert linux_sg.main(["--probe"], out=lines.append) == 2
+    assert linux_sg.main(["--probe", "sg1"], out=lines.append) == 2
+    assert linux_sg.main(["--frobnicate"], out=lines.append) == 2
+    assert any("usage:" in line for line in lines)
+
+
+def test_cli_probe_runs_the_motion_free_sequence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    d = tmp_path / "sg1" / "device"
+    d.mkdir(parents=True)
+    (d / "vendor").write_text("Nikon\n")
+    (d / "model").write_text("LS-9000 ED\n")
+    (d / "rev").write_text("1.00\n")
+    (d / "type").write_text("6\n")
+    monkeypatch.setattr(linux_sg, "_SYSFS_SCSI_GENERIC", str(tmp_path))
+    kernel = FakeSgKernel({0x12: {"payload": _INQUIRY_PAYLOAD}}).install(monkeypatch)
+
+    lines: list[str] = []
+    assert linux_sg.main(["--probe", "/dev/sg1"], out=lines.append) == 0
+    joined = "\n".join(lines)
+    assert "<- Nikon" in joined
+    assert "TEST UNIT READY: status=0x00" in joined
+    assert "product 'LS-9000 ED'" in joined
+    sg_io_cdbs = [entry[2][0] for entry in kernel.log if entry[0] == "sg_io"]
+    assert sg_io_cdbs == [0x00, 0x12]  # TUR then INQUIRY, nothing that moves film
+
+
+# ---------------------------------------------------------------------------
+# The independent ABI oracle: offsets and constants hand-derived from
+# include/scsi/sg.h @ v6.6 (LP64), NOT computed from the production struct.
+# ---------------------------------------------------------------------------
+
+_EXPECTED_LP64_OFFSETS = {
+    "interface_id": 0,
+    "dxfer_direction": 4,
+    "cmd_len": 8,
+    "mx_sb_len": 9,
+    "iovec_count": 10,
+    "dxfer_len": 12,
+    "dxferp": 16,
+    "cmdp": 24,
+    "sbp": 32,
+    "timeout": 40,
+    "flags": 44,
+    "pack_id": 48,
+    # 4 pad bytes: next field is a pointer needing 8-byte alignment.
+    "usr_ptr": 56,
+    "status": 64,
+    "masked_status": 65,
+    "msg_status": 66,
+    "sb_len_wr": 67,
+    "host_status": 68,
+    "driver_status": 70,
+    "resid": 72,
+    "duration": 76,
+    "info": 80,
+}
+
+
+def test_sg_io_hdr_matches_hand_derived_lp64_layout() -> None:
+    assert ctypes.sizeof(linux_sg._SgIoHdr) == 88
+    for name, expected in _EXPECTED_LP64_OFFSETS.items():
+        actual = getattr(linux_sg._SgIoHdr, name).offset
+        assert actual == expected, (
+            f"sg_io_hdr.{name} at offset {actual}, header derivation says "
+            f"{expected}"
+        )
+    assert [name for name, _ in linux_sg._SgIoHdr._fields_] == list(
+        _EXPECTED_LP64_OFFSETS
+    )
+
+
+def test_constants_match_the_kernel_headers() -> None:
+    # include/scsi/sg.h @ v6.6, values quoted in the module comments.
+    assert linux_sg._SG_IO == 0x2285
+    assert linux_sg._SG_GET_VERSION_NUM == 0x2282
+    assert linux_sg.DATA_TRANSFER_NONE == -1
+    assert linux_sg.DATA_TRANSFER_TO_TARGET == -2
+    assert linux_sg.DATA_TRANSFER_FROM_TARGET == -3
+    assert linux_sg._INTERFACE_ID == ord("S")
+    # include/scsi/scsi_device.h @ v6.6: SCSI_SENSE_BUFFERSIZE.
+    assert linux_sg._SENSE_BUFFER_SIZE == 96
+
+
+def test_transfer_ceiling_stays_in_lockstep_with_the_macos_lane() -> None:
+    from coolscanpy.transport.macos_scsi import MAX_TRANSFER_PER_TASK
+
+    assert MAX_TRANSFER_PER_IO == MAX_TRANSFER_PER_TASK
+    assert chunk_transfer_lengths(MAX_TRANSFER_PER_IO + 1) == [
+        MAX_TRANSFER_PER_IO,
+        1,
+    ]


### PR DESCRIPTION
The Linux twin of `coolscanpy.transport.macos_scsi`, closing the gap the nkscan v0.3.0 situation left open: their rewrite removed the Python bindings for now, and the #28 thread's Linux path currently points testers at a third-party CLI. With this lane, a FireWire Coolscan owner on Linux runs the same motion-free probe with coolscanpy itself:

```
python -m coolscanpy.transport.linux_sg
python -m coolscanpy.transport.linux_sg --probe /dev/sgN
```

What it is:

- A pure-ctypes client for the kernel's v3 `SG_IO` interface over the `/dev/sg*` nodes `firewire-sbp2` publishes. No compiled extension; the wheel stays pure Python; `fcntl` is imported inside the syscall seam so the module imports everywhere.
- Same surface as the macOS lane: sysfs discovery with the Nikon identity filter, exclusive claim (`O_EXCL` **is** the claim — contention surfaces as a named EBUSY error instead of a hang), fail-closed synchronous transactions (host/driver faults raise; CHECK CONDITION returns status + sense), motion-free probe trio, and the shared 1 MB chunking policy so a future protocol layer chunks identically on either transport.
- Scanning stays deliberately unwired pending real probe output — unchanged posture, now enforced on two OSes.

Contract grounding, per the FireWire-lane rule ("every constant from the header"): all `sg_io_hdr` fields, ioctl numbers, and constants are transcribed from `include/scsi/sg.h` and `include/scsi/scsi_device.h` at kernel tag v6.6. The offline tests carry an **independent LP64 ABI oracle** — hand-derived field offsets and the 88-byte struct size, not computed from the production declarations — plus a scripted fake kernel at the module's three syscall seams that parses the real header buffer, covering: inquiry round-trip, sense propagation, outbound data, EBUSY claim mapping, pre-v3 driver refusal with fd cleanup, EINTR retry, host/driver fault refusal (sense bit tolerated), post-close refusal, CDB/direction/ceiling guards, sysfs discovery, and the CLI's motion-free command sequence (pinned: TUR then INQUIRY, nothing else).

The fake caught one real bug during authoring: default-parameter binding froze the sysfs root at def time, making discovery redirection impossible; roots now resolve at call time.

FIREWIRE.md documents the Linux commands beside the macOS ones. Both `ports/tauri/vendor` mirrors updated; `scripts/check_ports_vendor_sync.sh` passes locally; 20 new tests, full transport suite green.