### PR TITLE
release: coolscanpy 0.5.0 version sync for v0.7.0-beta.2

### DIFF
--- a/bridge/uv.lock
+++ b/bridge/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/coolscanpy/CHANGELOG.md
+++ b/coolscanpy/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 0.5.0 - 2026-08-09
+
+- Linux SG_IO transport for FireWire Coolscans
+  (`coolscanpy.transport.linux_sg`): the Linux twin of `macos_scsi`, a
+  pure-ctypes client for the kernel's v3 `SG_IO` interface over the
+  `/dev/sg*` nodes `firewire-sbp2` publishes. Same surface as the macOS
+  lane -- sysfs discovery with the Nikon identity filter, an exclusive
+  `O_EXCL` claim, a fail-closed synchronous transaction primitive, a
+  motion-free probe CLI, and the shared 1 MB chunking policy. Struct
+  layout and constants are transcribed from the kernel v6.6 headers, with
+  an independent LP64 ABI oracle in the tests. Scanning on the FireWire
+  models stays deliberately refused pending real-hardware captures
+  (FIREWIRE.md, issue #28).
+- Density arithmetic is now bit-exact on any libm. `math.log10` is not
+  correctly rounded on every platform (glibc x86_64 rounds the red Nikon
+  density reference input one ULP low), which broke byte-exact density off
+  the reference platform. The density path now uses a correctly-rounded
+  `log10` (60-digit `Decimal`, round-to-nearest-double); it is
+  byte-identical on macOS-arm64 (already correctly rounded) and corrects
+  glibc, so a single pinned reference is valid on every host.
+
 ## 0.4.0 - 2026-08-09
 
 - macOS SCSI transport for FireWire Coolscans (`coolscanpy.transport.macos_scsi`):

--- a/coolscanpy/pyproject.toml
+++ b/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.4.0"
+version = "0.5.0"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/coolscanpy/uv.lock
+++ b/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/coolscanpy/CHANGELOG.md
+++ b/ports/tauri/vendor/coolscanpy/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 0.5.0 - 2026-08-09
+
+- Linux SG_IO transport for FireWire Coolscans
+  (`coolscanpy.transport.linux_sg`): the Linux twin of `macos_scsi`, a
+  pure-ctypes client for the kernel's v3 `SG_IO` interface over the
+  `/dev/sg*` nodes `firewire-sbp2` publishes. Same surface as the macOS
+  lane -- sysfs discovery with the Nikon identity filter, an exclusive
+  `O_EXCL` claim, a fail-closed synchronous transaction primitive, a
+  motion-free probe CLI, and the shared 1 MB chunking policy. Struct
+  layout and constants are transcribed from the kernel v6.6 headers, with
+  an independent LP64 ABI oracle in the tests. Scanning on the FireWire
+  models stays deliberately refused pending real-hardware captures
+  (FIREWIRE.md, issue #28).
+- Density arithmetic is now bit-exact on any libm. `math.log10` is not
+  correctly rounded on every platform (glibc x86_64 rounds the red Nikon
+  density reference input one ULP low), which broke byte-exact density off
+  the reference platform. The density path now uses a correctly-rounded
+  `log10` (60-digit `Decimal`, round-to-nearest-double); it is
+  byte-identical on macOS-arm64 (already correctly rounded) and corrects
+  glibc, so a single pinned reference is valid on every host.
+
 ## 0.4.0 - 2026-08-09
 
 - macOS SCSI transport for FireWire Coolscans (`coolscanpy.transport.macos_scsi`):

--- a/ports/tauri/vendor/coolscanpy/pyproject.toml
+++ b/ports/tauri/vendor/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.4.0"
+version = "0.5.0"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/ports/tauri/vendor/coolscanpy/uv.lock
+++ b/ports/tauri/vendor/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/scanstudio-bridge/uv.lock
+++ b/ports/tauri/vendor/scanstudio-bridge/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/scripts/check_coolscanpy_pypi_sync.sh
+++ b/scripts/check_coolscanpy_pypi_sync.sh
@@ -37,7 +37,7 @@ KNOWN_VENDORED_DIVERGENCE=(
   # its export surface for the class above
   "protocol/ls5000_single_pass/__init__.py|ce8aa97b707f5ef83f96128b378722191f7280bd41c1f3acbb04c75e3ea7523e|1f0f324034a95e2c8ca772ce52a78a800b0bf215d3ae4ec77422b08b1376856c"
   # pins differ because the two files above differ
-  "protocol/ls5000_single_pass/bundle.py|7c6d2afdf7835027cb6e96f0b91d74fcc2d2909fc0d26f4e0e9ebc62987c5a86|b96e91ebc65db338a8125625b30878780e2200e62048a8ba89d84f05dce5012d"
+  "protocol/ls5000_single_pass/bundle.py|10f2aedb2f7a371879098c7e0cfb31c58854fbccd0c46cb57f059fceb93f0559|ea18f5225b77ee7e54bd7c5bdf876b8a842fd895310ea8202a22482047c2c4bb"
   # packaged-app libusb resolution (app bundles its own signed binary)
   "protocol/ls5000_single_pass/usb_backend.py|afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62|666a476ce706a4a854aac50116575e7143f5a1a7c1b1085125347696d89348d1"
   # capture-timing receipt fields (started_at/duration)


### PR DESCRIPTION
Version-sync prep for the **v0.7.0-beta.2** release carrying the three Linux-preview fixes (#61 packaging, #62 density log10, #63 webview gate).

Bumps the bundled + vendored coolscanpy driver **0.4.0 → 0.5.0** (pyproject, CHANGELOG, uv.lock) and the bridge locks that pin it — same surface as prior version-sync PRs (#48/#52/#56). coolscanpy 0.5.0 carries:
- Linux SG_IO FireWire transport (`coolscanpy.transport.linux_sg`)
- correctly-rounded density `log10` (bit-exact on any libm)

## Release sequence (lockstep — order matters)

The release build's coolscanpy PyPI sync gate byte-compares the bundled driver against the **published PyPI sdist**, so:

1. **Publish coolscanpy 0.5.0 to PyPI** from the canonical repo (`rohanpandula/coolscanpy`, `port/cross-platform`) — it must carry linux_sg.py + the density fix so it matches the bundle. *(Requires PyPI credentials.)*
2. **Merge this PR.**
3. **Tag `v0.7.0-beta.2`** → the release workflow builds the 8 assets, the sync gate passes against the now-live PyPI 0.5.0, and it publishes.

Tagging before step 1 fails the gate by design.