### PR TITLE
coolscanpy 0.7.0 version sync for v0.7.0-beta.4

### DIFF
--- a/bridge/uv.lock
+++ b/bridge/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/coolscanpy/CHANGELOG.md
+++ b/coolscanpy/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.7.0 - 2026-08-10
+
+- Adapter identity: motion-free VPD 00h/01h probe
+  (`transport.adapter_identity`, `Device.adapter_identity()`) with the
+  interface specification's Table 2-2-2-2-1 vocabulary
+  (Mount / 6Strip / 36Strip / 240 / Feeder).
+- `Roll.preview()` now refuses positively-identified non-strip adapters
+  with the new typed `AdapterUnsupported` instead of dying in the
+  synchronized protocol as INTERNAL. Live-validated on a real LS-5000
+  with an MA-21 and a mounted slide: the advertised VPD page list is
+  adapter-dependent (the MA-21 drops pages 47h and E2h), so the
+  strip-captured preview trace cannot replay against a mount adapter.
+- The capture worker binds EVPD INQUIRY replay entries to the live
+  page-00h list: an unadvertised page's status-only 052400 refusal (the
+  live-proven shape, exact-pinned) is accepted and journaled, its paired
+  body read skipped. Strip feeders advertise every traced page, so their
+  replay is structurally unchanged (regression-tested against the
+  canonical plan).
+
 ## 0.6.0 - 2026-08-10
 
 - VPD dump: two-step dialect plus conformance validation.

--- a/coolscanpy/pyproject.toml
+++ b/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.6.0"
+version = "0.7.0"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/coolscanpy/uv.lock
+++ b/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/coolscanpy/CHANGELOG.md
+++ b/ports/tauri/vendor/coolscanpy/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.7.0 - 2026-08-10
+
+- Adapter identity: motion-free VPD 00h/01h probe
+  (`transport.adapter_identity`, `Device.adapter_identity()`) with the
+  interface specification's Table 2-2-2-2-1 vocabulary
+  (Mount / 6Strip / 36Strip / 240 / Feeder).
+- `Roll.preview()` now refuses positively-identified non-strip adapters
+  with the new typed `AdapterUnsupported` instead of dying in the
+  synchronized protocol as INTERNAL. Live-validated on a real LS-5000
+  with an MA-21 and a mounted slide: the advertised VPD page list is
+  adapter-dependent (the MA-21 drops pages 47h and E2h), so the
+  strip-captured preview trace cannot replay against a mount adapter.
+- The capture worker binds EVPD INQUIRY replay entries to the live
+  page-00h list: an unadvertised page's status-only 052400 refusal (the
+  live-proven shape, exact-pinned) is accepted and journaled, its paired
+  body read skipped. Strip feeders advertise every traced page, so their
+  replay is structurally unchanged (regression-tested against the
+  canonical plan).
+
 ## 0.6.0 - 2026-08-10
 
 - VPD dump: two-step dialect plus conformance validation.

--- a/ports/tauri/vendor/coolscanpy/pyproject.toml
+++ b/ports/tauri/vendor/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.6.0"
+version = "0.7.0"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/__init__.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/__init__.py
@@ -18,7 +18,7 @@ except Exception:  # pragma: no cover - only when the package isn't installed
     # Linux preview packages run directly from CorrespondingSource, where
     # distribution metadata is intentionally absent. Keep this fallback
     # aligned with pyproject.toml for accurate startup provenance.
-    __version__ = "0.4.0"
+    __version__ = "0.7.0"
 
 from coolscanpy._device import Device, get_devices, open
 from coolscanpy._roll import Roll

--- a/ports/tauri/vendor/coolscanpy/uv.lock
+++ b/ports/tauri/vendor/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/scanstudio-bridge/uv.lock
+++ b/ports/tauri/vendor/scanstudio-bridge/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },


### PR DESCRIPTION
Lockstep sync for the v0.7.0-beta.4 release, following the beta.2/beta.3 template: both pyprojects to 0.7.0, both CHANGELOGs, and all four coolscanpy-pinning locks (coolscanpy, vendored coolscanpy, bridge, vendored bridge). PyPI coolscanpy 0.7.0 is already live, so the tag-time sync gate has its comparison target.

One extra file beyond the template: the Linux CorrespondingSource `__init__.py` version fallback, stale at 0.4.0 since it was introduced (its own comment asks to keep it aligned with pyproject) — now 0.7.0.