### PR TITLE
Driver probe CLIs: VPD dump, unload timer, perforation, wedge recovery

### DIFF
--- a/coolscanpy/FIREWIRE.md
+++ b/coolscanpy/FIREWIRE.md
@@ -119,3 +119,26 @@ re-verified at v0.3.0: the table moved from `src/devices.rs` to
   FireWire units remains Linux-first (issue #16 discussion).
   coolscanpy's probe runs there through `linux_sg` with no extra
   install; the same paste-the-output ask in issue #28 applies.
+
+## Capability pages are walked, never indexed
+
+Capability pages are variable layouts. A parser follows each page's length
+prefixes and extend bits in order; it does not assign a permanent meaning to a
+fixed byte offset across scanner models. The byte positions in an interface
+specification are authoritative for the exact model documented by that
+specification, not a promise that another unit inserts every preceding field in
+the same place.
+
+The 2026-08-10 live LS-5000 dump gives a concrete length example. Its C1h page
+advertises `window_descriptor_len: 61`, while the SET WINDOW data header in the
+LS-5000 specification recommends a 50-byte window descriptor. The C1h set-value
+table itself specifies 61, so this is not a scanner/spec conflict; it is a
+warning against using the command header's recommended 50 as a capability-page
+layout constant.
+
+The reported nkscan v0.3.3 changelog example for the LS-8000 could not be
+verified from the local source bundle: no nkscan changelog was banked. The
+reported autofocus failure and the exact upstream wording therefore are not
+quoted here. Once that changelog is stored locally, its exact sentence should
+be added as the second model-specific regression example rather than
+reconstructed from memory.

--- a/coolscanpy/src/coolscanpy/cli/perforation_probe.py
+++ b/coolscanpy/src/coolscanpy/cli/perforation_probe.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Read the LS-5000's current thumbnail perforation table.
+
+Table 2-11-1 defines the READ(28h) CDB (``LS5kIFSpec.md:7557-7632``),
+Table 2-11-2 assigns read-only data type 8Eh to perforation information
+(``:7691-7691`` and ``:7850-7855``), and section 2-11-8 defines its 4-byte
+records (``:9003-9110``).  The scanner is first asked for the captured
+6-byte 8Eh length envelope and then for exactly that declared size.  READ
+uses control byte 80 as established by the LS-5000 corpus.
+
+The command never starts a scan or moves film.  Per the spec, 8Eh data exists
+after thumbnail scanning; CHECK CONDITION, or an empty pre-thumbnail length,
+is reported as an expected unavailable-data result rather than a traceback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from typing import Sequence
+
+from coolscanpy._logging import get_logger
+from coolscanpy.transport.adapter_status import _connect_device, _perform_transaction
+
+logger = get_logger(__name__)
+
+_DATA_TYPE = 0x8E
+_HEADER_LENGTH = 6
+_TABLE_PREFIX_LENGTH = 8
+_RECORD_LENGTH = 4
+_DATA_IN_PHASE = 0x03
+_GOOD_SENSE = "000000"
+_DEFAULT_TIMEOUT_MS = 30_000
+
+
+class PerforationProbeError(RuntimeError):
+    """The scanner returned a malformed perforation transaction."""
+
+
+class PerforationUnavailable(PerforationProbeError):
+    """No completed thumbnail traversal currently supplies 8Eh data."""
+
+
+@dataclass(frozen=True)
+class PerforationRecord:
+    """One 4-byte row from section 2-11-8."""
+
+    perforation_number: int
+    count_switched: bool
+    pattern_number: int
+    pulse_number: int
+
+
+@dataclass(frozen=True)
+class PerforationTable:
+    """Validated current 8Eh table."""
+
+    declared_length: int
+    records: tuple[PerforationRecord, ...]
+
+
+def _read_cdb(length: int) -> str:
+    if not 1 <= length <= 0xFFFFFF:
+        raise ValueError("READ transfer length must fit in three bytes")
+    return bytes(
+        (
+            0x28,
+            0x00,
+            _DATA_TYPE,
+            0x00,
+            0x00,
+            0x00,
+            (length >> 16) & 0xFF,
+            (length >> 8) & 0xFF,
+            length & 0xFF,
+            0x80,
+        )
+    ).hex()
+
+
+def _validated_read_payload(result: object, *, label: str) -> bytes:
+    phase = getattr(result, "phase", None)
+    if type(phase) is not int:
+        raise PerforationProbeError(f"{label} result has no integer protocol phase")
+
+    payload = getattr(result, "payload", None)
+    if not isinstance(payload, bytes):
+        raise PerforationProbeError(f"{label} result has no bytes payload")
+
+    status = getattr(result, "status", None)
+    if not isinstance(status, bytes) or len(status) != 8:
+        raise PerforationProbeError(f"{label} result must have an 8-byte status")
+
+    sense = getattr(result, "sense", None)
+    if not isinstance(sense, str) or sense != status[1:4].hex():
+        raise PerforationProbeError(
+            f"{label} result sense does not match its 8-byte status"
+        )
+    if status[5:] != bytes(3):
+        raise PerforationProbeError(f"{label} result has a malformed Nikon status")
+    if status[0] == 0x02:
+        raise PerforationUnavailable(
+            f"{label} returned CHECK CONDITION sense {sense}; "
+            "thumbnail perforation data is not available"
+        )
+    if phase != _DATA_IN_PHASE or status[0] != 0x00 or sense != _GOOD_SENSE:
+        raise PerforationProbeError(f"{label} refused with sense {sense}")
+    return payload
+
+
+def _perform_read(
+    ep_out: object,
+    ep_in: object,
+    *,
+    length: int,
+    sequence: str,
+) -> bytes:
+    try:
+        result = _perform_transaction(
+            ep_out,
+            ep_in,
+            {
+                "seq": sequence,
+                "name": "READ:8E",
+                "cdb": _read_cdb(length),
+                "request_len": length,
+                "request_parts": [length],
+            },
+            data_timeout_ms=_DEFAULT_TIMEOUT_MS,
+        )
+    except Exception as error:
+        raise PerforationProbeError(f"{sequence} transaction failed: {error}") from error
+    return _validated_read_payload(result, label=sequence)
+
+
+def _declared_table_length(header: bytes) -> int:
+    if len(header) != _HEADER_LENGTH or header[:4] != b"\x00\x8e\x00\x00":
+        raise PerforationProbeError(
+            f"8Eh length header is malformed: {header.hex()}"
+        )
+    declared = int.from_bytes(header[4:6], "big")
+    if declared < _TABLE_PREFIX_LENGTH:
+        raise PerforationUnavailable(
+            "scanner reports no completed thumbnail perforation table"
+        )
+    return declared
+
+
+def _decode_table(payload: bytes, *, expected_length: int) -> PerforationTable:
+    if len(payload) != expected_length:
+        raise PerforationProbeError(
+            f"8Eh table returned {len(payload)} bytes, expected {expected_length}"
+        )
+    if payload[:4] != b"\x00\x8e\x00\x00":
+        raise PerforationProbeError("8Eh table does not repeat its length envelope")
+    declared = int.from_bytes(payload[4:6], "big")
+    if declared != expected_length:
+        raise PerforationProbeError(
+            f"8Eh table declares {declared} bytes, expected {expected_length}"
+        )
+    body = payload[_TABLE_PREFIX_LENGTH:]
+    if len(body) % _RECORD_LENGTH:
+        raise PerforationProbeError("8Eh table is not 8 plus 4 bytes per record")
+
+    records = tuple(
+        PerforationRecord(
+            perforation_number=int.from_bytes(body[offset : offset + 2], "big"),
+            count_switched=bool(body[offset + 2] & 0x80),
+            pattern_number=body[offset + 2] & 0x7F,
+            pulse_number=body[offset + 3],
+        )
+        for offset in range(0, len(body), _RECORD_LENGTH)
+    )
+    return PerforationTable(declared_length=declared, records=records)
+
+
+def read_perforation_table(*, device_id: str | None = None) -> PerforationTable:
+    """Claim one scanner and read the current 8Eh table without motion."""
+
+    try:
+        if device_id is None:
+            device, interface, ep_out, ep_in, usb_util = _connect_device()
+        else:
+            device, interface, ep_out, ep_in, usb_util = _connect_device(
+                device_id=device_id
+            )
+    except Exception as error:
+        raise PerforationProbeError(f"could not open the scanner: {error}") from error
+
+    try:
+        header = _perform_read(
+            ep_out,
+            ep_in,
+            length=_HEADER_LENGTH,
+            sequence="8Eh length header",
+        )
+        declared = _declared_table_length(header)
+        payload = _perform_read(
+            ep_out,
+            ep_in,
+            length=declared,
+            sequence="8Eh table",
+        )
+        return _decode_table(payload, expected_length=declared)
+    finally:
+        try:
+            usb_util.release_interface(device, interface.bInterfaceNumber)
+        except Exception as error:
+            logger.debug(f"perforation probe could not release interface: {error}")
+        try:
+            usb_util.dispose_resources(device)
+        except Exception as error:
+            logger.debug(f"perforation probe could not dispose resources: {error}")
+
+
+def format_perforation_table(table: PerforationTable) -> str:
+    lines = [
+        f"perforation_table_bytes: {table.declared_length}",
+        f"perforation_records: {len(table.records)}",
+        "index perforation count_switched pattern pulse",
+    ]
+    lines.extend(
+        f"{index} {record.perforation_number} "
+        f"{str(record.count_switched).lower()} "
+        f"{record.pattern_number} {record.pulse_number}"
+        for index, record in enumerate(table.records, start=1)
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--device",
+        help="exact local USB device ID; default is fresh LS-5000 discovery",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        table = read_perforation_table(device_id=args.device)
+    except PerforationUnavailable as error:
+        print(f"CHECK CONDITION: {error}", file=sys.stderr)
+        return 3
+    except PerforationProbeError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+    print(format_perforation_table(table), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/coolscanpy/src/coolscanpy/cli/unload_timer.py
+++ b/coolscanpy/src/coolscanpy/cli/unload_timer.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Read the LS-5000 automatic unload timer with GET PARAMETER B4h.
+
+This probe is read-only: it sends GET PARAMETER (E1h) and never sends SET
+PARAMETER or EXECUTE.  The 9-byte request follows the B4h fields through the
+second setting value: Table 2-15-2 defines the first and second values at
+bytes 1--4 and 5--8 (``LS5kIFSpec.md:9755-9810``), Table 2-15-3 identifies
+B4h as ``Unload time set`` (``:9953-9957``), and Table 2-15-4 defines those
+values as seconds and 0=timer OFF / 1=timer ON (``:10165-10175``).  GET
+PARAMETER's E1h CDB and control byte 00 are specified by Table 2-16-1
+(``:10276-10347``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from typing import Sequence
+
+from coolscanpy._logging import get_logger
+from coolscanpy.transport.adapter_status import _connect_device, _perform_transaction
+
+logger = get_logger(__name__)
+
+_GET_PARAMETER_CDB = "e100b400000000000900"
+_PARAMETER_LENGTH = 9
+_DATA_IN_PHASE = 0x03
+_GOOD_SENSE = "000000"
+_DEFAULT_TIMEOUT_MS = 5_000
+
+
+class UnloadTimerError(RuntimeError):
+    """The scanner refused or returned an invalid B4h parameter."""
+
+
+@dataclass(frozen=True)
+class UnloadTimer:
+    """Current B4h values reported by the scanner."""
+
+    seconds: int
+    enabled: bool
+
+
+def _validated_payload(result: object) -> bytes:
+    phase = getattr(result, "phase", None)
+    if type(phase) is not int:
+        raise UnloadTimerError("GET PARAMETER result has no integer protocol phase")
+
+    payload = getattr(result, "payload", None)
+    if not isinstance(payload, bytes):
+        raise UnloadTimerError("GET PARAMETER result has no bytes payload")
+
+    status = getattr(result, "status", None)
+    if not isinstance(status, bytes) or len(status) != 8:
+        raise UnloadTimerError("GET PARAMETER result must have an 8-byte status")
+
+    sense = getattr(result, "sense", None)
+    if not isinstance(sense, str) or sense != status[1:4].hex():
+        raise UnloadTimerError(
+            "GET PARAMETER result sense does not match its 8-byte status"
+        )
+    if status[5:] != bytes(3):
+        raise UnloadTimerError("GET PARAMETER result has a malformed Nikon status")
+    if phase != _DATA_IN_PHASE or status[0] != 0x00 or sense != _GOOD_SENSE:
+        raise UnloadTimerError(f"GET PARAMETER B4h refused with sense {sense}")
+    if len(payload) != _PARAMETER_LENGTH:
+        raise UnloadTimerError(
+            f"GET PARAMETER B4h returned {len(payload)} bytes, "
+            f"expected {_PARAMETER_LENGTH}"
+        )
+    return payload
+
+
+def _decode_unload_timer(payload: bytes) -> UnloadTimer:
+    if len(payload) != _PARAMETER_LENGTH:
+        raise UnloadTimerError(
+            f"B4h parameter has {len(payload)} bytes, expected {_PARAMETER_LENGTH}"
+        )
+    seconds = int.from_bytes(payload[1:5], "big")
+    enabled_value = int.from_bytes(payload[5:9], "big")
+    if seconds != 0 and not 60 <= seconds <= 3_600:
+        raise UnloadTimerError(
+            f"B4h unload time {seconds} is outside the specified 60..3600 seconds"
+        )
+    if enabled_value not in (0, 1):
+        raise UnloadTimerError(
+            f"B4h timer enable value {enabled_value} is not 0 or 1"
+        )
+    return UnloadTimer(seconds=seconds, enabled=enabled_value == 1)
+
+
+def read_unload_timer(*, device_id: str | None = None) -> UnloadTimer:
+    """Claim one scanner, perform the read-only B4h query, and release it."""
+
+    try:
+        if device_id is None:
+            device, interface, ep_out, ep_in, usb_util = _connect_device()
+        else:
+            device, interface, ep_out, ep_in, usb_util = _connect_device(
+                device_id=device_id
+            )
+    except Exception as error:
+        raise UnloadTimerError(f"could not open the scanner: {error}") from error
+
+    try:
+        try:
+            result = _perform_transaction(
+                ep_out,
+                ep_in,
+                {
+                    "seq": "unload-timer",
+                    "name": "GET_PARAMETER:B4",
+                    "cdb": _GET_PARAMETER_CDB,
+                    "request_len": _PARAMETER_LENGTH,
+                    "request_parts": [_PARAMETER_LENGTH],
+                },
+                data_timeout_ms=_DEFAULT_TIMEOUT_MS,
+            )
+        except Exception as error:
+            raise UnloadTimerError(
+                f"GET PARAMETER B4h transaction failed: {error}"
+            ) from error
+        return _decode_unload_timer(_validated_payload(result))
+    finally:
+        try:
+            usb_util.release_interface(device, interface.bInterfaceNumber)
+        except Exception as error:
+            logger.debug(f"unload timer probe could not release interface: {error}")
+        try:
+            usb_util.dispose_resources(device)
+        except Exception as error:
+            logger.debug(f"unload timer probe could not dispose resources: {error}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--device",
+        help="exact local USB device ID; default is fresh LS-5000 discovery",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        timer = read_unload_timer(device_id=args.device)
+    except UnloadTimerError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+    print(f"unload_timer_seconds: {timer.seconds}")
+    print(f"unload_timer_enabled: {str(timer.enabled).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/coolscanpy/src/coolscanpy/cli/vpd_dump.py
+++ b/coolscanpy/src/coolscanpy/cli/vpd_dump.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Read and print the LS-5000 INQUIRY VPD pages over raw USB.
+
+This command is deliberately motion-free. It sends only standard INQUIRY and
+INQUIRY with EVPD set; it never sends SCAN, SET WINDOW, READ, or an eject or
+positioning command.
+
+Contract grounding: the standard ``12 00 00 00 24 80`` CDB, data-in phase
+``03h``, successful Nikon status envelope, and the EVPD form
+``12 01 <page> 00 <allocation> 80`` come from
+``protocol/ls5000_single_pass/data/replay-first-rgbi4-plan.jsonl``. Records
+5--16 and 25--30 in that capture also establish the four-byte EVPD header,
+the page-length byte at offset three, and the two-step read: allocation four
+first, then allocation four plus the returned page length. The five-second
+data timeout and the USB claim/release lifecycle match
+``transport.adapter_status``. The 16-byte rows, headings, uppercase hex, and
+printable-ASCII column match the recorded ``nkscan dump`` output in
+``digital-ice-2026/shortstrip-lab/live-attempts/20260810-nkscan-probe-real-5000/dump.out``.
+
+``nkscan dump`` instead uses one fixed-allocation read for each page. The
+difference is deliberate: this command reproduces the observed Nikon Scan
+dialect and exposes stale-tail buffer behavior differently. Responses are
+bounded by the length learned from the first header, so an overlong stale
+tail is not attributed to the page; an otherwise valid short body is printed
+at its actual length.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from typing import Sequence
+
+from coolscanpy._logging import get_logger
+from coolscanpy.transport.adapter_status import _connect_device, _perform_transaction
+
+logger = get_logger(__name__)
+
+_STANDARD_INQUIRY_CDB = "120000002480"
+_STANDARD_INQUIRY_LENGTH = 0x24
+_EVPD_HEADER_LENGTH = 0x04
+_INQUIRY_DATA_PHASE = 0x03
+_GOOD_SENSE = "000000"
+_DEFAULT_TIMEOUT_MS = 5_000
+_HEXDUMP_ROW_BYTES = 16
+_HEXDUMP_HEX_WIDTH = _HEXDUMP_ROW_BYTES * 3 - 1
+_MAX_INQUIRY_ALLOCATION = 0xFF
+
+
+class VpdDumpError(RuntimeError):
+    """The scanner refused or returned an invalid INQUIRY transaction."""
+
+
+@dataclass(frozen=True)
+class VpdDump:
+    """Validated payloads collected during one claimed USB session."""
+
+    standard_inquiry: bytes
+    pages: tuple[tuple[int, bytes], ...]
+    device_location: str
+
+
+def _inquiry_cdb(*, page_code: int, allocation: int) -> str:
+    if not 0 <= page_code <= 0xFF:
+        raise ValueError("VPD page code must fit in one byte")
+    if not 1 <= allocation <= _MAX_INQUIRY_ALLOCATION:
+        raise VpdDumpError(
+            f"INQUIRY allocation {allocation} does not fit the captured CDB"
+        )
+    return bytes((0x12, 0x01, page_code, 0x00, allocation, 0x80)).hex()
+
+
+def _validated_inquiry_payload(result: object, *, label: str) -> bytes:
+    """Return data only from a complete, successful Nikon INQUIRY reply."""
+
+    phase = getattr(result, "phase", None)
+    if type(phase) is not int:
+        raise VpdDumpError(f"{label} result has no integer protocol phase")
+
+    payload = getattr(result, "payload", None)
+    if not isinstance(payload, bytes):
+        raise VpdDumpError(f"{label} result has no bytes payload")
+
+    status = getattr(result, "status", None)
+    if not isinstance(status, bytes) or len(status) != 8:
+        raise VpdDumpError(f"{label} result must have an 8-byte status")
+
+    sense = getattr(result, "sense", None)
+    status_sense = status[1:4].hex()
+    if not isinstance(sense, str) or sense != status_sense:
+        raise VpdDumpError(f"{label} result sense does not match its 8-byte status")
+    if status[5:] != bytes(3):
+        raise VpdDumpError(f"{label} result has a malformed Nikon status envelope")
+    if phase != _INQUIRY_DATA_PHASE or sense != _GOOD_SENSE or status[0] != 0x00:
+        raise VpdDumpError(f"{label} refused with sense {sense}")
+    return payload
+
+
+def _perform_inquiry(
+    ep_out: object,
+    ep_in: object,
+    *,
+    cdb: str,
+    allocation: int,
+    sequence: str,
+) -> bytes:
+    try:
+        result = _perform_transaction(
+            ep_out,
+            ep_in,
+            {
+                "seq": sequence,
+                "name": "INQUIRY",
+                "cdb": cdb,
+                "request_len": allocation,
+                "request_parts": [allocation],
+            },
+            data_timeout_ms=_DEFAULT_TIMEOUT_MS,
+        )
+    except Exception as error:
+        raise VpdDumpError(f"{sequence} transaction failed: {error}") from error
+    return _validated_inquiry_payload(result, label=sequence)
+
+
+def _validate_vpd_header(payload: bytes, *, page_code: int, label: str) -> None:
+    if len(payload) < _EVPD_HEADER_LENGTH:
+        raise VpdDumpError(
+            f"{label} returned {len(payload)} bytes, fewer than the four-byte header"
+        )
+    if payload[0] != 0x06 or payload[1] != page_code or payload[2] != 0x00:
+        raise VpdDumpError(
+            f"{label} returned an unexpected VPD header {payload[:4].hex()}"
+        )
+
+
+def _fetch_vpd_page(ep_out: object, ep_in: object, page_code: int) -> bytes:
+    """Fetch one VPD page with the captured four-byte-header handshake."""
+
+    page_label = f"page {page_code:02X}h"
+    header = _perform_inquiry(
+        ep_out,
+        ep_in,
+        cdb=_inquiry_cdb(page_code=page_code, allocation=_EVPD_HEADER_LENGTH),
+        allocation=_EVPD_HEADER_LENGTH,
+        sequence=f"{page_label} header",
+    )
+    _validate_vpd_header(header, page_code=page_code, label=f"{page_label} header")
+
+    page_total = _EVPD_HEADER_LENGTH + header[3]
+    if page_total > _MAX_INQUIRY_ALLOCATION:
+        raise VpdDumpError(
+            f"{page_label} declares {page_total} bytes, beyond the captured CDB limit"
+        )
+    payload = _perform_inquiry(
+        ep_out,
+        ep_in,
+        cdb=_inquiry_cdb(page_code=page_code, allocation=page_total),
+        allocation=page_total,
+        sequence=page_label,
+    )
+    _validate_vpd_header(payload, page_code=page_code, label=page_label)
+    return payload[:page_total]
+
+
+def _parse_page_list(payload: bytes) -> tuple[int, ...]:
+    """Return advertised nonzero page codes, bounded by page 00h's length."""
+
+    _validate_vpd_header(payload, page_code=0x00, label="page 00h")
+    advertised = payload[4 : 4 + payload[3]]
+    return tuple(page_code for page_code in advertised if page_code != 0x00)
+
+
+def _device_location(device: object) -> str:
+    bus = getattr(device, "bus", None)
+    raw_ports = getattr(device, "port_numbers", None)
+    if type(bus) is int and raw_ports:
+        ports = tuple(raw_ports)
+        if ports and all(type(port) is int and port >= 0 for port in ports):
+            return f"usb:{bus:03d}-" + ".".join(str(port) for port in ports)
+
+    address = getattr(device, "address", None)
+    if type(bus) is int and type(address) is int:
+        return f"usb:{bus:03d}:{address:03d}"
+    return "usb:unknown"
+
+
+def collect_vpd_dump(*, device_id: str | None = None) -> VpdDump:
+    """Claim one LS-5000, collect standard INQUIRY and its advertised VPD."""
+
+    try:
+        if device_id is None:
+            device, interface, ep_out, ep_in, usb_util = _connect_device()
+        else:
+            device, interface, ep_out, ep_in, usb_util = _connect_device(
+                device_id=device_id
+            )
+    except Exception as error:
+        raise VpdDumpError(f"could not open the scanner: {error}") from error
+
+    try:
+        standard = _perform_inquiry(
+            ep_out,
+            ep_in,
+            cdb=_STANDARD_INQUIRY_CDB,
+            allocation=_STANDARD_INQUIRY_LENGTH,
+            sequence="standard INQUIRY",
+        )
+        if len(standard) != _STANDARD_INQUIRY_LENGTH:
+            raise VpdDumpError(
+                f"standard INQUIRY returned {len(standard)} bytes, "
+                f"expected {_STANDARD_INQUIRY_LENGTH}"
+            )
+
+        page_zero = _fetch_vpd_page(ep_out, ep_in, 0x00)
+        page_codes = _parse_page_list(page_zero)
+        pages = tuple(
+            (page_code, _fetch_vpd_page(ep_out, ep_in, page_code))
+            for page_code in page_codes
+        )
+        return VpdDump(
+            standard_inquiry=standard,
+            pages=pages,
+            device_location=_device_location(device),
+        )
+    finally:
+        try:
+            usb_util.release_interface(device, interface.bInterfaceNumber)
+        except Exception as error:
+            logger.debug(f"VPD dump could not release interface: {error}")
+        try:
+            usb_util.dispose_resources(device)
+        except Exception as error:
+            logger.debug(f"VPD dump could not dispose resources: {error}")
+
+
+def _hexdump(payload: bytes) -> str:
+    rows: list[str] = []
+    for offset in range(0, len(payload), _HEXDUMP_ROW_BYTES):
+        chunk = payload[offset : offset + _HEXDUMP_ROW_BYTES]
+        octets = " ".join(f"{value:02X}" for value in chunk)
+        printable = "".join(
+            chr(value) if 0x20 <= value <= 0x7E else "." for value in chunk
+        )
+        rows.append(f"  {offset:04X}  {octets:<{_HEXDUMP_HEX_WIDTH}}  {printable}")
+    return "\n".join(rows)
+
+
+def format_vpd_dump(dump: VpdDump) -> str:
+    """Format a dump for direct comparison with the nkscan reference."""
+
+    standard = dump.standard_inquiry
+    vendor = standard[8:16].decode("ascii", errors="replace").strip()
+    product = standard[16:32].decode("ascii", errors="replace").strip()
+    identity = f"{vendor} {product}".strip()
+    page_codes = tuple(page_code for page_code, _payload in dump.pages)
+    page_summary = " ".join(f"{page_code:02X}h" for page_code in page_codes)
+
+    lines = [
+        f"{identity:<20} {dump.device_location}",
+        "",
+        "== standard INQUIRY ==",
+        _hexdump(standard),
+        "",
+        f"  {len(page_codes)} pages:" + (f" {page_summary}" if page_summary else ""),
+    ]
+    for page_code, payload in dump.pages:
+        lines.extend(
+            (
+                "",
+                f"== page {page_code:02X}h ==",
+                _hexdump(payload),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--device",
+        help="exact local USB device ID; default is fresh LS-5000 discovery",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        dump = collect_vpd_dump(device_id=args.device)
+    except VpdDumpError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+    print(format_vpd_dump(dump), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/coolscanpy/src/coolscanpy/cli/wedge_recovery.py
+++ b/coolscanpy/src/coolscanpy/cli/wedge_recovery.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Plan or explicitly execute LS-5000 wedge-recovery motion commands.
+
+These are MOTION commands.  Live validation is owner-gated: the default is a
+dry run that opens no device and sends nothing; ``--execute`` also requires a
+single selected operation and an interactive ``yes`` confirmation.  There is
+no non-interactive confirmation bypass.
+
+Table 2-15-1 defines SET PARAMETER E0h and its 13-byte recommended parameter
+length (``LS5kIFSpec.md:9673-9736``).  Table 2-15-2 defines that zero-filled
+parameter envelope (``:9755-9809``), Table 2-15-3 assigns 80h Initialize and
+81h Return to origin (``:9868-9900``), and Table 2-15-4 marks both operations
+as having no parameters (``:10039-10088``).  The spec requires EXECUTE after
+SET PARAMETER to start the selected operation (``:9741-9753``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from typing import Sequence
+
+from coolscanpy._logging import get_logger
+from coolscanpy.transport.adapter_status import _connect_device, _perform_transaction
+
+logger = get_logger(__name__)
+
+_PARAMETER_LENGTH = 13
+_PARAMETER_DATA = bytes(_PARAMETER_LENGTH)
+_EXECUTE_CDB = "c10000000000"
+_GOOD_SENSE = "000000"
+_DEFAULT_TIMEOUT_MS = 30_000
+
+
+class WedgeRecoveryError(RuntimeError):
+    """The selected recovery command was refused or malformed."""
+
+
+@dataclass(frozen=True)
+class RecoveryOperation:
+    """One owner-selectable SET PARAMETER operation."""
+
+    key: str
+    label: str
+    operation_code: int
+
+    @property
+    def set_parameter_cdb(self) -> str:
+        return bytes(
+            (
+                0xE0,
+                0x00,
+                self.operation_code,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                _PARAMETER_LENGTH,
+                0x00,
+            )
+        ).hex()
+
+
+_OPERATIONS = (
+    RecoveryOperation("return-to-origin", "ReturnToOrigin", 0x81),
+    RecoveryOperation("initialize", "Initialize", 0x80),
+)
+_OPERATIONS_BY_KEY = {operation.key: operation for operation in _OPERATIONS}
+
+
+def format_plan(operations: Sequence[RecoveryOperation]) -> str:
+    lines = ["DRY RUN: no commands sent"]
+    for operation in operations:
+        lines.extend(
+            (
+                f"{operation.label} ({operation.operation_code:02X}h)",
+                f"  SET PARAMETER CDB: {operation.set_parameter_cdb}",
+                f"  parameter data ({_PARAMETER_LENGTH} bytes): {_PARAMETER_DATA.hex()}",
+                f"  EXECUTE CDB: {_EXECUTE_CDB}",
+                "  spec: LS5kIFSpec.md Tables 2-15-1 through 2-15-4",
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _validate_no_data_result(
+    result: object,
+    *,
+    label: str,
+    expected_phase: int,
+) -> None:
+    phase = getattr(result, "phase", None)
+    if type(phase) is not int:
+        raise WedgeRecoveryError(f"{label} result has no integer protocol phase")
+    payload = getattr(result, "payload", None)
+    if not isinstance(payload, bytes) or payload:
+        raise WedgeRecoveryError(f"{label} result must have an empty bytes payload")
+    status = getattr(result, "status", None)
+    if not isinstance(status, bytes) or len(status) != 8:
+        raise WedgeRecoveryError(f"{label} result must have an 8-byte status")
+    sense = getattr(result, "sense", None)
+    if not isinstance(sense, str) or sense != status[1:4].hex():
+        raise WedgeRecoveryError(
+            f"{label} result sense does not match its 8-byte status"
+        )
+    if status[5:] != bytes(3):
+        raise WedgeRecoveryError(f"{label} result has a malformed Nikon status")
+    if phase != expected_phase or status[0] != 0x00 or sense != _GOOD_SENSE:
+        raise WedgeRecoveryError(f"{label} refused with sense {sense}")
+
+
+def execute_operation(
+    operation: RecoveryOperation,
+    *,
+    device_id: str | None = None,
+) -> None:
+    """Send one confirmed SET PARAMETER + EXECUTE sequence and release USB."""
+
+    try:
+        if device_id is None:
+            device, interface, ep_out, ep_in, usb_util = _connect_device()
+        else:
+            device, interface, ep_out, ep_in, usb_util = _connect_device(
+                device_id=device_id
+            )
+    except Exception as error:
+        raise WedgeRecoveryError(f"could not open the scanner: {error}") from error
+
+    try:
+        try:
+            set_result = _perform_transaction(
+                ep_out,
+                ep_in,
+                {
+                    "seq": f"wedge-recovery-{operation.key}-set",
+                    "name": f"SET_PARAMETER:{operation.operation_code:02X}",
+                    "cdb": operation.set_parameter_cdb,
+                    "data_out": _PARAMETER_DATA.hex(),
+                },
+                data_timeout_ms=_DEFAULT_TIMEOUT_MS,
+            )
+            _validate_no_data_result(
+                set_result,
+                label=f"SET PARAMETER {operation.label}",
+                expected_phase=0x02,
+            )
+            execute_result = _perform_transaction(
+                ep_out,
+                ep_in,
+                {
+                    "seq": f"wedge-recovery-{operation.key}-execute",
+                    "name": "EXECUTE",
+                    "cdb": _EXECUTE_CDB,
+                },
+                data_timeout_ms=_DEFAULT_TIMEOUT_MS,
+            )
+            _validate_no_data_result(
+                execute_result,
+                label=f"EXECUTE {operation.label}",
+                expected_phase=0x01,
+            )
+        except WedgeRecoveryError:
+            raise
+        except Exception as error:
+            raise WedgeRecoveryError(
+                f"{operation.label} transaction failed: {error}"
+            ) from error
+    finally:
+        try:
+            usb_util.release_interface(device, interface.bInterfaceNumber)
+        except Exception as error:
+            logger.debug(f"wedge recovery could not release interface: {error}")
+        try:
+            usb_util.dispose_resources(device)
+        except Exception as error:
+            logger.debug(f"wedge recovery could not dispose resources: {error}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--operation",
+        choices=tuple(_OPERATIONS_BY_KEY),
+        help="one recovery operation; required with --execute",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="send the selected motion command after interactive confirmation",
+    )
+    parser.add_argument(
+        "--device",
+        help="exact local USB device ID; default is fresh LS-5000 discovery",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.execute and args.operation is None:
+        parser.error("--execute requires --operation")
+
+    selected = (
+        (_OPERATIONS_BY_KEY[args.operation],)
+        if args.operation is not None
+        else _OPERATIONS
+    )
+    print(format_plan(selected), end="")
+    if not args.execute:
+        return 0
+
+    operation = selected[0]
+    try:
+        confirmation = input(
+            f"Type yes to send {operation.label} MOTION commands [yes/NO]: "
+        )
+    except EOFError:
+        confirmation = ""
+    if confirmation.strip().lower() != "yes":
+        print("Cancelled; no commands sent.")
+        return 1
+
+    try:
+        execute_operation(operation, device_id=args.device)
+    except WedgeRecoveryError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+    print(f"SENT: {operation.label} SET PARAMETER + EXECUTE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/coolscanpy/tests/cli/test_perforation_probe.py
+++ b/coolscanpy/tests/cli/test_perforation_probe.py
@@ -1,0 +1,170 @@
+"""Hardware-free tests for the LS-5000 perforation-table probe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+
+from coolscanpy.cli import perforation_probe
+
+
+def _result(payload: bytes, *, phase: int = 0x03, status: bytes = bytes(8)):
+    return SimpleNamespace(
+        phase=phase,
+        payload=payload,
+        status=status,
+        sense=status[1:4].hex(),
+    )
+
+
+@dataclass
+class _FakeUsbUtil:
+    released: list[tuple[object, int]] = field(default_factory=list)
+    disposed: list[object] = field(default_factory=list)
+
+    def release_interface(self, device: object, number: int) -> None:
+        self.released.append((device, number))
+
+    def dispose_resources(self, device: object) -> None:
+        self.disposed.append(device)
+
+
+def test_two_step_read_uses_control_80_and_decodes_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=5)
+    usb_util = _FakeUsbUtil()
+    ep_out = object()
+    ep_in = object()
+    payloads = [
+        bytes.fromhex("008e00000010"),
+        bytes.fromhex("008e0000001000040010812200200533"),
+    ]
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        perforation_probe,
+        "_connect_device",
+        lambda: (device, interface, ep_out, ep_in, usb_util),
+    )
+
+    def perform(
+        out: object,
+        incoming: object,
+        entry: dict,
+        *,
+        data_timeout_ms: int,
+        deadline_monotonic: float | None = None,
+    ):
+        assert (out, incoming) == (ep_out, ep_in)
+        assert data_timeout_ms == 30_000
+        assert deadline_monotonic is None
+        calls.append(entry)
+        return _result(payloads.pop(0))
+
+    monkeypatch.setattr(perforation_probe, "_perform_transaction", perform)
+
+    table = perforation_probe.read_perforation_table()
+
+    assert table == perforation_probe.PerforationTable(
+        declared_length=16,
+        records=(
+            perforation_probe.PerforationRecord(16, True, 1, 34),
+            perforation_probe.PerforationRecord(32, False, 5, 51),
+        ),
+    )
+    assert [call["cdb"] for call in calls] == [
+        "28008e00000000000680",
+        "28008e00000000001080",
+    ]
+    assert [call["request_len"] for call in calls] == [6, 16]
+    assert [call["request_parts"] for call in calls] == [[6], [16]]
+    assert usb_util.released == [(device, 5)]
+    assert usb_util.disposed == [device]
+
+
+def test_formatted_table_is_stable() -> None:
+    table = perforation_probe.PerforationTable(
+        declared_length=12,
+        records=(perforation_probe.PerforationRecord(7, False, 3, 9),),
+    )
+
+    assert perforation_probe.format_perforation_table(table) == (
+        "perforation_table_bytes: 12\n"
+        "perforation_records: 1\n"
+        "index perforation count_switched pattern pulse\n"
+        "1 7 false 3 9\n"
+    )
+
+
+def test_check_condition_is_reported_as_expected_unavailable_data(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=6)
+    usb_util = _FakeUsbUtil()
+    monkeypatch.setattr(
+        perforation_probe,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+    check_condition = bytes.fromhex("02052c0000000000")
+    monkeypatch.setattr(
+        perforation_probe,
+        "_perform_transaction",
+        lambda *_args, **_kwargs: _result(
+            b"",
+            phase=0x01,
+            status=check_condition,
+        ),
+    )
+
+    assert perforation_probe.main([]) == 3
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        "CHECK CONDITION: 8Eh length header returned CHECK CONDITION sense "
+        "052c00; thumbnail perforation data is not available\n"
+    )
+    assert usb_util.released == [(device, 6)]
+    assert usb_util.disposed == [device]
+
+
+def test_prethumbnail_empty_length_is_cleanly_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=1)
+    usb_util = _FakeUsbUtil()
+    monkeypatch.setattr(
+        perforation_probe,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+    monkeypatch.setattr(
+        perforation_probe,
+        "_perform_transaction",
+        lambda *_args, **_kwargs: _result(bytes.fromhex("008e00000004")),
+    )
+
+    assert perforation_probe.main([]) == 3
+    captured = capsys.readouterr()
+    assert "no completed thumbnail perforation table" in captured.err
+    assert usb_util.released == [(device, 1)]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        bytes.fromhex("008f0000000c000400000000"),
+        bytes.fromhex("008e00000010000400000000"),
+        bytes.fromhex("008e0000000d00040000000000"),
+    ),
+)
+def test_malformed_tables_fail_closed(payload: bytes) -> None:
+    with pytest.raises(perforation_probe.PerforationProbeError):
+        perforation_probe._decode_table(payload, expected_length=len(payload))

--- a/coolscanpy/tests/cli/test_unload_timer.py
+++ b/coolscanpy/tests/cli/test_unload_timer.py
@@ -1,0 +1,152 @@
+"""Hardware-free tests for the LS-5000 unload-timer probe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+
+from coolscanpy.cli import unload_timer
+
+
+def _result(payload: bytes, *, phase: int = 0x03, status: bytes = bytes(8)):
+    return SimpleNamespace(
+        phase=phase,
+        payload=payload,
+        status=status,
+        sense=status[1:4].hex(),
+    )
+
+
+@dataclass
+class _FakeUsbUtil:
+    released: list[tuple[object, int]] = field(default_factory=list)
+    disposed: list[object] = field(default_factory=list)
+
+    def release_interface(self, device: object, number: int) -> None:
+        self.released.append((device, number))
+
+    def dispose_resources(self, device: object) -> None:
+        self.disposed.append(device)
+
+
+def test_read_uses_exact_b4_cdb_and_decodes_seconds_and_enable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=4)
+    usb_util = _FakeUsbUtil()
+    ep_out = object()
+    ep_in = object()
+    calls: list[tuple[object, object, dict, int]] = []
+
+    monkeypatch.setattr(
+        unload_timer,
+        "_connect_device",
+        lambda: (device, interface, ep_out, ep_in, usb_util),
+    )
+
+    def perform(
+        out: object,
+        incoming: object,
+        entry: dict,
+        *,
+        data_timeout_ms: int,
+        deadline_monotonic: float | None = None,
+    ):
+        assert deadline_monotonic is None
+        calls.append((out, incoming, entry, data_timeout_ms))
+        return _result(bytes.fromhex("000000025800000001"))
+
+    monkeypatch.setattr(unload_timer, "_perform_transaction", perform)
+
+    assert unload_timer.read_unload_timer() == unload_timer.UnloadTimer(
+        seconds=600,
+        enabled=True,
+    )
+    assert calls == [
+        (
+            ep_out,
+            ep_in,
+            {
+                "seq": "unload-timer",
+                "name": "GET_PARAMETER:B4",
+                "cdb": "e100b400000000000900",
+                "request_len": 9,
+                "request_parts": [9],
+            },
+            5_000,
+        )
+    ]
+    assert usb_util.released == [(device, 4)]
+    assert usb_util.disposed == [device]
+
+
+def test_timer_off_is_reported_without_sending_set(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=2)
+    usb_util = _FakeUsbUtil()
+    monkeypatch.setattr(
+        unload_timer,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+    monkeypatch.setattr(
+        unload_timer,
+        "_perform_transaction",
+        lambda *_args, **_kwargs: _result(
+            bytes.fromhex("0000000e1000000000")
+        ),
+    )
+
+    assert unload_timer.main([]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == (
+        "unload_timer_seconds: 3600\n"
+        "unload_timer_enabled: false\n"
+    )
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        bytes.fromhex("000000000100000002"),
+        bytes.fromhex("000000003b00000001"),
+        bytes.fromhex("0000000000000000"),
+    ),
+)
+def test_invalid_b4_values_fail_closed(payload: bytes) -> None:
+    with pytest.raises(unload_timer.UnloadTimerError):
+        unload_timer._decode_unload_timer(payload)
+
+
+def test_check_condition_exits_nonzero_and_releases_usb(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=7)
+    usb_util = _FakeUsbUtil()
+    monkeypatch.setattr(
+        unload_timer,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+    refused = bytes.fromhex("0205240000000000")
+    monkeypatch.setattr(
+        unload_timer,
+        "_perform_transaction",
+        lambda *_args, **_kwargs: _result(b"", phase=0x01, status=refused),
+    )
+
+    assert unload_timer.main([]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "refused with sense 052400" in captured.err
+    assert usb_util.released == [(device, 7)]
+    assert usb_util.disposed == [device]

--- a/coolscanpy/tests/cli/test_vpd_dump.py
+++ b/coolscanpy/tests/cli/test_vpd_dump.py
@@ -1,0 +1,208 @@
+"""Hardware-free tests for the LS-5000 VPD dump command."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+
+from coolscanpy.cli import vpd_dump
+
+
+# Captured by replay-first-rgbi4-plan.jsonl records 1, 5--6, 13--16.
+_STANDARD_INQUIRY = bytes.fromhex(
+    "068002021f0000004e696b6f6e2020204c532d35303030204544202020202020312e3033"
+)
+_PAGE_ZERO = bytes.fromhex("0600001300014041475051606162c1d1e1e3f0f8e2fbfc")
+_PAGE_F0 = bytes.fromhex(
+    "06f0003103400000000000001e6709c4"
+    "177001001241000000000000024a0258"
+    "0258010006470000000000001e68012c"
+    "04b0010005"
+)
+_PAGE_F8 = bytes.fromhex("06f8000d63055002510260046101620100")
+
+
+def _result(payload: bytes, *, phase: int = 0x03, status: bytes = bytes(8)):
+    return SimpleNamespace(
+        phase=phase,
+        payload=payload,
+        status=status,
+        sense=status[1:4].hex(),
+    )
+
+
+def _script_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+    payloads: list[bytes],
+) -> list[dict[str, object]]:
+    remaining = list(payloads)
+    calls: list[dict[str, object]] = []
+
+    def perform(
+        ep_out: object,
+        ep_in: object,
+        entry: dict,
+        *,
+        data_timeout_ms: int,
+        deadline_monotonic: float | None = None,
+    ):
+        calls.append(
+            {
+                "ep_out": ep_out,
+                "ep_in": ep_in,
+                "entry": entry,
+                "data_timeout_ms": data_timeout_ms,
+                "deadline_monotonic": deadline_monotonic,
+            }
+        )
+        assert remaining
+        return _result(remaining.pop(0))
+
+    monkeypatch.setattr(vpd_dump, "_perform_transaction", perform)
+    return calls
+
+
+def test_page_list_parse_uses_declared_length_and_ignores_page_zero() -> None:
+    stale_tail = bytes.fromhex("deadbeef")
+
+    assert vpd_dump._parse_page_list(_PAGE_ZERO + stale_tail) == (
+        0x01,
+        0x40,
+        0x41,
+        0x47,
+        0x50,
+        0x51,
+        0x60,
+        0x61,
+        0x62,
+        0xC1,
+        0xD1,
+        0xE1,
+        0xE3,
+        0xF0,
+        0xF8,
+        0xE2,
+        0xFB,
+        0xFC,
+    )
+
+
+def test_vpd_page_uses_header_then_exact_captured_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _script_transactions(
+        monkeypatch,
+        [bytes.fromhex("06f00031"), _PAGE_F0],
+    )
+
+    payload = vpd_dump._fetch_vpd_page(object(), object(), 0xF0)
+
+    assert payload == _PAGE_F0
+    assert [call["entry"]["cdb"] for call in calls] == [
+        "1201f0000480",
+        "1201f0003580",
+    ]
+    assert [call["entry"]["request_len"] for call in calls] == [4, 53]
+    assert [call["entry"]["request_parts"] for call in calls] == [[4], [53]]
+    assert [call["data_timeout_ms"] for call in calls] == [5_000, 5_000]
+
+
+@pytest.mark.parametrize(
+    ("returned", "expected"),
+    (
+        (_PAGE_F8[:12], _PAGE_F8[:12]),
+        (_PAGE_F8 + bytes.fromhex("c1d1e1e3f0"), _PAGE_F8),
+    ),
+)
+def test_vpd_page_tolerates_short_body_and_trims_stale_tail(
+    monkeypatch: pytest.MonkeyPatch,
+    returned: bytes,
+    expected: bytes,
+) -> None:
+    _script_transactions(
+        monkeypatch,
+        [bytes.fromhex("06f8000d"), returned],
+    )
+
+    assert vpd_dump._fetch_vpd_page(object(), object(), 0xF8) == expected
+
+
+def test_hexdump_matches_nkscan_row_format() -> None:
+    assert vpd_dump._hexdump(_STANDARD_INQUIRY) == (
+        "  0000  06 80 02 02 1F 00 00 00 4E 69 6B 6F 6E 20 20 20  "
+        "........Nikon   \n"
+        "  0010  4C 53 2D 35 30 30 30 20 45 44 20 20 20 20 20 20  "
+        "LS-5000 ED      \n"
+        "  0020  31 2E 30 33                                      1.03"
+    )
+
+
+def test_formatted_dump_uses_reference_sections_and_page_summary() -> None:
+    dump = vpd_dump.VpdDump(
+        standard_inquiry=_STANDARD_INQUIRY,
+        pages=((0xF8, _PAGE_F8),),
+        device_location="usb:001-2",
+    )
+
+    output = vpd_dump.format_vpd_dump(dump)
+
+    assert output.startswith(
+        "Nikon LS-5000 ED     usb:001-2\n\n== standard INQUIRY ==\n"
+    )
+    assert "\n  1 pages: F8h\n\n== page F8h ==\n" in output
+    assert output.endswith(
+        "  0010  00                                               .\n"
+    )
+
+
+@dataclass
+class _FakeUsbUtil:
+    released: list[tuple[object, int]] = field(default_factory=list)
+    disposed: list[object] = field(default_factory=list)
+
+    def release_interface(self, device: object, number: int) -> None:
+        self.released.append((device, number))
+
+    def dispose_resources(self, device: object) -> None:
+        self.disposed.append(device)
+
+
+def test_standard_inquiry_refusal_exits_nonzero_and_releases_usb(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = SimpleNamespace(bus=1, address=7, port_numbers=(2,))
+    interface = SimpleNamespace(bInterfaceNumber=3)
+    usb_util = _FakeUsbUtil()
+    selections: list[str] = []
+
+    def connect(*, device_id: str):
+        selections.append(device_id)
+        return device, interface, object(), object(), usb_util
+
+    monkeypatch.setattr(
+        vpd_dump,
+        "_connect_device",
+        connect,
+    )
+
+    refused_status = bytes.fromhex("0205200000000000")
+    monkeypatch.setattr(
+        vpd_dump,
+        "_perform_transaction",
+        lambda *_args, **_kwargs: _result(
+            b"",
+            phase=0x01,
+            status=refused_status,
+        ),
+    )
+
+    assert vpd_dump.main(["--device", "coolscan3:usb:libusb:001:007"]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "REFUSED: standard INQUIRY refused with sense 052000\n"
+    assert selections == ["coolscan3:usb:libusb:001:007"]
+    assert usb_util.released == [(device, 3)]
+    assert usb_util.disposed == [device]

--- a/coolscanpy/tests/cli/test_wedge_recovery.py
+++ b/coolscanpy/tests/cli/test_wedge_recovery.py
@@ -1,0 +1,151 @@
+"""Hardware-free tests for the guarded LS-5000 wedge-recovery CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+
+from coolscanpy.cli import wedge_recovery
+
+
+def _result(*, phase: int, status: bytes = bytes(8)):
+    return SimpleNamespace(
+        phase=phase,
+        payload=b"",
+        status=status,
+        sense=status[1:4].hex(),
+    )
+
+
+@dataclass
+class _FakeUsbUtil:
+    released: list[tuple[object, int]] = field(default_factory=list)
+    disposed: list[object] = field(default_factory=list)
+
+    def release_interface(self, device: object, number: int) -> None:
+        self.released.append((device, number))
+
+    def dispose_resources(self, device: object) -> None:
+        self.disposed.append(device)
+
+
+def test_default_is_dry_run_and_never_opens_device(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        wedge_recovery,
+        "_connect_device",
+        lambda **_kwargs: pytest.fail("dry run opened the scanner"),
+    )
+
+    assert wedge_recovery.main([]) == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out.startswith("DRY RUN: no commands sent\n")
+    assert "SET PARAMETER CDB: e0008100000000000d00" in captured.out
+    assert "SET PARAMETER CDB: e0008000000000000d00" in captured.out
+    assert captured.out.count("EXECUTE CDB: c10000000000") == 2
+
+
+def test_execute_no_confirmation_sends_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("builtins.input", lambda _prompt: "no")
+    monkeypatch.setattr(
+        wedge_recovery,
+        "_connect_device",
+        lambda **_kwargs: pytest.fail("cancelled execution opened the scanner"),
+    )
+
+    assert (
+        wedge_recovery.main(
+            ["--execute", "--operation", "return-to-origin"]
+        )
+        == 1
+    )
+    captured = capsys.readouterr()
+    assert "Cancelled; no commands sent.\n" in captured.out
+    assert "Initialize (80h)" not in captured.out
+
+
+@pytest.mark.parametrize(
+    ("key", "set_cdb"),
+    (
+        ("return-to-origin", "e0008100000000000d00"),
+        ("initialize", "e0008000000000000d00"),
+    ),
+)
+def test_confirmed_execution_sends_one_set_and_execute_sequence(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    key: str,
+    set_cdb: str,
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=3)
+    usb_util = _FakeUsbUtil()
+    calls: list[dict] = []
+    monkeypatch.setattr("builtins.input", lambda _prompt: "yes")
+    monkeypatch.setattr(
+        wedge_recovery,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+
+    def perform(
+        _ep_out: object,
+        _ep_in: object,
+        entry: dict,
+        *,
+        data_timeout_ms: int,
+        deadline_monotonic: float | None = None,
+    ):
+        assert data_timeout_ms == 30_000
+        assert deadline_monotonic is None
+        calls.append(entry)
+        return _result(phase=0x02 if len(calls) == 1 else 0x01)
+
+    monkeypatch.setattr(wedge_recovery, "_perform_transaction", perform)
+
+    assert wedge_recovery.main(["--execute", "--operation", key]) == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert [call["cdb"] for call in calls] == [set_cdb, "c10000000000"]
+    assert calls[0]["data_out"] == "00" * 13
+    assert "data_out" not in calls[1]
+    assert usb_util.released == [(device, 3)]
+    assert usb_util.disposed == [device]
+
+
+def test_refused_set_never_sends_execute_and_releases_usb(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=8)
+    usb_util = _FakeUsbUtil()
+    calls: list[dict] = []
+    monkeypatch.setattr("builtins.input", lambda _prompt: "yes")
+    monkeypatch.setattr(
+        wedge_recovery,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+    refused = bytes.fromhex("0205240000000000")
+
+    def perform(_out: object, _in: object, entry: dict, **_kwargs):
+        calls.append(entry)
+        return _result(phase=0x01, status=refused)
+
+    monkeypatch.setattr(wedge_recovery, "_perform_transaction", perform)
+
+    assert wedge_recovery.main(["--execute", "--operation", "initialize"]) == 2
+    captured = capsys.readouterr()
+    assert "refused with sense 052400" in captured.err
+    assert len(calls) == 1
+    assert usb_util.released == [(device, 8)]
+    assert usb_util.disposed == [device]

--- a/ports/tauri/vendor/coolscanpy/FIREWIRE.md
+++ b/ports/tauri/vendor/coolscanpy/FIREWIRE.md
@@ -119,3 +119,26 @@ re-verified at v0.3.0: the table moved from `src/devices.rs` to
   FireWire units remains Linux-first (issue #16 discussion).
   coolscanpy's probe runs there through `linux_sg` with no extra
   install; the same paste-the-output ask in issue #28 applies.
+
+## Capability pages are walked, never indexed
+
+Capability pages are variable layouts. A parser follows each page's length
+prefixes and extend bits in order; it does not assign a permanent meaning to a
+fixed byte offset across scanner models. The byte positions in an interface
+specification are authoritative for the exact model documented by that
+specification, not a promise that another unit inserts every preceding field in
+the same place.
+
+The 2026-08-10 live LS-5000 dump gives a concrete length example. Its C1h page
+advertises `window_descriptor_len: 61`, while the SET WINDOW data header in the
+LS-5000 specification recommends a 50-byte window descriptor. The C1h set-value
+table itself specifies 61, so this is not a scanner/spec conflict; it is a
+warning against using the command header's recommended 50 as a capability-page
+layout constant.
+
+The reported nkscan v0.3.3 changelog example for the LS-8000 could not be
+verified from the local source bundle: no nkscan changelog was banked. The
+reported autofocus failure and the exact upstream wording therefore are not
+quoted here. Once that changelog is stored locally, its exact sentence should
+be added as the second model-specific regression example rather than
+reconstructed from memory.

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/cli/perforation_probe.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/cli/perforation_probe.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Read the LS-5000's current thumbnail perforation table.
+
+Table 2-11-1 defines the READ(28h) CDB (``LS5kIFSpec.md:7557-7632``),
+Table 2-11-2 assigns read-only data type 8Eh to perforation information
+(``:7691-7691`` and ``:7850-7855``), and section 2-11-8 defines its 4-byte
+records (``:9003-9110``).  The scanner is first asked for the captured
+6-byte 8Eh length envelope and then for exactly that declared size.  READ
+uses control byte 80 as established by the LS-5000 corpus.
+
+The command never starts a scan or moves film.  Per the spec, 8Eh data exists
+after thumbnail scanning; CHECK CONDITION, or an empty pre-thumbnail length,
+is reported as an expected unavailable-data result rather than a traceback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from typing import Sequence
+
+from coolscanpy._logging import get_logger
+from coolscanpy.transport.adapter_status import _connect_device, _perform_transaction
+
+logger = get_logger(__name__)
+
+_DATA_TYPE = 0x8E
+_HEADER_LENGTH = 6
+_TABLE_PREFIX_LENGTH = 8
+_RECORD_LENGTH = 4
+_DATA_IN_PHASE = 0x03
+_GOOD_SENSE = "000000"
+_DEFAULT_TIMEOUT_MS = 30_000
+
+
+class PerforationProbeError(RuntimeError):
+    """The scanner returned a malformed perforation transaction."""
+
+
+class PerforationUnavailable(PerforationProbeError):
+    """No completed thumbnail traversal currently supplies 8Eh data."""
+
+
+@dataclass(frozen=True)
+class PerforationRecord:
+    """One 4-byte row from section 2-11-8."""
+
+    perforation_number: int
+    count_switched: bool
+    pattern_number: int
+    pulse_number: int
+
+
+@dataclass(frozen=True)
+class PerforationTable:
+    """Validated current 8Eh table."""
+
+    declared_length: int
+    records: tuple[PerforationRecord, ...]
+
+
+def _read_cdb(length: int) -> str:
+    if not 1 <= length <= 0xFFFFFF:
+        raise ValueError("READ transfer length must fit in three bytes")
+    return bytes(
+        (
+            0x28,
+            0x00,
+            _DATA_TYPE,
+            0x00,
+            0x00,
+            0x00,
+            (length >> 16) & 0xFF,
+            (length >> 8) & 0xFF,
+            length & 0xFF,
+            0x80,
+        )
+    ).hex()
+
+
+def _validated_read_payload(result: object, *, label: str) -> bytes:
+    phase = getattr(result, "phase", None)
+    if type(phase) is not int:
+        raise PerforationProbeError(f"{label} result has no integer protocol phase")
+
+    payload = getattr(result, "payload", None)
+    if not isinstance(payload, bytes):
+        raise PerforationProbeError(f"{label} result has no bytes payload")
+
+    status = getattr(result, "status", None)
+    if not isinstance(status, bytes) or len(status) != 8:
+        raise PerforationProbeError(f"{label} result must have an 8-byte status")
+
+    sense = getattr(result, "sense", None)
+    if not isinstance(sense, str) or sense != status[1:4].hex():
+        raise PerforationProbeError(
+            f"{label} result sense does not match its 8-byte status"
+        )
+    if status[5:] != bytes(3):
+        raise PerforationProbeError(f"{label} result has a malformed Nikon status")
+    if status[0] == 0x02:
+        raise PerforationUnavailable(
+            f"{label} returned CHECK CONDITION sense {sense}; "
+            "thumbnail perforation data is not available"
+        )
+    if phase != _DATA_IN_PHASE or status[0] != 0x00 or sense != _GOOD_SENSE:
+        raise PerforationProbeError(f"{label} refused with sense {sense}")
+    return payload
+
+
+def _perform_read(
+    ep_out: object,
+    ep_in: object,
+    *,
+    length: int,
+    sequence: str,
+) -> bytes:
+    try:
+        result = _perform_transaction(
+            ep_out,
+            ep_in,
+            {
+                "seq": sequence,
+                "name": "READ:8E",
+                "cdb": _read_cdb(length),
+                "request_len": length,
+                "request_parts": [length],
+            },
+            data_timeout_ms=_DEFAULT_TIMEOUT_MS,
+        )
+    except Exception as error:
+        raise PerforationProbeError(f"{sequence} transaction failed: {error}") from error
+    return _validated_read_payload(result, label=sequence)
+
+
+def _declared_table_length(header: bytes) -> int:
+    if len(header) != _HEADER_LENGTH or header[:4] != b"\x00\x8e\x00\x00":
+        raise PerforationProbeError(
+            f"8Eh length header is malformed: {header.hex()}"
+        )
+    declared = int.from_bytes(header[4:6], "big")
+    if declared < _TABLE_PREFIX_LENGTH:
+        raise PerforationUnavailable(
+            "scanner reports no completed thumbnail perforation table"
+        )
+    return declared
+
+
+def _decode_table(payload: bytes, *, expected_length: int) -> PerforationTable:
+    if len(payload) != expected_length:
+        raise PerforationProbeError(
+            f"8Eh table returned {len(payload)} bytes, expected {expected_length}"
+        )
+    if payload[:4] != b"\x00\x8e\x00\x00":
+        raise PerforationProbeError("8Eh table does not repeat its length envelope")
+    declared = int.from_bytes(payload[4:6], "big")
+    if declared != expected_length:
+        raise PerforationProbeError(
+            f"8Eh table declares {declared} bytes, expected {expected_length}"
+        )
+    body = payload[_TABLE_PREFIX_LENGTH:]
+    if len(body) % _RECORD_LENGTH:
+        raise PerforationProbeError("8Eh table is not 8 plus 4 bytes per record")
+
+    records = tuple(
+        PerforationRecord(
+            perforation_number=int.from_bytes(body[offset : offset + 2], "big"),
+            count_switched=bool(body[offset + 2] & 0x80),
+            pattern_number=body[offset + 2] & 0x7F,
+            pulse_number=body[offset + 3],
+        )
+        for offset in range(0, len(body), _RECORD_LENGTH)
+    )
+    return PerforationTable(declared_length=declared, records=records)
+
+
+def read_perforation_table(*, device_id: str | None = None) -> PerforationTable:
+    """Claim one scanner and read the current 8Eh table without motion."""
+
+    try:
+        if device_id is None:
+            device, interface, ep_out, ep_in, usb_util = _connect_device()
+        else:
+            device, interface, ep_out, ep_in, usb_util = _connect_device(
+                device_id=device_id
+            )
+    except Exception as error:
+        raise PerforationProbeError(f"could not open the scanner: {error}") from error
+
+    try:
+        header = _perform_read(
+            ep_out,
+            ep_in,
+            length=_HEADER_LENGTH,
+            sequence="8Eh length header",
+        )
+        declared = _declared_table_length(header)
+        payload = _perform_read(
+            ep_out,
+            ep_in,
+            length=declared,
+            sequence="8Eh table",
+        )
+        return _decode_table(payload, expected_length=declared)
+    finally:
+        try:
+            usb_util.release_interface(device, interface.bInterfaceNumber)
+        except Exception as error:
+            logger.debug(f"perforation probe could not release interface: {error}")
+        try:
+            usb_util.dispose_resources(device)
+        except Exception as error:
+            logger.debug(f"perforation probe could not dispose resources: {error}")
+
+
+def format_perforation_table(table: PerforationTable) -> str:
+    lines = [
+        f"perforation_table_bytes: {table.declared_length}",
+        f"perforation_records: {len(table.records)}",
+        "index perforation count_switched pattern pulse",
+    ]
+    lines.extend(
+        f"{index} {record.perforation_number} "
+        f"{str(record.count_switched).lower()} "
+        f"{record.pattern_number} {record.pulse_number}"
+        for index, record in enumerate(table.records, start=1)
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--device",
+        help="exact local USB device ID; default is fresh LS-5000 discovery",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        table = read_perforation_table(device_id=args.device)
+    except PerforationUnavailable as error:
+        print(f"CHECK CONDITION: {error}", file=sys.stderr)
+        return 3
+    except PerforationProbeError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+    print(format_perforation_table(table), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/cli/unload_timer.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/cli/unload_timer.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Read the LS-5000 automatic unload timer with GET PARAMETER B4h.
+
+This probe is read-only: it sends GET PARAMETER (E1h) and never sends SET
+PARAMETER or EXECUTE.  The 9-byte request follows the B4h fields through the
+second setting value: Table 2-15-2 defines the first and second values at
+bytes 1--4 and 5--8 (``LS5kIFSpec.md:9755-9810``), Table 2-15-3 identifies
+B4h as ``Unload time set`` (``:9953-9957``), and Table 2-15-4 defines those
+values as seconds and 0=timer OFF / 1=timer ON (``:10165-10175``).  GET
+PARAMETER's E1h CDB and control byte 00 are specified by Table 2-16-1
+(``:10276-10347``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from typing import Sequence
+
+from coolscanpy._logging import get_logger
+from coolscanpy.transport.adapter_status import _connect_device, _perform_transaction
+
+logger = get_logger(__name__)
+
+_GET_PARAMETER_CDB = "e100b400000000000900"
+_PARAMETER_LENGTH = 9
+_DATA_IN_PHASE = 0x03
+_GOOD_SENSE = "000000"
+_DEFAULT_TIMEOUT_MS = 5_000
+
+
+class UnloadTimerError(RuntimeError):
+    """The scanner refused or returned an invalid B4h parameter."""
+
+
+@dataclass(frozen=True)
+class UnloadTimer:
+    """Current B4h values reported by the scanner."""
+
+    seconds: int
+    enabled: bool
+
+
+def _validated_payload(result: object) -> bytes:
+    phase = getattr(result, "phase", None)
+    if type(phase) is not int:
+        raise UnloadTimerError("GET PARAMETER result has no integer protocol phase")
+
+    payload = getattr(result, "payload", None)
+    if not isinstance(payload, bytes):
+        raise UnloadTimerError("GET PARAMETER result has no bytes payload")
+
+    status = getattr(result, "status", None)
+    if not isinstance(status, bytes) or len(status) != 8:
+        raise UnloadTimerError("GET PARAMETER result must have an 8-byte status")
+
+    sense = getattr(result, "sense", None)
+    if not isinstance(sense, str) or sense != status[1:4].hex():
+        raise UnloadTimerError(
+            "GET PARAMETER result sense does not match its 8-byte status"
+        )
+    if status[5:] != bytes(3):
+        raise UnloadTimerError("GET PARAMETER result has a malformed Nikon status")
+    if phase != _DATA_IN_PHASE or status[0] != 0x00 or sense != _GOOD_SENSE:
+        raise UnloadTimerError(f"GET PARAMETER B4h refused with sense {sense}")
+    if len(payload) != _PARAMETER_LENGTH:
+        raise UnloadTimerError(
+            f"GET PARAMETER B4h returned {len(payload)} bytes, "
+            f"expected {_PARAMETER_LENGTH}"
+        )
+    return payload
+
+
+def _decode_unload_timer(payload: bytes) -> UnloadTimer:
+    if len(payload) != _PARAMETER_LENGTH:
+        raise UnloadTimerError(
+            f"B4h parameter has {len(payload)} bytes, expected {_PARAMETER_LENGTH}"
+        )
+    seconds = int.from_bytes(payload[1:5], "big")
+    enabled_value = int.from_bytes(payload[5:9], "big")
+    if seconds != 0 and not 60 <= seconds <= 3_600:
+        raise UnloadTimerError(
+            f"B4h unload time {seconds} is outside the specified 60..3600 seconds"
+        )
+    if enabled_value not in (0, 1):
+        raise UnloadTimerError(
+            f"B4h timer enable value {enabled_value} is not 0 or 1"
+        )
+    return UnloadTimer(seconds=seconds, enabled=enabled_value == 1)
+
+
+def read_unload_timer(*, device_id: str | None = None) -> UnloadTimer:
+    """Claim one scanner, perform the read-only B4h query, and release it."""
+
+    try:
+        if device_id is None:
+            device, interface, ep_out, ep_in, usb_util = _connect_device()
+        else:
+            device, interface, ep_out, ep_in, usb_util = _connect_device(
+                device_id=device_id
+            )
+    except Exception as error:
+        raise UnloadTimerError(f"could not open the scanner: {error}") from error
+
+    try:
+        try:
+            result = _perform_transaction(
+                ep_out,
+                ep_in,
+                {
+                    "seq": "unload-timer",
+                    "name": "GET_PARAMETER:B4",
+                    "cdb": _GET_PARAMETER_CDB,
+                    "request_len": _PARAMETER_LENGTH,
+                    "request_parts": [_PARAMETER_LENGTH],
+                },
+                data_timeout_ms=_DEFAULT_TIMEOUT_MS,
+            )
+        except Exception as error:
+            raise UnloadTimerError(
+                f"GET PARAMETER B4h transaction failed: {error}"
+            ) from error
+        return _decode_unload_timer(_validated_payload(result))
+    finally:
+        try:
+            usb_util.release_interface(device, interface.bInterfaceNumber)
+        except Exception as error:
+            logger.debug(f"unload timer probe could not release interface: {error}")
+        try:
+            usb_util.dispose_resources(device)
+        except Exception as error:
+            logger.debug(f"unload timer probe could not dispose resources: {error}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--device",
+        help="exact local USB device ID; default is fresh LS-5000 discovery",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        timer = read_unload_timer(device_id=args.device)
+    except UnloadTimerError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+    print(f"unload_timer_seconds: {timer.seconds}")
+    print(f"unload_timer_enabled: {str(timer.enabled).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/cli/vpd_dump.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/cli/vpd_dump.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Read and print the LS-5000 INQUIRY VPD pages over raw USB.
+
+This command is deliberately motion-free. It sends only standard INQUIRY and
+INQUIRY with EVPD set; it never sends SCAN, SET WINDOW, READ, or an eject or
+positioning command.
+
+Contract grounding: the standard ``12 00 00 00 24 80`` CDB, data-in phase
+``03h``, successful Nikon status envelope, and the EVPD form
+``12 01 <page> 00 <allocation> 80`` come from
+``protocol/ls5000_single_pass/data/replay-first-rgbi4-plan.jsonl``. Records
+5--16 and 25--30 in that capture also establish the four-byte EVPD header,
+the page-length byte at offset three, and the two-step read: allocation four
+first, then allocation four plus the returned page length. The five-second
+data timeout and the USB claim/release lifecycle match
+``transport.adapter_status``. The 16-byte rows, headings, uppercase hex, and
+printable-ASCII column match the recorded ``nkscan dump`` output in
+``digital-ice-2026/shortstrip-lab/live-attempts/20260810-nkscan-probe-real-5000/dump.out``.
+
+``nkscan dump`` instead uses one fixed-allocation read for each page. The
+difference is deliberate: this command reproduces the observed Nikon Scan
+dialect and exposes stale-tail buffer behavior differently. Responses are
+bounded by the length learned from the first header, so an overlong stale
+tail is not attributed to the page; an otherwise valid short body is printed
+at its actual length.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from typing import Sequence
+
+from coolscanpy._logging import get_logger
+from coolscanpy.transport.adapter_status import _connect_device, _perform_transaction
+
+logger = get_logger(__name__)
+
+_STANDARD_INQUIRY_CDB = "120000002480"
+_STANDARD_INQUIRY_LENGTH = 0x24
+_EVPD_HEADER_LENGTH = 0x04
+_INQUIRY_DATA_PHASE = 0x03
+_GOOD_SENSE = "000000"
+_DEFAULT_TIMEOUT_MS = 5_000
+_HEXDUMP_ROW_BYTES = 16
+_HEXDUMP_HEX_WIDTH = _HEXDUMP_ROW_BYTES * 3 - 1
+_MAX_INQUIRY_ALLOCATION = 0xFF
+
+
+class VpdDumpError(RuntimeError):
+    """The scanner refused or returned an invalid INQUIRY transaction."""
+
+
+@dataclass(frozen=True)
+class VpdDump:
+    """Validated payloads collected during one claimed USB session."""
+
+    standard_inquiry: bytes
+    pages: tuple[tuple[int, bytes], ...]
+    device_location: str
+
+
+def _inquiry_cdb(*, page_code: int, allocation: int) -> str:
+    if not 0 <= page_code <= 0xFF:
+        raise ValueError("VPD page code must fit in one byte")
+    if not 1 <= allocation <= _MAX_INQUIRY_ALLOCATION:
+        raise VpdDumpError(
+            f"INQUIRY allocation {allocation} does not fit the captured CDB"
+        )
+    return bytes((0x12, 0x01, page_code, 0x00, allocation, 0x80)).hex()
+
+
+def _validated_inquiry_payload(result: object, *, label: str) -> bytes:
+    """Return data only from a complete, successful Nikon INQUIRY reply."""
+
+    phase = getattr(result, "phase", None)
+    if type(phase) is not int:
+        raise VpdDumpError(f"{label} result has no integer protocol phase")
+
+    payload = getattr(result, "payload", None)
+    if not isinstance(payload, bytes):
+        raise VpdDumpError(f"{label} result has no bytes payload")
+
+    status = getattr(result, "status", None)
+    if not isinstance(status, bytes) or len(status) != 8:
+        raise VpdDumpError(f"{label} result must have an 8-byte status")
+
+    sense = getattr(result, "sense", None)
+    status_sense = status[1:4].hex()
+    if not isinstance(sense, str) or sense != status_sense:
+        raise VpdDumpError(f"{label} result sense does not match its 8-byte status")
+    if status[5:] != bytes(3):
+        raise VpdDumpError(f"{label} result has a malformed Nikon status envelope")
+    if phase != _INQUIRY_DATA_PHASE or sense != _GOOD_SENSE or status[0] != 0x00:
+        raise VpdDumpError(f"{label} refused with sense {sense}")
+    return payload
+
+
+def _perform_inquiry(
+    ep_out: object,
+    ep_in: object,
+    *,
+    cdb: str,
+    allocation: int,
+    sequence: str,
+) -> bytes:
+    try:
+        result = _perform_transaction(
+            ep_out,
+            ep_in,
+            {
+                "seq": sequence,
+                "name": "INQUIRY",
+                "cdb": cdb,
+                "request_len": allocation,
+                "request_parts": [allocation],
+            },
+            data_timeout_ms=_DEFAULT_TIMEOUT_MS,
+        )
+    except Exception as error:
+        raise VpdDumpError(f"{sequence} transaction failed: {error}") from error
+    return _validated_inquiry_payload(result, label=sequence)
+
+
+def _validate_vpd_header(payload: bytes, *, page_code: int, label: str) -> None:
+    if len(payload) < _EVPD_HEADER_LENGTH:
+        raise VpdDumpError(
+            f"{label} returned {len(payload)} bytes, fewer than the four-byte header"
+        )
+    if payload[0] != 0x06 or payload[1] != page_code or payload[2] != 0x00:
+        raise VpdDumpError(
+            f"{label} returned an unexpected VPD header {payload[:4].hex()}"
+        )
+
+
+def _fetch_vpd_page(ep_out: object, ep_in: object, page_code: int) -> bytes:
+    """Fetch one VPD page with the captured four-byte-header handshake."""
+
+    page_label = f"page {page_code:02X}h"
+    header = _perform_inquiry(
+        ep_out,
+        ep_in,
+        cdb=_inquiry_cdb(page_code=page_code, allocation=_EVPD_HEADER_LENGTH),
+        allocation=_EVPD_HEADER_LENGTH,
+        sequence=f"{page_label} header",
+    )
+    _validate_vpd_header(header, page_code=page_code, label=f"{page_label} header")
+
+    page_total = _EVPD_HEADER_LENGTH + header[3]
+    if page_total > _MAX_INQUIRY_ALLOCATION:
+        raise VpdDumpError(
+            f"{page_label} declares {page_total} bytes, beyond the captured CDB limit"
+        )
+    payload = _perform_inquiry(
+        ep_out,
+        ep_in,
+        cdb=_inquiry_cdb(page_code=page_code, allocation=page_total),
+        allocation=page_total,
+        sequence=page_label,
+    )
+    _validate_vpd_header(payload, page_code=page_code, label=page_label)
+    return payload[:page_total]
+
+
+def _parse_page_list(payload: bytes) -> tuple[int, ...]:
+    """Return advertised nonzero page codes, bounded by page 00h's length."""
+
+    _validate_vpd_header(payload, page_code=0x00, label="page 00h")
+    advertised = payload[4 : 4 + payload[3]]
+    return tuple(page_code for page_code in advertised if page_code != 0x00)
+
+
+def _device_location(device: object) -> str:
+    bus = getattr(device, "bus", None)
+    raw_ports = getattr(device, "port_numbers", None)
+    if type(bus) is int and raw_ports:
+        ports = tuple(raw_ports)
+        if ports and all(type(port) is int and port >= 0 for port in ports):
+            return f"usb:{bus:03d}-" + ".".join(str(port) for port in ports)
+
+    address = getattr(device, "address", None)
+    if type(bus) is int and type(address) is int:
+        return f"usb:{bus:03d}:{address:03d}"
+    return "usb:unknown"
+
+
+def collect_vpd_dump(*, device_id: str | None = None) -> VpdDump:
+    """Claim one LS-5000, collect standard INQUIRY and its advertised VPD."""
+
+    try:
+        if device_id is None:
+            device, interface, ep_out, ep_in, usb_util = _connect_device()
+        else:
+            device, interface, ep_out, ep_in, usb_util = _connect_device(
+                device_id=device_id
+            )
+    except Exception as error:
+        raise VpdDumpError(f"could not open the scanner: {error}") from error
+
+    try:
+        standard = _perform_inquiry(
+            ep_out,
+            ep_in,
+            cdb=_STANDARD_INQUIRY_CDB,
+            allocation=_STANDARD_INQUIRY_LENGTH,
+            sequence="standard INQUIRY",
+        )
+        if len(standard) != _STANDARD_INQUIRY_LENGTH:
+            raise VpdDumpError(
+                f"standard INQUIRY returned {len(standard)} bytes, "
+                f"expected {_STANDARD_INQUIRY_LENGTH}"
+            )
+
+        page_zero = _fetch_vpd_page(ep_out, ep_in, 0x00)
+        page_codes = _parse_page_list(page_zero)
+        pages = tuple(
+            (page_code, _fetch_vpd_page(ep_out, ep_in, page_code))
+            for page_code in page_codes
+        )
+        return VpdDump(
+            standard_inquiry=standard,
+            pages=pages,
+            device_location=_device_location(device),
+        )
+    finally:
+        try:
+            usb_util.release_interface(device, interface.bInterfaceNumber)
+        except Exception as error:
+            logger.debug(f"VPD dump could not release interface: {error}")
+        try:
+            usb_util.dispose_resources(device)
+        except Exception as error:
+            logger.debug(f"VPD dump could not dispose resources: {error}")
+
+
+def _hexdump(payload: bytes) -> str:
+    rows: list[str] = []
+    for offset in range(0, len(payload), _HEXDUMP_ROW_BYTES):
+        chunk = payload[offset : offset + _HEXDUMP_ROW_BYTES]
+        octets = " ".join(f"{value:02X}" for value in chunk)
+        printable = "".join(
+            chr(value) if 0x20 <= value <= 0x7E else "." for value in chunk
+        )
+        rows.append(f"  {offset:04X}  {octets:<{_HEXDUMP_HEX_WIDTH}}  {printable}")
+    return "\n".join(rows)
+
+
+def format_vpd_dump(dump: VpdDump) -> str:
+    """Format a dump for direct comparison with the nkscan reference."""
+
+    standard = dump.standard_inquiry
+    vendor = standard[8:16].decode("ascii", errors="replace").strip()
+    product = standard[16:32].decode("ascii", errors="replace").strip()
+    identity = f"{vendor} {product}".strip()
+    page_codes = tuple(page_code for page_code, _payload in dump.pages)
+    page_summary = " ".join(f"{page_code:02X}h" for page_code in page_codes)
+
+    lines = [
+        f"{identity:<20} {dump.device_location}",
+        "",
+        "== standard INQUIRY ==",
+        _hexdump(standard),
+        "",
+        f"  {len(page_codes)} pages:" + (f" {page_summary}" if page_summary else ""),
+    ]
+    for page_code, payload in dump.pages:
+        lines.extend(
+            (
+                "",
+                f"== page {page_code:02X}h ==",
+                _hexdump(payload),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--device",
+        help="exact local USB device ID; default is fresh LS-5000 discovery",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        dump = collect_vpd_dump(device_id=args.device)
+    except VpdDumpError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+    print(format_vpd_dump(dump), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/cli/wedge_recovery.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/cli/wedge_recovery.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Plan or explicitly execute LS-5000 wedge-recovery motion commands.
+
+These are MOTION commands.  Live validation is owner-gated: the default is a
+dry run that opens no device and sends nothing; ``--execute`` also requires a
+single selected operation and an interactive ``yes`` confirmation.  There is
+no non-interactive confirmation bypass.
+
+Table 2-15-1 defines SET PARAMETER E0h and its 13-byte recommended parameter
+length (``LS5kIFSpec.md:9673-9736``).  Table 2-15-2 defines that zero-filled
+parameter envelope (``:9755-9809``), Table 2-15-3 assigns 80h Initialize and
+81h Return to origin (``:9868-9900``), and Table 2-15-4 marks both operations
+as having no parameters (``:10039-10088``).  The spec requires EXECUTE after
+SET PARAMETER to start the selected operation (``:9741-9753``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from typing import Sequence
+
+from coolscanpy._logging import get_logger
+from coolscanpy.transport.adapter_status import _connect_device, _perform_transaction
+
+logger = get_logger(__name__)
+
+_PARAMETER_LENGTH = 13
+_PARAMETER_DATA = bytes(_PARAMETER_LENGTH)
+_EXECUTE_CDB = "c10000000000"
+_GOOD_SENSE = "000000"
+_DEFAULT_TIMEOUT_MS = 30_000
+
+
+class WedgeRecoveryError(RuntimeError):
+    """The selected recovery command was refused or malformed."""
+
+
+@dataclass(frozen=True)
+class RecoveryOperation:
+    """One owner-selectable SET PARAMETER operation."""
+
+    key: str
+    label: str
+    operation_code: int
+
+    @property
+    def set_parameter_cdb(self) -> str:
+        return bytes(
+            (
+                0xE0,
+                0x00,
+                self.operation_code,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                _PARAMETER_LENGTH,
+                0x00,
+            )
+        ).hex()
+
+
+_OPERATIONS = (
+    RecoveryOperation("return-to-origin", "ReturnToOrigin", 0x81),
+    RecoveryOperation("initialize", "Initialize", 0x80),
+)
+_OPERATIONS_BY_KEY = {operation.key: operation for operation in _OPERATIONS}
+
+
+def format_plan(operations: Sequence[RecoveryOperation]) -> str:
+    lines = ["DRY RUN: no commands sent"]
+    for operation in operations:
+        lines.extend(
+            (
+                f"{operation.label} ({operation.operation_code:02X}h)",
+                f"  SET PARAMETER CDB: {operation.set_parameter_cdb}",
+                f"  parameter data ({_PARAMETER_LENGTH} bytes): {_PARAMETER_DATA.hex()}",
+                f"  EXECUTE CDB: {_EXECUTE_CDB}",
+                "  spec: LS5kIFSpec.md Tables 2-15-1 through 2-15-4",
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _validate_no_data_result(
+    result: object,
+    *,
+    label: str,
+    expected_phase: int,
+) -> None:
+    phase = getattr(result, "phase", None)
+    if type(phase) is not int:
+        raise WedgeRecoveryError(f"{label} result has no integer protocol phase")
+    payload = getattr(result, "payload", None)
+    if not isinstance(payload, bytes) or payload:
+        raise WedgeRecoveryError(f"{label} result must have an empty bytes payload")
+    status = getattr(result, "status", None)
+    if not isinstance(status, bytes) or len(status) != 8:
+        raise WedgeRecoveryError(f"{label} result must have an 8-byte status")
+    sense = getattr(result, "sense", None)
+    if not isinstance(sense, str) or sense != status[1:4].hex():
+        raise WedgeRecoveryError(
+            f"{label} result sense does not match its 8-byte status"
+        )
+    if status[5:] != bytes(3):
+        raise WedgeRecoveryError(f"{label} result has a malformed Nikon status")
+    if phase != expected_phase or status[0] != 0x00 or sense != _GOOD_SENSE:
+        raise WedgeRecoveryError(f"{label} refused with sense {sense}")
+
+
+def execute_operation(
+    operation: RecoveryOperation,
+    *,
+    device_id: str | None = None,
+) -> None:
+    """Send one confirmed SET PARAMETER + EXECUTE sequence and release USB."""
+
+    try:
+        if device_id is None:
+            device, interface, ep_out, ep_in, usb_util = _connect_device()
+        else:
+            device, interface, ep_out, ep_in, usb_util = _connect_device(
+                device_id=device_id
+            )
+    except Exception as error:
+        raise WedgeRecoveryError(f"could not open the scanner: {error}") from error
+
+    try:
+        try:
+            set_result = _perform_transaction(
+                ep_out,
+                ep_in,
+                {
+                    "seq": f"wedge-recovery-{operation.key}-set",
+                    "name": f"SET_PARAMETER:{operation.operation_code:02X}",
+                    "cdb": operation.set_parameter_cdb,
+                    "data_out": _PARAMETER_DATA.hex(),
+                },
+                data_timeout_ms=_DEFAULT_TIMEOUT_MS,
+            )
+            _validate_no_data_result(
+                set_result,
+                label=f"SET PARAMETER {operation.label}",
+                expected_phase=0x02,
+            )
+            execute_result = _perform_transaction(
+                ep_out,
+                ep_in,
+                {
+                    "seq": f"wedge-recovery-{operation.key}-execute",
+                    "name": "EXECUTE",
+                    "cdb": _EXECUTE_CDB,
+                },
+                data_timeout_ms=_DEFAULT_TIMEOUT_MS,
+            )
+            _validate_no_data_result(
+                execute_result,
+                label=f"EXECUTE {operation.label}",
+                expected_phase=0x01,
+            )
+        except WedgeRecoveryError:
+            raise
+        except Exception as error:
+            raise WedgeRecoveryError(
+                f"{operation.label} transaction failed: {error}"
+            ) from error
+    finally:
+        try:
+            usb_util.release_interface(device, interface.bInterfaceNumber)
+        except Exception as error:
+            logger.debug(f"wedge recovery could not release interface: {error}")
+        try:
+            usb_util.dispose_resources(device)
+        except Exception as error:
+            logger.debug(f"wedge recovery could not dispose resources: {error}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--operation",
+        choices=tuple(_OPERATIONS_BY_KEY),
+        help="one recovery operation; required with --execute",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="send the selected motion command after interactive confirmation",
+    )
+    parser.add_argument(
+        "--device",
+        help="exact local USB device ID; default is fresh LS-5000 discovery",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.execute and args.operation is None:
+        parser.error("--execute requires --operation")
+
+    selected = (
+        (_OPERATIONS_BY_KEY[args.operation],)
+        if args.operation is not None
+        else _OPERATIONS
+    )
+    print(format_plan(selected), end="")
+    if not args.execute:
+        return 0
+
+    operation = selected[0]
+    try:
+        confirmation = input(
+            f"Type yes to send {operation.label} MOTION commands [yes/NO]: "
+        )
+    except EOFError:
+        confirmation = ""
+    if confirmation.strip().lower() != "yes":
+        print("Cancelled; no commands sent.")
+        return 1
+
+    try:
+        execute_operation(operation, device_id=args.device)
+    except WedgeRecoveryError as error:
+        print(f"REFUSED: {error}", file=sys.stderr)
+        return 2
+    print(f"SENT: {operation.label} SET PARAMETER + EXECUTE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ports/tauri/vendor/coolscanpy/tests/cli/test_perforation_probe.py
+++ b/ports/tauri/vendor/coolscanpy/tests/cli/test_perforation_probe.py
@@ -1,0 +1,170 @@
+"""Hardware-free tests for the LS-5000 perforation-table probe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+
+from coolscanpy.cli import perforation_probe
+
+
+def _result(payload: bytes, *, phase: int = 0x03, status: bytes = bytes(8)):
+    return SimpleNamespace(
+        phase=phase,
+        payload=payload,
+        status=status,
+        sense=status[1:4].hex(),
+    )
+
+
+@dataclass
+class _FakeUsbUtil:
+    released: list[tuple[object, int]] = field(default_factory=list)
+    disposed: list[object] = field(default_factory=list)
+
+    def release_interface(self, device: object, number: int) -> None:
+        self.released.append((device, number))
+
+    def dispose_resources(self, device: object) -> None:
+        self.disposed.append(device)
+
+
+def test_two_step_read_uses_control_80_and_decodes_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=5)
+    usb_util = _FakeUsbUtil()
+    ep_out = object()
+    ep_in = object()
+    payloads = [
+        bytes.fromhex("008e00000010"),
+        bytes.fromhex("008e0000001000040010812200200533"),
+    ]
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        perforation_probe,
+        "_connect_device",
+        lambda: (device, interface, ep_out, ep_in, usb_util),
+    )
+
+    def perform(
+        out: object,
+        incoming: object,
+        entry: dict,
+        *,
+        data_timeout_ms: int,
+        deadline_monotonic: float | None = None,
+    ):
+        assert (out, incoming) == (ep_out, ep_in)
+        assert data_timeout_ms == 30_000
+        assert deadline_monotonic is None
+        calls.append(entry)
+        return _result(payloads.pop(0))
+
+    monkeypatch.setattr(perforation_probe, "_perform_transaction", perform)
+
+    table = perforation_probe.read_perforation_table()
+
+    assert table == perforation_probe.PerforationTable(
+        declared_length=16,
+        records=(
+            perforation_probe.PerforationRecord(16, True, 1, 34),
+            perforation_probe.PerforationRecord(32, False, 5, 51),
+        ),
+    )
+    assert [call["cdb"] for call in calls] == [
+        "28008e00000000000680",
+        "28008e00000000001080",
+    ]
+    assert [call["request_len"] for call in calls] == [6, 16]
+    assert [call["request_parts"] for call in calls] == [[6], [16]]
+    assert usb_util.released == [(device, 5)]
+    assert usb_util.disposed == [device]
+
+
+def test_formatted_table_is_stable() -> None:
+    table = perforation_probe.PerforationTable(
+        declared_length=12,
+        records=(perforation_probe.PerforationRecord(7, False, 3, 9),),
+    )
+
+    assert perforation_probe.format_perforation_table(table) == (
+        "perforation_table_bytes: 12\n"
+        "perforation_records: 1\n"
+        "index perforation count_switched pattern pulse\n"
+        "1 7 false 3 9\n"
+    )
+
+
+def test_check_condition_is_reported_as_expected_unavailable_data(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=6)
+    usb_util = _FakeUsbUtil()
+    monkeypatch.setattr(
+        perforation_probe,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+    check_condition = bytes.fromhex("02052c0000000000")
+    monkeypatch.setattr(
+        perforation_probe,
+        "_perform_transaction",
+        lambda *_args, **_kwargs: _result(
+            b"",
+            phase=0x01,
+            status=check_condition,
+        ),
+    )
+
+    assert perforation_probe.main([]) == 3
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        "CHECK CONDITION: 8Eh length header returned CHECK CONDITION sense "
+        "052c00; thumbnail perforation data is not available\n"
+    )
+    assert usb_util.released == [(device, 6)]
+    assert usb_util.disposed == [device]
+
+
+def test_prethumbnail_empty_length_is_cleanly_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=1)
+    usb_util = _FakeUsbUtil()
+    monkeypatch.setattr(
+        perforation_probe,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+    monkeypatch.setattr(
+        perforation_probe,
+        "_perform_transaction",
+        lambda *_args, **_kwargs: _result(bytes.fromhex("008e00000004")),
+    )
+
+    assert perforation_probe.main([]) == 3
+    captured = capsys.readouterr()
+    assert "no completed thumbnail perforation table" in captured.err
+    assert usb_util.released == [(device, 1)]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        bytes.fromhex("008f0000000c000400000000"),
+        bytes.fromhex("008e00000010000400000000"),
+        bytes.fromhex("008e0000000d00040000000000"),
+    ),
+)
+def test_malformed_tables_fail_closed(payload: bytes) -> None:
+    with pytest.raises(perforation_probe.PerforationProbeError):
+        perforation_probe._decode_table(payload, expected_length=len(payload))

--- a/ports/tauri/vendor/coolscanpy/tests/cli/test_unload_timer.py
+++ b/ports/tauri/vendor/coolscanpy/tests/cli/test_unload_timer.py
@@ -1,0 +1,152 @@
+"""Hardware-free tests for the LS-5000 unload-timer probe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+
+from coolscanpy.cli import unload_timer
+
+
+def _result(payload: bytes, *, phase: int = 0x03, status: bytes = bytes(8)):
+    return SimpleNamespace(
+        phase=phase,
+        payload=payload,
+        status=status,
+        sense=status[1:4].hex(),
+    )
+
+
+@dataclass
+class _FakeUsbUtil:
+    released: list[tuple[object, int]] = field(default_factory=list)
+    disposed: list[object] = field(default_factory=list)
+
+    def release_interface(self, device: object, number: int) -> None:
+        self.released.append((device, number))
+
+    def dispose_resources(self, device: object) -> None:
+        self.disposed.append(device)
+
+
+def test_read_uses_exact_b4_cdb_and_decodes_seconds_and_enable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=4)
+    usb_util = _FakeUsbUtil()
+    ep_out = object()
+    ep_in = object()
+    calls: list[tuple[object, object, dict, int]] = []
+
+    monkeypatch.setattr(
+        unload_timer,
+        "_connect_device",
+        lambda: (device, interface, ep_out, ep_in, usb_util),
+    )
+
+    def perform(
+        out: object,
+        incoming: object,
+        entry: dict,
+        *,
+        data_timeout_ms: int,
+        deadline_monotonic: float | None = None,
+    ):
+        assert deadline_monotonic is None
+        calls.append((out, incoming, entry, data_timeout_ms))
+        return _result(bytes.fromhex("000000025800000001"))
+
+    monkeypatch.setattr(unload_timer, "_perform_transaction", perform)
+
+    assert unload_timer.read_unload_timer() == unload_timer.UnloadTimer(
+        seconds=600,
+        enabled=True,
+    )
+    assert calls == [
+        (
+            ep_out,
+            ep_in,
+            {
+                "seq": "unload-timer",
+                "name": "GET_PARAMETER:B4",
+                "cdb": "e100b400000000000900",
+                "request_len": 9,
+                "request_parts": [9],
+            },
+            5_000,
+        )
+    ]
+    assert usb_util.released == [(device, 4)]
+    assert usb_util.disposed == [device]
+
+
+def test_timer_off_is_reported_without_sending_set(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=2)
+    usb_util = _FakeUsbUtil()
+    monkeypatch.setattr(
+        unload_timer,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+    monkeypatch.setattr(
+        unload_timer,
+        "_perform_transaction",
+        lambda *_args, **_kwargs: _result(
+            bytes.fromhex("0000000e1000000000")
+        ),
+    )
+
+    assert unload_timer.main([]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == (
+        "unload_timer_seconds: 3600\n"
+        "unload_timer_enabled: false\n"
+    )
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        bytes.fromhex("000000000100000002"),
+        bytes.fromhex("000000003b00000001"),
+        bytes.fromhex("0000000000000000"),
+    ),
+)
+def test_invalid_b4_values_fail_closed(payload: bytes) -> None:
+    with pytest.raises(unload_timer.UnloadTimerError):
+        unload_timer._decode_unload_timer(payload)
+
+
+def test_check_condition_exits_nonzero_and_releases_usb(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=7)
+    usb_util = _FakeUsbUtil()
+    monkeypatch.setattr(
+        unload_timer,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+    refused = bytes.fromhex("0205240000000000")
+    monkeypatch.setattr(
+        unload_timer,
+        "_perform_transaction",
+        lambda *_args, **_kwargs: _result(b"", phase=0x01, status=refused),
+    )
+
+    assert unload_timer.main([]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "refused with sense 052400" in captured.err
+    assert usb_util.released == [(device, 7)]
+    assert usb_util.disposed == [device]

--- a/ports/tauri/vendor/coolscanpy/tests/cli/test_vpd_dump.py
+++ b/ports/tauri/vendor/coolscanpy/tests/cli/test_vpd_dump.py
@@ -1,0 +1,208 @@
+"""Hardware-free tests for the LS-5000 VPD dump command."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+
+from coolscanpy.cli import vpd_dump
+
+
+# Captured by replay-first-rgbi4-plan.jsonl records 1, 5--6, 13--16.
+_STANDARD_INQUIRY = bytes.fromhex(
+    "068002021f0000004e696b6f6e2020204c532d35303030204544202020202020312e3033"
+)
+_PAGE_ZERO = bytes.fromhex("0600001300014041475051606162c1d1e1e3f0f8e2fbfc")
+_PAGE_F0 = bytes.fromhex(
+    "06f0003103400000000000001e6709c4"
+    "177001001241000000000000024a0258"
+    "0258010006470000000000001e68012c"
+    "04b0010005"
+)
+_PAGE_F8 = bytes.fromhex("06f8000d63055002510260046101620100")
+
+
+def _result(payload: bytes, *, phase: int = 0x03, status: bytes = bytes(8)):
+    return SimpleNamespace(
+        phase=phase,
+        payload=payload,
+        status=status,
+        sense=status[1:4].hex(),
+    )
+
+
+def _script_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+    payloads: list[bytes],
+) -> list[dict[str, object]]:
+    remaining = list(payloads)
+    calls: list[dict[str, object]] = []
+
+    def perform(
+        ep_out: object,
+        ep_in: object,
+        entry: dict,
+        *,
+        data_timeout_ms: int,
+        deadline_monotonic: float | None = None,
+    ):
+        calls.append(
+            {
+                "ep_out": ep_out,
+                "ep_in": ep_in,
+                "entry": entry,
+                "data_timeout_ms": data_timeout_ms,
+                "deadline_monotonic": deadline_monotonic,
+            }
+        )
+        assert remaining
+        return _result(remaining.pop(0))
+
+    monkeypatch.setattr(vpd_dump, "_perform_transaction", perform)
+    return calls
+
+
+def test_page_list_parse_uses_declared_length_and_ignores_page_zero() -> None:
+    stale_tail = bytes.fromhex("deadbeef")
+
+    assert vpd_dump._parse_page_list(_PAGE_ZERO + stale_tail) == (
+        0x01,
+        0x40,
+        0x41,
+        0x47,
+        0x50,
+        0x51,
+        0x60,
+        0x61,
+        0x62,
+        0xC1,
+        0xD1,
+        0xE1,
+        0xE3,
+        0xF0,
+        0xF8,
+        0xE2,
+        0xFB,
+        0xFC,
+    )
+
+
+def test_vpd_page_uses_header_then_exact_captured_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _script_transactions(
+        monkeypatch,
+        [bytes.fromhex("06f00031"), _PAGE_F0],
+    )
+
+    payload = vpd_dump._fetch_vpd_page(object(), object(), 0xF0)
+
+    assert payload == _PAGE_F0
+    assert [call["entry"]["cdb"] for call in calls] == [
+        "1201f0000480",
+        "1201f0003580",
+    ]
+    assert [call["entry"]["request_len"] for call in calls] == [4, 53]
+    assert [call["entry"]["request_parts"] for call in calls] == [[4], [53]]
+    assert [call["data_timeout_ms"] for call in calls] == [5_000, 5_000]
+
+
+@pytest.mark.parametrize(
+    ("returned", "expected"),
+    (
+        (_PAGE_F8[:12], _PAGE_F8[:12]),
+        (_PAGE_F8 + bytes.fromhex("c1d1e1e3f0"), _PAGE_F8),
+    ),
+)
+def test_vpd_page_tolerates_short_body_and_trims_stale_tail(
+    monkeypatch: pytest.MonkeyPatch,
+    returned: bytes,
+    expected: bytes,
+) -> None:
+    _script_transactions(
+        monkeypatch,
+        [bytes.fromhex("06f8000d"), returned],
+    )
+
+    assert vpd_dump._fetch_vpd_page(object(), object(), 0xF8) == expected
+
+
+def test_hexdump_matches_nkscan_row_format() -> None:
+    assert vpd_dump._hexdump(_STANDARD_INQUIRY) == (
+        "  0000  06 80 02 02 1F 00 00 00 4E 69 6B 6F 6E 20 20 20  "
+        "........Nikon   \n"
+        "  0010  4C 53 2D 35 30 30 30 20 45 44 20 20 20 20 20 20  "
+        "LS-5000 ED      \n"
+        "  0020  31 2E 30 33                                      1.03"
+    )
+
+
+def test_formatted_dump_uses_reference_sections_and_page_summary() -> None:
+    dump = vpd_dump.VpdDump(
+        standard_inquiry=_STANDARD_INQUIRY,
+        pages=((0xF8, _PAGE_F8),),
+        device_location="usb:001-2",
+    )
+
+    output = vpd_dump.format_vpd_dump(dump)
+
+    assert output.startswith(
+        "Nikon LS-5000 ED     usb:001-2\n\n== standard INQUIRY ==\n"
+    )
+    assert "\n  1 pages: F8h\n\n== page F8h ==\n" in output
+    assert output.endswith(
+        "  0010  00                                               .\n"
+    )
+
+
+@dataclass
+class _FakeUsbUtil:
+    released: list[tuple[object, int]] = field(default_factory=list)
+    disposed: list[object] = field(default_factory=list)
+
+    def release_interface(self, device: object, number: int) -> None:
+        self.released.append((device, number))
+
+    def dispose_resources(self, device: object) -> None:
+        self.disposed.append(device)
+
+
+def test_standard_inquiry_refusal_exits_nonzero_and_releases_usb(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = SimpleNamespace(bus=1, address=7, port_numbers=(2,))
+    interface = SimpleNamespace(bInterfaceNumber=3)
+    usb_util = _FakeUsbUtil()
+    selections: list[str] = []
+
+    def connect(*, device_id: str):
+        selections.append(device_id)
+        return device, interface, object(), object(), usb_util
+
+    monkeypatch.setattr(
+        vpd_dump,
+        "_connect_device",
+        connect,
+    )
+
+    refused_status = bytes.fromhex("0205200000000000")
+    monkeypatch.setattr(
+        vpd_dump,
+        "_perform_transaction",
+        lambda *_args, **_kwargs: _result(
+            b"",
+            phase=0x01,
+            status=refused_status,
+        ),
+    )
+
+    assert vpd_dump.main(["--device", "coolscan3:usb:libusb:001:007"]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "REFUSED: standard INQUIRY refused with sense 052000\n"
+    assert selections == ["coolscan3:usb:libusb:001:007"]
+    assert usb_util.released == [(device, 3)]
+    assert usb_util.disposed == [device]

--- a/ports/tauri/vendor/coolscanpy/tests/cli/test_wedge_recovery.py
+++ b/ports/tauri/vendor/coolscanpy/tests/cli/test_wedge_recovery.py
@@ -1,0 +1,151 @@
+"""Hardware-free tests for the guarded LS-5000 wedge-recovery CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+
+from coolscanpy.cli import wedge_recovery
+
+
+def _result(*, phase: int, status: bytes = bytes(8)):
+    return SimpleNamespace(
+        phase=phase,
+        payload=b"",
+        status=status,
+        sense=status[1:4].hex(),
+    )
+
+
+@dataclass
+class _FakeUsbUtil:
+    released: list[tuple[object, int]] = field(default_factory=list)
+    disposed: list[object] = field(default_factory=list)
+
+    def release_interface(self, device: object, number: int) -> None:
+        self.released.append((device, number))
+
+    def dispose_resources(self, device: object) -> None:
+        self.disposed.append(device)
+
+
+def test_default_is_dry_run_and_never_opens_device(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        wedge_recovery,
+        "_connect_device",
+        lambda **_kwargs: pytest.fail("dry run opened the scanner"),
+    )
+
+    assert wedge_recovery.main([]) == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out.startswith("DRY RUN: no commands sent\n")
+    assert "SET PARAMETER CDB: e0008100000000000d00" in captured.out
+    assert "SET PARAMETER CDB: e0008000000000000d00" in captured.out
+    assert captured.out.count("EXECUTE CDB: c10000000000") == 2
+
+
+def test_execute_no_confirmation_sends_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("builtins.input", lambda _prompt: "no")
+    monkeypatch.setattr(
+        wedge_recovery,
+        "_connect_device",
+        lambda **_kwargs: pytest.fail("cancelled execution opened the scanner"),
+    )
+
+    assert (
+        wedge_recovery.main(
+            ["--execute", "--operation", "return-to-origin"]
+        )
+        == 1
+    )
+    captured = capsys.readouterr()
+    assert "Cancelled; no commands sent.\n" in captured.out
+    assert "Initialize (80h)" not in captured.out
+
+
+@pytest.mark.parametrize(
+    ("key", "set_cdb"),
+    (
+        ("return-to-origin", "e0008100000000000d00"),
+        ("initialize", "e0008000000000000d00"),
+    ),
+)
+def test_confirmed_execution_sends_one_set_and_execute_sequence(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    key: str,
+    set_cdb: str,
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=3)
+    usb_util = _FakeUsbUtil()
+    calls: list[dict] = []
+    monkeypatch.setattr("builtins.input", lambda _prompt: "yes")
+    monkeypatch.setattr(
+        wedge_recovery,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+
+    def perform(
+        _ep_out: object,
+        _ep_in: object,
+        entry: dict,
+        *,
+        data_timeout_ms: int,
+        deadline_monotonic: float | None = None,
+    ):
+        assert data_timeout_ms == 30_000
+        assert deadline_monotonic is None
+        calls.append(entry)
+        return _result(phase=0x02 if len(calls) == 1 else 0x01)
+
+    monkeypatch.setattr(wedge_recovery, "_perform_transaction", perform)
+
+    assert wedge_recovery.main(["--execute", "--operation", key]) == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert [call["cdb"] for call in calls] == [set_cdb, "c10000000000"]
+    assert calls[0]["data_out"] == "00" * 13
+    assert "data_out" not in calls[1]
+    assert usb_util.released == [(device, 3)]
+    assert usb_util.disposed == [device]
+
+
+def test_refused_set_never_sends_execute_and_releases_usb(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    device = object()
+    interface = SimpleNamespace(bInterfaceNumber=8)
+    usb_util = _FakeUsbUtil()
+    calls: list[dict] = []
+    monkeypatch.setattr("builtins.input", lambda _prompt: "yes")
+    monkeypatch.setattr(
+        wedge_recovery,
+        "_connect_device",
+        lambda: (device, interface, object(), object(), usb_util),
+    )
+    refused = bytes.fromhex("0205240000000000")
+
+    def perform(_out: object, _in: object, entry: dict, **_kwargs):
+        calls.append(entry)
+        return _result(phase=0x01, status=refused)
+
+    monkeypatch.setattr(wedge_recovery, "_perform_transaction", perform)
+
+    assert wedge_recovery.main(["--execute", "--operation", "initialize"]) == 2
+    captured = capsys.readouterr()
+    assert "refused with sense 052400" in captured.err
+    assert len(calls) == 1
+    assert usb_util.released == [(device, 8)]
+    assert usb_util.disposed == [device]


### PR DESCRIPTION
Four motion-safe probe CLIs for the LS-5000, all spec-cited to LS5kIFSpec.md and live-validated against real hardware today where applicable:

- `vpd_dump`: standard INQUIRY + full EVPD page walk in Nikon Scan's observed two-step dialect. Live output byte-identical (common prefix, all 18 pages) to an independent implementation's dump of the same unit.
- `unload_timer`: read-only GET PARAMETER B4h. Live read: the unit's auto-eject timer is enabled at 3600 seconds — closing the idle-eject characterization question.
- `perforation_probe`: read-only READ 8Eh; reports CHECK CONDITION cleanly when no thumbnail data exists.
- `wedge_recovery`: dry-run-default planner for SET PARAMETER 80h/81h + EXECUTE behind --execute plus interactive confirmation. 81h live-validated on the empty transport (accepted, homed, settled at steady idle).

Also records the walking-parsers rule in FIREWIRE.md (capability pages must be walked, never indexed). Vendor mirror carries byte-identical copies; sync guard green. Full driver suite: 1716 passed, 4 skipped, 1 xfailed.