### PR TITLE
Preview before project creation, serialized device operations

### DIFF
--- a/ports/tauri/app/src/__tests__/App.test.tsx
+++ b/ports/tauri/app/src/__tests__/App.test.tsx
@@ -167,6 +167,10 @@ describe("App shell reachability (06-03 Task 2)", () => {
         event: "scanner.thumbnail",
         payload: { frameIndex: 5, thumbnail: { brightness: 0.5 }, operationId },
       });
+      handle.emitEvent({
+        event: "scanner.thumbnailsComplete",
+        payload: { count: 36, operationId },
+      });
     });
 
     // Frame-detail reachability: select exactly one frame, then inspect.

--- a/ports/tauri/app/src/session/__tests__/policy-job-lifecycle.test.ts
+++ b/ports/tauri/app/src/session/__tests__/policy-job-lifecycle.test.ts
@@ -230,6 +230,14 @@ describe("SessionStore job lifecycle (scripted transport)", () => {
     } satisfies WireEvent);
     expect(store.getState().frameReceipts[13]).toEqual([first]);
 
+    handle.emitEvent({
+      event: "scan.completed",
+      payload: {
+        jobId: "job-1",
+        summary: { completed: [13], failed: [], skipped: [1], stopped: false },
+      },
+    } satisfies WireEvent);
+
     // A later job re-scanning the same frame appends, preserving history.
     await store.startScan([13], CAPTURE_RECIPE);
     const second = { ...receiptFor(13, 2100), jobId: "job-1" };

--- a/ports/tauri/app/src/session/__tests__/policy-preproject-preview.test.ts
+++ b/ports/tauri/app/src/session/__tests__/policy-preproject-preview.test.ts
@@ -1,0 +1,730 @@
+import { describe, expect, it } from "vitest";
+import { SessionStore, preProjectPreviewRegistration } from "../store/session";
+import { createScriptedTransport } from "../testing/harness";
+import type { DeviceInfo, ScanProject, ScannerStatus } from "../wire/types";
+
+const DEVICE: DeviceInfo = {
+  deviceId: "sim-strip",
+  model: "LS-5000 (simulated)",
+  kind: "simulated",
+  firmware: "sim-1",
+  connection: "virtual",
+};
+
+const STATUS: ScannerStatus = {
+  connected: true,
+  adapter: "SA-21",
+  mediaLoaded: true,
+  carrier: "strip6",
+  frameCount: 2,
+  lamp: "stable",
+  transport: "idle",
+  activeJobId: null,
+};
+
+function project(filmProcess: ScanProject["filmProcess"] = "bwNegative"): ScanProject {
+  return {
+    schemaVersion: 4,
+    id: "project-attached",
+    name: "Attached strip",
+    carrier: "strip6",
+    frameCount: 2,
+    filmProcess,
+    recipes: {
+      archive: {
+        enabled: false,
+        filenameTemplate: "scan_{frame:04d}",
+        destination: "/tmp/attached",
+      },
+      positive: {
+        enabled: true,
+        fileFormat: "tiff",
+        colorProfile: "adobeRgb1998",
+        filenameTemplate: "scan_{frame:04d}",
+        destination: "/tmp/attached",
+      },
+      preview: {
+        enabled: false,
+        fileFormat: "jpeg",
+        maxLongEdgePx: 1024,
+        filenameTemplate: "preview_{frame:04d}",
+        destination: "/tmp/attached",
+      },
+    },
+    rollMetadata: { keywords: [] },
+    createdAt: "2026-08-10T00:00:00Z",
+    frames: [1, 2].map((index) => ({ index, excluded: false, receipts: [] })),
+  };
+}
+
+function fixture() {
+  const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+  let persistedProject = project();
+  const handle = createScriptedTransport({
+    onRequest: (method, params) => {
+      calls.push({ method, params: params as Record<string, unknown> });
+      if (method === "scanner.connect") return { result: { device: DEVICE, status: STATUS } };
+      if (method === "scanner.acquireThumbnails") {
+        return { result: { accepted: true, frames: [1, 2] } };
+      }
+      if (method === "project.create") {
+        persistedProject = project();
+        return { result: { project: persistedProject, directory: "/tmp/attached" } };
+      }
+      if (method === "project.setFrameAlignment") {
+        const request = params as {
+          frameIndex: number;
+          alignment: ScanProject["frames"][number]["alignment"] | null;
+        };
+        persistedProject = {
+          ...persistedProject,
+          frames: persistedProject.frames.map((frame) => {
+            if (frame.index !== request.frameIndex) return frame;
+            if (request.alignment === null) {
+              const { alignment: _removed, ...withoutAlignment } = frame;
+              return withoutAlignment;
+            }
+            return { ...frame, alignment: request.alignment };
+          }),
+        };
+        return { result: { project: persistedProject } };
+      }
+      if (method === "project.open") {
+        return { result: { project: persistedProject, directory: "/tmp/attached" } };
+      }
+      if (method === "scan.start") return { result: { jobId: "job-active" } };
+      return { result: undefined };
+    },
+  });
+  return { store: new SessionStore(handle.transport), handle, calls };
+}
+
+async function completePreview() {
+  const value = fixture();
+  await value.store.connect(DEVICE.deviceId);
+  value.store.setPreviewFilmProcess("bwNegative");
+  await value.store.acquireThumbnails();
+  const operationId = value.calls.find(
+    (call) => call.method === "scanner.acquireThumbnails",
+  )?.params.operationId as string;
+  for (const frameIndex of [1, 2]) {
+    value.handle.emitEvent({
+      event: "scanner.thumbnail",
+      payload: {
+        frameIndex,
+        thumbnail: { brightness: frameIndex / 3 },
+        operationId,
+      },
+    });
+  }
+  value.handle.emitEvent({
+    event: "scanner.thumbnailsComplete",
+    payload: { count: 2, operationId },
+  });
+  return { ...value, operationId };
+}
+
+describe("pre-project preview attachment", () => {
+  it("recognizes only an exact, fully correlated completed registration", async () => {
+    const { store, operationId } = await completePreview();
+    expect(preProjectPreviewRegistration(store.getState())).toEqual({
+      operationId,
+      carrier: "strip6",
+      frameCount: 2,
+      filmProcess: "bwNegative",
+    });
+  });
+
+  it("keeps the completed token through the real backend's correlated terminal status", async () => {
+    const emptyStatus: ScannerStatus = {
+      ...STATUS,
+      mediaLoaded: false,
+      carrier: null,
+      frameCount: null,
+      motionArmed: true,
+      filmPresent: true,
+    };
+    const realDevice: DeviceInfo = { ...DEVICE, kind: "real" };
+    let operationId = "";
+    const handle = createScriptedTransport({
+      onRequest: (method, params) => {
+        if (method === "scanner.connect") {
+          return { result: { device: realDevice, status: emptyStatus } };
+        }
+        if (method === "scanner.acquireThumbnails") {
+          operationId = (params as Record<string, unknown>).operationId as string;
+          return { result: { accepted: true, frames: [1, 2] } };
+        }
+        return { result: undefined };
+      },
+    });
+    const store = new SessionStore(handle.transport);
+    await store.connect(realDevice.deviceId);
+    store.setPreviewFilmProcess("bwNegative");
+    await store.acquireThumbnails();
+    for (const frameIndex of [1, 2]) {
+      handle.emitEvent({
+        event: "scanner.thumbnail",
+        payload: { frameIndex, thumbnail: { brightness: 0.5 }, operationId },
+      });
+    }
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 2, operationId },
+    });
+    expect(preProjectPreviewRegistration(store.getState())).toBeNull();
+
+    handle.emitEvent({
+      event: "scanner.status",
+      payload: { status: STATUS, operationId },
+    });
+
+    expect(store.getState().latestCompletedPreviewOperationId).toBe(operationId);
+    expect(preProjectPreviewRegistration(store.getState())).toMatchObject({
+      operationId,
+      carrier: "strip6",
+      frameCount: 2,
+      filmProcess: "bwNegative",
+    });
+  });
+
+  it("waits for this real preview's correlated status instead of reusing an old same-count holder", async () => {
+    const realDevice: DeviceInfo = { ...DEVICE, kind: "real" };
+    const priorStatus: ScannerStatus = {
+      ...STATUS,
+      carrier: "mounted",
+      frameCount: 1,
+      motionArmed: true,
+      filmPresent: true,
+    };
+    const detectedStatus: ScannerStatus = {
+      ...priorStatus,
+      carrier: "strip6",
+    };
+    let operationId = "";
+    const handle = createScriptedTransport({
+      onRequest: (method, params) => {
+        if (method === "scanner.connect") {
+          return { result: { device: realDevice, status: priorStatus } };
+        }
+        if (method === "scanner.acquireThumbnails") {
+          operationId = (params as Record<string, unknown>).operationId as string;
+          return { result: { accepted: true, frames: [1] } };
+        }
+        return { result: undefined };
+      },
+    });
+    const store = new SessionStore(handle.transport);
+    await store.connect(realDevice.deviceId);
+    store.setPreviewFilmProcess("bwNegative");
+    await store.acquireThumbnails();
+    handle.emitEvent({
+      event: "scanner.thumbnail",
+      payload: { frameIndex: 1, thumbnail: { brightness: 0.5 }, operationId },
+    });
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 1, operationId },
+    });
+
+    expect(store.getState().previewOutcome).toBe("succeeded");
+    expect(preProjectPreviewRegistration(store.getState())).toBeNull();
+
+    handle.emitEvent({
+      event: "scanner.status",
+      payload: { status: detectedStatus, operationId },
+    });
+    expect(preProjectPreviewRegistration(store.getState())).toMatchObject({
+      operationId,
+      carrier: "strip6",
+      frameCount: 1,
+    });
+  });
+
+  it("drops out-of-range tiles when a correlated real re-preview detects fewer frames", async () => {
+    const realDevice: DeviceInfo = { ...DEVICE, kind: "real" };
+    const firstStatus: ScannerStatus = {
+      ...STATUS,
+      motionArmed: true,
+      filmPresent: true,
+    };
+    const secondStatus: ScannerStatus = {
+      ...firstStatus,
+      adapter: "MA-21",
+      carrier: "mounted",
+      frameCount: 1,
+    };
+    const operationIds: string[] = [];
+    const handle = createScriptedTransport({
+      onRequest: (method, params) => {
+        if (method === "scanner.connect") {
+          return { result: { device: realDevice, status: firstStatus } };
+        }
+        if (method === "scanner.acquireThumbnails") {
+          const operationId = (params as Record<string, unknown>).operationId as string;
+          operationIds.push(operationId);
+          return { result: { accepted: true, frames: operationIds.length === 1 ? [1, 2] : [1] } };
+        }
+        return { result: undefined };
+      },
+    });
+    const store = new SessionStore(handle.transport);
+    await store.connect(realDevice.deviceId);
+    await store.acquireThumbnails();
+    for (const frameIndex of [1, 2]) {
+      handle.emitEvent({
+        event: "scanner.thumbnail",
+        payload: {
+          frameIndex,
+          thumbnail: { brightness: 0.5 },
+          operationId: operationIds[0],
+        },
+      });
+    }
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 2, operationId: operationIds[0] },
+    });
+    handle.emitEvent({
+      event: "scanner.status",
+      payload: { status: firstStatus, operationId: operationIds[0] },
+    });
+    expect(Object.keys(store.getState().thumbnails).map(Number)).toEqual([1, 2]);
+
+    await store.acquireThumbnails();
+    expect(store.getState().thumbnails).toEqual({});
+    handle.emitEvent({
+      event: "scanner.thumbnail",
+      payload: {
+        frameIndex: 1,
+        thumbnail: { brightness: 0.6 },
+        operationId: operationIds[1],
+      },
+    });
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 1, operationId: operationIds[1] },
+    });
+    handle.emitEvent({
+      event: "scanner.status",
+      payload: { status: secondStatus, operationId: operationIds[1] },
+    });
+
+    expect(Object.keys(store.getState().thumbnails).map(Number)).toEqual([1]);
+    expect(preProjectPreviewRegistration(store.getState())).toMatchObject({
+      operationId: operationIds[1],
+      carrier: "mounted",
+      frameCount: 1,
+    });
+  });
+
+  it("keeps an invalidated preview lane locked until its correlated terminal", async () => {
+    const { store, handle, calls } = fixture();
+    await store.connect(DEVICE.deviceId);
+    await store.acquireThumbnails();
+    const operationId = calls.find(
+      (call) => call.method === "scanner.acquireThumbnails",
+    )?.params.operationId as string;
+    handle.emitEvent({
+      event: "scanner.thumbnail",
+      payload: { frameIndex: 1, thumbnail: { brightness: 0.5 }, operationId },
+    });
+
+    handle.emitEvent({
+      event: "scanner.status",
+      payload: { status: { ...STATUS, carrier: "mounted", frameCount: 1 } },
+    });
+
+    expect(store.getState().activeOperationId).toBe(operationId);
+    expect(store.getState().previewOutcome).toBe("active");
+    expect(store.getState().thumbnails).toEqual({});
+    await expect(store.acquireThumbnails()).rejects.toMatchObject({
+      code: "INVALID_PARAMS",
+      message: expect.stringMatching(/already active/),
+    });
+
+    handle.emitEvent({
+      event: "scanner.thumbnailsFailed",
+      payload: {
+        code: "BRIDGE_STREAM_STALLED",
+        message: "stale worker failed after its media was retired",
+        operationId,
+      },
+    });
+    expect(store.getState().previewOutcome).toBe("active");
+    expect(store.getState().previewError).toBeNull();
+
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 1, operationId },
+    });
+    expect(store.getState().activeOperationId).toBeNull();
+    expect(store.getState().previewOutcome).toBeNull();
+    expect(store.getState().latestCompletedPreviewOperationId).toBeNull();
+    expect(store.getState().previewFilmProcess).toBeNull();
+  });
+
+  it("refuses preview and project changes until a failed worker releases its lane", async () => {
+    const { store, handle, calls } = fixture();
+    await store.connect(DEVICE.deviceId);
+    await store.acquireThumbnails();
+    const activeOperationId = store.getState().activeOperationId;
+
+    await expect(
+      store.createProject("Unsafe", "strip6", 2, "c41ColorNegative"),
+    ).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+    await expect(store.openProject("/tmp/unsafe")).rejects.toMatchObject({
+      code: "INVALID_PARAMS",
+    });
+    await expect(
+      store.startScan([1], {
+        resolutionDpi: 4000,
+        bitDepth: 16,
+        multisamplePasses: 1,
+        channels: "rgbi",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+
+    expect(calls.some((call) => call.method === "project.create")).toBe(false);
+    expect(calls.some((call) => call.method === "project.open")).toBe(false);
+    expect(store.getState().activeOperationId).toBe(activeOperationId);
+    expect(store.getState().previewOutcome).toBe("active");
+
+    handle.emitEvent({
+      event: "scanner.thumbnailsFailed",
+      payload: {
+        code: "BRIDGE_STREAM_STALLED",
+        message: "worker is winding down",
+        operationId: activeOperationId,
+      },
+    });
+    expect(store.getState().previewOutcome).toBe("failed");
+    expect(store.getState().activeOperationId).toBe(activeOperationId);
+
+    await expect(store.acquireThumbnails()).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+    await expect(
+      store.createProject("Unsafe", "strip6", 2, "c41ColorNegative"),
+    ).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+    await expect(store.openProject("/tmp/unsafe")).rejects.toMatchObject({
+      code: "INVALID_PARAMS",
+    });
+    expect(calls.filter((call) => call.method === "scanner.acquireThumbnails")).toHaveLength(1);
+    expect(calls.some((call) => call.method === "project.create")).toBe(false);
+    expect(calls.some((call) => call.method === "project.open")).toBe(false);
+
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 0, operationId: activeOperationId },
+    });
+    expect(store.getState().activeOperationId).toBeNull();
+  });
+
+  it("blocks previews and project switches while a scan owns the session", async () => {
+    const { store, handle, calls } = fixture();
+    await store.createProject("Scanning", "strip6", 2, "bwNegative");
+    await store.startScan([1], {
+      resolutionDpi: 4000,
+      bitDepth: 16,
+      multisamplePasses: 1,
+      channels: "rgbi",
+    });
+    handle.emitEvent({
+      event: "scan.jobState",
+      payload: { jobId: "job-active", state: "scanning" },
+    });
+    const wireCount = calls.length;
+
+    await expect(store.acquireThumbnails()).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+    await expect(
+      store.createProject("Other", "strip6", 2, "bwNegative"),
+    ).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+    await expect(store.openProject("/tmp/other")).rejects.toMatchObject({
+      code: "INVALID_PARAMS",
+    });
+    await expect(
+      store.startScan([2], {
+        resolutionDpi: 4000,
+        bitDepth: 16,
+        multisamplePasses: 1,
+        channels: "rgbi",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+    expect(calls).toHaveLength(wireCount);
+    expect(store.getState().jobId).toBe("job-active");
+    expect(store.getState().jobState).toBe("scanning");
+  });
+
+  it("locks preview, project actions, and transforms across a slow project boundary", async () => {
+    let resolveCreate!: (value: unknown) => void;
+    const createResponse = new Promise<unknown>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const calls: string[] = [];
+    const handle = createScriptedTransport({
+      onRequest: (method) => {
+        calls.push(method);
+        if (method === "project.create") return { result: createResponse };
+        return { result: undefined };
+      },
+    });
+    const store = new SessionStore(handle.transport);
+
+    const creating = store.createProject("Slow", "strip6", 2, "bwNegative");
+    expect(store.getState().projectChangePending).toBe(true);
+    expect(store.frameTransformsAreEditable()).toBe(false);
+    store.rotateFrames([1], 90);
+    expect(store.getState().frameAlignmentDrafts).toEqual({});
+
+    await expect(store.acquireThumbnails()).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+    await expect(store.openProject("/tmp/other")).rejects.toMatchObject({
+      code: "INVALID_PARAMS",
+    });
+    await expect(
+      store.createProject("Other", "strip6", 2, "bwNegative"),
+    ).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+    await expect(store.setSpacingOffset(1, 0)).rejects.toMatchObject({
+      code: "INVALID_PARAMS",
+    });
+    expect(calls).toEqual(["project.create"]);
+
+    resolveCreate({ project: project(), directory: "/tmp/attached" });
+    await creating;
+    expect(store.getState().projectChangePending).toBe(false);
+    expect(store.getState().project?.id).toBe("project-attached");
+  });
+
+  it("publishes a store-wide lock while a device connection change is in flight", async () => {
+    let resolveConnect!: (value: unknown) => void;
+    const connectResponse = new Promise<unknown>((resolve) => {
+      resolveConnect = resolve;
+    });
+    const calls: string[] = [];
+    const handle = createScriptedTransport({
+      onRequest: (method) => {
+        calls.push(method);
+        if (method === "scanner.connect") return { result: connectResponse };
+        return { result: undefined };
+      },
+    });
+    const store = new SessionStore(handle.transport);
+    const connecting = store.connect(DEVICE.deviceId);
+
+    expect(store.getState().connectionChangePending).toBe(true);
+    await expect(store.acquireThumbnails()).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+    await expect(
+      store.createProject("Blocked", "strip6", 2, "bwNegative"),
+    ).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+    expect(calls).toEqual(["scanner.connect"]);
+
+    handle.emitEvent({ event: "scanner.status", payload: { status: STATUS } });
+    expect(store.getState().connection).toMatchObject({
+      connected: false,
+      device: null,
+    });
+
+    resolveConnect({ device: DEVICE, status: STATUS });
+    await connecting;
+    expect(store.getState().connectionChangePending).toBe(false);
+    expect(store.getState().connection.connected).toBe(true);
+  });
+
+  it("waits for an in-flight spacing adjustment before attaching and persisting the project", async () => {
+    let resolveSpacing!: (value: unknown) => void;
+    const spacingResponse = new Promise<unknown>((resolve) => {
+      resolveSpacing = resolve;
+    });
+    let operationId = "";
+    let persistedProject = project();
+    const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const handle = createScriptedTransport({
+      onRequest: (method, params) => {
+        const request = params as Record<string, unknown>;
+        calls.push({ method, params: request });
+        if (method === "scanner.connect") {
+          return { result: { device: DEVICE, status: STATUS } };
+        }
+        if (method === "scanner.acquireThumbnails") {
+          operationId = request.operationId as string;
+          return { result: { accepted: true, frames: [1, 2] } };
+        }
+        if (method === "roll.setSpacingOffset") return { result: spacingResponse };
+        if (method === "project.create") {
+          persistedProject = project();
+          return { result: { project: persistedProject, directory: "/tmp/attached" } };
+        }
+        if (method === "project.setFrameAlignment") {
+          const frameIndex = request.frameIndex as number;
+          const alignment = request.alignment as ScanProject["frames"][number]["alignment"];
+          persistedProject = {
+            ...persistedProject,
+            frames: persistedProject.frames.map((frame) =>
+              frame.index === frameIndex ? { ...frame, alignment } : frame,
+            ),
+          };
+          return { result: { project: persistedProject } };
+        }
+        return { result: undefined };
+      },
+    });
+    const store = new SessionStore(handle.transport);
+    await store.connect(DEVICE.deviceId);
+    store.setPreviewFilmProcess("bwNegative");
+    await store.acquireThumbnails();
+    for (const frameIndex of [1, 2]) {
+      handle.emitEvent({
+        event: "scanner.thumbnail",
+        payload: { frameIndex, thumbnail: { brightness: 0.5 }, operationId },
+      });
+    }
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 2, operationId },
+    });
+
+    const adjusting = store.setSpacingOffset(1, 12);
+    expect(store.getState().frameAlignmentMutationPending).toBe(true);
+    await expect(
+      store.createProject("Too soon", "strip6", 2, "bwNegative"),
+    ).rejects.toMatchObject({ code: "INVALID_PARAMS" });
+    expect(calls.some((call) => call.method === "project.create")).toBe(false);
+
+    resolveSpacing({ thumbnail: { brightness: 0.5, spacingOffset: 12 } });
+    await adjusting;
+    expect(store.getState().frameAlignmentDrafts[1]?.offsetRows).toBe(12);
+
+    await store.createProject("Attached", "strip6", 2, "bwNegative");
+    expect(
+      calls.find((call) => call.method === "project.setFrameAlignment")?.params,
+    ).toMatchObject({ frameIndex: 1, alignment: { offsetRows: 12 } });
+    expect(
+      store.getState().project?.frames.find((frame) => frame.index === 1)?.alignment
+        ?.offsetRows,
+    ).toBe(12);
+  });
+
+  it("does not replay unsaved alignment from one physical roll onto the next", async () => {
+    const { store, handle, calls } = await completePreview();
+    store.rotateFrames([1], 90);
+    expect(store.getState().frameAlignmentDrafts[1]).toBeDefined();
+
+    handle.emitEvent({
+      event: "scanner.status",
+      payload: {
+        status: { ...STATUS, carrier: "mounted", frameCount: 1 },
+      },
+    });
+
+    expect(store.getState().frameAlignmentDrafts).toEqual({});
+    await store.acquireThumbnails();
+    const acquireCalls = calls.filter(
+      (call) => call.method === "scanner.acquireThumbnails",
+    );
+    const secondOperationId = acquireCalls[acquireCalls.length - 1]
+      .params.operationId as string;
+    handle.emitEvent({
+      event: "scanner.thumbnail",
+      payload: {
+        frameIndex: 1,
+        thumbnail: { brightness: 0.5 },
+        operationId: secondOperationId,
+      },
+    });
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 1, operationId: secondOperationId },
+    });
+
+    expect(preProjectPreviewRegistration(store.getState())).toMatchObject({
+      operationId: secondOperationId,
+      carrier: "mounted",
+      frameCount: 1,
+    });
+    expect(store.getState().frameAlignmentDrafts).toEqual({});
+  });
+
+  it("preserves preview identity, tiles, selection, focus, and transforms when saving it", async () => {
+    const { store, operationId, calls } = await completePreview();
+    store.toggleFrameSelection(1, false);
+    store.focusFrame(1);
+    store.rotateFrames([1], 90);
+
+    await store.createProject("Attached strip", "strip6", 2, "bwNegative");
+    const state = store.getState();
+
+    expect(state.project?.id).toBe("project-attached");
+    expect(state.latestCompletedPreviewOperationId).toBe(operationId);
+    expect(state.previewOutcome).toBe("succeeded");
+    expect(state.previewFilmProcess).toBe("bwNegative");
+    expect(Object.keys(state.thumbnails).map(Number)).toEqual([1, 2]);
+    expect(state.thumbnailOperationIds).toEqual({ 1: operationId, 2: operationId });
+    expect(state.selectedFrameIndices).toEqual([1]);
+    expect(state.focusedFrameIndex).toBe(1);
+    expect(state.frameAlignmentDrafts[1]?.derivativeTransform?.rotationDegrees).toBe(90);
+    expect(
+      calls.find((call) => call.method === "project.setFrameAlignment")?.params,
+    ).toMatchObject({
+      frameIndex: 1,
+      alignment: {
+        derivativeTransform: { rotationDegrees: 90 },
+      },
+    });
+    expect(
+      state.project?.frames.find((frame) => frame.index === 1)?.alignment
+        ?.derivativeTransform?.rotationDegrees,
+    ).toBe(90);
+
+    await store.openProject("/tmp/attached");
+    expect(
+      store.getState().frameAlignmentDrafts[1]?.derivativeTransform?.rotationDegrees,
+    ).toBe(90);
+  });
+
+  it("refuses a process conflicting with the attached project's authority before the wire", async () => {
+    const { store, calls } = await completePreview();
+    await store.createProject("Attached strip", "strip6", 2, "bwNegative");
+    const before = calls.filter(
+      (call) => call.method === "scanner.acquireThumbnails",
+    ).length;
+
+    await expect(store.acquireThumbnails(undefined, "positive")).rejects.toMatchObject({
+      code: "INVALID_PARAMS",
+      message: expect.stringMatching(/filmProcess conflicts/),
+    });
+    expect(
+      calls.filter((call) => call.method === "scanner.acquireThumbnails"),
+    ).toHaveLength(before);
+  });
+
+  it("surfaces a malformed project.create result as a typed internal error", async () => {
+    const handle = createScriptedTransport({
+      onRequest: (method) =>
+        method === "project.create"
+          ? { result: { project: null, directory: "/tmp/bad" } }
+          : { result: undefined },
+    });
+    const store = new SessionStore(handle.transport);
+
+    await expect(
+      store.createProject("Bad", "strip6", 2, "bwNegative"),
+    ).rejects.toMatchObject({
+      code: "INTERNAL",
+      message: "project.create returned an invalid project",
+    });
+    expect(store.getState().project).toBeNull();
+    expect(store.getState().projectChangePending).toBe(false);
+  });
+
+  it("fully invalidates the attachment when a saved project is opened", async () => {
+    const { store } = await completePreview();
+    await store.openProject("/tmp/attached");
+    const state = store.getState();
+
+    expect(state.latestCompletedPreviewOperationId).toBeNull();
+    expect(state.previewFilmProcess).toBeNull();
+    expect(state.previewOutcome).toBeNull();
+    // The prior tiles may remain visible as stale context, but clearing their
+    // provenance makes them unusable for approval or scan authorization.
+    expect(Object.keys(state.thumbnails).map(Number)).toEqual([1, 2]);
+    expect(state.thumbnailOperationIds).toEqual({});
+  });
+});

--- a/ports/tauri/app/src/session/__tests__/policy-review-fixes.test.ts
+++ b/ports/tauri/app/src/session/__tests__/policy-review-fixes.test.ts
@@ -63,9 +63,12 @@ const PROJECT_WITH_ALIGNED_FRAME: ScanProject = {
   },
   rollMetadata: { keywords: [] },
   createdAt: "2026-07-22T09:00:00Z",
-  frames: [
-    { index: 2, excluded: false, alignment: { offsetRows: 9, approved: true }, receipts: [] },
-  ],
+  frames: Array.from({ length: 36 }, (_, offset) => {
+    const index = offset + 1;
+    return index === 2
+      ? { index, excluded: false, alignment: { offsetRows: 9, approved: true }, receipts: [] }
+      : { index, excluded: false, receipts: [] };
+  }),
 };
 
 async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
@@ -82,6 +85,7 @@ function approvalStore(overrides?: {
   setSpacingOffset?: (params: Record<string, unknown>) => { error: EngineError };
 }) {
   const calls: { method: string; params: Record<string, unknown> }[] = [];
+  let currentProject = structuredClone(PROJECT_WITH_ALIGNED_FRAME);
   const handle = createScriptedTransport({
     onRequest: (method, params) => {
       calls.push({ method, params: params as Record<string, unknown> });
@@ -97,10 +101,26 @@ function approvalStore(overrides?: {
               thumbnail: { imagePath: "/preview/frame-new.png", spacingOffset: 9 },
             },
           };
-        case "project.setFrameAlignment":
-          return { result: { project: PROJECT_WITH_ALIGNED_FRAME } };
+        case "project.setFrameAlignment": {
+          const request = params as {
+            frameIndex: number;
+            alignment: ScanProject["frames"][number]["alignment"] | null;
+          };
+          currentProject = {
+            ...currentProject,
+            frames: currentProject.frames.map((frame) => {
+              if (frame.index !== request.frameIndex) return frame;
+              if (request.alignment === null) {
+                const { alignment: _removed, ...withoutAlignment } = frame;
+                return withoutAlignment;
+              }
+              return { ...frame, alignment: request.alignment };
+            }),
+          };
+          return { result: { project: currentProject } };
+        }
         case "project.open":
-          return { result: { project: PROJECT_WITH_ALIGNED_FRAME, directory: "/proj-b" } };
+          return { result: { project: currentProject, directory: "/proj-b" } };
         case "scan.start":
           return { result: { jobId: "job-1" } };
         default:

--- a/ports/tauri/app/src/session/index.ts
+++ b/ports/tauri/app/src/session/index.ts
@@ -14,5 +14,13 @@ export const sessionStore = new SessionStore(createClientTransport());
 // internals.
 export const diagnosticTimeline = new DiagnosticTimeline();
 
-export { SessionStore };
-export type { SessionState } from "./store/session";
+export {
+  SessionStore,
+  preProjectPreviewRegistration,
+  sessionOperationBusy,
+} from "./store/session";
+export type {
+  FilmProcess,
+  PreProjectPreviewRegistration,
+  SessionState,
+} from "./store/session";

--- a/ports/tauri/app/src/session/store/__tests__/job-run-observation.test.ts
+++ b/ports/tauri/app/src/session/store/__tests__/job-run-observation.test.ts
@@ -56,6 +56,13 @@ describe("scan.progress observation (06-03)", () => {
       payload: { jobId: "job-9", frameIndex: 2, jobPercent: 50, etaSeconds: 5 },
     });
     expect(store.getState().scanProgress).not.toBeNull();
+    emitEvent({
+      event: "scan.completed",
+      payload: {
+        jobId: "job-9",
+        summary: { completed: [1, 2, 3], failed: [], skipped: [], stopped: false },
+      },
+    });
     await store.startScan([1, 2, 3], CAPTURE);
     expect(store.getState().scanProgress).toBeNull();
   });

--- a/ports/tauri/app/src/session/store/__tests__/selection.test.ts
+++ b/ports/tauri/app/src/session/store/__tests__/selection.test.ts
@@ -169,6 +169,49 @@ describe("SessionStore preview outcome exposure", () => {
     const { store } = scriptedFixture();
     expect(store.getState().previewOutcome).toBeNull();
     expect(store.getState().previewError).toBeNull();
+    expect(store.getState().previewRequestFailure).toBeNull();
+    expect(store.getState().previewFilmProcessSelection).toBe("c41ColorNegative");
+    expect(store.getState().previewFilmProcess).toBeNull();
+  });
+
+  it("commits the selected film process only on a correlated successful completion", async () => {
+    const { store, handle, calls } = scriptedFixture();
+    store.setPreviewFilmProcess("bwNegative");
+    await store.acquireThumbnails();
+    const active = calls[0].params.operationId as string;
+
+    expect(calls[0].params.filmProcess).toBe("bwNegative");
+    expect(store.getState().previewFilmProcess).toBeNull();
+
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 3, operationId: "another-operation" },
+    });
+    expect(store.getState().previewFilmProcess).toBeNull();
+
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 3, operationId: active },
+    });
+    expect(store.getState().previewFilmProcess).toBe("bwNegative");
+  });
+
+  it("invalidates a completed registration when the pre-project process changes", async () => {
+    const { store, handle, calls } = scriptedFixture();
+    await store.acquireThumbnails(undefined, "bwNegative");
+    const active = calls[0].params.operationId as string;
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 3, operationId: active },
+    });
+    expect(store.getState().previewFilmProcess).toBe("bwNegative");
+
+    store.setPreviewFilmProcess("positive");
+
+    expect(store.getState().previewFilmProcessSelection).toBe("positive");
+    expect(store.getState().previewFilmProcess).toBeNull();
+    expect(store.getState().previewOutcome).toBeNull();
+    expect(store.getState().latestCompletedPreviewOperationId).toBeNull();
   });
 
   it("tracks active -> failed and stays failed across the correlated failure pair", async () => {
@@ -231,6 +274,11 @@ describe("SessionStore preview outcome exposure", () => {
     expect(store.getState().previewOutcome).toBeNull();
     expect(store.getState().previewError).toBeNull();
     expect(store.getState().activeOperationId).toBeNull();
+    expect(store.getState().previewRequestFailure?.error).toEqual({
+      code: "SCANNER_BUSY",
+      message: "scanner is busy",
+      recoverable: false,
+    });
   });
 
   it("resets to null on loadMedia", async () => {
@@ -245,10 +293,16 @@ describe("SessionStore preview outcome exposure", () => {
       payload: { code: "BRIDGE_STREAM_STALLED", message: "preview stream stalled", operationId: active },
     });
     expect(store.getState().previewOutcome).toBe("failed");
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 0, operationId: active },
+    });
 
     await store.loadMedia("roll36");
     expect(store.getState().previewOutcome).toBeNull();
     expect(store.getState().previewError).toBeNull();
+    expect(store.getState().previewRequestFailure).toBeNull();
+    expect(store.getState().previewFilmProcess).toBeNull();
   });
 
   it("resets to null on a project change (#resetSessionBinding)", async () => {
@@ -263,9 +317,15 @@ describe("SessionStore preview outcome exposure", () => {
       payload: { code: "BRIDGE_STREAM_STALLED", message: "preview stream stalled", operationId: active },
     });
     expect(store.getState().previewOutcome).toBe("failed");
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 0, operationId: active },
+    });
 
     await store.createProject("Reset Project", "roll36", 36, "c41ColorNegative", "/tmp/reset");
     expect(store.getState().previewOutcome).toBeNull();
     expect(store.getState().previewError).toBeNull();
+    expect(store.getState().previewRequestFailure).toBeNull();
+    expect(store.getState().previewFilmProcess).toBeNull();
   });
 });

--- a/ports/tauri/app/src/session/store/session.ts
+++ b/ports/tauri/app/src/session/store/session.ts
@@ -126,6 +126,30 @@ export interface SessionState {
   // for the contact sheet's failure banner (never invented copy).
   previewOutcome: "active" | "succeeded" | "failed" | null;
   previewError: { code: string; message: string } | null;
+  // A request can be rejected before the asynchronous preview operation is
+  // accepted (for example HW_MOTION_NOT_ARMED). Keep that transport phase
+  // separate from scanner.thumbnailsFailed so typed hardware guidance and
+  // diagnostics remain reachable without inventing an async failure event.
+  previewRequestFailure: { operationId: string; error: EngineError } | null;
+  // Material selected for the next preview before a project exists, and the
+  // material actually committed by the most recent correlated completion.
+  // Project creation uses only the committed value; an ACK is not enough.
+  previewFilmProcessSelection: FilmProcess;
+  previewFilmProcess: FilmProcess | null;
+  // Real hardware publishes its authoritative detected carrier/count in a
+  // correlated status after thumbnailsComplete. Project attachment must wait
+  // for that status rather than reusing the previous preview's dimensions.
+  previewStatusOperationId: string | null;
+  // True while project.create/open owns the project boundary, including
+  // persistence of pre-project alignment drafts after an attachment.
+  projectChangePending: boolean;
+  // True while scanner.connect/disconnect or simulated media loading owns
+  // the device-session boundary.
+  connectionChangePending: boolean;
+  // Serializes user-visible spacing/alignment writes against preview,
+  // project, and scan boundaries so a late response cannot mutate drafts
+  // after a project attachment has already persisted its snapshot.
+  frameAlignmentMutationPending: boolean;
   // Subscriber-only UI selection state (05-03 Task 1): frame indices
   // 1..status.frameCount selected by the user. No wire call is attached; it
   // survives unrelated store notifications and is reset only by the
@@ -178,6 +202,18 @@ export interface SessionState {
   } | null;
 }
 
+/** One physical/project boundary owns the session at a time. */
+export function sessionOperationBusy(state: Readonly<SessionState>): boolean {
+  return (
+    state.activeOperationId !== null ||
+    state.projectChangePending ||
+    state.connectionChangePending ||
+    state.frameAlignmentMutationPending ||
+    state.scanStartPending ||
+    (state.jobState !== null && !isTerminalJobState(state.jobState))
+  );
+}
+
 interface JobStateEventPayload {
   jobId: string;
   state: unknown;
@@ -217,6 +253,13 @@ function createInitialState(): SessionState {
     approvedFrames: {},
     previewOutcome: null,
     previewError: null,
+    previewRequestFailure: null,
+    previewFilmProcessSelection: "c41ColorNegative",
+    previewFilmProcess: null,
+    previewStatusOperationId: null,
+    projectChangePending: false,
+    connectionChangePending: false,
+    frameAlignmentMutationPending: false,
     selectedFrameIndices: [],
     focusedFrameIndex: null,
     frameAlignmentDrafts: {},
@@ -232,6 +275,78 @@ function createInitialState(): SessionState {
     filmFeedInterrupted: null,
     scanProgress: null,
     lastCompletedSummary: null,
+  };
+}
+
+export interface PreProjectPreviewRegistration {
+  operationId: string;
+  carrier: "roll36" | "strip6" | "mounted" | null;
+  frameCount: number;
+  filmProcess: FilmProcess;
+}
+
+function projectHasExactFrameSet(project: ScanProject): boolean {
+  if (project.frames.length !== project.frameCount) return false;
+  const indices = new Set(project.frames.map((frame) => frame.index));
+  if (indices.size !== project.frameCount) return false;
+  for (let frameIndex = 1; frameIndex <= project.frameCount; frameIndex += 1) {
+    if (!indices.has(frameIndex)) return false;
+  }
+  return true;
+}
+
+/**
+ * Returns the evidence that may be attached to a newly-created project.
+ * Every frame must be present and correlated to the one completed operation;
+ * partial, stale, failed, or still-replaying previews fail closed.
+ */
+export function preProjectPreviewRegistration(
+  state: Readonly<SessionState>,
+): PreProjectPreviewRegistration | null {
+  if (
+    state.project !== null ||
+    state.previewOutcome !== "succeeded" ||
+    state.previewFilmProcess === null ||
+    state.latestCompletedPreviewOperationId === null ||
+    state.activeOperationId !== null ||
+    state.frameAlignmentMutationPending ||
+    state.failedFrameAlignmentReplayIndices.size > 0 ||
+    state.pendingFrameAlignmentReplayIndices.size > 0
+  ) {
+    return null;
+  }
+  const status = state.connection.status;
+  if (
+    status?.mediaLoaded !== true ||
+    status.connected !== true ||
+    !Number.isInteger(status.frameCount) ||
+    (status.frameCount ?? 0) <= 0
+  ) {
+    return null;
+  }
+  const frameCount = status.frameCount as number;
+  const operationId = state.latestCompletedPreviewOperationId;
+  if (
+    state.connection.device?.kind === "real" &&
+    state.previewStatusOperationId !== operationId
+  ) {
+    return null;
+  }
+  const thumbnailIndices = Object.keys(state.thumbnails).map(Number);
+  if (thumbnailIndices.length !== frameCount) return null;
+  for (let frameIndex = 1; frameIndex <= frameCount; frameIndex += 1) {
+    if (
+      state.thumbnails[frameIndex] === undefined ||
+      state.thumbnailOperationIds[frameIndex] !== operationId
+    ) {
+      return null;
+    }
+  }
+  return {
+    operationId,
+    carrier: status.carrier,
+    frameCount,
+    filmProcess: state.previewFilmProcess,
   };
 }
 
@@ -267,6 +382,22 @@ function normalizedDerivativeTransform(
   return transform === undefined
     ? { ...IDENTITY_DERIVATIVE_TRANSFORM }
     : { ...transform };
+}
+
+function frameAlignmentEquals(
+  left: FrameAlignment | undefined,
+  right: FrameAlignment | undefined,
+): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  const leftTransform = normalizedDerivativeTransform(left.derivativeTransform);
+  const rightTransform = normalizedDerivativeTransform(right.derivativeTransform);
+  return (
+    left.offsetRows === right.offsetRows &&
+    left.approved === right.approved &&
+    leftTransform.rotationDegrees === rightTransform.rotationDegrees &&
+    leftTransform.horizontalMirror === rightTransform.horizontalMirror &&
+    leftTransform.verticalMirror === rightTransform.verticalMirror
+  );
 }
 
 function normalizedScannerStatus(status: ScannerStatus): ScannerStatus {
@@ -473,6 +604,8 @@ export class SessionStore {
   // field (state.previewOutcome) is kept in lockstep at every assignment so
   // views can observe the outcome.
   #previewOutcome: "active" | "failed" | "succeeded" | null = null;
+  #pendingPreviewFilmProcess: { operationId: string; filmProcess: FilmProcess } | null = null;
+  #activePreviewAuthorizationEpoch: number | null = null;
 
   // Selection range-extend anchor (05-03 Task 1): the frame index of the
   // last non-extend toggle, which shift-extend ranges start from (mirrors
@@ -558,34 +691,58 @@ export class SessionStore {
     deviceId: string,
     options?: ConnectOptions,
   ): Promise<{ device: DeviceInfo; status: ScannerStatus }> {
+    if (sessionOperationBusy(this.#state)) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active scanner operation to finish before connecting a device",
+        recoverable: false,
+      } satisfies EngineError;
+    }
     const params: Record<string, unknown> = { deviceId };
     if (options !== undefined) params.options = options;
-    const result = (await this.transport.sendRequest("scanner.connect", params)) as {
-      device: DeviceInfo;
-      status: ScannerStatus;
-    };
-    const status = normalizedScannerStatus(result.status);
-    this.#state.connection = { connected: true, device: result.device, status };
-    // Approval-binding trigger 6 (reconnect): a new successful connect
-    // invalidates any prior completed-preview token.
-    this.#state.latestCompletedPreviewOperationId = null;
-    this.#state.filmFeedInterrupted = null;
-    this.#invalidateScanAuthorization();
+    this.#state.connectionChangePending = true;
     this.#notify();
-    return { ...result, status };
+    try {
+      const result = (await this.transport.sendRequest("scanner.connect", params)) as {
+        device: DeviceInfo;
+        status: ScannerStatus;
+      };
+      const status = normalizedScannerStatus(result.status);
+      this.#state.connection = { connected: true, device: result.device, status };
+      // Approval-binding trigger 6 (reconnect): a new successful connect
+      // invalidates any prior completed-preview token.
+      this.#invalidatePreviewRegistration();
+      this.#state.filmFeedInterrupted = null;
+      return { ...result, status };
+    } finally {
+      this.#state.connectionChangePending = false;
+      this.#notify();
+    }
   }
 
   /** Thin forward to scanner.disconnect; clears the connected device. */
   async disconnect(): Promise<unknown> {
-    const result = await this.transport.sendRequest("scanner.disconnect", {});
-    this.#state.connection = { connected: false, device: null, status: null };
-    // Approval-binding trigger 5 (disconnect): the current device-session
-    // binding cannot survive a lost session.
-    this.#state.latestCompletedPreviewOperationId = null;
-    this.#state.filmFeedInterrupted = null;
-    this.#invalidateScanAuthorization();
+    if (sessionOperationBusy(this.#state)) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active scanner operation to finish before disconnecting the device",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    this.#state.connectionChangePending = true;
     this.#notify();
-    return result;
+    try {
+      const result = await this.transport.sendRequest("scanner.disconnect", {});
+      this.#state.connection = { connected: false, device: null, status: null };
+      // Approval-binding trigger 5 (disconnect): the current device-session
+      // binding cannot survive a lost session.
+      this.#invalidatePreviewRegistration();
+      this.#state.filmFeedInterrupted = null;
+      return result;
+    } finally {
+      this.#state.connectionChangePending = false;
+      this.#notify();
+    }
   }
 
   /** Thin forward to scanner.list; no state field represents the listing. */
@@ -597,22 +754,57 @@ export class SessionStore {
 
   /** Thin forward to scanner.status; refreshes connection.status. */
   async refreshStatus(): Promise<ScannerStatus> {
+    const recoveryCandidate =
+      this.#state.connection.device?.kind === "real" &&
+      this.#state.previewOutcome === "succeeded" &&
+      this.#state.latestCompletedPreviewOperationId !== null &&
+      this.#state.previewStatusOperationId === null &&
+      this.#state.activeOperationId === null
+        ? {
+            operationId: this.#state.latestCompletedPreviewOperationId,
+            authorizationEpoch: this.#scanAuthorizationEpoch,
+          }
+        : null;
     const received = (await this.transport.sendRequest("scanner.status", {})) as ScannerStatus;
     const status = normalizedScannerStatus(received);
     const previous = this.#state.connection.status;
-    this.#state.connection = { ...this.#state.connection, status };
+    this.#state.connection = !status.connected
+      ? { connected: false, device: null, status }
+      : this.#state.connection.device !== null
+        ? { ...this.#state.connection, status }
+        : { ...this.#state.connection, connected: false, status };
+    const refreshEstablishesCompletedPreview =
+      recoveryCandidate !== null &&
+      this.#scanAuthorizationEpoch === recoveryCandidate.authorizationEpoch &&
+      this.#state.latestCompletedPreviewOperationId === recoveryCandidate.operationId &&
+      this.#state.previewOutcome === "succeeded" &&
+      status.connected === true &&
+      status.mediaLoaded === true &&
+      status.filmPresent !== false &&
+      Number.isInteger(status.frameCount) &&
+      (status.frameCount ?? 0) > 0;
+    if (refreshEstablishesCompletedPreview) {
+      this.#state.previewStatusOperationId = recoveryCandidate.operationId;
+    }
     const registrationChanged =
       status.connected === false ||
       status.filmPresent === false ||
-      (previous !== null &&
+      (!refreshEstablishesCompletedPreview && previous !== null &&
         ((previous.mediaLoaded === true && status.mediaLoaded === false) ||
           previous.carrier !== status.carrier ||
           previous.frameCount !== status.frameCount));
-    if (status.filmPresent === false) {
-      this.#invalidatePreviewRegistration();
-    } else if (registrationChanged) {
-      this.#state.latestCompletedPreviewOperationId = null;
-      this.#invalidateScanAuthorization();
+    if (status.filmPresent === false || registrationChanged) {
+      if (this.#state.activeOperationId !== null) {
+        this.#invalidateRegistrationPreservingActivePreviewLane();
+      } else {
+        this.#invalidatePreviewRegistration();
+      }
+    }
+    if (
+      status.motionArmed === true &&
+      this.#state.previewRequestFailure?.error.code === "HW_MOTION_NOT_ARMED"
+    ) {
+      this.#state.previewRequestFailure = null;
     }
     this.#notify();
     return status;
@@ -620,21 +812,30 @@ export class SessionStore {
 
   /** Thin forward to sim.loadMedia; refreshes connection.status. */
   async loadMedia(carrier: "roll36" | "strip6" | "mounted"): Promise<ScannerStatus> {
-    const received = (await this.transport.sendRequest("sim.loadMedia", { carrier })) as ScannerStatus;
-    const status = normalizedScannerStatus(received);
-    this.#state.connection = { ...this.#state.connection, status };
-    // Approval-binding trigger 3 (media reset): a succeeding loadMedia
-    // invalidates any prior completed-preview token. A media reset also
-    // starts the next preview fresh: the previous preview outcome (and its
-    // error, if any) no longer describes the loaded media.
-    this.#state.latestCompletedPreviewOperationId = null;
-    this.#previewOutcome = null;
-    this.#state.previewOutcome = null;
-    this.#state.previewError = null;
-    this.#state.filmFeedInterrupted = null;
-    this.#invalidateScanAuthorization();
+    if (sessionOperationBusy(this.#state)) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active scanner operation to finish before loading simulated media",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    this.#state.connectionChangePending = true;
     this.#notify();
-    return status;
+    try {
+      const received = (await this.transport.sendRequest("sim.loadMedia", { carrier })) as ScannerStatus;
+      const status = normalizedScannerStatus(received);
+      this.#state.connection = { ...this.#state.connection, status };
+      // Approval-binding trigger 3 (media reset): a succeeding loadMedia
+      // invalidates any prior completed-preview token. A media reset also
+      // starts the next preview fresh: the previous preview outcome (and its
+      // error, if any) no longer describes the loaded media.
+      this.#invalidatePreviewRegistration();
+      this.#state.filmFeedInterrupted = null;
+      return status;
+    } finally {
+      this.#state.connectionChangePending = false;
+      this.#notify();
+    }
   }
 
   /**
@@ -711,6 +912,20 @@ export class SessionStore {
     this.#notify();
   }
 
+  /** Selects the material for the next preview when no project is active. */
+  setPreviewFilmProcess(filmProcess: FilmProcess): void {
+    if (this.#state.project !== null || sessionOperationBusy(this.#state)) return;
+    if (this.#state.previewFilmProcessSelection === filmProcess) return;
+    this.#state.previewFilmProcessSelection = filmProcess;
+    if (this.#state.previewFilmProcess !== null) {
+      // The visible thumbnails were rendered for a different material. Do
+      // not let the project form silently save that completed registration
+      // after the operator has selected a new process for the roll.
+      this.#invalidatePreviewRegistration();
+    }
+    this.#notify();
+  }
+
   /**
    * Forward to scanner.acquireThumbnails with a fresh correlation token.
    * Preview correlation policy (04-03 Task 1): a fresh crypto.randomUUID()
@@ -725,7 +940,38 @@ export class SessionStore {
     frames?: number[],
     filmProcess?: FilmProcess,
   ): Promise<{ accepted: boolean; frames: number[] }> {
-    if (this.#previewOutcome === "active") {
+    if (this.#state.connectionChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the device connection change to finish before requesting a preview",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.projectChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active project change to finish before requesting a preview",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.frameAlignmentMutationPending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active frame-alignment change to finish before requesting a preview",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (
+      this.#state.scanStartPending ||
+      (this.#state.jobState !== null && !isTerminalJobState(this.#state.jobState))
+    ) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active scan to finish before requesting a preview",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.activeOperationId !== null) {
       throw {
         code: "INVALID_PARAMS",
         message:
@@ -733,16 +979,51 @@ export class SessionStore {
         recoverable: false,
       } satisfies EngineError;
     }
+    if (
+      this.#state.project !== null &&
+      filmProcess !== undefined &&
+      filmProcess !== this.#state.project.filmProcess
+    ) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "filmProcess conflicts with the active project's filmProcess",
+        recoverable: false,
+      } satisfies EngineError;
+    }
     const operationId = crypto.randomUUID();
+    const effectiveFilmProcess =
+      this.#state.project?.filmProcess ??
+      filmProcess ??
+      this.#state.previewFilmProcessSelection;
     this.#previewOutcome = "active";
     this.#state.previewOutcome = "active";
     this.#state.previewError = null;
+    this.#state.previewRequestFailure = null;
+    this.#state.previewFilmProcess = null;
+    this.#state.previewStatusOperationId = null;
+    if (this.#state.project === null && frames === undefined) {
+      // A pre-project full preview replaces the prior registration. Clear
+      // its tiles so a shorter real re-preview cannot retain out-of-range
+      // thumbnails that permanently prevent attachment.
+      this.#state.thumbnails = {};
+      this.#state.thumbnailOperationIds = {};
+      this.#state.selectedFrameIndices = [];
+      this.#state.focusedFrameIndex = null;
+      this.#selectionAnchor = null;
+    }
     this.#state.activeOperationId = operationId;
     this.#state.latestCompletedPreviewOperationId = null;
+    this.#pendingPreviewFilmProcess = { operationId, filmProcess: effectiveFilmProcess };
     this.#invalidateScanAuthorization();
-    const params: Record<string, unknown> = { operationId };
+    this.#activePreviewAuthorizationEpoch = this.#scanAuthorizationEpoch;
+    const params: Record<string, unknown> = {
+      operationId,
+      filmProcess: effectiveFilmProcess,
+    };
     if (frames !== undefined) params.frames = frames;
-    if (filmProcess !== undefined) params.filmProcess = filmProcess;
+    // Subscribers must see the lane become active before a slow transport ACK
+    // so a second click cannot queue another motion-capable request.
+    this.#notify();
     try {
       const result = (await this.transport.sendRequest("scanner.acquireThumbnails", params)) as {
         accepted: boolean;
@@ -751,11 +1032,40 @@ export class SessionStore {
       this.#notify();
       return result;
     } catch (error) {
-      this.#previewOutcome = null;
-      this.#state.previewOutcome = null;
-      this.#state.previewError = null;
-      this.#state.activeOperationId = null;
-      this.#notify();
+      // Events can arrive before the request response. A late rejection must
+      // not erase a correlated completion/failure (or a replacement lane).
+      if (
+        this.#state.activeOperationId === operationId &&
+        this.#previewOutcome === "active"
+      ) {
+        this.#previewOutcome = null;
+        this.#state.previewOutcome = null;
+        this.#state.previewError = null;
+        this.#state.activeOperationId = null;
+        this.#pendingPreviewFilmProcess = null;
+        this.#activePreviewAuthorizationEpoch = null;
+        const requestError: EngineError = isEngineError(error)
+          ? error
+          : {
+              code: "INTERNAL",
+              message: error instanceof Error ? error.message : "preview request failed",
+              recoverable: false,
+            };
+        this.#state.previewRequestFailure = { operationId, error: requestError };
+        if (isEngineError(error)) {
+          if (
+            error.code === "HW_MOTION_NOT_ARMED" &&
+            this.#state.connection.device?.kind === "real" &&
+            this.#state.connection.status !== null
+          ) {
+            this.#state.connection = {
+              ...this.#state.connection,
+              status: { ...this.#state.connection.status, motionArmed: false },
+            };
+          }
+        }
+        this.#notify();
+      }
       throw error;
     }
   }
@@ -795,6 +1105,31 @@ export class SessionStore {
    * invalidates that frame's prior recorded approval.
    */
   async setSpacingOffset(frameIndex: number, offsetRows: number): Promise<void> {
+    if (this.#state.connectionChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the device connection change to finish before adjusting spacing",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.projectChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active project change to finish before adjusting spacing",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (
+      this.#state.frameAlignmentMutationPending ||
+      this.#state.scanStartPending ||
+      (this.#state.jobState !== null && !isTerminalJobState(this.#state.jobState))
+    ) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active frame-alignment or scan boundary to finish before adjusting spacing",
+        recoverable: false,
+      } satisfies EngineError;
+    }
     const bounds = frameIndex === 1 ? { min: 0, max: 144 } : { min: -144, max: 144 };
     if (offsetRows < bounds.min || offsetRows > bounds.max) {
       throw {
@@ -811,51 +1146,57 @@ export class SessionStore {
         recoverable: false,
       } satisfies EngineError;
     }
-    const result = (await this.transport.sendRequest("roll.setSpacingOffset", {
-      frameIndex,
-      offsetRows,
-      operationId,
-    })) as { thumbnail?: unknown } | undefined;
-    if (this.#state.latestCompletedPreviewOperationId !== operationId) {
-      throw {
-        code: "INVALID_PARAMS",
-        message: "the spacing-offset response belongs to a superseded preview",
-        recoverable: false,
-      } satisfies EngineError;
-    }
-    // Fail closed: a malformed response is never applied; the prior tile and
-    // its approvals stay authoritative.
-    if (result === undefined || !isThumbnail(result.thumbnail)) return;
-    this.#state.thumbnails = { ...this.#state.thumbnails, [frameIndex]: result.thumbnail };
-    this.#state.thumbnailOperationIds = {
-      ...this.#state.thumbnailOperationIds,
-      [frameIndex]: operationId,
-    };
-    // Changing the offset invalidates prior manual approval for that frame.
-    const approved = this.#state.approvedFrames[operationId];
-    if (approved !== undefined) {
-      const remaining = approved.filter((frame) => frame !== frameIndex);
-      if (remaining.length === 0) {
-        const next = { ...this.#state.approvedFrames };
-        delete next[operationId];
-        this.#state.approvedFrames = next;
-      } else {
-        this.#state.approvedFrames = { ...this.#state.approvedFrames, [operationId]: remaining };
-      }
-    }
-    // Keep the confirmed transport offset and the independent presentation
-    // transform together in the one FrameAlignment object the engine owns.
-    // Persistence is intentionally deferred to the scan-start boundary.
-    const prior = this.#frameAlignmentFor(frameIndex);
-    this.#state.frameAlignmentDrafts = {
-      ...this.#state.frameAlignmentDrafts,
-      [frameIndex]: {
-        offsetRows: result.thumbnail.spacingOffset ?? offsetRows,
-        approved: false,
-        derivativeTransform: normalizedDerivativeTransform(prior?.derivativeTransform),
-      },
-    };
+    this.#state.frameAlignmentMutationPending = true;
     this.#notify();
+    try {
+      const result = (await this.transport.sendRequest("roll.setSpacingOffset", {
+        frameIndex,
+        offsetRows,
+        operationId,
+      })) as { thumbnail?: unknown } | undefined;
+      if (this.#state.latestCompletedPreviewOperationId !== operationId) {
+        throw {
+          code: "INVALID_PARAMS",
+          message: "the spacing-offset response belongs to a superseded preview",
+          recoverable: false,
+        } satisfies EngineError;
+      }
+      // Fail closed: a malformed response is never applied; the prior tile and
+      // its approvals stay authoritative.
+      if (result === undefined || !isThumbnail(result.thumbnail)) return;
+      this.#state.thumbnails = { ...this.#state.thumbnails, [frameIndex]: result.thumbnail };
+      this.#state.thumbnailOperationIds = {
+        ...this.#state.thumbnailOperationIds,
+        [frameIndex]: operationId,
+      };
+      // Changing the offset invalidates prior manual approval for that frame.
+      const approved = this.#state.approvedFrames[operationId];
+      if (approved !== undefined) {
+        const remaining = approved.filter((frame) => frame !== frameIndex);
+        if (remaining.length === 0) {
+          const next = { ...this.#state.approvedFrames };
+          delete next[operationId];
+          this.#state.approvedFrames = next;
+        } else {
+          this.#state.approvedFrames = { ...this.#state.approvedFrames, [operationId]: remaining };
+        }
+      }
+      // Keep the confirmed transport offset and the independent presentation
+      // transform together in the one FrameAlignment object the engine owns.
+      // Persistence is intentionally deferred to the scan-start boundary.
+      const prior = this.#frameAlignmentFor(frameIndex);
+      this.#state.frameAlignmentDrafts = {
+        ...this.#state.frameAlignmentDrafts,
+        [frameIndex]: {
+          offsetRows: result.thumbnail.spacingOffset ?? offsetRows,
+          approved: false,
+          derivativeTransform: normalizedDerivativeTransform(prior?.derivativeTransform),
+        },
+      };
+    } finally {
+      this.#state.frameAlignmentMutationPending = false;
+      this.#notify();
+    }
   }
 
   /**
@@ -870,29 +1211,60 @@ export class SessionStore {
     frameIndex: number,
     alignment: FrameAlignment | null,
   ): Promise<void> {
-    const result = (await this.transport.sendRequest("project.setFrameAlignment", {
-      frameIndex,
-      alignment,
-    })) as { project?: unknown } | undefined;
-    if (alignment === null) {
-      const next = { ...this.#state.frameAlignmentDrafts };
-      delete next[frameIndex];
-      this.#state.frameAlignmentDrafts = next;
-      // Removing the draft also removes any prior replay failure for the
-      // frame (review HIGH): a cleared alignment must not stay blocked by a
-      // failure that referred to the deleted offset.
-      this.#state.failedFrameAlignmentReplayIndices.delete(frameIndex);
-      this.#state.pendingFrameAlignmentReplayIndices.delete(frameIndex);
-    } else {
-      this.#state.frameAlignmentDrafts = {
-        ...this.#state.frameAlignmentDrafts,
-        [frameIndex]: alignment,
-      };
+    if (this.#state.connectionChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the device connection change to finish before saving frame transforms",
+        recoverable: false,
+      } satisfies EngineError;
     }
-    if (result !== undefined && isScanProject(result.project)) {
-      this.#state.project = result.project;
+    if (this.#state.projectChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active project change to finish before saving frame transforms",
+        recoverable: false,
+      } satisfies EngineError;
     }
+    if (
+      this.#state.frameAlignmentMutationPending ||
+      this.#state.scanStartPending ||
+      (this.#state.jobState !== null && !isTerminalJobState(this.#state.jobState))
+    ) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active frame-alignment or scan boundary to finish before saving frame transforms",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    this.#state.frameAlignmentMutationPending = true;
     this.#notify();
+    try {
+      const result = (await this.transport.sendRequest("project.setFrameAlignment", {
+        frameIndex,
+        alignment,
+      })) as { project?: unknown } | undefined;
+      if (alignment === null) {
+        const next = { ...this.#state.frameAlignmentDrafts };
+        delete next[frameIndex];
+        this.#state.frameAlignmentDrafts = next;
+        // Removing the draft also removes any prior replay failure for the
+        // frame (review HIGH): a cleared alignment must not stay blocked by a
+        // failure that referred to the deleted offset.
+        this.#state.failedFrameAlignmentReplayIndices.delete(frameIndex);
+        this.#state.pendingFrameAlignmentReplayIndices.delete(frameIndex);
+      } else {
+        this.#state.frameAlignmentDrafts = {
+          ...this.#state.frameAlignmentDrafts,
+          [frameIndex]: alignment,
+        };
+      }
+      if (result !== undefined && isScanProject(result.project)) {
+        this.#state.project = result.project;
+      }
+    } finally {
+      this.#state.frameAlignmentMutationPending = false;
+      this.#notify();
+    }
   }
 
   #frameAlignmentFor(frameIndex: number): FrameAlignment | undefined {
@@ -911,7 +1283,10 @@ export class SessionStore {
 
   /** Transform edits are drafts until the next scan-start persistence gate. */
   frameTransformsAreEditable(): boolean {
-    return this.#state.scanStartPending ||
+    return this.#state.activeOperationId !== null ||
+      this.#state.projectChangePending ||
+      this.#state.frameAlignmentMutationPending ||
+      this.#state.scanStartPending ||
       (this.#state.jobState !== null && !isTerminalJobState(this.#state.jobState))
       ? false
       : true;
@@ -1224,26 +1599,129 @@ export class SessionStore {
     filmProcess: "positive" | "c41ColorNegative" | "bwNegative" | "kodachrome",
     directory?: string,
   ): Promise<{ project: ScanProject; directory: string }> {
-    const params: Record<string, unknown> = { name, carrier, frameCount, filmProcess };
-    if (directory !== undefined) params.directory = directory;
-    const result = (await this.transport.sendRequest("project.create", params)) as {
-      project: ScanProject;
-      directory: string;
-    };
-    // Fail-closed commit: a malformed response never corrupts store state.
-    // A successful project change resets the session binding (review HIGH):
-    // preview tokens, approvals, and thumbnail provenance belong to the
-    // project context they were created under and must not leak across
-    // projects. Alignment drafts are rebuilt from the loaded project's own
-    // frames; any stale replay failure is cleared (replay re-runs after the
-    // next preview). The jobId is dropped so a previous job's late events
-    // can never match the new project's context.
-    if (isScanProject(result.project)) {
+    if (this.#state.connectionChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the device connection change to finish before creating a project",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.activeOperationId !== null) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active preview to finish before creating a project",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.frameAlignmentMutationPending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active frame-alignment change to finish before creating a project",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (
+      this.#state.scanStartPending ||
+      (this.#state.jobState !== null && !isTerminalJobState(this.#state.jobState))
+    ) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active scan to finish before creating a project",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.projectChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active project change to finish before creating a project",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    this.#state.projectChangePending = true;
+    this.#notify();
+    try {
+      const registration = preProjectPreviewRegistration(this.#state);
+      const attachCandidate =
+        registration !== null &&
+        registration.frameCount === frameCount &&
+        registration.filmProcess === filmProcess &&
+        (registration.carrier === null || registration.carrier === carrier)
+          ? { ...registration, authorizationEpoch: this.#scanAuthorizationEpoch }
+          : null;
+      const params: Record<string, unknown> = { name, carrier, frameCount, filmProcess };
+      if (directory !== undefined) params.directory = directory;
+      const rawResult = await this.transport.sendRequest("project.create", params);
+      if (
+        !isRecord(rawResult) ||
+        !isScanProject(rawResult.project) ||
+        typeof rawResult.directory !== "string"
+      ) {
+        throw {
+          code: "INTERNAL",
+          message: "project.create returned an invalid project",
+          recoverable: false,
+        } satisfies EngineError;
+      }
+      const result = {
+        project: rawResult.project,
+        directory: rawResult.directory,
+      };
+      const responseMatchesRequest =
+        result.project.carrier === carrier &&
+        result.project.frameCount === frameCount &&
+        result.project.filmProcess === filmProcess;
+      const attachmentProjectUsable =
+        responseMatchesRequest && projectHasExactFrameSet(result.project);
+      const currentRegistration = preProjectPreviewRegistration(this.#state);
+      const attachmentStillCurrent =
+        attachCandidate !== null &&
+        this.#scanAuthorizationEpoch === attachCandidate.authorizationEpoch &&
+        currentRegistration?.operationId === attachCandidate.operationId &&
+        currentRegistration.frameCount === attachCandidate.frameCount &&
+        currentRegistration.filmProcess === attachCandidate.filmProcess &&
+        currentRegistration.carrier === attachCandidate.carrier;
+
+      // project.create makes the returned project active in the engine. Adopt
+      // any structurally valid response even if its identity fields disagree,
+      // but detach the preview and surface the protocol violation fail-closed.
       this.#state.project = result.project;
-      this.#resetSessionBinding(result.project);
+      if (attachmentProjectUsable && attachmentStillCurrent) {
+        this.#attachProjectToPreview(result.project);
+        // Pre-project rotation/mirroring/spacing drafts become durable at
+        // the same attachment boundary. Without this write, closing and
+        // reopening the newly-created project silently loses those edits.
+        const persistenceEpoch = this.#scanAuthorizationEpoch;
+        const draftFrames = Object.keys(this.#state.frameAlignmentDrafts).map(Number);
+        await this.#persistFrameGeometryBeforeScan(
+          draftFrames,
+          persistenceEpoch,
+          result.project.id,
+        );
+      } else {
+        this.#resetSessionBinding(result.project);
+      }
+      if (!responseMatchesRequest) {
+        throw {
+          code: "INTERNAL",
+          message: "project.create returned a project that does not match the requested carrier, frame count, and film process",
+          recoverable: false,
+        } satisfies EngineError;
+      }
+      if (attachmentStillCurrent && !attachmentProjectUsable) {
+        throw {
+          code: "INTERNAL",
+          message: "project.create returned a malformed frame set for the completed preview",
+          recoverable: false,
+        } satisfies EngineError;
+      }
+      return {
+        project: this.#state.project ?? result.project,
+        directory: result.directory,
+      };
+    } finally {
+      this.#state.projectChangePending = false;
       this.#notify();
     }
-    return result;
   }
 
   /**
@@ -1258,13 +1736,16 @@ export class SessionStore {
     this.#previewOutcome = null;
     this.#state.previewOutcome = null;
     this.#state.previewError = null;
+    this.#state.previewRequestFailure = null;
+    this.#state.previewFilmProcess = null;
+    this.#state.previewStatusOperationId = null;
+    this.#pendingPreviewFilmProcess = null;
+    this.#activePreviewAuthorizationEpoch = null;
     this.#state.approvedFrames = {};
     this.#state.thumbnailOperationIds = {};
-    this.#state.jobId = null;
-    this.#state.scanStartPending = false;
-    this.#state.filmFeedInterrupted = null;
-    this.#jobBoundaryPending = false;
-    this.#pendingScanEvents = [];
+    this.#state.selectedFrameIndices = [];
+    this.#state.focusedFrameIndex = null;
+    this.#selectionAnchor = null;
     const drafts: Record<number, FrameAlignment> = {};
     for (const frame of project.frames) {
       if (frame.alignment !== undefined) drafts[frame.index] = frame.alignment;
@@ -1272,6 +1753,28 @@ export class SessionStore {
     this.#state.frameAlignmentDrafts = drafts;
     this.#state.failedFrameAlignmentReplayIndices = new Set();
     this.#state.pendingFrameAlignmentReplayIndices = new Set();
+    this.#resetProjectRuntime(project);
+  }
+
+  /**
+   * First save after an exact pre-project preview is an attachment boundary,
+   * not a media/project switch. Preserve registration and user review state
+   * while adopting the durable project's receipts and job boundary.
+   */
+  #attachProjectToPreview(project: ScanProject): void {
+    this.#state.activeOperationId = null;
+    this.#state.previewRequestFailure = null;
+    this.#pendingPreviewFilmProcess = null;
+    this.#activePreviewAuthorizationEpoch = null;
+    this.#resetProjectRuntime(project);
+  }
+
+  #resetProjectRuntime(project: ScanProject): void {
+    this.#state.jobId = null;
+    this.#state.scanStartPending = false;
+    this.#state.filmFeedInterrupted = null;
+    this.#jobBoundaryPending = false;
+    this.#pendingScanEvents = [];
     this.#invalidateScanAuthorization();
     const receipts: Record<number, ScanReceipt[]> = {};
     for (const frame of project.frames) {
@@ -1282,15 +1785,67 @@ export class SessionStore {
 
   /** Thin forward to project.open; records the active project. */
   async openProject(directory: string): Promise<{ project: ScanProject; directory: string }> {
-    const result = (await this.transport.sendRequest("project.open", {
-      directory,
-    })) as { project: ScanProject; directory: string };
-    if (isScanProject(result.project)) {
+    if (this.#state.connectionChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the device connection change to finish before opening a project",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.activeOperationId !== null) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active preview to finish before opening a project",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.frameAlignmentMutationPending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active frame-alignment change to finish before opening a project",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (
+      this.#state.scanStartPending ||
+      (this.#state.jobState !== null && !isTerminalJobState(this.#state.jobState))
+    ) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active scan to finish before opening a project",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.projectChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active project change to finish before opening a project",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    this.#state.projectChangePending = true;
+    this.#notify();
+    try {
+      const rawResult = await this.transport.sendRequest("project.open", { directory });
+      if (
+        !isRecord(rawResult) ||
+        !isScanProject(rawResult.project) ||
+        typeof rawResult.directory !== "string"
+      ) {
+        throw {
+          code: "INTERNAL",
+          message: "project.open returned an invalid project",
+          recoverable: false,
+        } satisfies EngineError;
+      }
+      const result = { project: rawResult.project, directory: rawResult.directory };
       this.#state.project = result.project;
       this.#resetSessionBinding(result.project);
+      return result;
+    } finally {
+      this.#state.projectChangePending = false;
       this.#notify();
     }
-    return result;
   }
 
   /** Thin forward to project.list; no state field represents the listing. */
@@ -1327,7 +1882,7 @@ export class SessionStore {
       const persisted = currentProject.frames.find((frame) => frame.index === frameIndex);
       if (persisted === undefined) continue;
       const desired = this.#state.frameAlignmentDrafts[frameIndex];
-      if (JSON.stringify(persisted.alignment) === JSON.stringify(desired)) continue;
+      if (frameAlignmentEquals(persisted.alignment, desired)) continue;
       const response = (await this.transport.sendRequest("project.setFrameAlignment", {
         frameIndex,
         alignment: desired ?? null,
@@ -1340,10 +1895,24 @@ export class SessionStore {
           recoverable: false,
         } satisfies EngineError;
       }
-      if (response.project.id !== startingProject.id) {
+      if (
+        response.project.id !== startingProject.id ||
+        response.project.carrier !== startingProject.carrier ||
+        response.project.frameCount !== startingProject.frameCount ||
+        response.project.filmProcess !== startingProject.filmProcess ||
+        !projectHasExactFrameSet(response.project)
+      ) {
         throw {
           code: "INVALID_PARAMS",
-          message: "the frame transform response belongs to a different project",
+          message: "the frame transform response belongs to a different or malformed project",
+          recoverable: false,
+        } satisfies EngineError;
+      }
+      const saved = response.project.frames.find((frame) => frame.index === frameIndex);
+      if (saved === undefined || !frameAlignmentEquals(saved.alignment, desired)) {
+        throw {
+          code: "INTERNAL",
+          message: `project.setFrameAlignment did not persist frame ${frameIndex}`,
           recoverable: false,
         } satisfies EngineError;
       }
@@ -1370,6 +1939,52 @@ export class SessionStore {
     output?: OutputRecipe,
     frameAlignments?: Record<number, FrameAlignment>,
   ): Promise<ScanStartResult> {
+    if (this.#state.connectionChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the device connection change to finish before starting a scan",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.filmFeedInterrupted !== null) {
+      throw {
+        code: "FILM_FEED_INTERRUPTED",
+        message:
+          "the previous film registration is no longer valid; reinsert the film, acquire a fresh preview, then resume the remaining frames",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.activeOperationId !== null) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active preview to finish before starting a scan",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.projectChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active project change to finish before starting a scan",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (this.#state.frameAlignmentMutationPending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active frame-alignment change to finish before starting a scan",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    if (
+      this.#state.scanStartPending ||
+      (this.#state.jobState !== null && !isTerminalJobState(this.#state.jobState))
+    ) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active scan to finish before starting another scan",
+        recoverable: false,
+      } satisfies EngineError;
+    }
     // Recipe mirroring (04-03 Task 2): client-side pre-validation running
     // BEFORE the needsApproval gate and the wire call. Defaults are applied
     // deterministically, B&W forcing mirrors domain.rs
@@ -1500,15 +2115,6 @@ export class SessionStore {
       } satisfies EngineError;
     }
 
-    if (this.#state.filmFeedInterrupted !== null) {
-      throw {
-        code: "FILM_FEED_INTERRUPTED",
-        message:
-          "the previous film registration is no longer valid; reinsert the film, acquire a fresh preview, then resume the remaining frames",
-        recoverable: false,
-      } satisfies EngineError;
-    }
-
     const params: Record<string, unknown> = { frames, recipe: effectiveCapture };
     if (effectiveProcessing !== undefined) params.processing = effectiveProcessing;
     if (resolved.output !== undefined) params.output = resolved.output;
@@ -1606,6 +2212,13 @@ export class SessionStore {
 
   /** Thin forward to project.pendingFrames. */
   async pendingFrames(): Promise<PendingFramesResult> {
+    if (this.#state.projectChangePending) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "wait for the active project change to finish before reading pending frames",
+        recoverable: false,
+      } satisfies EngineError;
+    }
     return (await this.transport.sendRequest("project.pendingFrames", {})) as PendingFramesResult;
   }
 
@@ -1634,9 +2247,42 @@ export class SessionStore {
     this.#previewOutcome = null;
     this.#state.previewOutcome = null;
     this.#state.previewError = null;
+    this.#state.previewRequestFailure = null;
+    this.#state.previewFilmProcess = null;
+    this.#state.previewStatusOperationId = null;
+    this.#pendingPreviewFilmProcess = null;
+    this.#activePreviewAuthorizationEpoch = null;
     this.#state.selectedFrameIndices = [];
     this.#state.focusedFrameIndex = null;
     this.#selectionAnchor = null;
+    this.#clearUnsavedPreProjectAlignment();
+    this.#invalidateScanAuthorization();
+  }
+
+  #clearUnsavedPreProjectAlignment(): void {
+    if (this.#state.project !== null) return;
+    this.#state.frameAlignmentDrafts = {};
+    this.#state.failedFrameAlignmentReplayIndices = new Set();
+    this.#state.pendingFrameAlignmentReplayIndices = new Set();
+  }
+
+  /**
+   * A generic status update cannot prove an asynchronous preview worker has
+   * released its physical lane. Retire its registration evidence and epoch,
+   * but keep the active operation/button lock until its correlated terminal.
+   */
+  #invalidateRegistrationPreservingActivePreviewLane(): void {
+    this.#state.thumbnails = {};
+    this.#state.thumbnailOperationIds = {};
+    this.#state.latestCompletedPreviewOperationId = null;
+    this.#state.approvedFrames = {};
+    this.#state.previewFilmProcess = null;
+    this.#state.previewStatusOperationId = null;
+    this.#pendingPreviewFilmProcess = null;
+    this.#state.selectedFrameIndices = [];
+    this.#state.focusedFrameIndex = null;
+    this.#selectionAnchor = null;
+    this.#clearUnsavedPreProjectAlignment();
     this.#invalidateScanAuthorization();
   }
 
@@ -1666,7 +2312,11 @@ export class SessionStore {
         if (!isRecord(payload) || !isScannerStatus(payload.status)) return;
         const previous = this.#state.connection.status;
         const status = normalizedScannerStatus(payload.status);
-        this.#state.connection = { ...this.#state.connection, status };
+        this.#state.connection = !status.connected
+          ? { connected: false, device: null, status }
+          : this.#state.connection.device !== null
+            ? { ...this.#state.connection, status }
+            : { ...this.#state.connection, connected: false, status };
         // Approval-binding invalidation observed through status transitions
         // (roll.approve triggers 4-5): eject (mediaLoaded true -> false),
         // media change (carrier/frameCount change), and disconnect
@@ -1675,6 +2325,15 @@ export class SessionStore {
         // correlated thumbnailsComplete / thumbnailsFailed+thumbnailsComplete
         // sequence does that, so an untagged generic status cannot terminate
         // an active preview.
+        const operationId =
+          typeof payload.operationId === "string" ? payload.operationId : null;
+        const statusBelongsToPreview =
+          operationId !== null &&
+          (operationId === this.#state.activeOperationId ||
+            operationId === this.#state.latestCompletedPreviewOperationId);
+        if (statusBelongsToPreview) {
+          this.#state.previewStatusOperationId = operationId;
+        }
         let registrationChanged = false;
         if (status.connected === false) {
           this.#state.latestCompletedPreviewOperationId = null;
@@ -1684,15 +2343,28 @@ export class SessionStore {
           const mediaChanged =
             previous.carrier !== status.carrier ||
             previous.frameCount !== status.frameCount;
-          if (ejected || mediaChanged) {
+          // The real backend emits thumbnailsComplete first and then a status
+          // event carrying the same operationId with the newly detected
+          // carrier/count. That transition establishes this preview; treating
+          // it as foreign media would immediately erase the token we just
+          // completed.
+          if (ejected || (mediaChanged && !statusBelongsToPreview)) {
             this.#state.latestCompletedPreviewOperationId = null;
             registrationChanged = true;
           }
         }
-        if (status.filmPresent === false) {
-          this.#invalidatePreviewRegistration();
-        } else if (registrationChanged) {
-          this.#invalidateScanAuthorization();
+        if (status.filmPresent === false || registrationChanged) {
+          if (this.#state.activeOperationId !== null) {
+            this.#invalidateRegistrationPreservingActivePreviewLane();
+          } else {
+            this.#invalidatePreviewRegistration();
+          }
+        }
+        if (
+          status.motionArmed === true &&
+          this.#state.previewRequestFailure?.error.code === "HW_MOTION_NOT_ARMED"
+        ) {
+          this.#state.previewRequestFailure = null;
         }
         this.#notify();
         return;
@@ -1712,7 +2384,8 @@ export class SessionStore {
         // accepted preview). Missing or mismatched tokens are no-ops.
         if (
           this.#state.activeOperationId === null ||
-          payload.operationId !== this.#state.activeOperationId
+          payload.operationId !== this.#state.activeOperationId ||
+          this.#activePreviewAuthorizationEpoch !== this.#scanAuthorizationEpoch
         ) {
           return;
         }
@@ -1731,7 +2404,8 @@ export class SessionStore {
         }
         if (
           this.#state.activeOperationId === null ||
-          payload.operationId !== this.#state.activeOperationId
+          payload.operationId !== this.#state.activeOperationId ||
+          this.#activePreviewAuthorizationEpoch !== this.#scanAuthorizationEpoch
         ) {
           return;
         }
@@ -1745,6 +2419,8 @@ export class SessionStore {
         this.#previewOutcome = "failed";
         this.#state.previewOutcome = "failed";
         this.#state.previewError = { code: payload.code, message: payload.message };
+        this.#pendingPreviewFilmProcess = null;
+        this.#state.previewFilmProcess = null;
         this.#notify();
         return;
       }
@@ -1763,10 +2439,17 @@ export class SessionStore {
         // thumbnailsFailed already marked it failed -- a zero-count
         // completion preceded by a failure is a FAILURE, not an empty
         // success.
-        if (this.#previewOutcome !== "failed") {
+        const previewStillAuthorized =
+          this.#activePreviewAuthorizationEpoch === this.#scanAuthorizationEpoch;
+        if (this.#previewOutcome !== "failed" && previewStillAuthorized) {
           this.#previewOutcome = "succeeded";
           this.#state.previewOutcome = "succeeded";
           this.#state.latestCompletedPreviewOperationId = payload.operationId;
+          if (this.#pendingPreviewFilmProcess?.operationId === payload.operationId) {
+            this.#state.previewFilmProcess =
+              this.#pendingPreviewFilmProcess.filmProcess;
+          }
+          this.#pendingPreviewFilmProcess = null;
           this.#state.filmFeedInterrupted = null;
           // A successful preview is the trigger for replaying every saved
           // frame-alignment draft through roll.setSpacingOffset (Task 2);
@@ -1774,8 +2457,19 @@ export class SessionStore {
           // those frames excluded from startScan.
           const replayEpoch = this.#alignmentReplayEpoch;
           void this.#replayFrameAlignmentDrafts(payload.operationId, replayEpoch);
+        } else if (this.#previewOutcome !== "failed") {
+          // A foreign/untagged status changed media identity while this
+          // worker was active. Its terminal releases the lane but cannot
+          // resurrect registration evidence for the superseded media.
+          this.#previewOutcome = null;
+          this.#state.previewOutcome = null;
+          this.#state.previewError = null;
+          this.#state.latestCompletedPreviewOperationId = null;
+          this.#state.previewFilmProcess = null;
         }
         this.#state.activeOperationId = null;
+        this.#activePreviewAuthorizationEpoch = null;
+        this.#pendingPreviewFilmProcess = null;
         this.#notify();
         return;
       }

--- a/ports/tauri/app/src/views/ContactSheet.module.css
+++ b/ports/tauri/app/src/views/ContactSheet.module.css
@@ -37,6 +37,32 @@
   font-weight: 600;
 }
 
+.previewProcessControl {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #374151;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.previewProcessControl select {
+  padding: 0.32rem 0.45rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #ffffff;
+}
+
+.previewReadiness {
+  display: flex;
+  max-width: 62ch;
+  align-items: center;
+  gap: 0.5rem;
+  color: #92400e;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
 .focusControl select {
   padding: 0.32rem 0.45rem;
   border: 1px solid #d1d5db;

--- a/ports/tauri/app/src/views/ContactSheet.tsx
+++ b/ports/tauri/app/src/views/ContactSheet.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useSyncExternalStore } from "react";
-import { sessionStore, type SessionState } from "../session";
-import type { DerivativeTransform, Thumbnail } from "../session/wire/types";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import {
+  sessionStore,
+  type FilmProcess,
+  type SessionState,
+} from "../session";
+import { sessionOperationBusy } from "../session/store/session";
+import type { DerivativeTransform, EngineError, Thumbnail } from "../session/wire/types";
 import styles from "./ContactSheet.module.css";
 
 // useSyncExternalStore requires a referentially stable snapshot between
@@ -31,6 +36,12 @@ function stableGetSnapshot(): Readonly<SessionState> {
 }
 
 const CARRIERS = ["roll36", "strip6", "mounted"] as const;
+const FILM_PROCESSES: Array<{ value: FilmProcess; label: string }> = [
+  { value: "positive", label: "Positive" },
+  { value: "c41ColorNegative", label: "Color negative (C-41)" },
+  { value: "bwNegative", label: "B&W negative" },
+  { value: "kodachrome", label: "Kodachrome" },
+];
 
 // Behaviorally equivalent to ThumbnailGridView's shaded-tile rendering (gray
 // tile shaded by brightness with a tint cast), not pixel-identical.
@@ -67,12 +78,37 @@ function shortcutTargetIsEditable(target: EventTarget | null): boolean {
   );
 }
 
+function requestErrorOf(error: unknown): Pick<EngineError, "code" | "message"> {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    "message" in error &&
+    typeof (error as { code: unknown }).code === "string" &&
+    typeof (error as { message: unknown }).message === "string"
+  ) {
+    return error as Pick<EngineError, "code" | "message">;
+  }
+  return {
+    code: "INTERNAL",
+    message: error instanceof Error ? error.message : "scanner status request failed",
+  };
+}
+
 export interface ContactSheetProps {
   onInspectFrame?: (frameIndex: number) => void;
   onCapture?: () => void;
 }
 
 export default function ContactSheet({ onInspectFrame, onCapture }: ContactSheetProps = {}) {
+  const [statusRefreshError, setStatusRefreshError] = useState<Pick<
+    EngineError,
+    "code" | "message"
+  > | null>(null);
+  const [mediaLoadError, setMediaLoadError] = useState<Pick<
+    EngineError,
+    "code" | "message"
+  > | null>(null);
   const state = useSyncExternalStore(stableSubscribe, stableGetSnapshot);
   const status = state.connection.status;
   const project = state.project;
@@ -80,14 +116,48 @@ export default function ContactSheet({ onInspectFrame, onCapture }: ContactSheet
   const connected = state.connection.connected;
   const deviceKind = state.connection.device?.kind ?? null;
   const canLoadSimulatedMedia = !mediaLoaded && connected && deviceKind === "simulated";
-  const canPreview =
-    project !== null && (mediaLoaded || (connected && deviceKind === "real"));
+  const canPreview = mediaLoaded || (connected && deviceKind === "real");
+  const motionReadiness =
+    deviceKind !== "real"
+      ? "notApplicable"
+      : status?.motionArmed === true
+        ? "ready"
+        : status?.motionArmed === false
+          ? "notEnabled"
+          : "unknown";
+  const motionReady = motionReadiness === "ready" || motionReadiness === "notApplicable";
+  const transportReady = status?.transport === "idle";
+  const operationBusy = sessionOperationBusy(state);
+  const previewDisabled = operationBusy || !motionReady || !transportReady;
   const frameCount = mediaLoaded ? (status?.frameCount ?? 0) : 0;
   const selectionEmpty = state.selectedFrameIndices.length === 0;
   const transformsEditable =
-    !state.scanStartPending &&
-    (state.jobState === null || ["completed", "failed", "stopped"].includes(state.jobState));
+    !operationBusy;
   const focusedFrameIndex = state.focusedFrameIndex;
+
+  useEffect(() => {
+    if (motionReadiness === "ready") setStatusRefreshError(null);
+  }, [motionReadiness]);
+
+  const checkScanner = async (): Promise<void> => {
+    setStatusRefreshError(null);
+    try {
+      await sessionStore.refreshStatus();
+    } catch (error) {
+      setStatusRefreshError(requestErrorOf(error));
+    }
+  };
+
+  const loadSimulatedMedia = async (
+    carrier: (typeof CARRIERS)[number],
+  ): Promise<void> => {
+    setMediaLoadError(null);
+    try {
+      await sessionStore.loadMedia(carrier);
+    } catch (error) {
+      setMediaLoadError(requestErrorOf(error));
+    }
+  };
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
@@ -119,8 +189,10 @@ export default function ContactSheet({ onInspectFrame, onCapture }: ContactSheet
   }, [focusedFrameIndex, transformsEditable]);
 
   const preview = (): void => {
-    if (project === null) return;
-    void sessionStore.acquireThumbnails(undefined, project.filmProcess);
+    const filmProcess = project?.filmProcess ?? state.previewFilmProcessSelection;
+    // SessionStore owns the typed request-failure state. Deliberately consume
+    // the rejection here so a UI click never becomes an unhandled promise.
+    void sessionStore.acquireThumbnails(undefined, filmProcess).catch(() => {});
   };
 
   const frames: number[] = [];
@@ -138,12 +210,18 @@ export default function ContactSheet({ onInspectFrame, onCapture }: ContactSheet
                 key={carrier}
                 type="button"
                 className={styles.controlButton}
-                onClick={() => void sessionStore.loadMedia(carrier)}
+                disabled={operationBusy}
+                onClick={() => void loadSimulatedMedia(carrier)}
               >
                 {carrier}
               </button>
             ))}
           </div>
+        )}
+        {mediaLoadError !== null && (
+          <p className={styles.failureBanner} role="alert" data-testid="media-load-error">
+            {mediaLoadError.code}: {mediaLoadError.message}
+          </p>
         )}
         {!mediaLoaded && !canLoadSimulatedMedia && (
           <p className={styles.mediaGuidance} data-testid="no-media-guidance">
@@ -152,16 +230,62 @@ export default function ContactSheet({ onInspectFrame, onCapture }: ContactSheet
               : "Connect a scanner to preview film."}
           </p>
         )}
+        {project === null && canPreview && (
+          <label className={styles.previewProcessControl}>
+            Film process for preview
+            <select
+              value={state.previewFilmProcessSelection}
+              disabled={
+                operationBusy
+              }
+              onChange={(event) =>
+                sessionStore.setPreviewFilmProcess(event.target.value as FilmProcess)
+              }
+            >
+              {FILM_PROCESSES.map(({ value, label }) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
         {canPreview && (
           <button
             type="button"
             className={styles.controlButton}
             data-testid="preview-button"
-            disabled={state.previewOutcome === "active"}
+            disabled={previewDisabled}
             onClick={preview}
           >
             Preview
           </button>
+        )}
+        {canPreview && !motionReady && (
+          <div className={styles.previewReadiness} data-testid="preview-readiness-guidance">
+            <span>
+              {motionReadiness === "notEnabled"
+                ? "Motion authorization is not enabled for this app session. Reopen ScanStudio using the documented owner-authorized hardware launch procedure; the app never enables motion on your behalf."
+                : "Motion readiness is unavailable. Check scanner status; preview remains disabled until readiness can be confirmed."}
+            </span>
+            <button
+              type="button"
+              className={styles.controlButton}
+              onClick={() => void checkScanner()}
+            >
+              Check scanner
+            </button>
+            {statusRefreshError !== null && (
+              <p className={styles.failureBanner} role="alert" data-testid="status-refresh-error">
+                {statusRefreshError.code}: {statusRefreshError.message}
+              </p>
+            )}
+          </div>
+        )}
+        {canPreview && motionReady && !transportReady && (
+          <p className={styles.mediaGuidance} data-testid="preview-readiness-guidance">
+            Wait for the scanner transport to become idle before previewing.
+          </p>
         )}
         {mediaLoaded && (
           <div className={styles.selectionControls}>
@@ -184,7 +308,10 @@ export default function ContactSheet({ onInspectFrame, onCapture }: ContactSheet
                 type="button"
                 className={styles.controlButton}
                 data-testid="capture-action"
-                disabled={selectionEmpty}
+                disabled={
+                  selectionEmpty ||
+                  operationBusy
+                }
                 onClick={onCapture}
               >
                 Capture selected
@@ -340,6 +467,11 @@ export default function ContactSheet({ onInspectFrame, onCapture }: ContactSheet
       {state.previewOutcome === "failed" && (
         <p className={styles.failureBanner} role="alert" data-testid="preview-failure">
           {state.previewError?.message ?? "Preview failed"}
+        </p>
+      )}
+      {state.previewRequestFailure !== null && (
+        <p className={styles.failureBanner} role="alert" data-testid="preview-request-failure">
+          {state.previewRequestFailure.error.message}
         </p>
       )}
       {mediaLoaded && frameCount > 0 && (

--- a/ports/tauri/app/src/views/DeviceBar.module.css
+++ b/ports/tauri/app/src/views/DeviceBar.module.css
@@ -44,6 +44,21 @@
   border: 1px solid #e5e7eb;
 }
 
+.connectionState,
+.connectionHint {
+  align-self: flex-start;
+  font-size: 0.75rem;
+}
+
+.connectionState {
+  color: #047857;
+  font-weight: 600;
+}
+
+.connectionHint {
+  color: #6b7280;
+}
+
 .controlButton {
   align-self: flex-start;
   padding: 0.35rem 0.75rem;
@@ -51,6 +66,12 @@
   border: 1px solid #d1d5db;
   background: #ffffff;
   cursor: pointer;
+}
+
+.controlButton:disabled {
+  color: #9ca3af;
+  background: #f9fafb;
+  cursor: not-allowed;
 }
 
 .statusBlock {

--- a/ports/tauri/app/src/views/DeviceBar.tsx
+++ b/ports/tauri/app/src/views/DeviceBar.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { sessionStore, type SessionState } from "../session";
-import type { DeviceInfo } from "../session/wire/types";
+import { sessionOperationBusy } from "../session/store/session";
+import type { DeviceInfo, EngineError } from "../session/wire/types";
 import DiagnosticReportActions from "./DiagnosticReportActions";
 import HardwareErrorPanel from "./HardwareErrorPanel";
 import HardwareStatusChips from "./HardwareStatusChips";
@@ -33,8 +34,37 @@ function stableGetSnapshot(): Readonly<SessionState> {
   return cachedSnapshot;
 }
 
+function connectionErrorOf(error: unknown): EngineError {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    "message" in error &&
+    typeof (error as { code: unknown }).code === "string" &&
+    typeof (error as { message: unknown }).message === "string"
+  ) {
+    return {
+      code: (error as { code: string }).code,
+      message: (error as { message: string }).message,
+      recoverable:
+        "recoverable" in error &&
+        typeof (error as { recoverable: unknown }).recoverable === "boolean"
+          ? (error as { recoverable: boolean }).recoverable
+          : false,
+    };
+  }
+  return {
+    code: "INTERNAL",
+    message: error instanceof Error ? error.message : "scanner connection request failed",
+    recoverable: false,
+  };
+}
+
 export default function DeviceBar() {
   const [devices, setDevices] = useState<DeviceInfo[] | null>(null);
+  const [connectionPending, setConnectionPending] = useState<string | null>(null);
+  const connectionPendingRef = useRef(false);
+  const [connectionError, setConnectionError] = useState<EngineError | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -55,6 +85,41 @@ export default function DeviceBar() {
   const connected = state.connection.connected;
   const status = state.connection.status;
   const device = state.connection.device;
+  const operationBusy = sessionOperationBusy(state);
+  const visibleError =
+    state.previewRequestFailure?.error ??
+    state.filmFeedInterrupted ??
+    connectionError;
+
+  const connect = async (deviceId: string): Promise<void> => {
+    if (connectionPendingRef.current || operationBusy) return;
+    connectionPendingRef.current = true;
+    setConnectionPending(deviceId);
+    setConnectionError(null);
+    try {
+      await sessionStore.connect(deviceId);
+    } catch (error) {
+      setConnectionError(connectionErrorOf(error));
+    } finally {
+      connectionPendingRef.current = false;
+      setConnectionPending(null);
+    }
+  };
+
+  const disconnect = async (): Promise<void> => {
+    if (connectionPendingRef.current || operationBusy) return;
+    connectionPendingRef.current = true;
+    setConnectionPending("disconnect");
+    setConnectionError(null);
+    try {
+      await sessionStore.disconnect();
+    } catch (error) {
+      setConnectionError(connectionErrorOf(error));
+    } finally {
+      connectionPendingRef.current = false;
+      setConnectionPending(null);
+    }
+  };
   // Hardware tri-state chips only ever mount for a real backend session --
   // the simulator omits motionArmed/filmPresent entirely (PROTOCOL.md:
   // "null is never absence"; the simulator omits the field rather than
@@ -66,33 +131,53 @@ export default function DeviceBar() {
     <div className={styles.deviceBar}>
       <h2 className={styles.heading}>Devices</h2>
       <ul className={styles.deviceList}>
-        {(devices ?? []).map((device) => (
-          <li
-            key={device.deviceId}
-            className={styles.deviceCard}
-            data-testid={`device-card-${device.deviceId}`}
-          >
-            <div className={styles.deviceModel}>{device.model}</div>
-            <span className={styles.kindBadge}>{device.kind}</span>
-            {connected ? (
-              <button
-                type="button"
-                className={styles.controlButton}
-                onClick={() => void sessionStore.disconnect()}
-              >
-                Disconnect
-              </button>
-            ) : (
-              <button
-                type="button"
-                className={styles.controlButton}
-                onClick={() => void sessionStore.connect(device.deviceId)}
-              >
-                Connect
-              </button>
-            )}
-          </li>
-        ))}
+        {(devices ?? []).map((listedDevice) => {
+          const isActive =
+            connected && device?.deviceId === listedDevice.deviceId;
+          const connectionBlocked = connected && !isActive;
+
+          return (
+            <li
+              key={listedDevice.deviceId}
+              className={styles.deviceCard}
+              data-testid={`device-card-${listedDevice.deviceId}`}
+            >
+              <div className={styles.deviceModel}>{listedDevice.model}</div>
+              <span className={styles.kindBadge}>{listedDevice.kind}</span>
+              {isActive ? (
+                <>
+                  <span className={styles.connectionState}>Active</span>
+                  <button
+                    type="button"
+                    className={styles.controlButton}
+                    disabled={operationBusy || connectionPending !== null}
+                    onClick={() => void disconnect()}
+                  >
+                    Disconnect
+                  </button>
+                </>
+              ) : (
+                <>
+                  {connectionBlocked && (
+                    <span className={styles.connectionHint}>
+                      Disconnect active device first
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    className={styles.controlButton}
+                    disabled={
+                      connectionBlocked || operationBusy || connectionPending !== null
+                    }
+                    onClick={() => void connect(listedDevice.deviceId)}
+                  >
+                    Connect
+                  </button>
+                </>
+              )}
+            </li>
+          );
+        })}
       </ul>
       {status !== null && (
         <dl className={styles.statusBlock} data-testid="scanner-status">
@@ -133,13 +218,13 @@ export default function DeviceBar() {
         />
       )}
       <HardwareErrorPanel
-        error={state.filmFeedInterrupted}
+        error={visibleError}
         thumbnailsFailed={
           state.previewOutcome === "failed" ? state.previewError : null
         }
       />
       <DiagnosticReportActions
-        error={state.filmFeedInterrupted}
+        error={visibleError}
         thumbnailsFailed={
           state.previewOutcome === "failed" ? state.previewError : null
         }

--- a/ports/tauri/app/src/views/FrameDetail/SpacingOffsetControl.tsx
+++ b/ports/tauri/app/src/views/FrameDetail/SpacingOffsetControl.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { sessionStore, type SessionState } from "../../session";
+import { sessionOperationBusy } from "../../session/store/session";
 import styles from "./FrameDetail.module.css";
 
 // useSyncExternalStore requires a referentially stable snapshot between
@@ -79,6 +80,7 @@ export default function SpacingOffsetControl({ frameIndex }: { frameIndex: numbe
 
   const parsed = Number.parseInt(value, 10);
   const clampedDisplay = Number.isNaN(parsed) ? range.min : clamp(parsed, range.min, range.max);
+  const adjustmentDisabled = sessionOperationBusy(state);
 
   const commit = async (raw: string): Promise<void> => {
     const parsedInput = Number.parseInt(raw, 10);
@@ -135,6 +137,7 @@ export default function SpacingOffsetControl({ frameIndex }: { frameIndex: numbe
           value={value}
           min={range.min}
           max={range.max}
+          disabled={adjustmentDisabled}
           aria-label={`Spacing offset for frame ${frameIndex}`}
           onChange={(event) => setValue(event.target.value)}
           onBlur={() => void commit(value)}
@@ -148,6 +151,7 @@ export default function SpacingOffsetControl({ frameIndex }: { frameIndex: numbe
           data-testid="spacing-offset-drag"
           min={range.min}
           max={range.max}
+          disabled={adjustmentDisabled}
           step={1}
           value={clampedDisplay}
           aria-label={`Spacing offset drag handle for frame ${frameIndex}`}

--- a/ports/tauri/app/src/views/HardwareErrorPanel.tsx
+++ b/ports/tauri/app/src/views/HardwareErrorPanel.tsx
@@ -91,8 +91,9 @@ export default function HardwareErrorPanel({
           {error.message}
         </p>
         <p className={styles.guidance} data-testid="motion-independent-guidance">
-          The motion latch is operator-owned: arm it at the machine before scanning.
-          The app never arms motion on your behalf.
+          Motion authorization is operator-owned. Reopen ScanStudio using the
+          documented owner-authorized hardware launch procedure. The app never
+          enables motion on your behalf.
         </p>
       </div>
     );

--- a/ports/tauri/app/src/views/ProjectPanel.module.css
+++ b/ports/tauri/app/src/views/ProjectPanel.module.css
@@ -45,6 +45,13 @@
   color: #b91c1c;
 }
 
+.registrationSummary {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
 .error {
   margin: 0;
   padding: 0.5rem 0.75rem;

--- a/ports/tauri/app/src/views/ProjectPanel.tsx
+++ b/ports/tauri/app/src/views/ProjectPanel.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState, useSyncExternalStore } from "react";
 import { homeDir } from "@tauri-apps/api/path";
 import { open } from "@tauri-apps/plugin-dialog";
 import { sessionStore, type SessionState } from "../session";
+import {
+  preProjectPreviewRegistration,
+  sessionOperationBusy,
+} from "../session/store/session";
 import type { ProjectSummary } from "../session/wire/types";
 import { frameCountRangeFor, validateFrameCount, type Carrier } from "./projectRules";
 import styles from "./ProjectPanel.module.css";
@@ -58,6 +62,7 @@ export default function ProjectPanel() {
   const [carrier, setCarrier] = useState<Carrier>("roll36");
   const [frameCount, setFrameCount] = useState("36");
   const [filmProcess, setFilmProcess] = useState<FilmProcess>("positive");
+  const [carrierConfirmed, setCarrierConfirmed] = useState(false);
   const [directory, setDirectory] = useState<string | undefined>(undefined);
   const [recent, setRecent] = useState<ProjectSummary[] | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -65,6 +70,25 @@ export default function ProjectPanel() {
 
   const state = useSyncExternalStore(stableSubscribe, stableGetSnapshot);
   const project = state.project;
+  const previewRegistration = preProjectPreviewRegistration(state);
+  const operationBusy = sessionOperationBusy(state);
+
+  useEffect(() => {
+    if (previewRegistration === null) return;
+    if (previewRegistration.carrier !== null) {
+      setCarrier(previewRegistration.carrier);
+      setCarrierConfirmed(true);
+    } else {
+      setCarrierConfirmed(false);
+    }
+    setFrameCount(String(previewRegistration.frameCount));
+    setFilmProcess(previewRegistration.filmProcess);
+  }, [
+    previewRegistration?.operationId,
+    previewRegistration?.carrier,
+    previewRegistration?.frameCount,
+    previewRegistration?.filmProcess,
+  ]);
 
   useEffect(() => {
     let cancelled = false;
@@ -85,10 +109,34 @@ export default function ProjectPanel() {
     };
   }, []);
 
-  const count = Number(frameCount);
-  const range = frameCountRangeFor(carrier);
-  const validation = validateFrameCount(carrier, count);
-  const createDisabled = name.trim() === "" || !validation.valid || submitting;
+  const resolvedCarrier = previewRegistration?.carrier ?? carrier;
+  const count = previewRegistration?.frameCount ?? Number(frameCount);
+  const resolvedFilmProcess = previewRegistration?.filmProcess ?? filmProcess;
+  const range = frameCountRangeFor(resolvedCarrier);
+  const validation = validateFrameCount(resolvedCarrier, count);
+  const holderNeedsConfirmation =
+    previewRegistration !== null &&
+    previewRegistration.carrier === null &&
+    !carrierConfirmed;
+  const completedPreviewNeedsRecovery =
+    project === null &&
+    state.previewOutcome === "succeeded" &&
+    state.previewFilmProcess !== null &&
+    previewRegistration === null;
+  const waitingForDetectedStatus =
+    completedPreviewNeedsRecovery &&
+    state.connection.device?.kind === "real" &&
+    state.latestCompletedPreviewOperationId !== null &&
+    state.previewStatusOperationId !== state.latestCompletedPreviewOperationId;
+  const previewRegistrationIncomplete =
+    completedPreviewNeedsRecovery && !waitingForDetectedStatus;
+  const createDisabled =
+    name.trim() === "" ||
+    !validation.valid ||
+    holderNeedsConfirmation ||
+    completedPreviewNeedsRecovery ||
+    submitting ||
+    operationBusy;
 
   const pickDirectory = async (): Promise<void> => {
     try {
@@ -111,9 +159,9 @@ export default function ProjectPanel() {
     try {
       await sessionStore.createProject(
         name.trim(),
-        carrier,
+        resolvedCarrier,
         count,
-        filmProcess,
+        resolvedFilmProcess,
         directory,
       );
     } catch (err) {
@@ -127,6 +175,15 @@ export default function ProjectPanel() {
     setError(null);
     try {
       await sessionStore.openProject(summary.directory);
+    } catch (err) {
+      setError(messageOf(err));
+    }
+  };
+
+  const refreshPreviewStatus = async (): Promise<void> => {
+    setError(null);
+    try {
+      await sessionStore.refreshStatus();
     } catch (err) {
       setError(messageOf(err));
     }
@@ -155,8 +212,12 @@ export default function ProjectPanel() {
         <label htmlFor="project-carrier">Carrier</label>
         <select
           id="project-carrier"
-          value={carrier}
-          onChange={(event) => setCarrier(event.target.value as Carrier)}
+          value={resolvedCarrier}
+          disabled={previewRegistration?.carrier !== null && previewRegistration !== null}
+          onChange={(event) => {
+            setCarrier(event.target.value as Carrier);
+            setCarrierConfirmed(true);
+          }}
         >
           {CARRIERS.map((option) => (
             <option key={option} value={option}>
@@ -170,13 +231,15 @@ export default function ProjectPanel() {
           type="number"
           min={range.min}
           max={range.max}
-          value={frameCount}
+          value={previewRegistration === null ? frameCount : String(previewRegistration.frameCount)}
+          readOnly={previewRegistration !== null}
           onChange={(event) => setFrameCount(event.target.value)}
         />
         <label htmlFor="project-film-process">Film process</label>
         <select
           id="project-film-process"
-          value={filmProcess}
+          value={resolvedFilmProcess}
+          disabled={previewRegistration !== null}
           onChange={(event) => setFilmProcess(event.target.value as FilmProcess)}
         >
           {FILM_PROCESSES.map((option) => (
@@ -185,6 +248,48 @@ export default function ProjectPanel() {
             </option>
           ))}
         </select>
+        {previewRegistration !== null && (
+          <p className={styles.registrationSummary} data-testid="preview-registration-summary">
+            {previewRegistration.frameCount} frames detected with {previewRegistration.filmProcess}.
+            {previewRegistration.carrier === null
+              ? " Confirm the loaded film holder before creating the project."
+              : " These values are locked to the completed preview."}
+          </p>
+        )}
+        {waitingForDetectedStatus && (
+          <>
+            <p className={styles.registrationSummary} data-testid="preview-status-pending">
+              Waiting for the scanner to report the detected holder and frame count.
+            </p>
+            <button
+              type="button"
+              className={styles.controlButton}
+              data-testid="refresh-preview-status"
+              disabled={operationBusy}
+              onClick={() => void refreshPreviewStatus()}
+            >
+              Check scanner
+            </button>
+          </>
+        )}
+        {previewRegistrationIncomplete && (
+          <p className={styles.registrationSummary} data-testid="preview-registration-incomplete">
+            Preview registration is incomplete or a saved spacing adjustment could not be
+            restored. Choose Preview again before creating the project.
+          </p>
+        )}
+        {previewRegistration !== null &&
+          previewRegistration.carrier === null &&
+          !carrierConfirmed && (
+            <button
+              type="button"
+              className={styles.controlButton}
+              data-testid="confirm-preview-carrier"
+              onClick={() => setCarrierConfirmed(true)}
+            >
+              Confirm {carrier} holder
+            </button>
+          )}
         <div className={styles.directoryRow}>
           <button type="button" className={styles.controlButton} onClick={() => void pickDirectory()}>
             Choose output folder
@@ -213,6 +318,9 @@ export default function ProjectPanel() {
               type="button"
               className={styles.recentRow}
               data-testid={`recent-project-${summary.id}`}
+              disabled={
+                operationBusy || submitting
+              }
               onClick={() => void openRecent(summary)}
             >
               <span className={styles.recentName}>{summary.name}</span>

--- a/ports/tauri/app/src/views/ScanRun/__tests__/ScanRunView.test.tsx
+++ b/ports/tauri/app/src/views/ScanRun/__tests__/ScanRunView.test.tsx
@@ -115,6 +115,13 @@ async function runFixture(): Promise<Fixture> {
   await store.loadMedia("roll36");
   await store.createProject("Run Roll", "roll36", 36, "c41ColorNegative");
   await store.acquireThumbnails();
+  const previewOperationId = calls.find(
+    (call) => call.method === "scanner.acquireThumbnails",
+  )?.params.operationId as string;
+  handle.emitEvent({
+    event: "scanner.thumbnailsComplete",
+    payload: { count: 36, operationId: previewOperationId },
+  });
   await store.startScan([1, 2, 3, 4, 13], {
     resolutionDpi: 4000,
     bitDepth: 16,

--- a/ports/tauri/app/src/views/__tests__/ContactSheet.test.tsx
+++ b/ports/tauri/app/src/views/__tests__/ContactSheet.test.tsx
@@ -40,6 +40,12 @@ const EMPTY_STATUS: ScannerStatus = {
   frameCount: null,
 };
 
+const REAL_EMPTY_ARMED: ScannerStatus = {
+  ...EMPTY_STATUS,
+  motionArmed: true,
+  filmPresent: true,
+};
+
 const SIMULATED_DEVICE: DeviceInfo = {
   deviceId: "sim-ls5000-0",
   model: "LS-5000 (simulated)",
@@ -171,12 +177,41 @@ describe("ContactSheet", () => {
 
     const loadCall = fixture.calls.find((c) => c.method === "sim.loadMedia");
     expect(loadCall?.params.carrier).toBe("strip6");
-    // The loaded status from the scripted response swaps the controls for the
-    // grid. With no active project there is nothing to preview from, so no
-    // Preview button renders (filmProcess comes from the project).
+    // The loaded status swaps the controls for the grid and exposes the
+    // pre-project preview flow. Film process is selected before the project
+    // exists so the detected frame registration can be saved afterward.
     expect(await screen.findByTestId("contact-grid")).toBeInTheDocument();
     expect(screen.queryByTestId("load-media-controls")).toBeNull();
-    expect(screen.queryByTestId("preview-button")).toBeNull();
+    expect(screen.getByTestId("preview-button")).toBeEnabled();
+    expect(screen.getByLabelText("Film process for preview")).toHaveValue(
+      "c41ColorNegative",
+    );
+  });
+
+  it("consumes and surfaces a simulated-media load rejection", async () => {
+    const fixture = contactFixture({
+      device: SIMULATED_DEVICE,
+      status: EMPTY_STATUS,
+      onRequest: (method) =>
+        method === "sim.loadMedia"
+          ? {
+              error: {
+                code: "NOT_CONNECTED",
+                message: "the simulator disconnected before media could load",
+                recoverable: true,
+              },
+            }
+          : undefined,
+    });
+    await fixture.store.connect(SIMULATED_DEVICE.deviceId);
+    mocks.sessionStore = fixture.store;
+    const user = userEvent.setup();
+    render(<ContactSheet />);
+
+    await user.click(screen.getByRole("button", { name: "roll36" }));
+    expect(await screen.findByTestId("media-load-error")).toHaveTextContent(
+      "NOT_CONNECTED: the simulator disconnected before media could load",
+    );
   });
 
   it("asks a disconnected user to connect without offering simulator carrier controls", () => {
@@ -192,14 +227,12 @@ describe("ContactSheet", () => {
     expect(fixture.calls.some((call) => call.method === "sim.loadMedia")).toBe(false);
   });
 
-  it("offers the first real preview before registration without sending simulator commands", async () => {
+  it("offers the first real preview before a project exists and sends the selected process", async () => {
     const fixture = contactFixture({
       device: REAL_DEVICE,
-      status: EMPTY_STATUS,
-      project: PROJECT,
+      status: REAL_EMPTY_ARMED,
     });
     await fixture.store.connect(REAL_DEVICE.deviceId);
-    await fixture.store.createProject("Contact Sheet Roll", "roll36", 36, "c41ColorNegative");
     mocks.sessionStore = fixture.store;
     const user = userEvent.setup();
 
@@ -209,12 +242,107 @@ describe("ContactSheet", () => {
       "Load film in the scanner, then choose Preview to establish the current frame registration.",
     );
     expect(screen.queryByTestId("load-media-controls")).toBeNull();
+    expect(screen.queryByTestId("active-project")).toBeNull();
+    await user.selectOptions(
+      screen.getByLabelText("Film process for preview"),
+      "bwNegative",
+    );
     const preview = screen.getByTestId("preview-button");
     await act(async () => {
       await user.click(preview);
     });
-    expect(fixture.calls.some((call) => call.method === "scanner.acquireThumbnails")).toBe(true);
+    const acquire = fixture.calls.find(
+      (call) => call.method === "scanner.acquireThumbnails",
+    );
+    expect(acquire?.params.filmProcess).toBe("bwNegative");
+    expect(fixture.calls.some((call) => call.method === "project.create")).toBe(false);
     expect(fixture.calls.some((call) => call.method === "sim.loadMedia")).toBe(false);
+  });
+
+  it.each([false, undefined])(
+    "keeps real Preview visible but fail-closed when motionArmed is %s",
+    async (motionArmed) => {
+      const fixture = contactFixture({
+        device: REAL_DEVICE,
+        status: { ...EMPTY_STATUS, motionArmed, filmPresent: true },
+      });
+      await fixture.store.connect(REAL_DEVICE.deviceId);
+      mocks.sessionStore = fixture.store;
+      const user = userEvent.setup();
+
+      render(<ContactSheet />);
+
+      expect(screen.getByTestId("preview-button")).toBeVisible();
+      expect(screen.getByTestId("preview-button")).toBeDisabled();
+      expect(screen.getByTestId("preview-readiness-guidance")).toHaveTextContent(
+        motionArmed === false
+          ? /motion authorization.*owner-authorized/i
+          : /motion readiness is unavailable.*check scanner status/i,
+      );
+      await user.click(screen.getByTestId("preview-button"));
+      expect(
+        fixture.calls.some((call) => call.method === "scanner.acquireThumbnails"),
+      ).toBe(false);
+    },
+  );
+
+  it("surfaces a typed scanner-status refresh failure from unknown motion readiness", async () => {
+    const fixture = contactFixture({
+      device: REAL_DEVICE,
+      status: { ...EMPTY_STATUS, motionArmed: undefined, filmPresent: true },
+      onRequest: (method) =>
+        method === "scanner.status"
+          ? {
+              error: {
+                code: "BRIDGE_UNAVAILABLE",
+                message: "scanner bridge did not answer",
+                recoverable: true,
+              },
+            }
+          : undefined,
+    });
+    await fixture.store.connect(REAL_DEVICE.deviceId);
+    mocks.sessionStore = fixture.store;
+    const user = userEvent.setup();
+    render(<ContactSheet />);
+
+    await user.click(screen.getByRole("button", { name: "Check scanner" }));
+    expect(await screen.findByTestId("status-refresh-error")).toHaveTextContent(
+      "BRIDGE_UNAVAILABLE: scanner bridge did not answer",
+    );
+  });
+
+  it("terminates a synchronous preview rejection and renders the exact bridge message", async () => {
+    const fixture = contactFixture({
+      device: REAL_DEVICE,
+      status: REAL_EMPTY_ARMED,
+      onRequest: (method) =>
+        method === "scanner.acquireThumbnails"
+          ? {
+              error: {
+                code: "HW_MOTION_NOT_ARMED",
+                message: "motion authorization is not armed for this process",
+                recoverable: false,
+              },
+            }
+          : undefined,
+    });
+    await fixture.store.connect(REAL_DEVICE.deviceId);
+    mocks.sessionStore = fixture.store;
+    const user = userEvent.setup();
+    const unhandled = vi.fn();
+    window.addEventListener("unhandledrejection", unhandled);
+
+    render(<ContactSheet />);
+    await act(async () => {
+      await user.click(screen.getByTestId("preview-button"));
+    });
+
+    expect(await screen.findByTestId("preview-request-failure")).toHaveTextContent(
+      "motion authorization is not armed for this process",
+    );
+    expect(unhandled).not.toHaveBeenCalled();
+    window.removeEventListener("unhandledrejection", unhandled);
   });
 
   it("calls acquireThumbnails with the project's filmProcess and disables the button while a preview is active", async () => {
@@ -352,6 +480,10 @@ describe("ContactSheet", () => {
           thumbnail: { imagePath: "/scans/frames/frame-0002.png" },
           operationId,
         },
+      });
+      fixture.emitEvent({
+        event: "scanner.thumbnailsComplete",
+        payload: { count: 1, operationId },
       });
     });
     await user.click(screen.getByTestId("contact-tile-2"));

--- a/ports/tauri/app/src/views/__tests__/DeviceBar.test.tsx
+++ b/ports/tauri/app/src/views/__tests__/DeviceBar.test.tsx
@@ -14,7 +14,15 @@ afterEach(cleanup);
 // app/src/session/index.ts, which wraps the Tauri invoke bridge and cannot
 // run under jsdom. Replace the module with a hoisted holder that each test
 // points at a fresh SessionStore built on a scripted transport.
-const mocks = vi.hoisted(() => ({ sessionStore: null as unknown }));
+const mocks = vi.hoisted(() => ({
+  sessionStore: null as unknown,
+  diagnosticTimeline: {
+    record: vi.fn(),
+    sessionId: "test-session",
+    summaryLines: [] as string[],
+    toJsonl: () => "",
+  },
+}));
 vi.mock("../../session", () => mocks);
 
 const SIM_DEVICE: DeviceInfo = {
@@ -23,6 +31,14 @@ const SIM_DEVICE: DeviceInfo = {
   kind: "simulated",
   firmware: "1.0.0",
   connection: "USB",
+};
+
+const REAL_DEVICE: DeviceInfo = {
+  deviceId: "real-ls5000-0",
+  model: "Nikon LS-5000",
+  kind: "real",
+  firmware: "1.02",
+  connection: "usb",
 };
 
 const CONNECTED_STATUS: ScannerStatus = {
@@ -89,30 +105,121 @@ describe("DeviceBar", () => {
     expect(disconnectSpy).toHaveBeenCalled();
   });
 
-  it("never renders the simulated label on a real device's card", async () => {
-    const realDevice: DeviceInfo = {
-      deviceId: "real-ls5000-0",
-      model: "Nikon LS-5000",
-      kind: "real" as DeviceInfo["kind"],
-      firmware: "2.4.1",
-      connection: "SCSI",
-    };
-    mocks.sessionStore = scriptedFixture([realDevice]);
+  it("only lets the active device disconnect when multiple devices are listed", async () => {
+    const store = scriptedFixture([SIM_DEVICE, REAL_DEVICE], CONNECTED_STATUS);
+    await store.connect(SIM_DEVICE.deviceId);
+    mocks.sessionStore = store;
+    const connectSpy = vi.spyOn(store, "connect");
+    const user = userEvent.setup();
+
     render(<DeviceBar />);
-    const card = await screen.findByTestId(`device-card-${realDevice.deviceId}`);
-    expect(card).toHaveTextContent(realDevice.model);
+
+    const activeCard = await screen.findByTestId(`device-card-${SIM_DEVICE.deviceId}`);
+    const inactiveCard = screen.getByTestId(`device-card-${REAL_DEVICE.deviceId}`);
+    expect(within(activeCard).getByRole("button", { name: "Disconnect" })).toBeEnabled();
+    expect(within(activeCard).getByText("Active")).toBeInTheDocument();
+    expect(within(inactiveCard).queryByRole("button", { name: "Disconnect" })).toBeNull();
+    const inactiveConnect = within(inactiveCard).getByRole("button", { name: "Connect" });
+    expect(inactiveConnect).toBeDisabled();
+    expect(inactiveCard).toHaveTextContent("Disconnect active device first");
+    expect(screen.getAllByRole("button", { name: "Disconnect" })).toHaveLength(1);
+
+    await user.click(inactiveConnect);
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
+  it("releases the active card when the engine reports an asynchronous disconnect", async () => {
+    const handle = createScriptedTransport({
+      onRequest: (method) => {
+        if (method === "scanner.list") return { result: { devices: [SIM_DEVICE] } };
+        if (method === "scanner.connect") {
+          return { result: { device: SIM_DEVICE, status: CONNECTED_STATUS } };
+        }
+        return { result: undefined };
+      },
+    });
+    const store = new SessionStore(handle.transport);
+    await store.connect(SIM_DEVICE.deviceId);
+    mocks.sessionStore = store;
+    render(<DeviceBar />);
+    expect(await screen.findByText("Active")).toBeInTheDocument();
+
+    act(() => {
+      handle.emitEvent({
+        event: "scanner.status",
+        payload: {
+          status: {
+            ...CONNECTED_STATUS,
+            connected: false,
+            mediaLoaded: false,
+            carrier: null,
+            frameCount: null,
+            transport: "idle",
+          },
+        },
+      });
+    });
+
+    expect(screen.queryByText("Active")).toBeNull();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeEnabled();
+    expect(store.getState().connection).toMatchObject({
+      connected: false,
+      device: null,
+    });
+  });
+
+  it("consumes and surfaces a typed connection rejection", async () => {
+    const handle = createScriptedTransport({
+      onRequest: (method) => {
+        if (method === "scanner.list") return { result: { devices: [SIM_DEVICE] } };
+        if (method === "scanner.connect") {
+          return {
+            error: {
+              code: "ALREADY_CONNECTED",
+              message: "another scanner session already owns the bridge",
+              recoverable: true,
+            },
+          };
+        }
+        return { result: undefined };
+      },
+    });
+    mocks.sessionStore = new SessionStore(handle.transport);
+    const user = userEvent.setup();
+    render(<DeviceBar />);
+
+    await user.click(await screen.findByRole("button", { name: "Connect" }));
+    const panel = await screen.findByTestId("hardware-error-panel");
+    expect(panel).toHaveTextContent("ALREADY_CONNECTED");
+    expect(panel).toHaveTextContent("another scanner session already owns the bridge");
+  });
+
+  it("normalizes a malformed connection rejection without trusting missing fields", async () => {
+    const store = scriptedFixture([SIM_DEVICE]);
+    vi.spyOn(store, "connect").mockRejectedValue({
+      code: "BROKEN_ADAPTER",
+      message: "adapter returned an incomplete error",
+    });
+    mocks.sessionStore = store;
+    const user = userEvent.setup();
+    render(<DeviceBar />);
+
+    await user.click(await screen.findByRole("button", { name: "Connect" }));
+    const panel = await screen.findByTestId("hardware-error-panel");
+    expect(panel).toHaveTextContent("BROKEN_ADAPTER");
+    expect(panel).toHaveTextContent("adapter returned an incomplete error");
+  });
+
+  it("never renders the simulated label on a real device's card", async () => {
+    mocks.sessionStore = scriptedFixture([REAL_DEVICE]);
+    render(<DeviceBar />);
+    const card = await screen.findByTestId(`device-card-${REAL_DEVICE.deviceId}`);
+    expect(card).toHaveTextContent(REAL_DEVICE.model);
     expect(within(card).getByText("real")).toBeInTheDocument();
     expect(within(card).queryByText(/simulated/i)).toBeNull();
   });
 
   it("describes real mediaLoaded as preview registration, not film presence", async () => {
-    const realDevice: DeviceInfo = {
-      deviceId: "real-ls5000-0",
-      model: "Nikon LS-5000",
-      kind: "real",
-      firmware: "1.02",
-      connection: "usb",
-    };
     const realStatus: ScannerStatus = {
       ...CONNECTED_STATUS,
       mediaLoaded: false,
@@ -122,8 +229,8 @@ describe("DeviceBar", () => {
       filmPresent: true,
       motionArmed: false,
     };
-    const store = scriptedFixture([realDevice], realStatus);
-    await store.connect(realDevice.deviceId);
+    const store = scriptedFixture([REAL_DEVICE], realStatus);
+    await store.connect(REAL_DEVICE.deviceId);
     mocks.sessionStore = store;
 
     render(<DeviceBar />);
@@ -131,5 +238,45 @@ describe("DeviceBar", () => {
     expect(await screen.findByText("Preview registration")).toBeInTheDocument();
     expect(screen.getByText("Not established")).toBeInTheDocument();
     expect(screen.queryByText("No media")).toBeNull();
+  });
+
+  it("routes an immediate motion refusal into the typed hardware panel and diagnostics", async () => {
+    const readyStatus: ScannerStatus = {
+      ...CONNECTED_STATUS,
+      transport: "idle",
+      motionArmed: true,
+      filmPresent: true,
+    };
+    const handle = createScriptedTransport({
+      onRequest: (method) => {
+        if (method === "scanner.list") return { result: { devices: [REAL_DEVICE] } };
+        if (method === "scanner.connect") {
+          return { result: { device: REAL_DEVICE, status: readyStatus } };
+        }
+        if (method === "scanner.acquireThumbnails") {
+          return {
+            error: {
+              code: "HW_MOTION_NOT_ARMED",
+              message: "motion authorization expired",
+              recoverable: false,
+            },
+          };
+        }
+        return { result: undefined };
+      },
+    });
+    const store = new SessionStore(handle.transport);
+    await store.connect(REAL_DEVICE.deviceId);
+    await expect(store.acquireThumbnails()).rejects.toMatchObject({
+      code: "HW_MOTION_NOT_ARMED",
+    });
+    mocks.sessionStore = store;
+
+    render(<DeviceBar />);
+
+    const panel = await screen.findByTestId("hardware-error-panel");
+    expect(panel).toHaveAttribute("data-code", "HW_MOTION_NOT_ARMED");
+    expect(panel).toHaveTextContent("motion authorization expired");
+    expect(screen.getByTestId("diagnostic-report-actions")).toBeInTheDocument();
   });
 });

--- a/ports/tauri/app/src/views/__tests__/ProjectPanel.test.tsx
+++ b/ports/tauri/app/src/views/__tests__/ProjectPanel.test.tsx
@@ -5,7 +5,13 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionStore } from "../../session/store/session";
 import { createScriptedTransport } from "../../session/testing/harness";
-import type { EngineError, ProjectSummary, ScanProject } from "../../session/wire/types";
+import type {
+  DeviceInfo,
+  EngineError,
+  ProjectSummary,
+  ScanProject,
+  ScannerStatus,
+} from "../../session/wire/types";
 import ProjectPanel from "../ProjectPanel";
 
 afterEach(cleanup);
@@ -152,6 +158,170 @@ describe("ProjectPanel", () => {
     expect(banner).toHaveTextContent("36 frames");
   });
 
+  it("uses preview identity and explicitly confirms an unknown holder", async () => {
+    const device: DeviceInfo = {
+      deviceId: "sim-strip",
+      model: "LS-5000 (simulated)",
+      kind: "simulated",
+      firmware: "sim-1",
+      connection: "virtual",
+    };
+    const status: ScannerStatus = {
+      connected: true,
+      adapter: "SA-21",
+      mediaLoaded: true,
+      carrier: null,
+      frameCount: 2,
+      lamp: "stable",
+      transport: "idle",
+      activeJobId: null,
+    };
+    const registeredProject: ScanProject = {
+      ...PROJECT,
+      id: "proj-registered",
+      name: "Registered strip",
+      carrier: "roll36",
+      frameCount: 2,
+      filmProcess: "bwNegative",
+      frames: [1, 2].map((index) => ({ index, excluded: false, receipts: [] })),
+    };
+    const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const handle = createScriptedTransport({
+      onRequest: (method, params) => {
+        calls.push({ method, params: params as Record<string, unknown> });
+        if (method === "scanner.connect") return { result: { device, status } };
+        if (method === "scanner.acquireThumbnails") {
+          return { result: { accepted: true, frames: [1, 2] } };
+        }
+        if (method === "project.list") return { result: { projects: [] } };
+        if (method === "project.create") {
+          return {
+            result: { project: registeredProject, directory: "/tmp/registered" },
+          };
+        }
+        return { result: undefined };
+      },
+    });
+    const store = new SessionStore(handle.transport);
+    await store.connect(device.deviceId);
+    store.setPreviewFilmProcess("bwNegative");
+    await store.acquireThumbnails();
+    const operationId = calls.find(
+      (call) => call.method === "scanner.acquireThumbnails",
+    )?.params.operationId as string;
+    for (const frameIndex of [1, 2]) {
+      handle.emitEvent({
+        event: "scanner.thumbnail",
+        payload: { frameIndex, thumbnail: { brightness: 0.5 }, operationId },
+      });
+    }
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 2, operationId },
+    });
+    mocks.sessionStore = store;
+    const createSpy = vi.spyOn(store, "createProject");
+    const user = userEvent.setup();
+
+    render(<ProjectPanel />);
+
+    expect(await screen.findByTestId("preview-registration-summary")).toHaveTextContent(
+      "2 frames detected with bwNegative",
+    );
+    expect(screen.getByLabelText("Carrier")).toHaveValue("roll36");
+    expect(screen.getByLabelText("Carrier")).toBeEnabled();
+    expect(screen.getByLabelText("Frame count")).toHaveValue(2);
+    expect(screen.getByLabelText("Frame count")).toHaveAttribute("readonly");
+    expect(screen.getByLabelText("Film process")).toHaveValue("bwNegative");
+    expect(screen.getByLabelText("Film process")).toBeDisabled();
+
+    await user.type(screen.getByLabelText("Project name"), "Registered strip");
+    expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+    await user.click(screen.getByTestId("confirm-preview-carrier"));
+    expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "Create" }));
+    });
+    expect(createSpy).toHaveBeenCalledWith(
+      "Registered strip",
+      "roll36",
+      2,
+      "bwNegative",
+      undefined,
+    );
+    expect(screen.queryByTestId("project-error")).toBeNull();
+  });
+
+  it("keeps Create disabled until a real preview reports its correlated detected holder", async () => {
+    const device: DeviceInfo = {
+      deviceId: "real-ls5000",
+      model: "LS-5000",
+      kind: "real",
+      firmware: "1.0",
+      connection: "usb",
+    };
+    const priorStatus: ScannerStatus = {
+      connected: true,
+      adapter: "MA-21",
+      mediaLoaded: true,
+      carrier: "mounted",
+      frameCount: 1,
+      lamp: "stable",
+      transport: "idle",
+      activeJobId: null,
+      motionArmed: true,
+      filmPresent: true,
+    };
+    const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const handle = createScriptedTransport({
+      onRequest: (method, params) => {
+        calls.push({ method, params: params as Record<string, unknown> });
+        if (method === "scanner.connect") return { result: { device, status: priorStatus } };
+        if (method === "scanner.acquireThumbnails") {
+          return { result: { accepted: true, frames: [1] } };
+        }
+        if (method === "scanner.status") {
+          return {
+            result: { ...priorStatus, adapter: "SA-21", carrier: "strip6" },
+          };
+        }
+        if (method === "project.list") return { result: { projects: [] } };
+        return { result: undefined };
+      },
+    });
+    const store = new SessionStore(handle.transport);
+    await store.connect(device.deviceId);
+    store.setPreviewFilmProcess("bwNegative");
+    await store.acquireThumbnails();
+    const operationId = calls.find(
+      (call) => call.method === "scanner.acquireThumbnails",
+    )?.params.operationId as string;
+    handle.emitEvent({
+      event: "scanner.thumbnail",
+      payload: { frameIndex: 1, thumbnail: { brightness: 0.5 }, operationId },
+    });
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 1, operationId },
+    });
+    mocks.sessionStore = store;
+    const user = userEvent.setup();
+    render(<ProjectPanel />);
+
+    await user.type(await screen.findByLabelText("Project name"), "Detected strip");
+    expect(screen.getByTestId("preview-status-pending")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+
+    await act(async () => {
+      await user.click(screen.getByTestId("refresh-preview-status"));
+    });
+    expect(await screen.findByTestId("preview-registration-summary")).toHaveTextContent(
+      "1 frames detected with bwNegative",
+    );
+    expect(screen.getByLabelText("Carrier")).toHaveValue("strip6");
+    expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
+  });
+
   it("passes the native picker's returned directory to createProject when one is chosen", async () => {
     dialogMocks.open.mockResolvedValue("/Users/test/My Scans");
     const store = projectFixture((method) => {
@@ -219,6 +389,19 @@ describe("ProjectPanel", () => {
       await user.click(row);
     });
     expect(openSpy).toHaveBeenCalledWith("/scans/old-roll");
+  });
+
+  it("disables create and open actions while a preview owns the lane", async () => {
+    const store = projectFixture();
+    await store.acquireThumbnails();
+    mocks.sessionStore = store;
+    const user = userEvent.setup();
+    render(<ProjectPanel />);
+
+    await user.type(await screen.findByLabelText("Project name"), "Blocked");
+    expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+    expect(await screen.findByTestId("recent-project-proj-2")).toBeDisabled();
+    expect(screen.getByTestId("recent-project-proj-3")).toBeDisabled();
   });
 
   it("displays a rejected create's error message verbatim", async () => {


### PR DESCRIPTION
Fixes #26's latest workflow failure.

- Preview now works before project creation, with film-process selection and detected carrier/frame count.
- Motion readiness and immediate hardware failures are surfaced clearly.
- Project creation safely attaches completed previews and preserves alignment work.
- Device cards identify only the active scanner and serialize connection/media/project/scan operations.
- Closes a set of preview, scan, alignment, connection, and project-boundary races.

Webview suite: 395 passed, 6 skipped across 58 files; production TypeScript/Vite build passes. An independent adversarial review pass was triaged: its one valid medium finding (unsafe normalization of incomplete connection errors) is fixed here with regression coverage; its claimed high-severity identifier typo was disproved by source inspection, type-check, and runtime tests.