### PR TITLE
fix(density): correctly-rounded log10 so density is bit-exact on any libm

### DIFF
--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -35,7 +35,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "worker.py": "f625057c5619c9ddf94d7e233c6ac9d2a86e300c1a8b1bd8d7f5f03d0eac8c24",
     "manual_frames.py": "f30f0003e081c3a98610d5700d7e6b6ee4d182b9d5228932f3304f1307d4815f",
     "usb_backend.py": "afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62",
-    "density.py": "be7e1e11635edcc70e150fd7454625a478effbb2446017b2cb56676dcb5ebed9",
+    "density.py": "c2c47de2886bc4b60197d2721b6d72050a76f1095760590fa7bb34a728b9da76",
     "packed.py": "856315714e4f7e81f42e1ca93917e4cc0feb03b24915c2ad604302bfdca46f87",
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/density.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/density.py
@@ -42,8 +42,10 @@ For the archived source, rows 75 through 224 yield selected means
 ``(33182.166666666664, 29120.114583333332, 22777.90625)``.  Together with the
 three calibration numerators and the source-pass ``f03`` triplet
 ``(70307, 136614, 125470)``, they reproduce Nikon's captured density doubles.
-Preserving Nikon's multiply/divide/divide operation order before macOS
-``log10`` matches all three binary64 results exactly.
+Preserving Nikon's multiply/divide/divide operation order and taking a
+correctly-rounded ``log10`` (:func:`correctly_rounded_log10`, not the host
+libm, which is 1 ULP off on some platforms) matches all three binary64
+results exactly on any host.
 
 The separate 285-dpi RGBI pass is the analyzer/builder raster, not the density
 source.  Its ``f02``/final-fine exposure triplet must remain a distinct field
@@ -57,6 +59,7 @@ import json
 import math
 import struct
 from dataclasses import dataclass
+from decimal import Decimal, localcontext
 
 import numpy as np
 
@@ -188,14 +191,39 @@ def _require_u32(value: object, label: str) -> int:
     return value
 
 
-def verify_nikon_density_arithmetic_backend() -> None:
-    """Fail closed when this host's binary64/libm result is not Nikon-exact.
+def correctly_rounded_log10(value: float) -> float:
+    """Round-half-even float64 ``log10(value)``, independent of the host libm.
 
-    The recovered multiply/divide/divide order alone is insufficient on a
-    platform whose ``log10`` rounds the green reference input one ULP away
-    from the captured Nikon result.  Replaying all three pinned reference
-    inputs at runtime makes that platform dependency explicit before any
-    density result can be promoted.
+    ``math.log10`` is not correctly rounded on every platform: glibc x86_64
+    rounds the red Nikon density reference input one ULP low
+    (``3fd8b159777b9d5e`` vs the correctly-rounded ``3fd8b159777b9d5f``),
+    which broke byte-exact density off the reference platform. Computing in
+    wide-precision ``Decimal`` and letting ``float()`` round to the nearest
+    double yields the correctly-rounded result on any host -- bit-identical
+    to the doubles captured on the reference platform, where ``math.log10``
+    already happened to be correctly rounded. This runs three times per scan
+    (once per channel) on a scalar, so the ``Decimal`` cost is irrelevant.
+
+    ``value`` is a finite float64, so ``Decimal(value)`` is its exact value;
+    60 digits keeps the ln/ln10 quotient far enough from any rounding
+    boundary that the final ``float()`` is correctly rounded.
+    """
+
+    with localcontext() as ctx:
+        ctx.prec = 60
+        return float(Decimal(value).ln() / Decimal(10).ln())
+
+
+def verify_nikon_density_arithmetic_backend() -> None:
+    """Fail closed unless the correctly-rounded log10 reproduces the refs.
+
+    The recovered multiply/divide/divide order plus a correctly-rounded
+    ``log10`` (:func:`correctly_rounded_log10`) must reproduce all three
+    pinned Nikon reference doubles exactly. Replaying them at runtime keeps
+    the invariant explicit before any density result can be promoted, and
+    catches a regression in the rounding backend on any platform. The single
+    reference is valid on every host because the backend is now
+    platform-independent, not the host libm.
     """
 
     actual: list[str] = []
@@ -208,11 +236,11 @@ def verify_nikon_density_arithmetic_backend() -> None:
         product = float(numerator) * row_mean
         quotient = product / float(denominator)
         ratio = FULL_SCALE / quotient
-        actual.append(struct.pack(">d", math.log10(ratio)).hex())
+        actual.append(struct.pack(">d", correctly_rounded_log10(ratio)).hex())
     if tuple(actual) != _ARITHMETIC_REFERENCE_BINARY64_BE_HEX:
         raise RuntimeError(
-            "host math.log10 is not bit-exact for the Nikon density reference "
-            f"triplet: got {tuple(actual)!r}"
+            "correctly-rounded log10 does not reproduce the Nikon density "
+            f"reference triplet: got {tuple(actual)!r}"
         )
 
 
@@ -1647,7 +1675,7 @@ def evaluate_nikon_density(
             raise ValueError(
                 f"{CHANNELS[index]} density ratio is not positive and finite"
             )
-        raw = math.log10(ratio)
+        raw = correctly_rounded_log10(ratio)
         if not math.isfinite(raw):
             raise ValueError(f"{CHANNELS[index]} density is not finite")
         lower, upper = _DENSITY_RANGES[index]

--- a/coolscanpy/tests/conftest.py
+++ b/coolscanpy/tests/conftest.py
@@ -19,47 +19,10 @@ preserved as a direct module import, matching the source layout.
 
 from __future__ import annotations
 
-import struct
-
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def _accepted_nikon_density_test_backend(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Emulate the accepted macOS ``log10`` only in tests on other hosts.
-
-    Production must keep refusing a host whose libm differs by one ULP from
-    the Nikon/macOS reference triplet.  Linux CI still needs to exercise the
-    transport, ownership, and failure-cleanup paths that construct density
-    evidence, though.  Patch only the three exact reference inputs and leave
-    every other ``log10`` call on the real host implementation.
-    """
-    from coolscanpy.protocol.ls5000_single_pass import density
-
-    try:
-        density.verify_nikon_density_arithmetic_backend()
-    except RuntimeError as error:
-        if "host math.log10 is not bit-exact" not in str(error):
-            raise
-    else:
-        return
-
-    host_log10 = density.math.log10
-    accepted: dict[float, float] = {}
-    for numerator, denominator, row_mean, expected_hex in zip(
-        density._ARITHMETIC_REFERENCE_NUMERATORS,
-        density._ARITHMETIC_REFERENCE_DENOMINATORS,
-        density._ARITHMETIC_REFERENCE_ROW_MEANS,
-        density._ARITHMETIC_REFERENCE_BINARY64_BE_HEX,
-        strict=True,
-    ):
-        product = float(numerator) * row_mean
-        quotient = product / float(denominator)
-        ratio = density.FULL_SCALE / quotient
-        accepted[ratio] = struct.unpack(">d", bytes.fromhex(expected_hex))[0]
-
-    def accepted_log10(value: float) -> float:
-        return accepted.get(value, host_log10(value))
-
-    monkeypatch.setattr(density.math, "log10", accepted_log10)
-    density.verify_nikon_density_arithmetic_backend()
+# The density arithmetic backend used to depend on the host libm's log10,
+# which is 1 ULP off on glibc x86_64 for the red reference input. An autouse
+# fixture here patched the three reference ratios so non-macOS CI could still
+# exercise the density-evidence paths. The backend is now correctly-rounded
+# and platform-independent (density.correctly_rounded_log10), so
+# verify_nikon_density_arithmetic_backend() passes on every host and no such
+# workaround is needed; the fixture was removed rather than left as dead code.

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_density.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_density.py
@@ -435,6 +435,53 @@ def test_density_evaluator_uses_first_maximum_and_skips_saturated_rows() -> None
     )
 
 
+def test_correctly_rounded_log10_reproduces_reference_triplet_on_any_libm() -> None:
+    # The density backend must be platform-independent: glibc x86_64 rounds the
+    # red reference input one ULP low via math.log10 (3fd8b159777b9d5e), where
+    # the correctly-rounded value is 3fd8b159777b9d5f. correctly_rounded_log10
+    # must reproduce all three captured reference doubles regardless of the
+    # host libm, so a single pinned reference stays valid on every platform.
+    from coolscanpy.protocol.ls5000_single_pass.density import (
+        correctly_rounded_log10,
+        _ARITHMETIC_REFERENCE_BINARY64_BE_HEX,
+        _ARITHMETIC_REFERENCE_DENOMINATORS,
+        _ARITHMETIC_REFERENCE_NUMERATORS,
+        _ARITHMETIC_REFERENCE_ROW_MEANS,
+        FULL_SCALE,
+    )
+
+    actual = []
+    for numerator, denominator, row_mean in zip(
+        _ARITHMETIC_REFERENCE_NUMERATORS,
+        _ARITHMETIC_REFERENCE_DENOMINATORS,
+        _ARITHMETIC_REFERENCE_ROW_MEANS,
+        strict=True,
+    ):
+        ratio = FULL_SCALE / ((float(numerator) * row_mean) / float(denominator))
+        actual.append(struct.pack(">d", correctly_rounded_log10(ratio)).hex())
+    assert tuple(actual) == _ARITHMETIC_REFERENCE_BINARY64_BE_HEX
+
+    # The exact red-channel ratio whose glibc math.log10 is 1 ULP low: pin the
+    # correctly-rounded result directly so the backend can't silently regress
+    # to a libm passthrough.
+    red_ratio = FULL_SCALE / (
+        (float(_ARITHMETIC_REFERENCE_NUMERATORS[0]) * _ARITHMETIC_REFERENCE_ROW_MEANS[0])
+        / float(_ARITHMETIC_REFERENCE_DENOMINATORS[0])
+    )
+    assert struct.pack(">d", correctly_rounded_log10(red_ratio)).hex() == (
+        "3fd8b159777b9d5f"
+    )
+    # Sanity: correctly-rounded never disagrees with libm by more than 1 ULP.
+    for value in (2.4312216427815936, 10.0, 1.0000000001, 999.999):
+        cr = correctly_rounded_log10(value)
+        assert abs(cr - math.log10(value)) <= abs(cr) * 2**-52 + 5e-324
+
+
+def test_verify_nikon_density_arithmetic_backend_passes_after_fix() -> None:
+    # Must not raise on any host now that the backend is correctly-rounded.
+    verify_nikon_density_arithmetic_backend()
+
+
 def test_archived_density_means_reproduce_all_three_binary64_outputs_exactly() -> None:
     image = _archived_means_source_image()
     wire = _wire_from_image(image)
@@ -699,13 +746,15 @@ def test_runtime_arithmetic_gate_refuses_one_ulp_log10_drift(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     verify_nikon_density_arithmetic_backend()
-    real_log10 = density_module.math.log10
+    real_backend = density_module.correctly_rounded_log10
 
     def drifted_log10(value: float) -> float:
-        return math.nextafter(real_log10(value), math.inf)
+        return math.nextafter(real_backend(value), math.inf)
 
-    monkeypatch.setattr(density_module.math, "log10", drifted_log10)
-    with pytest.raises(RuntimeError, match="not bit-exact"):
+    # The guard now validates the correctly-rounded backend itself (not the
+    # host libm): a 1-ULP drift in that backend must still fail closed.
+    monkeypatch.setattr(density_module, "correctly_rounded_log10", drifted_log10)
+    with pytest.raises(RuntimeError, match="does not reproduce"):
         verify_nikon_density_arithmetic_backend()
 
 

--- a/ports/tauri/packaging/linux/assemble-staging.sh
+++ b/ports/tauri/packaging/linux/assemble-staging.sh
@@ -149,6 +149,23 @@ else
     printf '%s\n' 'skipping python-sane build on non-Linux staging host; strict Linux verification requires it'
 fi
 
+# (4b) Make the curated site-packages and the GPL coolscanpy source resolvable
+# by the bundled interpreter's OWN default sys.path. The bridge process injects
+# these two directories at runtime, but the capture worker is spawned as an
+# isolated `python -I -B` child (protocol/ls5000_single_pass/capture_process.py)
+# that inherits none of that injection -- so without this it dies with
+# `ModuleNotFoundError: No module named 'coolscanpy'` (and would then miss numpy
+# et al. too) and no real preview/scan can run. `-I` implies `-E -s -P` but not
+# `-S`, so site.py still processes this .pth. Paths are derived from sys.prefix
+# at startup because the AppImage mountpoint (/tmp/.mount_*) is only known then.
+# coolscanpy is NOT copied here: it stays solely under CorrespondingSource so
+# the GPL corresponding-source boundary is unchanged.
+INTERP_SITE_PACKAGES="$STAGING_ROOT/BridgeRuntime/python/lib/python3.13/site-packages"
+require_directory "bundled interpreter site-packages" "$INTERP_SITE_PACKAGES"
+cat > "$INTERP_SITE_PACKAGES/scanstudio-bridge-runtime.pth" <<'PTH'
+import os,sys; _br=os.path.dirname(sys.prefix); _p=[os.path.join(_br,'site-packages'),os.path.join(os.path.dirname(_br),'CorrespondingSource','coolscanpy','src')]; sys.path[:0]=[q for q in _p if os.path.isdir(q) and q not in sys.path]
+PTH
+
 # (5) per-wheel license collection.
 collect_python_wheel_licenses "$SITE_PACKAGES_DIR" "$STAGING_ROOT/Licenses/python-wheels"
 

--- a/ports/tauri/packaging/linux/verify-bundle.sh
+++ b/ports/tauri/packaging/linux/verify-bundle.sh
@@ -129,6 +129,20 @@ if [[ "$host_is_linux" -eq 1 ]]; then
         printf 'FAIL  isolated bridge + python-sane import\n' >&2
         failures=$((failures + 1))
     fi
+    # The capture worker is spawned as `python -I -B` with NO path injection
+    # (protocol/ls5000_single_pass/capture_process.py), so it must resolve
+    # coolscanpy + its whole runtime chain from the interpreter's own default
+    # sys.path -- the scanstudio-bridge-runtime.pth is what makes that true.
+    # This is the check whose absence let the packaging gap ship: the injected
+    # import above passes even when the worker cannot start. Import the worker
+    # module itself, exactly as the child does, with no argv paths.
+    worker_bootstrap='import coolscanpy, numpy, cv2, tifffile, sane, usb; import coolscanpy.protocol.ls5000_single_pass.worker'
+    if "$root/BridgeRuntime/python/bin/python3.13" -I -B -c "$worker_bootstrap" 2>/dev/null; then
+        printf 'PASS  isolated capture-worker import (no path injection)\n'
+    else
+        printf 'FAIL  isolated capture-worker import (no path injection) -- coolscanpy/deps not on the bundled interpreter default path\n' >&2
+        failures=$((failures + 1))
+    fi
     if [[ -x "$root/scanstudio-bridge" ]] \
         && timeout 15s "$root/scanstudio-bridge" --version </dev/null >/dev/null 2>&1; then
         printf 'PASS  bundled bridge launch/import smoke\n'

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -28,11 +28,14 @@ CANONICAL_MANIFEST_FILENAME = "replay-first-rgbi4-manifest.json"
 # density-source cap-0x10d/f03 exposures, the proven 97-dpi reservation-preview
 # evidence, runtime arithmetic gate, and exact per-frame ownership receipt.
 CAPTURE_BUNDLE_COMPONENT_SHA256 = {
+    # Resealed 2026-08-07 (FEEDING-UX-LADDER-OVERNIGHT-20260807.md, Rung 4
+    # scan-side wiring): both files gained CaptureBatchRequest/LiveBatchJob's
+    # additive manual_boundary_rows field plus its batch-job.json plumbing.
     "capture_process.py": "6208a95b23bba84ee0903a07a0d583a9840c5332cbdc60f38a4b574a050d24e2",
     "worker.py": "f625057c5619c9ddf94d7e233c6ac9d2a86e300c1a8b1bd8d7f5f03d0eac8c24",
     "manual_frames.py": "f30f0003e081c3a98610d5700d7e6b6ee4d182b9d5228932f3304f1307d4815f",
-    "usb_backend.py": "77499a606dc48049521d2fd0359a0405cb55525242843d61165b642c78841208",
-    "density.py": "be7e1e11635edcc70e150fd7454625a478effbb2446017b2cb56676dcb5ebed9",
+    "usb_backend.py": "afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62",
+    "density.py": "c2c47de2886bc4b60197d2721b6d72050a76f1095760590fa7bb34a728b9da76",
     "packed.py": "856315714e4f7e81f42e1ca93917e4cc0feb03b24915c2ad604302bfdca46f87",
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/density.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/density.py
@@ -42,8 +42,10 @@ For the archived source, rows 75 through 224 yield selected means
 ``(33182.166666666664, 29120.114583333332, 22777.90625)``.  Together with the
 three calibration numerators and the source-pass ``f03`` triplet
 ``(70307, 136614, 125470)``, they reproduce Nikon's captured density doubles.
-Preserving Nikon's multiply/divide/divide operation order before macOS
-``log10`` matches all three binary64 results exactly.
+Preserving Nikon's multiply/divide/divide operation order and taking a
+correctly-rounded ``log10`` (:func:`correctly_rounded_log10`, not the host
+libm, which is 1 ULP off on some platforms) matches all three binary64
+results exactly on any host.
 
 The separate 285-dpi RGBI pass is the analyzer/builder raster, not the density
 source.  Its ``f02``/final-fine exposure triplet must remain a distinct field
@@ -57,6 +59,7 @@ import json
 import math
 import struct
 from dataclasses import dataclass
+from decimal import Decimal, localcontext
 
 import numpy as np
 
@@ -188,14 +191,39 @@ def _require_u32(value: object, label: str) -> int:
     return value
 
 
-def verify_nikon_density_arithmetic_backend() -> None:
-    """Fail closed when this host's binary64/libm result is not Nikon-exact.
+def correctly_rounded_log10(value: float) -> float:
+    """Round-half-even float64 ``log10(value)``, independent of the host libm.
 
-    The recovered multiply/divide/divide order alone is insufficient on a
-    platform whose ``log10`` rounds the green reference input one ULP away
-    from the captured Nikon result.  Replaying all three pinned reference
-    inputs at runtime makes that platform dependency explicit before any
-    density result can be promoted.
+    ``math.log10`` is not correctly rounded on every platform: glibc x86_64
+    rounds the red Nikon density reference input one ULP low
+    (``3fd8b159777b9d5e`` vs the correctly-rounded ``3fd8b159777b9d5f``),
+    which broke byte-exact density off the reference platform. Computing in
+    wide-precision ``Decimal`` and letting ``float()`` round to the nearest
+    double yields the correctly-rounded result on any host -- bit-identical
+    to the doubles captured on the reference platform, where ``math.log10``
+    already happened to be correctly rounded. This runs three times per scan
+    (once per channel) on a scalar, so the ``Decimal`` cost is irrelevant.
+
+    ``value`` is a finite float64, so ``Decimal(value)`` is its exact value;
+    60 digits keeps the ln/ln10 quotient far enough from any rounding
+    boundary that the final ``float()`` is correctly rounded.
+    """
+
+    with localcontext() as ctx:
+        ctx.prec = 60
+        return float(Decimal(value).ln() / Decimal(10).ln())
+
+
+def verify_nikon_density_arithmetic_backend() -> None:
+    """Fail closed unless the correctly-rounded log10 reproduces the refs.
+
+    The recovered multiply/divide/divide order plus a correctly-rounded
+    ``log10`` (:func:`correctly_rounded_log10`) must reproduce all three
+    pinned Nikon reference doubles exactly. Replaying them at runtime keeps
+    the invariant explicit before any density result can be promoted, and
+    catches a regression in the rounding backend on any platform. The single
+    reference is valid on every host because the backend is now
+    platform-independent, not the host libm.
     """
 
     actual: list[str] = []
@@ -208,11 +236,11 @@ def verify_nikon_density_arithmetic_backend() -> None:
         product = float(numerator) * row_mean
         quotient = product / float(denominator)
         ratio = FULL_SCALE / quotient
-        actual.append(struct.pack(">d", math.log10(ratio)).hex())
+        actual.append(struct.pack(">d", correctly_rounded_log10(ratio)).hex())
     if tuple(actual) != _ARITHMETIC_REFERENCE_BINARY64_BE_HEX:
         raise RuntimeError(
-            "host math.log10 is not bit-exact for the Nikon density reference "
-            f"triplet: got {tuple(actual)!r}"
+            "correctly-rounded log10 does not reproduce the Nikon density "
+            f"reference triplet: got {tuple(actual)!r}"
         )
 
 
@@ -1647,7 +1675,7 @@ def evaluate_nikon_density(
             raise ValueError(
                 f"{CHANNELS[index]} density ratio is not positive and finite"
             )
-        raw = math.log10(ratio)
+        raw = correctly_rounded_log10(ratio)
         if not math.isfinite(raw):
             raise ValueError(f"{CHANNELS[index]} density is not finite")
         lower, upper = _DENSITY_RANGES[index]

--- a/ports/tauri/vendor/coolscanpy/tests/conftest.py
+++ b/ports/tauri/vendor/coolscanpy/tests/conftest.py
@@ -19,47 +19,10 @@ preserved as a direct module import, matching the source layout.
 
 from __future__ import annotations
 
-import struct
-
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def _accepted_nikon_density_test_backend(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Emulate the accepted macOS ``log10`` only in tests on other hosts.
-
-    Production must keep refusing a host whose libm differs by one ULP from
-    the Nikon/macOS reference triplet.  Linux CI still needs to exercise the
-    transport, ownership, and failure-cleanup paths that construct density
-    evidence, though.  Patch only the three exact reference inputs and leave
-    every other ``log10`` call on the real host implementation.
-    """
-    from coolscanpy.protocol.ls5000_single_pass import density
-
-    try:
-        density.verify_nikon_density_arithmetic_backend()
-    except RuntimeError as error:
-        if "host math.log10 is not bit-exact" not in str(error):
-            raise
-    else:
-        return
-
-    host_log10 = density.math.log10
-    accepted: dict[float, float] = {}
-    for numerator, denominator, row_mean, expected_hex in zip(
-        density._ARITHMETIC_REFERENCE_NUMERATORS,
-        density._ARITHMETIC_REFERENCE_DENOMINATORS,
-        density._ARITHMETIC_REFERENCE_ROW_MEANS,
-        density._ARITHMETIC_REFERENCE_BINARY64_BE_HEX,
-        strict=True,
-    ):
-        product = float(numerator) * row_mean
-        quotient = product / float(denominator)
-        ratio = density.FULL_SCALE / quotient
-        accepted[ratio] = struct.unpack(">d", bytes.fromhex(expected_hex))[0]
-
-    def accepted_log10(value: float) -> float:
-        return accepted.get(value, host_log10(value))
-
-    monkeypatch.setattr(density.math, "log10", accepted_log10)
-    density.verify_nikon_density_arithmetic_backend()
+# The density arithmetic backend used to depend on the host libm's log10,
+# which is 1 ULP off on glibc x86_64 for the red reference input. An autouse
+# fixture here patched the three reference ratios so non-macOS CI could still
+# exercise the density-evidence paths. The backend is now correctly-rounded
+# and platform-independent (density.correctly_rounded_log10), so
+# verify_nikon_density_arithmetic_backend() passes on every host and no such
+# workaround is needed; the fixture was removed rather than left as dead code.

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_density.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_density.py
@@ -435,6 +435,53 @@ def test_density_evaluator_uses_first_maximum_and_skips_saturated_rows() -> None
     )
 
 
+def test_correctly_rounded_log10_reproduces_reference_triplet_on_any_libm() -> None:
+    # The density backend must be platform-independent: glibc x86_64 rounds the
+    # red reference input one ULP low via math.log10 (3fd8b159777b9d5e), where
+    # the correctly-rounded value is 3fd8b159777b9d5f. correctly_rounded_log10
+    # must reproduce all three captured reference doubles regardless of the
+    # host libm, so a single pinned reference stays valid on every platform.
+    from coolscanpy.protocol.ls5000_single_pass.density import (
+        correctly_rounded_log10,
+        _ARITHMETIC_REFERENCE_BINARY64_BE_HEX,
+        _ARITHMETIC_REFERENCE_DENOMINATORS,
+        _ARITHMETIC_REFERENCE_NUMERATORS,
+        _ARITHMETIC_REFERENCE_ROW_MEANS,
+        FULL_SCALE,
+    )
+
+    actual = []
+    for numerator, denominator, row_mean in zip(
+        _ARITHMETIC_REFERENCE_NUMERATORS,
+        _ARITHMETIC_REFERENCE_DENOMINATORS,
+        _ARITHMETIC_REFERENCE_ROW_MEANS,
+        strict=True,
+    ):
+        ratio = FULL_SCALE / ((float(numerator) * row_mean) / float(denominator))
+        actual.append(struct.pack(">d", correctly_rounded_log10(ratio)).hex())
+    assert tuple(actual) == _ARITHMETIC_REFERENCE_BINARY64_BE_HEX
+
+    # The exact red-channel ratio whose glibc math.log10 is 1 ULP low: pin the
+    # correctly-rounded result directly so the backend can't silently regress
+    # to a libm passthrough.
+    red_ratio = FULL_SCALE / (
+        (float(_ARITHMETIC_REFERENCE_NUMERATORS[0]) * _ARITHMETIC_REFERENCE_ROW_MEANS[0])
+        / float(_ARITHMETIC_REFERENCE_DENOMINATORS[0])
+    )
+    assert struct.pack(">d", correctly_rounded_log10(red_ratio)).hex() == (
+        "3fd8b159777b9d5f"
+    )
+    # Sanity: correctly-rounded never disagrees with libm by more than 1 ULP.
+    for value in (2.4312216427815936, 10.0, 1.0000000001, 999.999):
+        cr = correctly_rounded_log10(value)
+        assert abs(cr - math.log10(value)) <= abs(cr) * 2**-52 + 5e-324
+
+
+def test_verify_nikon_density_arithmetic_backend_passes_after_fix() -> None:
+    # Must not raise on any host now that the backend is correctly-rounded.
+    verify_nikon_density_arithmetic_backend()
+
+
 def test_archived_density_means_reproduce_all_three_binary64_outputs_exactly() -> None:
     image = _archived_means_source_image()
     wire = _wire_from_image(image)
@@ -699,13 +746,15 @@ def test_runtime_arithmetic_gate_refuses_one_ulp_log10_drift(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     verify_nikon_density_arithmetic_backend()
-    real_log10 = density_module.math.log10
+    real_backend = density_module.correctly_rounded_log10
 
     def drifted_log10(value: float) -> float:
-        return math.nextafter(real_log10(value), math.inf)
+        return math.nextafter(real_backend(value), math.inf)
 
-    monkeypatch.setattr(density_module.math, "log10", drifted_log10)
-    with pytest.raises(RuntimeError, match="not bit-exact"):
+    # The guard now validates the correctly-rounded backend itself (not the
+    # host libm): a 1-ULP drift in that backend must still fail closed.
+    monkeypatch.setattr(density_module, "correctly_rounded_log10", drifted_log10)
+    with pytest.raises(RuntimeError, match="does not reproduce"):
         verify_nikon_density_arithmetic_backend()
 
 


### PR DESCRIPTION
## The bug (deepest of the Linux-preview blockers, found live)

Driving a real LS-5000 from Linux, the preview moved film for ~60s then failed closed:

```
PyCoolscanError: RuntimeError: host math.log10 is not bit-exact for the Nikon density reference triplet
```

`verify_nikon_density_arithmetic_backend()` pins three binary64 `log10` results captured on macOS-arm64 and required the host libm to reproduce them. **glibc x86_64 rounds the red reference input one ULP low** — `3fd8b159777b9d5e` vs the correctly-rounded `3fd8b159777b9d5f`. High-precision check confirms the pinned reference is the correctly-rounded value (err 2.0e-17) and glibc is wrong (3.5e-17); green/blue match. So on Linux the density guard could never pass and no preview/scan could complete.

## The fix

`log10` in the density path runs **exactly three times per scan** (once per channel, on a scalar row-mean), so correctness is free: compute in 60-digit `Decimal` and let `float()` round to nearest double — the correctly-rounded result on every host.

- **Byte-identical on macOS-arm64** (its `math.log10` was already correctly rounded here, so output doesn't change and the validated baseline still holds).
- **Corrects glibc** (`…9d5e` → `…9d5f`).
- One pinned reference is now valid on every platform, because the backend is platform-independent rather than the host libm.

Verified on both macOS and glibc x86_64: all three references reproduce exactly; the guard passes on glibc where it was failing.

## Details

- The guard now validates that the correctly-rounded backend reproduces the references (message: "does not reproduce"), and its 1-ULP drift test patches that backend.
- `tests/conftest.py` had an autouse fixture that patched the three ratios so non-macOS CI could run the density paths — removed, since the backend is now platform-independent (that workaround was itself a symptom of this bug).
- `bundle.py`'s `density.py` component sha re-pinned; the aggregate `CAPTURE_BUNDLE_SHA256` derives from it. Full coolscanpy suite green; `ports/tauri/vendor` mirror synced; `check_ports_vendor_sync.sh` passes.
- Ships to PyPI in lockstep with the next coolscanpy release.

Second of the three-defect Linux-preview fix set (#61 packaging; this density; webview create→state.project still open).