### PR TITLE
coolscanpy 0.6.0 version sync for v0.7.0-beta.3

### DIFF
--- a/bridge/uv.lock
+++ b/bridge/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/coolscanpy/CHANGELOG.md
+++ b/coolscanpy/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.0 - 2026-08-10
+
+- VPD dump: two-step dialect plus conformance validation.
+- unload-timer: GET B4h with the live 3600s/enabled reading.
+- perforation: 8Eh probe.
+- wedge-recovery: dry-run planner with 81h live acceptance.
+
 # Changelog
 
 ## Unreleased

--- a/coolscanpy/pyproject.toml
+++ b/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.5.0"
+version = "0.6.0"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/coolscanpy/uv.lock
+++ b/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/coolscanpy/CHANGELOG.md
+++ b/ports/tauri/vendor/coolscanpy/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.0 - 2026-08-10
+
+- VPD dump: two-step dialect plus conformance validation.
+- unload-timer: GET B4h with the live 3600s/enabled reading.
+- perforation: 8Eh probe.
+- wedge-recovery: dry-run planner with 81h live acceptance.
+
 # Changelog
 
 ## Unreleased

--- a/ports/tauri/vendor/coolscanpy/pyproject.toml
+++ b/ports/tauri/vendor/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.5.0"
+version = "0.6.0"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/ports/tauri/vendor/coolscanpy/uv.lock
+++ b/ports/tauri/vendor/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/scanstudio-bridge/uv.lock
+++ b/ports/tauri/vendor/scanstudio-bridge/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },


### PR DESCRIPTION
Syncs the bundled driver to 0.6.0 (four probe CLIs) across primary and vendor mirrors with changelog entries, matching the beta.2 sync pattern. Merge after coolscanpy 0.6.0 is live on PyPI; the release sync gate byte-compares against the published sdist at tag time. No bundle.py repin needed — the canonical exemption sha is unchanged this cycle.