### PR TITLE
fix(linux): make coolscanpy resolvable to the isolated capture worker

### DIFF
--- a/ports/tauri/packaging/linux/assemble-staging.sh
+++ b/ports/tauri/packaging/linux/assemble-staging.sh
@@ -149,6 +149,23 @@ else
     printf '%s\n' 'skipping python-sane build on non-Linux staging host; strict Linux verification requires it'
 fi
 
+# (4b) Make the curated site-packages and the GPL coolscanpy source resolvable
+# by the bundled interpreter's OWN default sys.path. The bridge process injects
+# these two directories at runtime, but the capture worker is spawned as an
+# isolated `python -I -B` child (protocol/ls5000_single_pass/capture_process.py)
+# that inherits none of that injection -- so without this it dies with
+# `ModuleNotFoundError: No module named 'coolscanpy'` (and would then miss numpy
+# et al. too) and no real preview/scan can run. `-I` implies `-E -s -P` but not
+# `-S`, so site.py still processes this .pth. Paths are derived from sys.prefix
+# at startup because the AppImage mountpoint (/tmp/.mount_*) is only known then.
+# coolscanpy is NOT copied here: it stays solely under CorrespondingSource so
+# the GPL corresponding-source boundary is unchanged.
+INTERP_SITE_PACKAGES="$STAGING_ROOT/BridgeRuntime/python/lib/python3.13/site-packages"
+require_directory "bundled interpreter site-packages" "$INTERP_SITE_PACKAGES"
+cat > "$INTERP_SITE_PACKAGES/scanstudio-bridge-runtime.pth" <<'PTH'
+import os,sys; _br=os.path.dirname(sys.prefix); _p=[os.path.join(_br,'site-packages'),os.path.join(os.path.dirname(_br),'CorrespondingSource','coolscanpy','src')]; sys.path[:0]=[q for q in _p if os.path.isdir(q) and q not in sys.path]
+PTH
+
 # (5) per-wheel license collection.
 collect_python_wheel_licenses "$SITE_PACKAGES_DIR" "$STAGING_ROOT/Licenses/python-wheels"
 

--- a/ports/tauri/packaging/linux/verify-bundle.sh
+++ b/ports/tauri/packaging/linux/verify-bundle.sh
@@ -129,6 +129,20 @@ if [[ "$host_is_linux" -eq 1 ]]; then
         printf 'FAIL  isolated bridge + python-sane import\n' >&2
         failures=$((failures + 1))
     fi
+    # The capture worker is spawned as `python -I -B` with NO path injection
+    # (protocol/ls5000_single_pass/capture_process.py), so it must resolve
+    # coolscanpy + its whole runtime chain from the interpreter's own default
+    # sys.path -- the scanstudio-bridge-runtime.pth is what makes that true.
+    # This is the check whose absence let the packaging gap ship: the injected
+    # import above passes even when the worker cannot start. Import the worker
+    # module itself, exactly as the child does, with no argv paths.
+    worker_bootstrap='import coolscanpy, numpy, cv2, tifffile, sane, usb; import coolscanpy.protocol.ls5000_single_pass.worker'
+    if "$root/BridgeRuntime/python/bin/python3.13" -I -B -c "$worker_bootstrap" 2>/dev/null; then
+        printf 'PASS  isolated capture-worker import (no path injection)\n'
+    else
+        printf 'FAIL  isolated capture-worker import (no path injection) -- coolscanpy/deps not on the bundled interpreter default path\n' >&2
+        failures=$((failures + 1))
+    fi
     if [[ -x "$root/scanstudio-bridge" ]] \
         && timeout 15s "$root/scanstudio-bridge" --version </dev/null >/dev/null 2>&1; then
         printf 'PASS  bundled bridge launch/import smoke\n'


### PR DESCRIPTION
## The bug (found in live testing against a real LS-5000 on Linux)

On the v0.7.0-beta.1 Linux AppImage, **every real preview/scan dies before capture** with:

```
CAPTURE_WORKER_BOOTSTRAP_FAILED: ModuleNotFoundError: No module named 'coolscanpy'
```

The transport connects, telemetry reads, SAFE-02 arms, the preview dispatches — then the capture worker can't even import its own package. So the shipped Linux build cannot scan at all.

## Root cause

- `coolscanpy` ships only under `CorrespondingSource/coolscanpy/src` (GPL source), injected into the **bridge process's** `sys.path` at runtime.
- The curated deps (numpy/opencv/tifffile/…) ship only under `BridgeRuntime/site-packages`, added by that same runtime injection.
- But the capture worker is spawned as an isolated `python -I -B -c …` child (`protocol/ls5000_single_pass/capture_process.py`) that inherits **none** of that injection. It resolves imports from the bundled interpreter's own default `sys.path`, where neither coolscanpy nor the deps live.

## The fix

Staging writes `scanstudio-bridge-runtime.pth` into the bundled interpreter's own site-packages. `-I` implies `-E -s -P` but **not** `-S`, so `site.py` still processes `.pth` files. The line derives `BridgeRuntime` from `sys.prefix` at startup (the AppImage mountpoint `/tmp/.mount_*` is only known then) and prepends the curated site-packages + the coolscanpy source.

coolscanpy is **not** copied — it stays solely under `CorrespondingSource`, so the GPL corresponding-source boundary is unchanged.

## Guard against regression

`verify-bundle.sh` gains the check whose absence let this ship: import the worker module under `python -I` with **no path injection**, exactly as the child does. The prior isolated-import check injected the three roots, so it passed even when the worker couldn't start.

Validated on a real extracted bundle: `import coolscanpy, numpy, cv2, tifffile, sane, usb; import coolscanpy.protocol.ls5000_single_pass.worker` succeeds under `-I` with the .pth, fails without it.

Part of a three-defect Linux-preview fix set (packaging / density log10 portability / webview create→state.project); this is the packaging one.