### PR TITLE
security: authenticate beta release toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
+        with:
+          toolchain: '1.97.1'
+      - name: Verify exact Rust toolchain
+        run: python3 -I -S -B scripts/verify_pinned_rust.py
       - name: Test Swift app and Rust engine
         working-directory: app/ScanStudio
         run: make test
@@ -38,13 +42,15 @@ jobs:
     # every job keeps test and package environments interchangeable.
     env:
       UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          python-version: "3.13"
+      - name: Install exact uv and managed Python build toolchain
+        run: |
+          python3 -I -S -B scripts/install_pinned_uv_python.py \
+            --install-root "$RUNNER_TEMP/scanstudio-uv-python"
       - name: Install bridge dependencies
         working-directory: bridge
         run: uv sync --locked
@@ -57,13 +63,15 @@ jobs:
     runs-on: macos-15
     env:
       UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          python-version: "3.13"
+      - name: Install exact uv and managed Python build toolchain
+        run: |
+          python3 -I -S -B scripts/install_pinned_uv_python.py \
+            --install-root "$RUNNER_TEMP/scanstudio-uv-python"
       - name: Test direct-USB library and packaging logic
         working-directory: coolscanpy
         run: uv run pytest
@@ -119,32 +127,25 @@ jobs:
             upload-artifact: false
     env:
       UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          python-version: "3.13"
-      - name: Install optional SANE binding build prerequisite
-        # The release does not copy Homebrew's libusb: package_app.sh builds
-        # the signed app-owned copy from hash-pinned source at the declared
-        # deployment target. sane-backends is needed only to compile the
-        # optional python-sane compatibility binding included in the bundle.
-        run: brew install sane-backends
-      - name: Point the compiler at Homebrew's headers and libraries
-        # GitHub Actions does not expand $(...) inside an `env:` block, and
-        # Homebrew's prefix varies by runner architecture (/opt/homebrew on
-        # Apple silicon, /usr/local on Intel), so resolve it here and export
-        # it through GITHUB_ENV for every later step in this job -- python-sane
-        # needs sane.h to build its C extension against.
+          toolchain: '1.97.1'
+      - name: Install exact uv and managed Python build toolchain
         run: |
-          echo "CPPFLAGS=-I$(brew --prefix)/include" >> "$GITHUB_ENV"
-          echo "LDFLAGS=-L$(brew --prefix)/lib" >> "$GITHUB_ENV"
-      - name: Install locked bridge dependencies (with scanner extra)
+          python3 -I -S -B scripts/install_pinned_uv_python.py \
+            --install-root "$RUNNER_TEMP/scanstudio-uv-python"
+      - name: Verify exact Rust toolchain
+        run: python3 -I -S -B scripts/verify_pinned_rust.py
+      - name: Install locked production bridge dependencies
         working-directory: bridge
-        run: uv sync --locked --extra scanner
+        # python-sane is intentionally built by package_app.sh from its exact
+        # locked sdist against the private source-pinned SANE link SDK.
+        run: uv sync --locked --no-dev --no-install-package python-sane
       - name: Build and verify the local package
         # make package runs package_app.sh then test_packaged_bridge.sh on the
         # built ScanStudio.app -- the relocation-safe bridge check -- so this
@@ -173,13 +174,15 @@ jobs:
     needs: package
     env:
       UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          python-version: "3.13"
+      - name: Install exact uv and managed Python build toolchain
+        run: |
+          python3 -I -S -B scripts/install_pinned_uv_python.py \
+            --install-root "$RUNNER_TEMP/scanstudio-uv-python"
       - name: Warm the locked dependency cache for offline source verification
         working-directory: bridge
         run: uv sync --locked
@@ -202,13 +205,15 @@ jobs:
     needs: package
     env:
       UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          python-version: "3.13"
+      - name: Install exact uv and managed Python build toolchain
+        run: |
+          python3 -I -S -B scripts/install_pinned_uv_python.py \
+            --install-root "$RUNNER_TEMP/scanstudio-uv-python"
       - name: Warm the locked dependency cache
         # Keeps the runner environment interchangeable with the other uv-managed
         # jobs (see the bridge job note) so script behaviour is reproducible.

--- a/.github/workflows/ports.yml
+++ b/.github/workflows/ports.yml
@@ -25,21 +25,28 @@ jobs:
     name: Assemble Windows offline resources
     runs-on: ubuntu-22.04
     timeout-minutes: 45
+    env:
+      UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: ports/tauri/app/package-lock.json
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.13'
+      - name: Install exact Node and Python build toolchains
+        run: |
+          python3 -I -S -B scripts/install_pinned_node.py \
+            --install-root "$RUNNER_TEMP/scanstudio-node"
+          python3 -I -S -B scripts/install_pinned_uv_python.py \
+            --install-root "$RUNNER_TEMP/scanstudio-uv-python"
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
-      - name: Install pinned Rust dependency notice generator
-        run: cargo install --locked --version 0.9.1 --features cli cargo-about
+        with:
+          toolchain: '1.97.1'
+      - name: Verify exact Rust toolchain
+        run: python3 -I -S -B scripts/verify_pinned_rust.py
+      - name: Install authenticated Rust dependency notice generator
+        run: |
+          python3 -I -S -B scripts/install_pinned_cargo_about.py \
+            --install-root "$RUNNER_TEMP/scanstudio-cargo-about"
       - name: Assemble and verify the WSL2 resource bundle
         working-directory: ports/tauri
         env:
@@ -61,6 +68,9 @@ jobs:
     needs: windows-resources
     runs-on: windows-latest
     timeout-minutes: 90
+    env:
+      UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -75,17 +85,20 @@ jobs:
           New-Item -ItemType Directory -Force -Path ports/tauri/packaging/.staging | Out-Null
           tar -xzf "$env:RUNNER_TEMP/windows-staging/windows-staging.tar.gz" -C ports/tauri/packaging/.staging
           if ($LASTEXITCODE -ne 0) { throw "Could not restore Windows staging" }
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: ports/tauri/app/package-lock.json
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.13'
+      - name: Install exact Node and Python build toolchains
+        shell: pwsh
+        run: |
+          python -I -S -B scripts/install_pinned_node.py `
+            --install-root "$env:RUNNER_TEMP\scanstudio-node"
+          if ($LASTEXITCODE -ne 0) { throw "Pinned Node installation failed" }
+          python -I -S -B scripts/install_pinned_uv_python.py `
+            --install-root "$env:RUNNER_TEMP\scanstudio-uv-python"
+          if ($LASTEXITCODE -ne 0) { throw "Pinned uv/Python installation failed" }
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
-      - name: Install NSIS
-        run: choco install nsis --yes --no-progress
+        with:
+          toolchain: '1.97.1'
+      - name: Verify exact Rust toolchain
+        run: python -I -S -B scripts/verify_pinned_rust.py
       - name: Build, install, smoke-test, and re-extract both Windows packages
         shell: pwsh
         run: |
@@ -96,30 +109,35 @@ jobs:
   linux:
     name: Build and verify Linux x64 Preview
     runs-on: ubuntu-22.04
+    container: ubuntu@sha256:0199853f6d6b20b0424f3c5694a72a62764f01e6a771b1eb48a4197848986c7e
     timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash
+    env:
+      UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
       - name: Install Linux build and runtime prerequisites
+        run: scripts/install_ubuntu_build_prerequisites.sh
+      - name: Install exact Node and Python build toolchains
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential curl file libayatana-appindicator3-dev libfuse2 libgtk-3-dev \
-            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev librsvg2-dev \
-            libsane-dev libssl-dev libusb-1.0-0 libwebkit2gtk-4.1-dev squashfs-tools \
-            libxdo-dev patchelf pkg-config sane-utils wget
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: ports/tauri/app/package-lock.json
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.13'
+          python3 -I -S -B scripts/install_pinned_node.py \
+            --install-root "$RUNNER_TEMP/scanstudio-node"
+          python3 -I -S -B scripts/install_pinned_uv_python.py \
+            --install-root "$RUNNER_TEMP/scanstudio-uv-python"
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
-      - name: Install pinned Rust dependency notice generator
-        run: cargo install --locked --version 0.9.1 --features cli cargo-about
+        with:
+          toolchain: '1.97.1'
+      - name: Verify exact Rust toolchain
+        run: python3 -I -S -B scripts/verify_pinned_rust.py
+      - name: Install authenticated Rust dependency notice generator
+        run: |
+          python3 -I -S -B scripts/install_pinned_cargo_about.py \
+            --install-root "$RUNNER_TEMP/scanstudio-cargo-about"
       - name: Build, extract, smoke-test, and re-extract both Linux packages
         env:
           # linuxdeploy is itself an AppImage; running it needs FUSE, which the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  authorize:
+    name: Authorize tag from reviewed main history
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Verify tag commit, main containment, and full notes
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_TYPE" = tag
+          test "$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")" = "$GITHUB_SHA"
+          git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main
+          version="${GITHUB_REF_NAME#v}"
+          python3 -I -S -B scripts/verify_release_notes.py \
+            "docs/releases/$GITHUB_REF_NAME.md" "$GITHUB_REF_NAME" "$version"
+
   release:
     name: Build and verify ${{ matrix.arch }} DMG
+    needs: authorize
     # A universal bundle is impossible because the pinned cv2/numpy wheels are
     # not universal, so each architecture is built natively on its own runner
     # through the SAME verified `make dmg` path (codesign --deep --strict,
@@ -46,6 +65,7 @@ jobs:
       # the same verified `make dmg` path used locally, so a release is only
       # publishable if the exact signed app passes the packaging verification.
       UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -54,32 +74,25 @@ jobs:
         # Owner policy (2026-08-08): a release may not ship driver code that
         # standalone `pip install coolscanpy` users would not have -- version
         # skew between the two makes field reports for the same film
-        # incomparable. Content-compared against the latest published sdist
-        # (version strings are checked second; an unbumped version with
-        # changed code is exactly the failure mode). Publish the matching
-        # coolscanpy release from the canonical repo first, then re-tag.
+        # incomparable. Content is compared against the exact authenticated
+        # 0.7.1 sdist (version strings are checked second; an unbumped version
+        # with changed code is exactly the failure mode). Publish the matching
+        # coolscanpy release from the canonical repo before tagging ScanStudio.
         run: bash scripts/check_coolscanpy_pypi_sync.sh
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          python-version: "3.13"
-      - name: Install optional SANE binding build prerequisite
-        # The release does not copy Homebrew's libusb: package_app.sh builds
-        # the signed app-owned copy from hash-pinned source. sane-backends is
-        # needed only to compile the optional python-sane compatibility
-        # binding included in the bundle.
-        run: brew install sane-backends
-      - name: Point the compiler at Homebrew's headers and libraries
-        # GitHub Actions does not expand $(...) inside an `env:` block and the
-        # Homebrew prefix varies by runner arch (/opt/homebrew on arm64,
-        # /usr/local on x86_64), so resolve it here and export it through
-        # GITHUB_ENV for every later step in this job.
+          toolchain: '1.97.1'
+      - name: Install exact uv and managed Python build toolchain
         run: |
-          echo "CPPFLAGS=-I$(brew --prefix)/include" >> "$GITHUB_ENV"
-          echo "LDFLAGS=-L$(brew --prefix)/lib" >> "$GITHUB_ENV"
-      - name: Install locked bridge dependencies (with scanner extra)
+          python3 -I -S -B scripts/install_pinned_uv_python.py \
+            --install-root "$RUNNER_TEMP/scanstudio-uv-python"
+      - name: Verify exact Rust toolchain
+        run: python3 -I -S -B scripts/verify_pinned_rust.py
+      - name: Install locked production bridge dependencies
         working-directory: bridge
-        run: uv sync --locked --extra scanner
+        # package_app.sh compiles exact python-sane 2.9.2 separately against
+        # the source-pinned, private SANE 1.4.0 link SDK.
+        run: uv sync --locked --no-dev --no-install-package python-sane
       - name: Resolve release version from the tag
         # The workflow only runs on `v*` tag pushes, so the exact-match tag
         # is authoritative; fall back to GITHUB_REF_NAME minus the leading v.
@@ -137,23 +150,31 @@ jobs:
 
   windows-resources:
     name: Assemble Windows offline resources
+    needs: authorize
     runs-on: ubuntu-22.04
     timeout-minutes: 45
+    env:
+      UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: ports/tauri/app/package-lock.json
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.13'
+      - name: Install exact Node and Python build toolchains
+        run: |
+          python3 -I -S -B scripts/install_pinned_node.py \
+            --install-root "$RUNNER_TEMP/scanstudio-node"
+          python3 -I -S -B scripts/install_pinned_uv_python.py \
+            --install-root "$RUNNER_TEMP/scanstudio-uv-python"
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
-      - name: Install pinned Rust dependency notice generator
-        run: cargo install --locked --version 0.9.1 --features cli cargo-about
+        with:
+          toolchain: '1.97.1'
+      - name: Verify exact Rust toolchain
+        run: python3 -I -S -B scripts/verify_pinned_rust.py
+      - name: Install authenticated Rust dependency notice generator
+        run: |
+          python3 -I -S -B scripts/install_pinned_cargo_about.py \
+            --install-root "$RUNNER_TEMP/scanstudio-cargo-about"
       - name: Assemble and verify the WSL2 resource bundle
         working-directory: ports/tauri
         env:
@@ -175,6 +196,9 @@ jobs:
     needs: windows-resources
     runs-on: windows-latest
     timeout-minutes: 90
+    env:
+      UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -189,17 +213,20 @@ jobs:
           New-Item -ItemType Directory -Force -Path ports/tauri/packaging/.staging | Out-Null
           tar -xzf "$env:RUNNER_TEMP/windows-staging/windows-staging.tar.gz" -C ports/tauri/packaging/.staging
           if ($LASTEXITCODE -ne 0) { throw "Could not restore Windows staging" }
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: ports/tauri/app/package-lock.json
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.13'
+      - name: Install exact Node and Python build toolchains
+        shell: pwsh
+        run: |
+          python -I -S -B scripts/install_pinned_node.py `
+            --install-root "$env:RUNNER_TEMP\scanstudio-node"
+          if ($LASTEXITCODE -ne 0) { throw "Pinned Node installation failed" }
+          python -I -S -B scripts/install_pinned_uv_python.py `
+            --install-root "$env:RUNNER_TEMP\scanstudio-uv-python"
+          if ($LASTEXITCODE -ne 0) { throw "Pinned uv/Python installation failed" }
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
-      - name: Install NSIS
-        run: choco install nsis --yes --no-progress
+        with:
+          toolchain: '1.97.1'
+      - name: Verify exact Rust toolchain
+        run: python -I -S -B scripts/verify_pinned_rust.py
       - name: Resolve release version from the tag
         shell: pwsh
         run: |
@@ -220,31 +247,37 @@ jobs:
 
   linux:
     name: Build and verify Linux x64 Preview
+    needs: authorize
     runs-on: ubuntu-22.04
+    container: ubuntu@sha256:0199853f6d6b20b0424f3c5694a72a62764f01e6a771b1eb48a4197848986c7e
     timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash
+    env:
+      UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
       - name: Install Linux build and runtime prerequisites
+        run: scripts/install_ubuntu_build_prerequisites.sh
+      - name: Install exact Node and Python build toolchains
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential curl file libayatana-appindicator3-dev libfuse2 libgtk-3-dev \
-            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev librsvg2-dev \
-            libsane-dev libssl-dev libusb-1.0-0 libwebkit2gtk-4.1-dev squashfs-tools \
-            libxdo-dev patchelf pkg-config sane-utils wget
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: ports/tauri/app/package-lock.json
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.13'
+          python3 -I -S -B scripts/install_pinned_node.py \
+            --install-root "$RUNNER_TEMP/scanstudio-node"
+          python3 -I -S -B scripts/install_pinned_uv_python.py \
+            --install-root "$RUNNER_TEMP/scanstudio-uv-python"
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
-      - name: Install pinned Rust dependency notice generator
-        run: cargo install --locked --version 0.9.1 --features cli cargo-about
+        with:
+          toolchain: '1.97.1'
+      - name: Verify exact Rust toolchain
+        run: python3 -I -S -B scripts/verify_pinned_rust.py
+      - name: Install authenticated Rust dependency notice generator
+        run: |
+          python3 -I -S -B scripts/install_pinned_cargo_about.py \
+            --install-root "$RUNNER_TEMP/scanstudio-cargo-about"
       - name: Resolve release version from the tag
         run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
       - name: Build, extract, smoke-test, and re-extract both Linux packages

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -30,8 +30,15 @@ the package check proves a relocated bundled Python process resolves that
 exact app-owned file rather than a Homebrew copy.
 
 The bundle also includes `python-sane` for CoolscanPy's optional plain-scan
-and software-eject paths. It deliberately does **not** include an operating-
-system SANE backend; the bundled `_sane` extension expects a compatible host
+and software-eject paths. Version 2.9.2 is compiled from the exact sdist in the
+bridge lock (SHA-256
+`50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe`)
+against a private build-only SANE 1.4.0 link SDK. That SDK is built from the
+upstream release archive with SHA-256
+`f99205c903dfe2fb8990f0c531232c9a00ec9c2c66ac7cb0ce50b4af9f407a72`;
+neither it nor a SANE runtime is distributed. The package retains python-sane's
+permissive `COPYING` text, exact source archive, and rebuild controls under
+`Contents/Resources`. The bundled `_sane` extension expects a compatible host
 `libsane.1.dylib` when one of those optional paths is used. The supported
 LS-5000 color-roll workflow does not require SANE: discovery and connection
 fall back to direct USB when SANE is absent, while status, preview, and color
@@ -103,7 +110,7 @@ Before distributing `ScanStudio.app`, a DMG, or any other binary artifact:
 1. Regenerate the resolved dependency inventory from the exact `Cargo.lock` used to build the release.
 2. Include the full text of every selected Rust dependency license and the required copyright notices in the shipped archive or app bundle.
 3. Include the MIT license for this project.
-4. A `make package` bundle includes `scanstudio-bridge`: verify its GPL-3.0-only license, CoolscanPy source, CPython license, Python wheel metadata/licenses, and libusb license, notice, binary, complete pinned source archive, exact build script, and rebuild instructions are present in `Contents/Resources/Licenses`, `Contents/Resources/CorrespondingSource`, and `Contents/Frameworks`.
+4. A `make package` bundle includes `scanstudio-bridge`: verify its GPL-3.0-only license, CoolscanPy source, CPython license, Python wheel metadata/licenses, python-sane source/rebuild controls, and libusb license, notice, binary, complete pinned source archive, exact build script, and rebuild instructions are present in `Contents/Resources/Licenses`, `Contents/Resources/CorrespondingSource`, and `Contents/Frameworks`; also verify no SANE link SDK or SANE runtime was shipped.
 5. Keep Nikon software and private evidence out of the release.
 6. Recheck this document after every dependency or packaging change.
 

--- a/app/ScanStudio/Makefile
+++ b/app/ScanStudio/Makefile
@@ -1,4 +1,4 @@
-.PHONY: engine app package package-check dmg test run smoke launcher-check parity render-color-candidates render-geometry-candidates render-ice-candidates clean check-cargo check-swift check-tools
+.PHONY: engine app sane-link-sdk package package-check dmg test run smoke launcher-check parity render-color-candidates render-geometry-candidates render-ice-candidates clean check-cargo check-swift check-tools
 
 # Tool paths are discovered from the caller's PATH. Override CARGO or SWIFT
 # explicitly when using a non-standard toolchain installation.
@@ -29,6 +29,13 @@ engine: check-cargo
 
 app: check-swift
 	$(SWIFT) build
+
+# Central entry point for inspecting the source-pinned, build-only SANE SDK.
+# The create-only output is deliberately separate from the app bundle and is
+# removed by `make clean`; package_app.sh uses a private per-run equivalent.
+sane-link-sdk:
+	mkdir -p .build
+	./scripts/build_sane_link_sdk.sh "$(CURDIR)/.build/sane-link-sdk"
 
 package: check-tools
 	./scripts/package_app.sh

--- a/app/ScanStudio/README.md
+++ b/app/ScanStudio/README.md
@@ -106,10 +106,13 @@ The real-device backend speaks the NDJSON contract in
 [`protocol/BRIDGE.md`](protocol/BRIDGE.md) to `scanstudio-bridge`, the
 GPL-3.0-only CoolscanPy helper. `make package` includes that helper, a
 relocatable CPython 3.13 runtime, production Python dependencies (including
-`python-sane`), a signed app-owned libusb built from pinned source for the
-app's macOS 14 deployment target, and visible license/source material inside
-`ScanStudio.app`. It does not include Nikon software or an operating-system
-SANE backend.
+`python-sane` 2.9.2 built from its exact locked sdist), a signed app-owned
+libusb built from pinned source for the app's macOS 14 deployment target, and
+visible license/source material inside `ScanStudio.app`. The python-sane C
+extension is compiled against a private, source-pinned SANE 1.4.0 link SDK;
+the packager proves the SDK-only Mach-O identity before rewriting it to the
+architecture's canonical host `libsane.1.dylib` path. The private SDK and SANE
+runtime are never shipped. The app also does not include Nikon software.
 
 The package launcher resolves a bridge in this order: `SCANSTUDIO_BRIDGE_CMD`,
 the user bridge-command file, the bundled helper, then `PATH`. Set
@@ -142,6 +145,15 @@ software-eject paths; those optional actions need a compatible system SANE
 backend (`brew install sane-backends` on the tested Apple Silicon setup). If
 an unavailable optional path is requested, it fails rather than pretending it
 succeeded; it does not turn a real scanner into the simulator.
+
+Release and CI packaging do not install Homebrew SANE as a build input. Use
+`make sane-link-sdk` only to inspect the create-only private SDK generated from
+the exact sane-backends 1.4.0 archive (SHA-256
+`f99205c903dfe2fb8990f0c531232c9a00ec9c2c66ac7cb0ce50b4af9f407a72`).
+`make package` performs the same source build in private staging, compiles the
+exact python-sane 2.9.2 sdist from the bridge lock, and rejects mismatched
+architecture, macOS 14 minimum, ABI, RPATHs, build paths, extra extensions,
+or accidental SDK/runtime files before signing.
 
 The device bar identifies a connected real device as `real` and the simulator
 as `simulated`. Selecting a device is separate from confirming that film is

--- a/app/ScanStudio/scripts/build_sane_link_sdk.sh
+++ b/app/ScanStudio/scripts/build_sane_link_sdk.sh
@@ -1,0 +1,489 @@
+#!/bin/zsh
+# Build the macOS-only, private SANE link SDK used to compile python-sane.
+# The SDK is never a runtime dependency and must never be copied into the app.
+set -euo pipefail
+
+script_dir="${0:A:h}"
+package_root="${script_dir:h}"
+repository_root="${package_root:h:h}"
+sdk_destination="${1:-}"
+binding_destination="${2:-}"
+bridge_source="${3:-$repository_root/bridge}"
+bridge_python="${4:-$bridge_source/.venv/bin/python}"
+
+sane_version="1.4.0"
+sane_source_url="https://gitlab.com/-/project/429008/uploads/843c156420e211859e974f78f64c3ea3/sane-backends-1.4.0.tar.gz"
+sane_source_sha256="f99205c903dfe2fb8990f0c531232c9a00ec9c2c66ac7cb0ce50b4af9f407a72"
+sane_source_size="7505056"
+sane_archive_entries="1295"
+sane_archive_expanded_size="37519360"
+python_sane_version="2.9.2"
+python_sane_source_url="https://files.pythonhosted.org/packages/45/e9/e8baff69fc2347606c547201204d4b4843c7ad8ecb9164eceee42016eff6/python_sane-2.9.2.tar.gz"
+python_sane_source_sha256="50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe"
+python_sane_source_size="22513"
+python_sane_archive_entries="22"
+python_sane_archive_expanded_size="122880"
+deployment_target="14.0"
+source_date_epoch="1748131200"
+sane_source_override="${SCANSTUDIO_SANE_SOURCE_ARCHIVE:-}"
+python_sane_source_override="${SCANSTUDIO_PYTHON_SANE_SOURCE_ARCHIVE:-}"
+
+die() {
+    print -u2 "Pinned SANE link-SDK build refused: $*"
+    exit 1
+}
+
+require_regular_file() {
+    local label="$1"
+    local target="$2"
+    [[ -f "$target" && ! -L "$target" ]] || die "$label is missing, not regular, or a symlink: $target"
+}
+
+require_new_directory() {
+    local label="$1"
+    local target="$2"
+    [[ "$target" == /* ]] || die "$label must be an absolute path: $target"
+    local parent="${target:h}"
+    [[ -d "$parent" && ! -L "$parent" ]] || die "$label parent is missing, not a directory, or a symlink: $parent"
+    [[ ! -e "$target" && ! -L "$target" ]] || die "$label already exists: $target"
+    mkdir -m 700 "$target" || die "could not create $label with create-only semantics: $target"
+}
+
+sha256() {
+    shasum -a 256 "$1" | awk '{print $1}'
+}
+
+download_exact() {
+    local label="$1"
+    local url="$2"
+    local expected_size="$3"
+    local expected_sha256="$4"
+    local destination="$5"
+    local partial="${destination}.download"
+    [[ ! -e "$partial" && ! -L "$partial" ]] || die "$label partial download path already exists"
+    curl --fail --location --silent --show-error \
+        --proto '=https' --tlsv1.2 \
+        --connect-timeout 20 --max-time 180 \
+        --max-filesize "$expected_size" \
+        --output "$partial" "$url"
+    require_regular_file "$label download" "$partial"
+    local actual_size
+    actual_size="$(stat -f '%z' "$partial")"
+    [[ "$actual_size" == "$expected_size" ]] \
+        || die "$label size mismatch: expected $expected_size, got $actual_size"
+    local actual_sha256
+    actual_sha256="$(sha256 "$partial")"
+    [[ "$actual_sha256" == "$expected_sha256" ]] \
+        || die "$label SHA-256 mismatch: expected $expected_sha256, got $actual_sha256"
+    mv "$partial" "$destination"
+}
+
+copy_exact() {
+    local label="$1"
+    local source="$2"
+    local expected_size="$3"
+    local expected_sha256="$4"
+    local destination="$5"
+    local partial="${destination}.copy"
+    require_regular_file "$label override" "$source"
+    [[ ! -e "$partial" && ! -L "$partial" ]] || die "$label copy path already exists"
+    [[ "$(stat -f '%z' "$source")" == "$expected_size" ]] \
+        || die "$label override size does not match the pinned archive"
+    install -m 600 "$source" "$partial"
+    require_regular_file "$label copied archive" "$partial"
+    [[ "$(stat -f '%z' "$partial")" == "$expected_size" ]] \
+        || die "$label copied archive size changed"
+    [[ "$(sha256 "$partial")" == "$expected_sha256" ]] \
+        || die "$label copied archive SHA-256 does not match the pin"
+    mv "$partial" "$destination"
+}
+
+validate_archive() {
+    local label="$1"
+    local archive="$2"
+    local expected_prefix="$3"
+    local expected_entries="$4"
+    local expected_expanded_size="$5"
+    local entries expanded
+    entries="$(tar -tzf "$archive" | wc -l | tr -d ' ')"
+    [[ "$entries" == "$expected_entries" ]] \
+        || die "$label entry count mismatch: expected $expected_entries, got $entries"
+    expanded="$(gzip -dc "$archive" | wc -c | tr -d ' ')"
+    [[ "$expanded" == "$expected_expanded_size" ]] \
+        || die "$label expanded size mismatch: expected $expected_expanded_size, got $expanded"
+    if tar -tvzf "$archive" | awk 'substr($1, 1, 1) != "-" && substr($1, 1, 1) != "d" { found=1 } END { exit !found }'; then
+        die "$label contains an entry that is not a regular file or directory"
+    fi
+    if tar -tzf "$archive" | awk -v prefix="$expected_prefix/" '
+        index($0, prefix) != 1 || $0 ~ /(^|\/)\.\.($|\/)/ || $0 ~ /\/\// { bad=1 }
+        END { exit !bad }
+    '; then
+        die "$label contains an unexpected or unsafe member path"
+    fi
+}
+
+verify_no_rpath() {
+    local label="$1"
+    local target="$2"
+    if otool -l "$target" | awk '$2 == "LC_RPATH" { found=1 } END { exit !found }'; then
+        die "$label contains LC_RPATH"
+    fi
+}
+
+verify_arch_and_minos() {
+    local label="$1"
+    local target="$2"
+    local expected_arch="$3"
+    local architectures minimum
+    architectures="$(lipo -archs "$target")"
+    [[ "$architectures" == "$expected_arch" ]] \
+        || die "$label architecture is '$architectures', expected '$expected_arch'"
+    minimum="$(vtool -show-build "$target" | awk '$1 == "minos" { print $2; exit }')"
+    [[ "$minimum" == "$deployment_target" ]] \
+        || die "$label minimum macOS is '$minimum', expected '$deployment_target'"
+}
+
+[[ -n "$sdk_destination" ]] \
+    || die "usage: build_sane_link_sdk.sh SDK_DESTINATION [BINDING_VENV BRIDGE_SOURCE PYTHON]"
+if [[ -n "$binding_destination" && "$#" -ne 4 ]]; then
+    die "binding preparation requires exactly SDK_DESTINATION BINDING_VENV BRIDGE_SOURCE PYTHON"
+fi
+if [[ -z "$binding_destination" && "$#" -ne 1 ]]; then
+    die "SDK-only preparation accepts exactly one destination argument"
+fi
+
+host_arch="$(uname -m)"
+case "$host_arch" in
+    arm64)
+        host_sane_path="/opt/homebrew/opt/sane-backends/lib/libsane.1.dylib"
+        ;;
+    x86_64)
+        host_sane_path="/usr/local/opt/sane-backends/lib/libsane.1.dylib"
+        ;;
+    *)
+        die "unsupported macOS build architecture: $host_arch"
+        ;;
+esac
+sentinel_install_name="/__ScanStudio_SANE_Link_SDK_ONLY_${sane_version//./_}_${host_arch}__/libsane.1.dylib"
+
+require_new_directory "SANE link SDK destination" "$sdk_destination"
+sdk_destination="${sdk_destination:A}"
+sdk_work="$sdk_destination/.work"
+mkdir -m 700 "$sdk_work"
+source_archive="$sdk_work/sane-backends-$sane_version.tar.gz"
+if [[ -n "$sane_source_override" ]]; then
+    copy_exact "sane-backends source" "$sane_source_override" "$sane_source_size" \
+        "$sane_source_sha256" "$source_archive"
+else
+    download_exact "sane-backends source" "$sane_source_url" "$sane_source_size" \
+        "$sane_source_sha256" "$source_archive"
+fi
+validate_archive "sane-backends source" "$source_archive" \
+    "sane-backends-$sane_version" "$sane_archive_entries" "$sane_archive_expanded_size"
+
+source_parent="$sdk_work/source"
+build_root="$sdk_work/build"
+build_home="$sdk_work/home"
+build_tmp="$sdk_work/tmp"
+mkdir -m 700 "$source_parent" "$build_root" "$build_home" "$build_tmp"
+tar -xzf "$source_archive" -C "$source_parent"
+source_root="$source_parent/sane-backends-$sane_version"
+require_regular_file "sane-backends configure script" "$source_root/configure"
+require_regular_file "SANE public header" "$source_root/include/sane/sane.h"
+if find "$source_root" -type l -print -quit | grep -q .; then
+    die "validated sane-backends source unexpectedly extracted a symlink"
+fi
+
+build_jobs="$(sysctl -n hw.ncpu)"
+[[ "$build_jobs" == <-> && "$build_jobs" -ge 1 && "$build_jobs" -le 256 ]] \
+    || die "invalid host CPU count: $build_jobs"
+sdk_prefix="/__ScanStudio_SANE_Link_SDK_${sane_version//./_}_${host_arch}__"
+configure_log="$sdk_work/configure.log"
+build_log="$sdk_work/build.log"
+secure_path="/usr/bin:/bin:/usr/sbin:/sbin"
+if ! (
+    cd "$build_root"
+    env -i \
+        HOME="$build_home" PATH="$secure_path" TMPDIR="$build_tmp" \
+        LANG=C LC_ALL=C ZERO_AR_DATE=1 SOURCE_DATE_EPOCH="$source_date_epoch" \
+        MACOSX_DEPLOYMENT_TARGET="$deployment_target" \
+        CC=/usr/bin/clang CXX=/usr/bin/clang++ \
+        CFLAGS="-O2 -mmacosx-version-min=$deployment_target -fdebug-prefix-map=$sdk_work=/sane-sdk -ffile-prefix-map=$sdk_work=/sane-sdk" \
+        CXXFLAGS="-O2 -mmacosx-version-min=$deployment_target -fdebug-prefix-map=$sdk_work=/sane-sdk -ffile-prefix-map=$sdk_work=/sane-sdk" \
+        LDFLAGS="-mmacosx-version-min=$deployment_target" \
+        BACKENDS=net PRELOADABLE_BACKENDS= \
+        "$source_root/configure" \
+            --prefix="$sdk_prefix" \
+            --disable-dependency-tracking \
+            --disable-static --enable-shared --disable-rpath \
+            --disable-nls --disable-locking --disable-ipv6 \
+            --disable-preload --disable-local-backends \
+            --without-gphoto2 --without-v4l --without-avahi \
+            --without-snmp --without-systemd --without-usb \
+            --without-libcurl --without-poppler-glib \
+            --without-usb-record-replay
+) > "$configure_log" 2>&1; then
+    print -u2 "Pinned sane-backends configure failed; final output follows:"
+    tail -n 200 "$configure_log" >&2
+    exit 1
+fi
+if ! env -i \
+    HOME="$build_home" PATH="$secure_path" TMPDIR="$build_tmp" \
+    LANG=C LC_ALL=C ZERO_AR_DATE=1 SOURCE_DATE_EPOCH="$source_date_epoch" \
+    MACOSX_DEPLOYMENT_TARGET="$deployment_target" \
+    /usr/bin/make -C "$build_root" -j "$build_jobs" > "$build_log" 2>&1; then
+    print -u2 "Pinned sane-backends build failed; final output follows:"
+    tail -n 200 "$build_log" >&2
+    exit 1
+fi
+
+built_library="$build_root/backend/.libs/libsane.1.dylib"
+require_regular_file "built SANE link library" "$built_library"
+verify_arch_and_minos "built SANE link library" "$built_library" "$host_arch"
+verify_no_rpath "built SANE link library" "$built_library"
+install_name_tool -id "$sentinel_install_name" "$built_library"
+[[ "$(otool -D "$built_library" | tail -n +2 | head -n 1)" == "$sentinel_install_name" ]] \
+    || die "SANE link library did not retain its unique SDK-only install identity"
+if otool -L "$built_library" | tail -n +3 | awk '{print $1}' \
+    | grep -Ev '^(/usr/lib/|/System/Library/)' | grep -q .; then
+    otool -L "$built_library" >&2
+    die "SANE link library has a non-system transitive dependency"
+fi
+if ! otool -L "$built_library" | sed -n '2p' | grep -qF '(compatibility version 6.0.0, current version 6.0.0)'; then
+    otool -L "$built_library" >&2
+    die "SANE link library ABI version is not the reviewed 6.0.0"
+fi
+for symbol in _sane_init _sane_exit _sane_get_devices _sane_open _sane_close \
+    _sane_get_option_descriptor _sane_control_option _sane_get_parameters \
+    _sane_start _sane_read _sane_cancel _sane_set_io_mode _sane_get_select_fd; do
+    nm -gU "$built_library" | awk '{print $3}' | grep -Fxq "$symbol" \
+        || die "SANE link library is missing required ABI symbol $symbol"
+done
+if strings -a "$built_library" | grep -Fq "$sdk_work"; then
+    die "SANE link library retains its private build path"
+fi
+
+mkdir -m 700 "$sdk_destination/include" "$sdk_destination/include/sane" "$sdk_destination/lib"
+install -m 644 "$source_root/include/sane/sane.h" "$sdk_destination/include/sane/sane.h"
+install -m 755 "$built_library" "$sdk_destination/lib/libsane.1.dylib"
+ln -s libsane.1.dylib "$sdk_destination/lib/libsane.dylib"
+print -r -- "$sane_version" > "$sdk_destination/VERSION"
+print -r -- "$sane_source_url" > "$sdk_destination/SOURCE_URL"
+print -r -- "$sane_source_sha256" > "$sdk_destination/SOURCE_SHA256"
+print -r -- "$sentinel_install_name" > "$sdk_destination/SENTINEL_INSTALL_NAME"
+print -r -- "$host_sane_path" > "$sdk_destination/CANONICAL_HOST_SANE_PATH"
+print -r -- "$(sha256 "$sdk_destination/include/sane/sane.h")" > "$sdk_destination/HEADER_SHA256"
+print -r -- "$(sha256 "$sdk_destination/lib/libsane.1.dylib")" > "$sdk_destination/LIBRARY_SHA256"
+
+# The source tree and compiled intermediate graph are private build inputs, not
+# a runtime. Keep only the minimal header/library SDK and its immutable receipt.
+rm -rf "$sdk_work"
+if find "$sdk_destination" -mindepth 1 -maxdepth 1 \
+    ! -name include ! -name lib ! -name VERSION ! -name SOURCE_URL \
+    ! -name SOURCE_SHA256 ! -name SENTINEL_INSTALL_NAME \
+    ! -name CANONICAL_HOST_SANE_PATH ! -name HEADER_SHA256 \
+    ! -name LIBRARY_SHA256 -print -quit | grep -q .; then
+    die "SANE link SDK contains an unexpected top-level entry"
+fi
+
+if [[ -z "$binding_destination" ]]; then
+    print "Built private SANE $sane_version link SDK for macOS $deployment_target ($host_arch): $sdk_destination"
+    exit 0
+fi
+
+require_directory_parent="${binding_destination:h}"
+[[ -d "$require_directory_parent" && ! -L "$require_directory_parent" ]] \
+    || die "python-sane venv parent is missing, not a directory, or a symlink: $require_directory_parent"
+[[ "$binding_destination" == /* ]] || die "python-sane venv destination must be absolute"
+[[ ! -e "$binding_destination" && ! -L "$binding_destination" ]] \
+    || die "python-sane venv destination already exists: $binding_destination"
+[[ -d "$bridge_source" && ! -L "$bridge_source" ]] \
+    || die "bridge source is missing, not a directory, or a symlink: $bridge_source"
+require_regular_file "bridge lockfile" "$bridge_source/uv.lock"
+[[ -x "$bridge_python" && ! -L "$bridge_python" || -x "$bridge_python" ]] \
+    || die "bridge Python is not executable: $bridge_python"
+
+"$bridge_python" -I -B - "$bridge_source/uv.lock" <<'PYTHON'
+from pathlib import Path
+import platform
+import sys
+import tomllib
+
+if platform.python_implementation() != "CPython" or sys.version_info[:3] != (3, 13, 14):
+    raise SystemExit(
+        f"python-sane must be compiled with exact CPython 3.13.14, got {platform.python_implementation()} {platform.python_version()}"
+    )
+lock = tomllib.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+matches = [package for package in lock.get("package", []) if package.get("name") == "python-sane"]
+if len(matches) != 1:
+    raise SystemExit(f"expected exactly one python-sane lock package, found {len(matches)}")
+expected = {
+    "version": "2.9.2",
+    "url": "https://files.pythonhosted.org/packages/45/e9/e8baff69fc2347606c547201204d4b4843c7ad8ecb9164eceee42016eff6/python_sane-2.9.2.tar.gz",
+    "hash": "sha256:50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe",
+    "size": 22513,
+    "upload-time": "2025-07-21T21:20:21.735Z",
+}
+package = matches[0]
+actual = {"version": package.get("version"), **package.get("sdist", {})}
+if actual != expected:
+    raise SystemExit(f"python-sane lock provenance changed: {actual!r}")
+if package.get("wheels"):
+    raise SystemExit("python-sane lock unexpectedly gained a binary wheel")
+PYTHON
+
+uv_path="$(command -v uv || true)"
+[[ -n "$uv_path" && -x "$uv_path" ]] || die "uv is required to install locked runtime dependencies"
+uv_version_output="$($uv_path --version)"
+[[ "${${(z)uv_version_output}[1,2]}" == "uv 0.11.30" ]] \
+    || die "uv 0.11.30 is required, got '$uv_version_output'"
+
+binding_work="$sdk_destination/.binding-work"
+mkdir -m 700 "$binding_work"
+binding_home="$binding_work/home"
+binding_tmp="$binding_work/tmp"
+python_source_parent="$binding_work/source"
+mkdir -m 700 "$binding_home" "$binding_tmp" "$python_source_parent"
+python_source_archive="$binding_work/python_sane-$python_sane_version.tar.gz"
+if [[ -n "$python_sane_source_override" ]]; then
+    copy_exact "python-sane source" "$python_sane_source_override" \
+        "$python_sane_source_size" "$python_sane_source_sha256" "$python_source_archive"
+else
+    download_exact "python-sane source" "$python_sane_source_url" "$python_sane_source_size" \
+        "$python_sane_source_sha256" "$python_source_archive"
+fi
+validate_archive "python-sane source" "$python_source_archive" \
+    "python_sane-$python_sane_version" "$python_sane_archive_entries" \
+    "$python_sane_archive_expanded_size"
+tar -xzf "$python_source_archive" -C "$python_source_parent"
+python_source_root="$python_source_parent/python_sane-$python_sane_version"
+require_regular_file "python-sane C source" "$python_source_root/_sane.c"
+require_regular_file "python-sane module" "$python_source_root/sane.py"
+require_regular_file "python-sane metadata" "$python_source_root/PKG-INFO"
+require_regular_file "python-sane license" "$python_source_root/COPYING"
+if find "$python_source_root" -type l -print -quit | grep -q .; then
+    die "validated python-sane source unexpectedly extracted a symlink"
+fi
+
+# Resolve every production dependency from the exact lock into a new venv.
+# Local projects and python-sane are deliberately skipped: their source is
+# copied separately, while python-sane is compiled below without a wheel,
+# mutable PEP 517 build dependency, or cache.
+uv_dir="${uv_path:h}"
+if ! (
+    cd "$bridge_source"
+    env -i \
+        HOME="$binding_home" PATH="$secure_path:$uv_dir" TMPDIR="$binding_tmp" \
+        LANG=C LC_ALL=C \
+        UV_PROJECT_ENVIRONMENT="$binding_destination" \
+        UV_PYTHON="$bridge_python" UV_PYTHON_PREFERENCE=only-managed \
+        UV_PYTHON_DOWNLOADS=never UV_NO_CONFIG=1 UV_NO_ENV_FILE=1 UV_NO_PROGRESS=1 \
+        "$uv_path" sync --locked --extra scanner --no-dev --no-cache \
+            --no-install-local --no-install-package python-sane \
+            --python "$bridge_python"
+); then
+    die "locked production dependency sync failed"
+fi
+
+binding_python="$binding_destination/bin/python"
+[[ -x "$binding_python" ]] || die "locked dependency sync did not create the private package venv"
+site_packages="$binding_destination/lib/python3.13/site-packages"
+[[ -d "$site_packages" && ! -L "$site_packages" ]] \
+    || die "private package venv has no regular Python 3.13 site-packages directory"
+python_include="$($bridge_python -I -B -c 'import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))')"
+extension_suffix="$($bridge_python -I -B -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')"
+[[ "$extension_suffix" == ".cpython-313-darwin.so" ]] \
+    || die "unexpected CPython extension ABI suffix: $extension_suffix"
+[[ -d "$python_include" && ! -L "$python_include" ]] \
+    || die "CPython include directory is missing, not a directory, or a symlink: $python_include"
+
+extension="$site_packages/_sane$extension_suffix"
+[[ ! -e "$extension" && ! -L "$extension" ]] \
+    || die "python-sane extension destination unexpectedly exists"
+compile_log="$binding_work/python-sane-build.log"
+if ! env -i \
+    HOME="$binding_home" PATH="$secure_path" TMPDIR="$binding_tmp" \
+    LANG=C LC_ALL=C ZERO_AR_DATE=1 SOURCE_DATE_EPOCH="$source_date_epoch" \
+    MACOSX_DEPLOYMENT_TARGET="$deployment_target" \
+    /usr/bin/clang -bundle -undefined dynamic_lookup \
+        -O2 -fPIC -arch "$host_arch" -mmacosx-version-min="$deployment_target" \
+        -fdebug-prefix-map="$binding_work=/python-sane-$python_sane_version" \
+        -ffile-prefix-map="$binding_work=/python-sane-$python_sane_version" \
+        -I "$python_include" -I "$sdk_destination/include" \
+        "$python_source_root/_sane.c" \
+        -L "$sdk_destination/lib" -lsane \
+        -o "$extension" > "$compile_log" 2>&1; then
+    print -u2 "Pinned python-sane source build failed; final output follows:"
+    tail -n 200 "$compile_log" >&2
+    exit 1
+fi
+install -m 644 "$python_source_root/sane.py" "$site_packages/sane.py"
+dist_info="$site_packages/python_sane-$python_sane_version.dist-info"
+mkdir -m 755 "$dist_info" "$dist_info/licenses"
+install -m 644 "$python_source_root/PKG-INFO" "$dist_info/METADATA"
+install -m 644 "$python_source_root/COPYING" "$dist_info/licenses/COPYING"
+print -r -- 'scanstudio-pinned-source-builder' > "$dist_info/INSTALLER"
+
+extension_matches=("$site_packages"/_sane*.so(N))
+dist_matches=("$site_packages"/python_sane-*.dist-info(N/))
+(( ${#extension_matches} == 1 )) || die "private venv must contain exactly one regular _sane extension"
+(( ${#dist_matches} == 1 )) || die "private venv must contain exactly one python-sane dist-info directory"
+"$binding_python" -I -B - "$dist_info/METADATA" <<'PYTHON'
+from email.parser import Parser
+from pathlib import Path
+import sys
+
+metadata = Parser().parsestr(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if metadata["Name"] != "python-sane" or metadata["Version"] != "2.9.2":
+    raise SystemExit("python-sane distribution metadata is not exactly python-sane 2.9.2")
+PYTHON
+verify_arch_and_minos "python-sane extension" "$extension" "$host_arch"
+verify_no_rpath "python-sane extension" "$extension"
+nm -g "$extension" | awk '{print $3}' | grep -Fxq _PyInit__sane \
+    || die "python-sane extension does not export the CPython _sane initializer"
+dependency_lines="$(otool -L "$extension" | tail -n +2 | awk '{print $1}')"
+[[ "$(print -r -- "$dependency_lines" | grep -Fxc "$sentinel_install_name")" == 1 ]] \
+    || die "python-sane extension did not link exactly once to the SDK sentinel identity"
+if print -r -- "$dependency_lines" | grep -vFx "$sentinel_install_name" \
+    | grep -Ev '^(/usr/lib/|/System/Library/)' | grep -q .; then
+    otool -L "$extension" >&2
+    die "python-sane extension has a non-system dependency besides the SDK sentinel"
+fi
+if strings -a "$extension" | grep -Fq "$binding_work"; then
+    die "python-sane extension retains its private build path"
+fi
+
+source_extension_sha256="$(sha256 "$extension")"
+install_name_tool -change "$sentinel_install_name" "$host_sane_path" "$extension"
+dependency_lines="$(otool -L "$extension" | tail -n +2 | awk '{print $1}')"
+[[ "$(print -r -- "$dependency_lines" | grep -Fxc "$host_sane_path")" == 1 ]] \
+    || die "python-sane extension does not reference exactly one canonical host SANE library"
+if print -r -- "$dependency_lines" | grep -Fq '__ScanStudio_SANE_Link_SDK'; then
+    die "python-sane extension retains the SDK sentinel after canonical rewrite"
+fi
+verify_arch_and_minos "rewritten python-sane extension" "$extension" "$host_arch"
+verify_no_rpath "rewritten python-sane extension" "$extension"
+
+provenance="$binding_destination/.scanstudio-python-sane-provenance"
+mkdir -m 700 "$provenance"
+install -m 644 "$python_source_archive" "$provenance/python_sane-$python_sane_version.tar.gz"
+print -r -- "$python_sane_version" > "$provenance/VERSION"
+print -r -- "$python_sane_source_url" > "$provenance/SOURCE_URL"
+print -r -- "$python_sane_source_sha256" > "$provenance/SOURCE_SHA256"
+print -r -- "$host_sane_path" > "$provenance/CANONICAL_HOST_SANE_PATH"
+print -r -- "${extension:t}" > "$provenance/EXTENSION_BASENAME"
+print -r -- "$source_extension_sha256" > "$provenance/EXTENSION_BEFORE_REWRITE_SHA256"
+print -r -- "$(sha256 "$extension")" > "$provenance/EXTENSION_SHA256"
+
+rm -rf "$binding_work"
+if find "$binding_destination" -type f \
+    \( -name 'libsane*.dylib' -o -name 'libsane*.so*' \) -print -quit | grep -q .; then
+    die "private package venv accidentally contains a SANE runtime library"
+fi
+if grep -R -a -q -F "$sdk_destination" "$binding_destination"; then
+    die "private package venv retains a SANE SDK build path"
+fi
+
+print "Built pinned python-sane $python_sane_version for macOS $deployment_target ($host_arch)"
+print "Extension $extension"
+print "Host SANE $host_sane_path"

--- a/app/ScanStudio/scripts/package_app.sh
+++ b/app/ScanStudio/scripts/package_app.sh
@@ -15,7 +15,6 @@ coolscanpy_source="${COOLSCANPY_SOURCE:-$package_root/../../coolscanpy}"
 # links libpython through @executable_path, unlike the machine's Homebrew
 # Framework Python, whose absolute Cellar linkage cannot be relocated.
 bridge_python="${SCANSTUDIO_BRIDGE_PYTHON:-$bridge_source/.venv/bin/python}"
-bridge_site_packages="${SCANSTUDIO_BRIDGE_SITE_PACKAGES:-$bridge_source/.venv/lib/python3.13/site-packages}"
 
 require_directory() {
     local label="$1"
@@ -77,21 +76,18 @@ copy_python_runtime_dependencies() {
 
 require_directory "bridge source (SCANSTUDIO_BRIDGE_SOURCE)" "$bridge_source"
 require_directory "CoolscanPy source (COOLSCANPY_SOURCE)" "$coolscanpy_source"
-require_directory "bridge site-packages (SCANSTUDIO_BRIDGE_SITE_PACKAGES)" "$bridge_site_packages"
 if [[ ! -x "$bridge_python" ]]; then
-    print -u2 "ScanStudio package prerequisite missing: Python 3.13 ('$bridge_python'). Set SCANSTUDIO_BRIDGE_PYTHON to an installed Python 3.13 interpreter."
+    print -u2 "ScanStudio package prerequisite missing: exact CPython 3.13.14 ('$bridge_python'). Set SCANSTUDIO_BRIDGE_PYTHON to the reviewed uv-managed interpreter."
     exit 127
+fi
+if ! "$bridge_python" -I -B -c 'import platform, sys; assert platform.python_implementation() == "CPython" and sys.version_info[:3] == (3, 13, 14)'; then
+    print -u2 "Refusing to package with anything other than exact CPython 3.13.14."
+    exit 66
 fi
 if [[ ! -f "$bridge_source/LICENSE" || ! -f "$coolscanpy_source/LICENSE" ]]; then
     print -u2 "Refusing to package bridge without its GPL source license and CoolscanPy's GPL source license."
     exit 66
 fi
-if [[ ! -f "$bridge_site_packages/sane.py" ]] \
-    || ! find "$bridge_site_packages" -maxdepth 1 -type d -name 'python_sane-*.dist-info' -print -quit | grep -q .; then
-    print -u2 "Refusing to package the optional plain-scan/eject compatibility binding without python-sane. Install the scanner extra into SCANSTUDIO_BRIDGE_SITE_PACKAGES."
-    exit 66
-fi
-
 # Version and sealed capture identity have one source of truth: the exact
 # CoolscanPy pyproject/lock/source tree copied below.  Run the stdlib-only gate
 # before spending time on native builds, then use its parsed version for every
@@ -106,9 +102,14 @@ coolscanpy_version="$(
         "$coolscanpy_source" --print-version
 )"
 
-bridge_runtime_prefix="$($bridge_python -c 'import sys; print(sys.base_prefix)')"
+bridge_runtime_prefix="$($bridge_python -I -B -c 'import sys; print(sys.base_prefix)')"
+bridge_sysconfig_prefix="$($bridge_python -I -B -c 'import sysconfig; print(sysconfig.get_config_var("prefix"))')"
 if [[ ! -x "$bridge_runtime_prefix/bin/python3.13" ]]; then
     print -u2 "Refusing to package a non-relocatable Python runtime: expected '$bridge_runtime_prefix/bin/python3.13'."
+    exit 66
+fi
+if [[ "$bridge_sysconfig_prefix" != /* ]]; then
+    print -u2 "Refusing to package a Python runtime with a non-absolute sysconfig prefix: '$bridge_sysconfig_prefix'."
     exit 66
 fi
 if otool -L "$bridge_runtime_prefix/bin/python3.13" | tail -n +2 | grep -qE '/(opt/homebrew|usr/local|Users)/'; then
@@ -145,6 +146,29 @@ cleanup() {
     rm -rf "$staging_root"
 }
 trap cleanup EXIT
+
+# Build the optional python-sane compatibility extension from its exact
+# locked 2.9.2 sdist against a private, source-built SANE 1.4.0 link SDK.
+# The helper rewrites the SDK-only sentinel dependency to the canonical host
+# SANE path only after proving the link provenance, ABI, architecture, and
+# macOS floor. Neither the SDK nor a SANE runtime is copied into the app.
+sane_link_sdk="$staging_root/sane-link-sdk"
+package_venv="$staging_root/bridge-package-venv"
+"$script_dir/build_sane_link_sdk.sh" \
+    "$sane_link_sdk" "$package_venv" "$bridge_source" "$bridge_python"
+bridge_site_packages="$package_venv/lib/python3.13/site-packages"
+require_directory "private locked package site-packages" "$bridge_site_packages"
+python_sane_provenance="$package_venv/.scanstudio-python-sane-provenance"
+require_directory "pinned python-sane provenance" "$python_sane_provenance"
+python_sane_extension_name="$(<"$python_sane_provenance/EXTENSION_BASENAME")"
+python_sane_extension_sha256="$(<"$python_sane_provenance/EXTENSION_SHA256")"
+python_sane_host_path="$(<"$python_sane_provenance/CANONICAL_HOST_SANE_PATH")"
+source_python_sane_extension="$bridge_site_packages/$python_sane_extension_name"
+if [[ ! -f "$source_python_sane_extension" || -L "$source_python_sane_extension" ]] \
+    || [[ "$(shasum -a 256 "$source_python_sane_extension" | awk '{print $1}')" != "$python_sane_extension_sha256" ]]; then
+    print -u2 "Refusing to package when the prepared python-sane extension disagrees with its pinned-source receipt."
+    exit 1
+fi
 
 # Build libusb from a hash-pinned upstream archive at the app's declared
 # deployment target. Copying the builder's Homebrew dylib is not acceptable:
@@ -225,6 +249,53 @@ mkdir -p "$staged_app/Contents/Resources/BridgeRuntime" \
 rsync -a --delete --exclude '__pycache__/' --exclude '*.pyc' \
     "$bridge_runtime_prefix/" "$staged_app/Contents/Resources/BridgeRuntime/python/"
 copy_python_runtime_dependencies "$bridge_site_packages" "$staged_app/Contents/Resources/BridgeRuntime/site-packages"
+staged_site_packages="$staged_app/Contents/Resources/BridgeRuntime/site-packages"
+staged_python_sane_extensions=("$staged_site_packages"/_sane*.so(N.))
+staged_python_sane_dist_info=("$staged_site_packages"/python_sane-*.dist-info(N/))
+if (( ${#staged_python_sane_extensions} != 1 || ${#staged_python_sane_dist_info} != 1 )); then
+    print -u2 "Refusing package: expected exactly one regular python-sane extension and one dist-info directory."
+    exit 1
+fi
+staged_python_sane_extension="${staged_python_sane_extensions[1]}"
+if [[ "${staged_python_sane_extension:t}" != "$python_sane_extension_name" ]] \
+    || [[ "$(shasum -a 256 "$staged_python_sane_extension" | awk '{print $1}')" != "$python_sane_extension_sha256" ]]; then
+    print -u2 "Refusing package: staged python-sane bytes differ from the pinned-source prepared extension."
+    exit 1
+fi
+if [[ "$(lipo -archs "$staged_python_sane_extension")" != "$app_architectures" ]]; then
+    print -u2 "Refusing package: python-sane extension architecture does not match the app."
+    exit 1
+fi
+python_sane_minimum="$(vtool -show-build "$staged_python_sane_extension" | awk '$1 == "minos" { print $2; exit }')"
+if [[ "$python_sane_minimum" != "$app_minimum" ]]; then
+    print -u2 "Refusing package: python-sane minimum macOS is '$python_sane_minimum', expected '$app_minimum'."
+    exit 1
+fi
+if otool -l "$staged_python_sane_extension" \
+    | awk '$2 == "LC_RPATH" { found=1 } END { exit !found }'; then
+    print -u2 "Refusing package: python-sane extension contains LC_RPATH."
+    exit 1
+fi
+python_sane_dependencies="$(otool -L "$staged_python_sane_extension" | tail -n +2 | awk '{print $1}')"
+if [[ "$(print -r -- "$python_sane_dependencies" | grep -Fxc "$python_sane_host_path")" != 1 ]] \
+    || print -r -- "$python_sane_dependencies" | grep -Fq '__ScanStudio_SANE_Link_SDK' \
+    || print -r -- "$python_sane_dependencies" | grep -vFx "$python_sane_host_path" \
+        | grep -Ev '^(/usr/lib/|/System/Library/)' | grep -q .; then
+    print -u2 "Refusing package: python-sane linkage is not exactly the reviewed host-SANE ABI plus system libraries."
+    otool -L "$staged_python_sane_extension" >&2
+    exit 1
+fi
+if ! grep -q '^Name: python-sane$' "${staged_python_sane_dist_info[1]}/METADATA" \
+    || ! grep -q '^Version: 2.9.2$' "${staged_python_sane_dist_info[1]}/METADATA"; then
+    print -u2 "Refusing package: python-sane distribution metadata is not exactly 2.9.2."
+    exit 1
+fi
+if find "$staged_site_packages" -maxdepth 1 -type f \
+    \( -name 'libsane*.dylib' -o -name 'libsane*.so*' \) -print -quit | grep -q . \
+    || grep -R -a -q -F "$sane_link_sdk" "$staged_site_packages"; then
+    print -u2 "Refusing package: private SANE SDK or runtime material leaked into staged site-packages."
+    exit 1
+fi
 # The GPL source is intentionally imported from CorrespondingSource rather
 # than an editable wheel. Retain just the neutral distribution metadata that
 # the bridge uses to report its own version; it contains no local checkout
@@ -274,7 +345,17 @@ if ! command -v uv >/dev/null 2>&1; then
     print -u2 "Refusing to package GPL corresponding source without uv: it is required to generate the portable sibling-source lockfile."
     exit 127
 fi
-(cd "$staged_bridge_source" && uv lock --offline)
+uv_executable="$(command -v uv)"
+uv_lock_home="$staging_root/uv-lock-home"
+mkdir -m 700 "$uv_lock_home"
+(
+    cd "$staged_bridge_source"
+    env -i \
+        HOME="$uv_lock_home" PATH="${uv_executable:h}:/usr/bin:/bin" \
+        LANG=C LC_ALL=C UV_PYTHON_DOWNLOADS=never \
+        "$uv_executable" --no-config lock --offline --no-cache \
+            --managed-python --python "$bridge_python"
+)
 install_name_tool -id '@rpath/libpython3.13.dylib' \
     "$staged_app/Contents/Resources/BridgeRuntime/python/lib/libpython3.13.dylib"
 # uv's generated sysconfig table records its build cache prefix. It is not a
@@ -282,18 +363,79 @@ install_name_tool -id '@rpath/libpython3.13.dylib' \
 # public bundle. Replace it with an intentionally non-filesystem placeholder;
 # CPython derives the real prefix from its relocated executable.
 runtime_sysconfig="$staged_app/Contents/Resources/BridgeRuntime/python/lib/python3.13/_sysconfigdata__darwin_darwin.py"
-"$bridge_python" - "$runtime_sysconfig" "$bridge_runtime_prefix" <<'PYTHON'
+"$bridge_python" -I -B - \
+    "$runtime_sysconfig" "$bridge_runtime_prefix" "$bridge_sysconfig_prefix" <<'PYTHON'
+import ast
 from pathlib import Path
+import pprint
+import re
 import sys
 
 config_path = Path(sys.argv[1])
-build_prefix = sys.argv[2]
-contents = config_path.read_text()
-if build_prefix not in contents:
-    raise SystemExit("packaged CPython sysconfig table did not contain its expected build prefix")
-config_path.write_text(contents.replace(build_prefix, "/__SCANSTUDIO_BUNDLED_PYTHON__"))
+runtime_prefixes = sorted(set(sys.argv[2:]), key=len, reverse=True)
+contents = config_path.read_text(encoding="utf-8")
+module = ast.parse(contents, filename=str(config_path))
+assignments = [
+    node for node in module.body
+    if isinstance(node, ast.Assign)
+    and len(node.targets) == 1
+    and isinstance(node.targets[0], ast.Name)
+    and node.targets[0].id == "build_time_vars"
+]
+if len(assignments) != 1:
+    raise SystemExit("packaged CPython sysconfig table has an unexpected structure")
+build_time_vars = ast.literal_eval(assignments[0].value)
+if not isinstance(build_time_vars, dict):
+    raise SystemExit("packaged CPython sysconfig table is not a literal dictionary")
+
+placeholder = "/__SCANSTUDIO_BUNDLED_PYTHON__"
+path_component = r"[^/\s:;,'\"(){}\[\]<>]+"
+ephemeral_roots = (
+    re.compile(
+        rf"/(?:private/)?var/folders/{path_component}/{path_component}/"
+        rf"(?:T|C)/{path_component}"
+    ),
+    re.compile(rf"/(?:private/)?tmp/{path_component}"),
+)
+replacement_count = 0
+
+def scrub(value):
+    global replacement_count
+    if isinstance(value, str):
+        for prefix in runtime_prefixes:
+            count = value.count(prefix)
+            if count:
+                value = value.replace(prefix, placeholder)
+                replacement_count += count
+        for pattern in ephemeral_roots:
+            value, count = pattern.subn(placeholder, value)
+            replacement_count += count
+        return value
+    if isinstance(value, dict):
+        return {scrub(key): scrub(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [scrub(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(scrub(item) for item in value)
+    return value
+
+sanitized = scrub(build_time_vars)
+if replacement_count == 0:
+    raise SystemExit("packaged CPython sysconfig table contained no expected build prefix")
+rendered = (
+    "# system configuration generated and used by the sysconfig module\n"
+    "build_time_vars = "
+    + pprint.pformat(sanitized, sort_dicts=True, width=120)
+    + "\n"
+)
+if re.search(r"/(?:private/)?var/folders/|/(?:private/)?tmp/|/Users/", rendered):
+    raise SystemExit("packaged CPython sysconfig table retains a private build path")
+if any(prefix in rendered for prefix in runtime_prefixes):
+    raise SystemExit("packaged CPython sysconfig table retains its runtime build prefix")
+config_path.write_text(rendered, encoding="utf-8")
 PYTHON
-"$staged_app/Contents/Resources/BridgeRuntime/python/bin/python3.13" -c 'import sysconfig; assert sysconfig.get_config_var("VERSION") == "3.13"'
+"$staged_app/Contents/Resources/BridgeRuntime/python/bin/python3.13" \
+    -I -B -c 'import sysconfig; assert sysconfig.get_config_var("VERSION") == "3.13"'
 # The import above validates the scrubbed table but can recreate bytecode with
 # the build machine's filename metadata. Remove that generated bytecode before
 # signing; CPython can regenerate ordinary caches after installation.
@@ -322,6 +464,17 @@ print -r -- $'Rebuild the bundled libusb library on macOS with Apple command-lin
     > "$staged_app/Contents/Resources/CorrespondingSource/libusb/REBUILD.txt"
 print -r -- $'libusb 1.0.30\nLicense: LGPL-2.1-or-later\nSource: https://github.com/libusb/libusb/releases/download/v1.0.30/libusb-1.0.30.tar.bz2\nSource SHA-256: fea36f34f9156400209595e300840767ab1a385ede1dc7ee893015aea9c6dbaf\nBundled library: Contents/Frameworks/coolscanpy/_native/libusb-1.0.dylib\nThe complete pinned source archive, exact build script, and rebuild instructions are under Contents/Resources/CorrespondingSource/libusb.\n' \
     > "$staged_app/Contents/Resources/Licenses/libusb-NOTICE.txt"
+mkdir -p "$staged_app/Contents/Resources/CorrespondingSource/python-sane"
+install -m 644 \
+    "$python_sane_provenance/python_sane-2.9.2.tar.gz" \
+    "$staged_app/Contents/Resources/CorrespondingSource/python-sane/python_sane-2.9.2.tar.gz"
+install -m 755 \
+    "$script_dir/build_sane_link_sdk.sh" \
+    "$staged_app/Contents/Resources/CorrespondingSource/python-sane/build_sane_link_sdk.sh"
+print -r -- $'Rebuild the bundled python-sane extension on macOS with Apple command-line developer tools, exact uv 0.11.30, the ScanStudio bridge/CoolScanPy sibling source tree, and exact CPython 3.13.14:\n\n  SCANSTUDIO_PYTHON_SANE_SOURCE_ARCHIVE="$PWD/python_sane-2.9.2.tar.gz" \\\n  ./build_sane_link_sdk.sh \\\n    "$PWD/rebuilt-sane-link-sdk" "$PWD/rebuilt-python-sane-venv" \\\n    /path/to/scanstudio-bridge /path/to/exact/python3.13\n\nThe script verifies the adjacent source archive SHA-256 (50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe), downloads and verifies sane-backends 1.4.0 for a private build-only link SDK, and targets macOS deployment target 14.0. It proves the SDK-only Mach-O identity, architecture, minimum OS, ABI, dependencies, and lack of RPATH before rewriting the extension to the architecture-specific canonical host libsane.1.dylib path. No SANE runtime library is bundled.\n' \
+    > "$staged_app/Contents/Resources/CorrespondingSource/python-sane/REBUILD.txt"
+print -r -- $'python-sane 2.9.2\nLicense: permissive python-sane license; see the packaged COPYING text\nSource: https://files.pythonhosted.org/packages/45/e9/e8baff69fc2347606c547201204d4b4843c7ad8ecb9164eceee42016eff6/python_sane-2.9.2.tar.gz\nSource SHA-256: 50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe\nThe exact source archive and source-build instructions are under Contents/Resources/CorrespondingSource/python-sane. The package contains only the extension and Python module, never the private SANE link SDK or a SANE runtime.\n' \
+    > "$staged_app/Contents/Resources/Licenses/python-sane-NOTICE.txt"
 for dist_info in "$staged_app/Contents/Resources/BridgeRuntime/site-packages"/*.dist-info; do
     [[ -d "$dist_info" ]] || continue
     dist_name="${dist_info:t}"
@@ -448,9 +601,27 @@ listed in python-wheels. libusb 1.0.30 is dynamically loaded from the signed
 app bundle under LGPL-2.1-or-later; its license and notice are here and its
 complete pinned source archive is in ../CorrespondingSource/libusb. Normal
 LS-5000 color-roll detection, preview, and capture require no host driver.
-The bundled python-sane binding still needs a compatible system SANE backend
-for its optional plain-scan and software-eject paths.
+The python-sane 2.9.2 binding is built from the exact source and instructions
+in ../CorrespondingSource/python-sane against a private SANE 1.4.0 link SDK.
+The SDK and SANE runtime are not bundled; optional plain-scan and software-
+eject paths still need a compatible system SANE backend.
 LICENSES
+
+# Final runtime-boundary proof before signing: source/rebuild material is
+# visible, but neither the private SDK, its sentinel linkage, nor libsane may
+# appear anywhere executable or loadable in the app.
+runtime_scan_targets=(
+    "$staged_app/Contents/MacOS"
+    "$staged_app/Contents/Frameworks"
+    "$staged_app/Contents/Resources/BridgeRuntime"
+)
+if find "${runtime_scan_targets[@]}" -type f \
+    \( -name 'libsane*.dylib' -o -name 'libsane*.so*' \) -print -quit | grep -q . \
+    || grep -R -a -q -F '__ScanStudio_SANE_Link_SDK' "${runtime_scan_targets[@]}" \
+    || grep -R -a -q -F "$sane_link_sdk" "${runtime_scan_targets[@]}"; then
+    print -u2 "Refusing package: private SANE SDK identity, path, or runtime leaked into executable app content."
+    exit 1
+fi
 
 # Swift links object provenance strings into the executable even in a release
 # build. Remove local symbol/debug tables after the source-path remap and

--- a/app/ScanStudio/scripts/test_packaged_bridge.sh
+++ b/app/ScanStudio/scripts/test_packaged_bridge.sh
@@ -80,12 +80,99 @@ if [[ "$libusb_architectures" != "$app_architectures" ]]; then
     exit 1
 fi
 
+site_packages="$relocated_app/Contents/Resources/BridgeRuntime/site-packages"
+python_sane_extensions=("$site_packages"/_sane*.so(N.))
+python_sane_dist_info=("$site_packages"/python_sane-*.dist-info(N/))
+if (( ${#python_sane_extensions} != 1 || ${#python_sane_dist_info} != 1 )); then
+    print -u2 "packaged bridge check failed: expected exactly one regular python-sane extension and one dist-info directory"
+    exit 1
+fi
+python_sane_extension="${python_sane_extensions[1]}"
+case "$app_architectures" in
+    arm64)
+        python_sane_host_path="/opt/homebrew/opt/sane-backends/lib/libsane.1.dylib"
+        ;;
+    x86_64)
+        python_sane_host_path="/usr/local/opt/sane-backends/lib/libsane.1.dylib"
+        ;;
+    *)
+        print -u2 "packaged bridge check failed: unsupported app architecture '$app_architectures' for python-sane"
+        exit 1
+        ;;
+esac
+python_sane_minimum="$(vtool -show-build "$python_sane_extension" | awk '$1 == "minos" { print $2; exit }')"
+if [[ "$(lipo -archs "$python_sane_extension")" != "$app_architectures" \
+    || "$python_sane_minimum" != "$app_minimum" ]]; then
+    print -u2 "packaged bridge check failed: python-sane architecture/minimum OS does not match the app"
+    exit 1
+fi
+if otool -l "$python_sane_extension" \
+    | awk '$2 == "LC_RPATH" { found=1 } END { exit !found }'; then
+    print -u2 "packaged bridge check failed: python-sane contains LC_RPATH"
+    exit 1
+fi
+python_sane_dependencies="$(otool -L "$python_sane_extension" | tail -n +2 | awk '{print $1}')"
+if [[ "$(print -r -- "$python_sane_dependencies" | grep -Fxc "$python_sane_host_path")" != 1 ]] \
+    || print -r -- "$python_sane_dependencies" | grep -Fq '__ScanStudio_SANE_Link_SDK' \
+    || print -r -- "$python_sane_dependencies" | grep -vFx "$python_sane_host_path" \
+        | grep -Ev '^(/usr/lib/|/System/Library/)' | grep -q .; then
+    print -u2 "packaged bridge check failed: python-sane linkage is not the canonical host SANE ABI plus system libraries"
+    otool -L "$python_sane_extension" >&2
+    exit 1
+fi
+if ! nm -g "$python_sane_extension" | awk '{print $3}' | grep -Fxq _PyInit__sane \
+    || ! grep -q '^Name: python-sane$' "${python_sane_dist_info[1]}/METADATA" \
+    || ! grep -q '^Version: 2.9.2$' "${python_sane_dist_info[1]}/METADATA"; then
+    print -u2 "packaged bridge check failed: python-sane ABI or distribution metadata changed"
+    exit 1
+fi
+python_sane_source="$relocated_app/Contents/Resources/CorrespondingSource/python-sane/python_sane-2.9.2.tar.gz"
+python_sane_builder="$relocated_app/Contents/Resources/CorrespondingSource/python-sane/build_sane_link_sdk.sh"
+python_sane_rebuild="$relocated_app/Contents/Resources/CorrespondingSource/python-sane/REBUILD.txt"
+if [[ ! -f "$python_sane_source" || -L "$python_sane_source" \
+    || ! -x "$python_sane_builder" || -L "$python_sane_builder" \
+    || ! -f "$python_sane_rebuild" || -L "$python_sane_rebuild" ]]; then
+    print -u2 "packaged bridge check failed: python-sane source or rebuild controls are missing, non-regular, or symlinks"
+    exit 1
+fi
+if [[ "$(stat -f '%z' "$python_sane_source")" != 22513 \
+    || "$(shasum -a 256 "$python_sane_source" | awk '{print $1}')" \
+        != 50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe ]] \
+    || ! cmp -s "$python_sane_builder" "$script_dir/build_sane_link_sdk.sh" \
+    || ! zsh -n "$python_sane_builder" \
+    || ! grep -q 'f99205c903dfe2fb8990f0c531232c9a00ec9c2c66ac7cb0ce50b4af9f407a72' "$python_sane_builder" \
+    || ! grep -q '50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe' "$python_sane_builder" \
+    || ! grep -q 'SCANSTUDIO_PYTHON_SANE_SOURCE_ARCHIVE' "$python_sane_builder" \
+    || ! grep -q 'macOS deployment target 14.0' "$python_sane_rebuild"; then
+    print -u2 "packaged bridge check failed: python-sane source provenance or rebuild controls changed"
+    exit 1
+fi
+runtime_scan_targets=(
+    "$relocated_app/Contents/MacOS"
+    "$relocated_app/Contents/Frameworks"
+    "$relocated_app/Contents/Resources/BridgeRuntime"
+)
+if find "${runtime_scan_targets[@]}" -type f \
+    \( -name 'libsane*.dylib' -o -name 'libsane*.so*' \) -print -quit | grep -q . \
+    || grep -R -a -q -F '__ScanStudio_SANE_Link_SDK' "${runtime_scan_targets[@]}" \
+    || grep -R -a -q -E '/(var/folders|private/tmp)/[^/[:space:]]+/(sane|python.sane)' \
+        "${runtime_scan_targets[@]}"; then
+    print -u2 "packaged bridge check failed: private SANE SDK identity/path or SANE runtime leaked into executable app content"
+    exit 1
+fi
+
 base_dir="$workdir/isolated bridge base"
 output="$workdir/bridge.ndjson"
 bridge="$relocated_app/Contents/MacOS/scanstudio-bridge"
 engine="$relocated_app/Contents/MacOS/scanstudio-engine"
 runtime_python="$relocated_app/Contents/Resources/BridgeRuntime/python/bin/python3.13"
+runtime_sysconfig="$relocated_app/Contents/Resources/BridgeRuntime/python/lib/python3.13/_sysconfigdata__darwin_darwin.py"
 coolscanpy_pyproject="$relocated_app/Contents/Resources/CorrespondingSource/coolscanpy/pyproject.toml"
+if [[ ! -f "$runtime_sysconfig" || -L "$runtime_sysconfig" ]] \
+    || grep -a -q -E '/(private/)?var/folders/|/(private/)?tmp/|/Users/' "$runtime_sysconfig"; then
+    print -u2 "packaged bridge check failed: bundled CPython sysconfig retains a private build path"
+    exit 1
+fi
 coolscanpy_version="$(
     "$runtime_python" -I -B - "$coolscanpy_pyproject" <<'PYTHON'
 import sys
@@ -143,8 +230,24 @@ source_verify="$workdir/corresponding source verify"
 mkdir -p "$source_verify"
 ditto "$relocated_app/Contents/Resources/CorrespondingSource/scanstudio-bridge" "$source_verify/scanstudio-bridge"
 ditto "$relocated_app/Contents/Resources/CorrespondingSource/coolscanpy" "$source_verify/coolscanpy"
-if ! (cd "$source_verify/scanstudio-bridge" && uv sync --locked --offline --no-install-project --no-dev); then
-    print -u2 "packaged bridge check failed: corresponding source cannot resolve its shipped sibling CoolscanPy source with uv sync --locked"
+uv_executable="$(command -v uv || true)"
+uv_version_output="${uv_executable:+$("$uv_executable" --version 2>/dev/null || true)}"
+if [[ -z "$uv_executable" || ! -x "$uv_executable" \
+    || "${${(z)uv_version_output}[1,2]}" != "uv 0.11.30" ]]; then
+    print -u2 "packaged bridge check failed: exact uv 0.11.30 is required to verify corresponding source"
+    exit 1
+fi
+source_verify_home="$workdir/source-verify-home"
+mkdir -m 700 "$source_verify_home"
+if ! (
+    cd "$source_verify/scanstudio-bridge"
+    env -i \
+        HOME="$source_verify_home" PATH="${uv_executable:h}:/usr/bin:/bin" \
+        LANG=C LC_ALL=C UV_PYTHON_DOWNLOADS=never \
+        "$uv_executable" --no-config lock --check --offline --no-cache \
+            --python "$runtime_python"
+); then
+    print -u2 "packaged bridge check failed: corresponding-source lock does not prove its shipped sibling CoolScanPy source relation"
     exit 1
 fi
 "$script_dir/test_launcher.sh" \

--- a/docs/releases/v0.7.0-beta.7.md
+++ b/docs/releases/v0.7.0-beta.7.md
@@ -1,0 +1,214 @@
+# ScanStudio v0.7.0-beta.7
+
+This is a security, data-integrity, and reliability release. It remediates the
+27 findings from the complete adversarial audit (SS-COMP-001 through
+SS-COMP-027) under the platform boundaries listed below. The main visible
+workflow is intentionally familiar; most of this release is about making sure
+that scanner ownership, retained scan data, metadata, update packages, and
+recovery state cannot be confused or redirected when something fails.
+
+The `v0.7.0-beta.6` tag build was cancelled after a mutable `uv` toolchain
+input was discovered. Cancellation completed before the publication job ran:
+no draft or published GitHub release and no release assets were created.
+`v0.7.0-beta.7` is therefore the first published artifact set containing this
+remediation.
+
+Because Apple signing credentials are not configured yet, the macOS builds are
+still ad-hoc signed and not notarized. Update checking and download verification
+remain available, but in-app installation now deliberately fails closed. Use a
+manually downloaded, checksum-verified DMG for this beta.
+
+## Everything that changed
+
+### Scan-data and evidence publication
+
+- Every reviewed archive, raw, positive, preview, meter, sidecar, and full
+  capture-evidence destination is acquired as held, no-follow authority before
+  scanner motion. Publication no longer re-resolves an attacker-replaceable
+  pathname after preflight.
+- Output names are checked for physical aliases and collisions before motion.
+  New outputs are create-only; an existing file is never silently overwritten.
+  Multi-file publications use checked rollback, and ambiguous cleanup is held
+  for recovery instead of deleting an object whose identity cannot be proven.
+- The optional full capture package now copies bounded, snapshotted sources into
+  a held package directory, durably commits its manifest, and verifies the held
+  destination before and after commit. Destination swaps, package swaps,
+  collisions, source growth, and outside-sentinel attacks have dedicated
+  regressions.
+- The project root is acquired before scan preflight and retained through
+  output publication, receipt append, recipe merge, and metadata binding. A
+  namespace replacement cannot redirect later work into a different project.
+- Windows output authority is limited to local NTFS. UNC paths, ReFS, unsafe
+  filesystems, and unsupported raw-negative export are refused before motion.
+  WSL capture sources are moved through protected, held staging.
+
+### Metadata, manifests, and ExifTool
+
+- Metadata application is now a durable transaction with an authoritative
+  recovery journal. Recovery validates journal ownership and file identity;
+  planted or ambiguous journals cannot authorize destructive cleanup.
+- Manifest locking, project-recipe merge, receipt append, and metadata binding
+  operate through the already-held project root. Temporary and final files are
+  bounded, synchronized, identity-checked, and published without following
+  symlinks.
+- ExifTool is executed from an exact verified distribution snapshot through a
+  held file descriptor, with user configuration disabled and a sanitized
+  environment. Distribution files, input targets, stdout, stderr, hashes,
+  copies, and deadlines are bounded.
+- Metadata targets are derived from trusted project receipts and held project
+  authority. Edited project paths can no longer redirect ExifTool to an
+  unrelated writable file.
+
+### Bridge and scanner-process ownership
+
+- Bridge events are bound to the exact bridge generation and operation token.
+  Delayed events from an older preview or scan are rejected instead of being
+  relabeled as part of a later job.
+- Engine-to-bridge NDJSON records are capped at 1 MiB and the bridge event queue
+  is bounded at 128 records. Oversized, malformed, duplicate, stale, or
+  unowned messages fail closed.
+- Capture workers stay inside the bridge-owned lifetime fence. Shutdown is not
+  acknowledged until owned work exits, and a replacement bridge is not allowed
+  to race a surviving descendant.
+- Hardware-moving bridge parameters now use strict schemas instead of coercion.
+  Job identifiers are single-use operation tokens, and cancellation, shutdown,
+  timeout, and reconnect paths preserve their ownership boundaries.
+- The native engine client has bounded request and termination waits, validates
+  bridge ownership and protocol identity, and cannot accumulate an unbounded
+  pending request or stderr buffer.
+
+### Update and package trust
+
+- The macOS updater now requires an independent publisher root from the running
+  installed app: the signed `ScanStudioUpdateTeamIdentifier` must match the
+  Developer ID Team ID and exact designated requirement. The running, mounted,
+  staged, and installed apps must all be Developer ID signed, securely
+  timestamped, notarized, and stapled.
+- A candidate update must contain exactly one root-level `ScanStudio.app` with
+  the expected bundle identifier, launcher, release stamp, architecture, and
+  supported macOS floor. Mount and detach operations are bounded, and detach is
+  attempted on every exit path.
+- There is no placeholder publisher identity or permissive fallback. Until real
+  Apple credentials exist, the updater reports that automatic installation is
+  unavailable rather than trusting an ad-hoc signature and server-supplied
+  checksum as publisher identity.
+- Every remaining external GitHub Action reference is pinned to a reviewed full
+  commit SHA, checkout credentials are disabled, and a structural policy gate
+  rejects mutable refs, hidden action wrappers, and ambiguous YAML forms. The
+  write-capable release job still byte-verifies the exact eight published
+  assets.
+- Release packaging installs hash-pinned `uv` 0.11.30, Node.js 22.23.2, npm
+  10.9.8, and managed CPython 3.13.14 build 20260718 into new private roots.
+  It verifies the downloaded archives and executables before first use, then
+  verifies the exact Rust 1.97.1 compiler and Cargo identities supplied by the
+  reviewed Rust toolchain action. Mutable setup-action caches, `latest`, and
+  minor-only tool versions are no longer release authorities.
+- The optional macOS SANE binding is compiled from the exact python-sane 2.9.2
+  source against a private link SDK built from hash-pinned sane-backends 1.4.0;
+  neither the SDK nor libsane is bundled. Linux builds use a digest-pinned base
+  image and signed timestamped Ubuntu snapshot. Windows NSIS/WebView2 and Linux
+  AppImage build tools are downloaded into a private Tauri tools tree, verified
+  by exact SHA-256 and full-tree policy, and rechecked before publication.
+- Windows and Linux Python payloads are selected through committed
+  hash-required requirements plus an exact filename, size, and SHA-256 artifact
+  lock, then verified before bounded extraction. The Rust notice generator is
+  built from the authenticated cargo-about 0.9.1 crate and locked dependency
+  graph, and the CoolScanPy parity gate safely extracts one exact authenticated
+  0.7.1 source distribution instead of trusting the mutable PyPI latest pointer.
+- CoolScanPy source identity now comes from one project version, the capture
+  bundle is sealed against the actual packaged bytes, and Windows/Linux package
+  verification executes the worker preflight against the assembled tree. The
+  release gate also byte-compares the bundled driver with the published PyPI
+  source distribution.
+- Canonical engine and bridge sources are synchronized into the Tauri vendor
+  tree with explicit, byte-sensitive fingerprints for the intentional Windows
+  and WSL differences. Packaging refuses unexplained drift.
+- Release notes are now committed with the tagged source. Publication validates
+  the exact tag/version filename and required full-changelog sections, then
+  verifies that GitHub preserved the exact body both before and after publishing.
+
+### App and interface integrity
+
+- Native and Tauri metadata Apply actions are authorized only by the current
+  preview. Editing metadata invalidates the old command preview instead of
+  applying stale arguments.
+- Year-only dates are no longer silently converted to January when month
+  precision is selected. A month is committed only after the user supplies one.
+- Repeated manual-boundary drag callbacks replace the in-flight boundary rather
+  than leaving ghost boundaries behind.
+- Defect analysis uses the project and frame's authoritative effective recipe
+  instead of renderer-supplied defaults.
+- Windows setup navigation cannot hide Stop while a real hardware job is
+  active. The Scan Run Eject control now performs the operation, reports its
+  result, and remains unavailable when ejection is unsafe.
+- Diagnostic-bundle writes are atomic and verified; a failed write is reported
+  as a failure instead of displaying a false “Saved” message.
+- Update errors, missing publisher trust, unsupported adapters, and recovery
+  holds are surfaced as typed, actionable states rather than generic internal
+  failures.
+
+## Validation
+
+- Native macOS app: 78 XCTest tests and 475 Swift Testing tests passed.
+- Tauri frontend: 403 tests passed, 6 expected tests skipped, and the production
+  build passed.
+- Canonical Rust engine: 509 library tests passed; 129 integration tests passed
+  with 2 environment-gated tests ignored. This includes 44 real-backend
+  end-to-end tests and 37 real-backend mapping tests.
+- Vendored Rust engine: 524 library tests passed; 129 integration tests passed
+  with 2 environment-gated tests ignored; 12 Windows/WSL path tests passed.
+- Vendored Python bridge: 368 tests passed; the focused packaged transport suite
+  passed 60 tests.
+- The complete CoolScanPy suite passed with only its documented skips and
+  expected failure.
+- Windows GNU build-std checking and vendored GNU/MSVC compile checks passed.
+  Windows runtime tests were not run because no Windows host was available.
+- Both macOS architecture package builds, release-engine staging, package
+  relocation checks, updater verification, workflow-pin policy, CoolScanPy
+  source identity, vendor synchronization, and release smoke checks passed.
+- Final whitespace validation passed in both active ScanStudio worktrees.
+
+## Platform support and installation
+
+- **macOS Apple Silicon — Beta:** the Nikon LS-5000 real-film workflow remains
+  the validated hardware path. Download
+  `ScanStudio-0.7.0-beta.7-macOS-arm64.dmg`.
+- **macOS Intel — Preview:** built and package-tested natively in CI; real
+  scanner validation is still pending. Download
+  `ScanStudio-0.7.0-beta.7-macOS-x86_64.dmg`.
+- **Windows x64 — Preview:** use the setup executable on a clean system. The
+  portable zip requires Microsoft Edge WebView2 to be installed already.
+  Scanner access requires WSL2, Ubuntu 24.04, and usbipd-win; real-scanner
+  validation is still pending.
+- **Linux x64 — Preview:** choose the AppImage or portable tarball. The host must
+  provide compatible SANE/libusb runtime packages, scanner permissions, and the
+  normal desktop runtime dependencies.
+
+All macOS builds in this release are ad-hoc signed and unnotarized. The Windows
+installer and Linux packages are unsigned. Download from the GitHub Releases
+page, verify the package against `SHA256SUMS`, and keep the prior installed app
+or DMG as a rollback artifact. On macOS, use the normal Control-click **Open**
+confirmation if Gatekeeper asks; do not disable Gatekeeper globally.
+
+## Known limitations
+
+- No Apple Team ID, Developer ID Application identity, secure signing timestamp,
+  notarization, or staple is configured yet. Automatic installation therefore
+  fails closed by design; this beta must be installed manually.
+- Intel macOS, Windows, and Linux remain previews without real-scanner
+  end-to-end validation. Windows compile and packaging checks passed, but no
+  Windows runtime host was available for this remediation.
+- A malicious already-running process under the same Unix user can still attack
+  OS-private scratch before a child opens it. Eliminating that residual boundary
+  requires redesigning the live bridge around transferred file descriptors or
+  an operating-system sandbox.
+- When Unix cannot prove identity-bound deletion after an ambiguous commit, the
+  affected private workspace or output is deliberately retained as a recovery
+  hold. This favors evidence preservation over automatic cleanup.
+- Windows scan destinations must be local NTFS; UNC and ReFS destinations are
+  refused. Raw-negative export is not supported on the Windows/WSL path and is
+  refused before motion.
+- Linux packages rely on compatible host SANE/libusb and desktop libraries. The
+  Tauri GUI and real scanner have not been validated end to end on Linux.
+- The separate web/gateway remediation is not included in these desktop release
+  packages.

--- a/ports/tauri/app/src-tauri/tauri.conf.json
+++ b/ports/tauri/app/src-tauri/tauri.conf.json
@@ -24,6 +24,7 @@
   },
   "bundle": {
     "active": true,
+    "useLocalToolsDir": true,
     "targets": ["app", "dmg", "appimage", "nsis"],
     "icon": [
       "icons/32x32.png",

--- a/ports/tauri/packaging/install_pinned_tauri_tools.py
+++ b/ports/tauri/packaging/install_pinned_tauri_tools.py
@@ -1,0 +1,674 @@
+#!/usr/bin/env python3
+"""Prepare and verify Tauri 2.11.4's unpackaged external build tools.
+
+Cargo and npm locks do not cover the programs that Tauri downloads while it
+builds AppImage and NSIS bundles.  Release packaging calls this program before
+Tauri so those mutable downloads are replaced by an exact, private tool tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path, PurePosixPath
+import stat
+import sys
+import time
+import unicodedata
+import urllib.request
+import zipfile
+
+
+TAURI_VERSION = "2.11.4"
+DOWNLOAD_DEADLINE_SECONDS = 900
+DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+MAX_NSIS_ENTRIES = 1_000
+MAX_NSIS_EXPANDED_BYTES = 32 * 1024 * 1024
+
+DANGEROUS_ENVIRONMENT = (
+    "CARGO_TARGET_DIR",
+    "NSIS_PATH",
+    "TAURI_BUNDLER_TOOLS_GITHUB_MIRROR",
+    "TAURI_BUNDLER_TOOLS_GITHUB_MIRROR_TEMPLATE",
+)
+
+LINUX_ASSETS = (
+    {
+        "name": "AppRun-x86_64",
+        "url": (
+            "https://api.github.com/repos/tauri-apps/binary-releases/"
+            "releases/assets/274691722"
+        ),
+        "size": 31_552,
+        "sha256": "f30140a43a0a59e46db21bdefdf749b9e9f2c6946e92afabbacf98b8ae73fb4f",
+    },
+    {
+        "name": "linuxdeploy-x86_64.AppImage",
+        "url": (
+            "https://api.github.com/repos/tauri-apps/binary-releases/"
+            "releases/assets/182515537"
+        ),
+        "size": 13_264_064,
+        "sha256": "e762bea85c8eb0d4b3508d46e5c1f037f717d0f9303ae3b4aafc8b04991fa1ef",
+        "installed_sha256": (
+            "20eebde3c18ae2e44279bd624fc72482503aece216d5d77f10932235342f71c1"
+        ),
+        "zero_range": (8, 11),
+    },
+    {
+        "name": "linuxdeploy-plugin-gtk.sh",
+        "url": (
+            "https://raw.githubusercontent.com/tauri-apps/"
+            "linuxdeploy-plugin-gtk/"
+            "b5eb8d05b4c0ed40107fe2158c5d8527f94568ef/"
+            "linuxdeploy-plugin-gtk.sh"
+        ),
+        "size": 11_648,
+        "sha256": "cb379f9b0733e9ad9f8bd78f8c2fa038aef2478523bb7d4c8e64ff6a1ea3501a",
+    },
+    {
+        "name": "linuxdeploy-plugin-gstreamer.sh",
+        "url": (
+            "https://raw.githubusercontent.com/tauri-apps/"
+            "linuxdeploy-plugin-gstreamer/"
+            "2a2e67491c32995a3f279ad0ecbe77abd512b42a/"
+            "linuxdeploy-plugin-gstreamer.sh"
+        ),
+        "size": 4_857,
+        "sha256": "c107b49d84edbffc6ab226ed1007e0626a4f7aa2c3a36b7782bef62351d49e94",
+    },
+    {
+        "name": "linuxdeploy-plugin-appimage.AppImage",
+        "url": (
+            "https://api.github.com/repos/linuxdeploy/"
+            "linuxdeploy-plugin-appimage/releases/assets/497460911"
+        ),
+        "size": 16_484_856,
+        "sha256": "a45d3e227bc7f397e9cf6bfa4c9507494efa2293357b6e86690a3de2ca992e79",
+    },
+)
+
+NSIS_ARCHIVE = {
+    "name": "nsis-3.11.zip",
+    "url": (
+        "https://api.github.com/repos/tauri-apps/binary-releases/"
+        "releases/assets/317051073"
+    ),
+    "size": 2_361_546,
+    "sha256": "c7d27f780ddb6cffb4730138cd1591e841f4b7edb155856901cdf5f214394fa1",
+}
+NSIS_ARCHIVE_ROOT = "nsis-3.11"
+NSIS_BASE_FILE_COUNT = 441
+NSIS_BASE_DIRECTORY_COUNT = 56
+NSIS_BASE_EXPANDED_BYTES = 7_134_287
+NSIS_BASE_TREE_SHA256 = (
+    "bc20c89980c5fc301b692ae2b16f6c7b07d86fa8aa716787bfa033ee94a1f501"
+)
+NSIS_PLUGIN = {
+    "name": "nsis_tauri_utils.dll",
+    "url": (
+        "https://api.github.com/repos/tauri-apps/nsis-tauri-utils/"
+        "releases/assets/345882097"
+    ),
+    "size": 34_304,
+    "sha256": "5ba143b5db4a87d32d6e7802e033330aae56cbceabe0d1e3ba41948385ad4709",
+}
+
+WEBVIEW2_GUID = "e4dd9b83-b7e3-4d17-8d7c-e14cdd7c3a51"
+WEBVIEW2_ASSET = {
+    "name": "MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
+    "url": (
+        "https://msedge.sf.dl.delivery.mp.microsoft.com/"
+        "filestreamingservice/files/"
+        f"{WEBVIEW2_GUID}/MicrosoftEdgeWebView2RuntimeInstallerX64.exe"
+    ),
+    "size": 209_653_456,
+    "sha256": "f8d4ab074c22a0cd136434f37c6b34dfb64ebf8a32ce42e03bd8f2a6b51a3892",
+}
+
+WINDOWS_RESERVED_NAMES = {
+    "AUX",
+    "CON",
+    "NUL",
+    "PRN",
+    *(f"COM{number}" for number in range(1, 10)),
+    *(f"LPT{number}" for number in range(1, 10)),
+}
+
+
+class ToolError(RuntimeError):
+    """Raised when pinned tool preparation or verification must fail closed."""
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _is_reparse_point(metadata: os.stat_result) -> bool:
+    attributes = getattr(metadata, "st_file_attributes", 0)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return bool(attributes & reparse_flag)
+
+
+def _assert_plain_directory(path: Path) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as error:
+        raise ToolError(f"required directory is missing: {path}") from error
+    if not stat.S_ISDIR(metadata.st_mode) or _is_reparse_point(metadata):
+        raise ToolError(f"directory is a link, reparse point, or special file: {path}")
+
+
+def _assert_plain_path_components(path: Path) -> None:
+    absolute = path.absolute()
+    existing: list[Path] = []
+    current = absolute
+    while True:
+        if current.exists() or current.is_symlink():
+            existing.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    for component in reversed(existing):
+        _assert_plain_directory(component)
+
+
+def _assert_plain_regular_file(path: Path) -> os.stat_result:
+    try:
+        before = path.lstat()
+    except FileNotFoundError as error:
+        raise ToolError(f"required pinned tool is missing: {path}") from error
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or _is_reparse_point(before)
+        or before.st_nlink != 1
+    ):
+        raise ToolError(
+            f"pinned tool is a link, reparse point, hard link, or special file: {path}"
+        )
+    return before
+
+
+def hash_regular_file(path: Path, *, expected_size: int | None = None) -> str:
+    _assert_plain_regular_file(path)
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        held = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(held.st_mode)
+            or _is_reparse_point(held)
+            or held.st_nlink != 1
+        ):
+            raise ToolError(
+                f"opened pinned tool is a link, reparse point, hard link, "
+                f"or special file: {path}"
+            )
+        authoritative_size = held.st_size
+        if expected_size is not None and authoritative_size != expected_size:
+            raise ToolError(
+                f"pinned tool size mismatch for {path}: "
+                f"expected {expected_size}, got {authoritative_size}"
+            )
+
+        def held_digest() -> str:
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            digest = hashlib.sha256()
+            received = 0
+            while chunk := os.read(descriptor, DOWNLOAD_CHUNK_BYTES):
+                received += len(chunk)
+                if received > authoritative_size:
+                    raise ToolError(f"pinned tool grew while hashing: {path}")
+                digest.update(chunk)
+            if received != authoritative_size:
+                raise ToolError(f"short read while hashing pinned tool: {path}")
+            return digest.hexdigest()
+
+        first_digest = held_digest()
+        second_digest = held_digest()
+        after = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(after.st_mode)
+            or _is_reparse_point(after)
+            or after.st_nlink != 1
+            or after.st_size != authoritative_size
+            or second_digest != first_digest
+        ):
+            raise ToolError(f"pinned tool changed while hashing: {path}")
+        return first_digest
+    finally:
+        os.close(descriptor)
+
+
+def _check_no_environment_overrides() -> None:
+    inherited = [name for name in DANGEROUS_ENVIRONMENT if name in os.environ]
+    if inherited:
+        raise ToolError(
+            "refusing inherited Tauri toolchain overrides: " + ", ".join(inherited)
+        )
+
+
+def _open_exclusive(path: Path, mode: int = 0o600):
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
+        mode,
+    )
+    return os.fdopen(descriptor, "wb")
+
+
+def download_asset(asset: dict[str, object], destination: Path) -> None:
+    url = str(asset["url"])
+    expected_size = int(asset["size"])
+    expected_sha256 = str(asset["sha256"])
+    if not url.startswith("https://"):
+        raise ToolError(f"pinned tool URL is not HTTPS: {url}")
+
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/octet-stream",
+            "Accept-Encoding": "identity",
+            "User-Agent": f"ScanStudio-Tauri/{TAURI_VERSION}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    deadline = time.monotonic() + DOWNLOAD_DEADLINE_SECONDS
+    with urllib.request.urlopen(request, timeout=45) as response:  # noqa: S310
+        final_url = response.geturl()
+        if not final_url.startswith("https://"):
+            raise ToolError(f"pinned tool download left HTTPS: {final_url}")
+        if response.headers.get("Content-Encoding") not in (None, "identity"):
+            raise ToolError("compressed HTTP transfer is not allowed")
+        length_header = response.headers.get("Content-Length")
+        if length_header is None or not length_header.isdecimal():
+            raise ToolError("pinned tool download omitted a valid Content-Length")
+        declared_size = int(length_header)
+        if declared_size != expected_size:
+            raise ToolError(
+                "pinned tool Content-Length mismatch: "
+                f"expected {expected_size}, got {declared_size}"
+            )
+
+        digest = hashlib.sha256()
+        received = 0
+        with _open_exclusive(destination) as output:
+            while chunk := response.read(
+                min(DOWNLOAD_CHUNK_BYTES, expected_size - received + 1)
+            ):
+                if time.monotonic() > deadline:
+                    raise ToolError("pinned tool download exceeded its total deadline")
+                received += len(chunk)
+                if received > expected_size:
+                    raise ToolError("pinned tool download exceeded its pinned size")
+                digest.update(chunk)
+                output.write(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        if received != expected_size:
+            raise ToolError(
+                f"pinned tool download was short: expected {expected_size}, got {received}"
+            )
+        actual_sha256 = digest.hexdigest()
+        if actual_sha256 != expected_sha256:
+            raise ToolError(
+                "pinned tool digest mismatch: "
+                f"expected {expected_sha256}, got {actual_sha256}"
+            )
+
+
+def validated_zip_member(name: str, expected_root: str) -> PurePosixPath:
+    if not name or "\\" in name or "\x00" in name or name.startswith("/"):
+        raise ToolError(f"unsafe NSIS archive member name: {name!r}")
+    raw_parts = name.rstrip("/").split("/")
+    if not raw_parts or any(part in ("", ".", "..") for part in raw_parts):
+        raise ToolError(f"unsafe NSIS archive member path: {name!r}")
+    for part in raw_parts:
+        if ":" in part or part.endswith((".", " ")):
+            raise ToolError(f"Windows-ambiguous NSIS archive member: {name!r}")
+        stem = part.split(".", 1)[0].upper()
+        if stem in WINDOWS_RESERVED_NAMES:
+            raise ToolError(f"Windows device name in NSIS archive: {name!r}")
+    path = PurePosixPath(*raw_parts)
+    if len(path.parts) < 2 or path.parts[0] != expected_root:
+        raise ToolError(f"NSIS archive member escaped its pinned root: {name!r}")
+    return path
+
+
+def _collision_key(path: PurePosixPath) -> str:
+    return unicodedata.normalize("NFC", path.as_posix()).casefold()
+
+
+def extract_nsis_archive(archive: Path, destination: Path) -> None:
+    try:
+        destination.mkdir(mode=0o700)
+    except FileExistsError as error:
+        raise ToolError(f"NSIS destination already exists: {destination}") from error
+
+    with zipfile.ZipFile(archive) as bundle:
+        members = bundle.infolist()
+        if len(members) != NSIS_BASE_FILE_COUNT or len(members) > MAX_NSIS_ENTRIES:
+            raise ToolError(
+                "unexpected NSIS archive entry count: "
+                f"expected {NSIS_BASE_FILE_COUNT}, got {len(members)}"
+            )
+        total = 0
+        seen: set[str] = set()
+        validated: list[tuple[zipfile.ZipInfo, PurePosixPath]] = []
+        for member in members:
+            path = validated_zip_member(member.filename, NSIS_ARCHIVE_ROOT)
+            key = _collision_key(path)
+            if key in seen:
+                raise ToolError(
+                    f"duplicate or case-colliding NSIS archive member: {member.filename!r}"
+                )
+            seen.add(key)
+            if member.is_dir() or member.flag_bits & 0x1:
+                raise ToolError(f"unsupported NSIS archive member: {member.filename!r}")
+            mode = member.external_attr >> 16
+            file_type = stat.S_IFMT(mode)
+            if stat.S_ISLNK(mode) or file_type not in (0, stat.S_IFREG):
+                raise ToolError(
+                    f"NSIS archive contains a link or special file: {member.filename!r}"
+                )
+            total += member.file_size
+            if member.file_size < 0 or total > MAX_NSIS_EXPANDED_BYTES:
+                raise ToolError("NSIS archive expanded size exceeds its bound")
+            validated.append((member, path))
+        if total != NSIS_BASE_EXPANDED_BYTES:
+            raise ToolError(
+                "NSIS archive expanded size mismatch: "
+                f"expected {NSIS_BASE_EXPANDED_BYTES}, got {total}"
+            )
+
+        for member, path in validated:
+            relative = Path(*path.parts[1:])
+            output_path = destination / relative
+            output_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            copied = 0
+            with (
+                bundle.open(member, "r") as source,
+                _open_exclusive(output_path) as output,
+            ):
+                while chunk := source.read(DOWNLOAD_CHUNK_BYTES):
+                    copied += len(chunk)
+                    if copied > member.file_size:
+                        raise ToolError(
+                            f"NSIS member exceeded declared size: {member.filename!r}"
+                        )
+                    output.write(chunk)
+                output.flush()
+                os.fsync(output.fileno())
+            if copied != member.file_size:
+                raise ToolError(f"short NSIS archive member: {member.filename!r}")
+
+
+def _tree_commit(
+    root: Path, *, excluded_directories: frozenset[str] = frozenset()
+) -> tuple[str, int, int, int]:
+    _assert_plain_directory(root)
+    records: list[str] = []
+    file_count = 0
+    directory_count = 0
+    total_bytes = 0
+    seen: set[str] = set()
+
+    def visit(directory: Path, relative_directory: PurePosixPath) -> None:
+        nonlocal file_count, directory_count, total_bytes
+        with os.scandir(directory) as scanner:
+            entries = sorted(scanner, key=lambda item: item.name)
+        for entry in entries:
+            relative = relative_directory / entry.name
+            relative_text = relative.as_posix()
+            key = unicodedata.normalize("NFC", relative_text).casefold()
+            if key in seen:
+                raise ToolError(
+                    f"case-colliding path in pinned tool tree: {relative_text}"
+                )
+            seen.add(key)
+            metadata = entry.stat(follow_symlinks=False)
+            if _is_reparse_point(metadata) or stat.S_ISLNK(metadata.st_mode):
+                raise ToolError(
+                    f"link or reparse point in pinned tool tree: {relative_text}"
+                )
+            if stat.S_ISDIR(metadata.st_mode):
+                if relative_text in excluded_directories:
+                    continue
+                directory_count += 1
+                records.append(f"D\0{relative_text}\n")
+                visit(Path(entry.path), relative)
+            elif stat.S_ISREG(metadata.st_mode):
+                digest = hash_regular_file(
+                    Path(entry.path), expected_size=metadata.st_size
+                )
+                file_count += 1
+                total_bytes += metadata.st_size
+                records.append(f"F\0{relative_text}\0{metadata.st_size}\0{digest}\n")
+            else:
+                raise ToolError(f"special file in pinned tool tree: {relative_text}")
+
+    visit(root, PurePosixPath())
+    payload = "".join(sorted(records)).encode("utf-8")
+    return sha256_bytes(payload), file_count, directory_count, total_bytes
+
+
+def _exact_entries(directory: Path, *, directories: set[str], files: set[str]) -> None:
+    _assert_plain_directory(directory)
+    actual_directories: set[str] = set()
+    actual_files: set[str] = set()
+    collision_keys: set[str] = set()
+    with os.scandir(directory) as scanner:
+        entries = list(scanner)
+    for entry in entries:
+        key = unicodedata.normalize("NFC", entry.name).casefold()
+        if key in collision_keys:
+            raise ToolError(
+                f"case-colliding entry in pinned tool directory: {entry.path}"
+            )
+        collision_keys.add(key)
+        metadata = entry.stat(follow_symlinks=False)
+        if _is_reparse_point(metadata) or stat.S_ISLNK(metadata.st_mode):
+            raise ToolError(
+                f"link or reparse point in pinned tool directory: {entry.path}"
+            )
+        if stat.S_ISDIR(metadata.st_mode):
+            actual_directories.add(entry.name)
+        elif stat.S_ISREG(metadata.st_mode):
+            actual_files.add(entry.name)
+        else:
+            raise ToolError(f"special entry in pinned tool directory: {entry.path}")
+    if actual_directories != directories or actual_files != files:
+        raise ToolError(
+            f"unexpected pinned tool directory contents at {directory}: "
+            f"directories={sorted(actual_directories)}, files={sorted(actual_files)}"
+        )
+
+
+def _assert_asset(path: Path, asset: dict[str, object], *, installed: bool) -> str:
+    expected_sha256 = str(
+        asset.get("installed_sha256", asset["sha256"]) if installed else asset["sha256"]
+    )
+    actual_sha256 = hash_regular_file(path, expected_size=int(asset["size"]))
+    if actual_sha256 != expected_sha256:
+        raise ToolError(
+            f"pinned tool digest mismatch for {path}: "
+            f"expected {expected_sha256}, got {actual_sha256}"
+        )
+    return actual_sha256
+
+
+def verify_linux(tools_root: Path) -> None:
+    expected_names = {str(asset["name"]) for asset in LINUX_ASSETS}
+    _exact_entries(tools_root, directories=set(), files=expected_names)
+    for asset in LINUX_ASSETS:
+        path = tools_root / str(asset["name"])
+        _assert_asset(path, asset, installed=True)
+        if os.name != "nt" and stat.S_IMODE(path.stat().st_mode) != 0o700:
+            raise ToolError(f"pinned Linux tool mode is not exactly 0700: {path}")
+
+
+def _verify_nsis_base(nsis_root: Path) -> None:
+    tree_sha256, files, directories, total_bytes = _tree_commit(
+        nsis_root,
+        excluded_directories=frozenset({"Plugins/x86-unicode/additional"}),
+    )
+    actual = (tree_sha256, files, directories, total_bytes)
+    expected = (
+        NSIS_BASE_TREE_SHA256,
+        NSIS_BASE_FILE_COUNT,
+        NSIS_BASE_DIRECTORY_COUNT,
+        NSIS_BASE_EXPANDED_BYTES,
+    )
+    if actual != expected:
+        raise ToolError(
+            f"NSIS 3.11 full-tree manifest mismatch: expected {expected}, got {actual}"
+        )
+
+
+def verify_windows(tools_root: Path) -> None:
+    nsis_root = tools_root / "NSIS"
+    architecture_root = tools_root / "x64"
+    guid_root = architecture_root / WEBVIEW2_GUID
+    plugin_root = nsis_root / "Plugins" / "x86-unicode" / "additional"
+
+    _exact_entries(tools_root, directories={"NSIS", "x64"}, files=set())
+    _exact_entries(architecture_root, directories={WEBVIEW2_GUID}, files=set())
+    _exact_entries(guid_root, directories=set(), files={str(WEBVIEW2_ASSET["name"])})
+    _exact_entries(plugin_root, directories=set(), files={str(NSIS_PLUGIN["name"])})
+    _verify_nsis_base(nsis_root)
+    _assert_asset(plugin_root / str(NSIS_PLUGIN["name"]), NSIS_PLUGIN, installed=True)
+    _assert_asset(
+        guid_root / str(WEBVIEW2_ASSET["name"]), WEBVIEW2_ASSET, installed=True
+    )
+
+
+def _create_tools_root(target_directory: Path) -> Path:
+    _assert_plain_path_components(target_directory.parent)
+    if target_directory.exists() or target_directory.is_symlink():
+        _assert_plain_directory(target_directory)
+    else:
+        target_directory.mkdir(mode=0o700)
+    tools_root = target_directory / ".tauri"
+    try:
+        tools_root.mkdir(mode=0o700)
+    except FileExistsError as error:
+        raise ToolError(
+            f"refusing pre-existing Tauri tool cache: {tools_root}"
+        ) from error
+    return tools_root
+
+
+def prepare_linux(tools_root: Path) -> None:
+    for asset in LINUX_ASSETS:
+        path = tools_root / str(asset["name"])
+        download_asset(asset, path)
+        before = _assert_plain_regular_file(path)
+        _assert_asset(path, asset, installed=False)
+        flags = os.O_RDWR | getattr(os, "O_BINARY", 0)
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(path, flags)
+        try:
+            held = os.fstat(descriptor)
+            if (held.st_dev, held.st_ino) != (before.st_dev, before.st_ino):
+                raise ToolError(f"Linux tool changed before finalization: {path}")
+            if "zero_range" in asset:
+                start, end = asset["zero_range"]  # type: ignore[misc]
+                start = int(start)
+                end = int(end)
+                if start < 0 or end <= start or end > held.st_size:
+                    raise ToolError(f"invalid pinned Linux tool patch range: {path}")
+                os.lseek(descriptor, start, os.SEEK_SET)
+                if os.write(descriptor, b"\0" * (end - start)) != end - start:
+                    raise ToolError(f"short pinned Linux tool patch write: {path}")
+            os.fchmod(descriptor, 0o700)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        _assert_asset(path, asset, installed=True)
+    verify_linux(tools_root)
+
+
+def prepare_windows(tools_root: Path) -> None:
+    archive = tools_root / "_nsis-3.11.zip"
+    download_asset(NSIS_ARCHIVE, archive)
+    _assert_asset(archive, NSIS_ARCHIVE, installed=False)
+    nsis_root = tools_root / "NSIS"
+    extract_nsis_archive(archive, nsis_root)
+    _verify_nsis_base(nsis_root)
+    archive.unlink()
+
+    plugin_root = nsis_root / "Plugins" / "x86-unicode" / "additional"
+    plugin_root.mkdir(mode=0o700)
+    plugin = plugin_root / str(NSIS_PLUGIN["name"])
+    download_asset(NSIS_PLUGIN, plugin)
+
+    guid_root = tools_root / "x64" / WEBVIEW2_GUID
+    guid_root.mkdir(mode=0o700, parents=True)
+    webview = guid_root / str(WEBVIEW2_ASSET["name"])
+    download_asset(WEBVIEW2_ASSET, webview)
+    verify_windows(tools_root)
+
+
+def prepare(platform_name: str, target_directory: Path) -> Path:
+    _check_no_environment_overrides()
+    tools_root = _create_tools_root(target_directory.absolute())
+    if platform_name == "linux":
+        prepare_linux(tools_root)
+    elif platform_name == "windows":
+        prepare_windows(tools_root)
+    else:  # pragma: no cover - argparse owns this boundary
+        raise ToolError(f"unsupported Tauri tool platform: {platform_name}")
+    return tools_root
+
+
+def verify(platform_name: str, target_directory: Path) -> Path:
+    _check_no_environment_overrides()
+    target_directory = target_directory.absolute()
+    _assert_plain_path_components(target_directory)
+    tools_root = target_directory / ".tauri"
+    if platform_name == "linux":
+        verify_linux(tools_root)
+    elif platform_name == "windows":
+        verify_windows(tools_root)
+    else:  # pragma: no cover - argparse owns this boundary
+        raise ToolError(f"unsupported Tauri tool platform: {platform_name}")
+    return tools_root
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("prepare", "verify"))
+    parser.add_argument("platform", choices=("linux", "windows"))
+    parser.add_argument(
+        "--target-directory",
+        required=True,
+        type=Path,
+        help="the exact Cargo target directory that will contain .tauri",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.operation == "prepare":
+            tools_root = prepare(args.platform, args.target_directory)
+        else:
+            tools_root = verify(args.platform, args.target_directory)
+    except (OSError, ToolError, zipfile.BadZipFile) as error:
+        print(f"pinned Tauri tool verification failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        f"Tauri {TAURI_VERSION} {args.platform} external tools "
+        f"{args.operation} verified at {tools_root}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ports/tauri/packaging/linux/assemble-staging.sh
+++ b/ports/tauri/packaging/linux/assemble-staging.sh
@@ -26,6 +26,16 @@ SCANSTUDIO_APP_SOURCE="${SCANSTUDIO_APP_SOURCE:-$repo_root/app}"
 CPYTHON_URL="https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.13.14%2B20260728-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
 CPYTHON_SHA256="6734c3e643c75e860c36ee3a7904e8e6bafbf3232d89b17ffd5fbfa72ab2816c"
 
+# Committed target-specific lock for every package artifact used below. The
+# verifier binds package/version, target ABI, exact filename, byte size, and
+# SHA-256 before any wheel is extracted or any sdist is built.
+PYTHON_ARTIFACT_LOCK="$repo_root/packaging/python-artifacts-linux-cp313-x86_64.lock.json"
+PYTHON_ARTIFACT_SHA256="$repo_root/packaging/python-artifacts-linux-cp313-x86_64.sha256"
+PYTHON_WHEEL_REQUIREMENTS="$repo_root/packaging/python-wheels-linux-cp313-x86_64.requirements.txt"
+PYTHON_SANE_REQUIREMENTS="$repo_root/packaging/python-sane-linux-cp313-x86_64.requirements.txt"
+PYTHON_ARTIFACT_VERIFIER="$repo_root/packaging/verify_python_artifact_lock.py"
+PYTHON_SANE_URL="https://files.pythonhosted.org/packages/source/p/python-sane/python_sane-2.9.2.tar.gz"
+
 SITE_PACKAGES_DIR="$STAGING_ROOT/BridgeRuntime/site-packages"
 PYTHON_BIN="$STAGING_ROOT/BridgeRuntime/python/bin/python3.13"
 
@@ -37,6 +47,17 @@ require_file "bridge source LICENSE" "$SCANSTUDIO_BRIDGE_SOURCE/LICENSE"
 require_file "CoolscanPy source LICENSE" "$COOLSCANPY_SOURCE/LICENSE"
 require_file "frontend package lock" "$SCANSTUDIO_APP_SOURCE/package-lock.json"
 require_file "Tauri app Cargo lock" "$SCANSTUDIO_APP_SOURCE/src-tauri/Cargo.lock"
+require_file "Python artifact lock" "$PYTHON_ARTIFACT_LOCK"
+require_file "Python artifact checksum ledger" "$PYTHON_ARTIFACT_SHA256"
+require_file "Python wheel requirements" "$PYTHON_WHEEL_REQUIREMENTS"
+require_file "python-sane requirements" "$PYTHON_SANE_REQUIREMENTS"
+require_file "Python artifact verifier" "$PYTHON_ARTIFACT_VERIFIER"
+
+"$HOST_PYTHON" -I -B "$PYTHON_ARTIFACT_VERIFIER" \
+    --lock "$PYTHON_ARTIFACT_LOCK" \
+    --wheel-requirements "$PYTHON_WHEEL_REQUIREMENTS" \
+    --sdist-requirements "$PYTHON_SANE_REQUIREMENTS" \
+    --sha256sums "$PYTHON_ARTIFACT_SHA256"
 
 COOLSCANPY_IDENTITY_VERIFIER="$repo_root/../../scripts/verify_coolscanpy_source.py"
 require_file "CoolscanPy package identity verifier" "$COOLSCANPY_IDENTITY_VERIFIER"
@@ -54,7 +75,10 @@ download_dir="$(mktemp -d)"
 extract_tmp="$(mktemp -d)"
 trap 'rm -rf "$download_dir" "$extract_tmp"' EXIT
 cpython_tarball="$download_dir/cpython.tar.gz"
-curl -fL --retry 3 -o "$cpython_tarball" "$CPYTHON_URL"
+curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+    --connect-timeout 20 --max-time 600 --speed-limit 1024 --speed-time 60 \
+    --max-filesize 268435456 --retry 3 --retry-delay 1 --retry-all-errors \
+    --output "$cpython_tarball" "$CPYTHON_URL"
 verify_sha256 "$CPYTHON_SHA256" "$cpython_tarball"
 tar -xzf "$cpython_tarball" -C "$extract_tmp"
 mkdir -p "$STAGING_ROOT/BridgeRuntime"
@@ -79,10 +103,9 @@ mkdir -p "$STAGING_ROOT/CorrespondingSource"
 copy_corresponding_source "$SCANSTUDIO_BRIDGE_SOURCE" "$STAGING_ROOT/CorrespondingSource/scanstudio-bridge"
 copy_corresponding_source "$COOLSCANPY_SOURCE" "$STAGING_ROOT/CorrespondingSource/coolscanpy"
 
-# (4) curated site-packages. The seven exact versions are resolved for the
-# pinned CPython ABI and verified by the strict bundle gate below. Python
-# wheels are downloaded for the Linux target via the bundled interpreter's own
-# pip, unzipped into site-packages, and the .whl archives deleted.
+# (4) curated site-packages. The seven runtime wheels are selected from one
+# committed, hash-required target download and verified as an exact artifact
+# set before the bounded no-link extractor writes anything into site-packages.
 mkdir -p "$SITE_PACKAGES_DIR"
 # The bundled CPython is a Linux-only binary and cannot execute on non-Linux
 # hosts (the local macOS packaging gate). `pip download` with explicit
@@ -90,29 +113,31 @@ mkdir -p "$SITE_PACKAGES_DIR"
 # the identical target wheels from any interpreter, so fall back to the host
 # python3's pip on such hosts while keeping the bundled interpreter's pip
 # authoritative on a real Linux build host.
-CURATED_PACKAGES=(
-    "numpy==2.5.1"
-    "tifffile==2026.7.31"
-    "imagecodecs==2026.6.26"
-    "opencv-python-headless==4.14.0.94"
-    "pyusb==1.3.1"
-    "Jinja2==3.1.6"
-    "MarkupSafe==3.0.3"
-)
-PIP_DOWNLOAD_ARGS=(download --no-deps --only-binary=:all: --python-version 313 \
-    --implementation cp --abi cp313 --platform manylinux_2_28_x86_64 \
-    -d "$SITE_PACKAGES_DIR")
 pip_python="$PYTHON_BIN"
 if [[ "$(uname -s)" != "Linux" ]] && ! "$PYTHON_BIN" -I -c 'import sys' >/dev/null 2>&1; then
-    pip_python="python3"
+    pip_python="$HOST_PYTHON"
 fi
-for package in "${CURATED_PACKAGES[@]}"; do
-    "$pip_python" -m pip "${PIP_DOWNLOAD_ARGS[@]}" "$package"
-done
-while IFS= read -r -d '' wheel; do
-    python3 -m zipfile -e "$wheel" "$SITE_PACKAGES_DIR"
-    rm -f "$wheel"
-done < <(find "$SITE_PACKAGES_DIR" -maxdepth 1 -type f -name '*.whl' -print0)
+python_artifacts="$download_dir/python-artifacts"
+mkdir -p "$python_artifacts"
+"$pip_python" -I -B -m pip --isolated --disable-pip-version-check \
+    --no-cache-dir download --require-hashes --no-deps --only-binary=:all: \
+    --python-version 313 --implementation cp --abi cp313 \
+    --platform manylinux_2_28_x86_64 --index-url https://pypi.org/simple \
+    --dest "$python_artifacts" --requirement "$PYTHON_WHEEL_REQUIREMENTS"
+
+sane_sdist="$python_artifacts/python_sane-2.9.2.tar.gz"
+curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+    --connect-timeout 20 --max-time 180 --speed-limit 1024 --speed-time 30 \
+    --max-filesize 1048576 --retry 3 --retry-delay 1 --retry-all-errors \
+    --output "$sane_sdist" "$PYTHON_SANE_URL"
+
+"$HOST_PYTHON" -I -B "$PYTHON_ARTIFACT_VERIFIER" \
+    --lock "$PYTHON_ARTIFACT_LOCK" \
+    --wheel-requirements "$PYTHON_WHEEL_REQUIREMENTS" \
+    --sdist-requirements "$PYTHON_SANE_REQUIREMENTS" \
+    --sha256sums "$PYTHON_ARTIFACT_SHA256" \
+    --directory "$python_artifacts" \
+    --extract-wheels "$SITE_PACKAGES_DIR" --wheel-role runtime
 
 # python-sane has no prebuilt wheel. A real Linux bundle must compile it for
 # the bundled CPython 3.13 against the build host's libsane-dev. The exact
@@ -128,20 +153,13 @@ if [[ "$(uname -s)" == "Linux" ]]; then
     build_tools="$download_dir/python-build-tools"
     mkdir -p "$sane_build" "$build_tools"
 
-    setuptools_wheel="$download_dir/setuptools-83.0.0-py3-none-any.whl"
-    curl -fL --retry 3 -o "$setuptools_wheel" \
-        "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl"
-    verify_sha256 \
-        "29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3" \
-        "$setuptools_wheel"
-    python3 -m zipfile -e "$setuptools_wheel" "$build_tools"
-
-    sane_sdist="$download_dir/python_sane-2.9.2.tar.gz"
-    curl -fL --retry 3 -o "$sane_sdist" \
-        "https://files.pythonhosted.org/packages/source/p/python-sane/python_sane-2.9.2.tar.gz"
-    verify_sha256 \
-        "50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe" \
-        "$sane_sdist"
+    "$HOST_PYTHON" -I -B "$PYTHON_ARTIFACT_VERIFIER" \
+        --lock "$PYTHON_ARTIFACT_LOCK" \
+        --wheel-requirements "$PYTHON_WHEEL_REQUIREMENTS" \
+        --sdist-requirements "$PYTHON_SANE_REQUIREMENTS" \
+        --sha256sums "$PYTHON_ARTIFACT_SHA256" \
+        --directory "$python_artifacts" \
+        --extract-wheels "$build_tools" --wheel-role build
 
     CC=gcc CXX=g++ PYTHONPATH="$build_tools" "$PYTHON_BIN" -m pip wheel \
         --disable-pip-version-check --no-index --no-deps --no-build-isolation \

--- a/ports/tauri/packaging/linux/build-and-verify.sh
+++ b/ports/tauri/packaging/linux/build-and-verify.sh
@@ -18,6 +18,8 @@ port_root="$(cd "$script_dir/../.." && pwd)"
 app_root="$port_root/app"
 staging_root="$port_root/packaging/.staging/linux"
 verifier="$script_dir/verify-bundle.sh"
+pinned_tools="$port_root/packaging/install_pinned_tauri_tools.py"
+cargo_target="$app_root/src-tauri/target"
 
 temporary_root="$(mktemp -d)"
 trap 'rm -rf "$temporary_root"' EXIT
@@ -104,12 +106,20 @@ PY
 (
     cd "$app_root"
     npm ci
+    tauri_cli_version="$(./node_modules/.bin/tauri --version)"
+    if [[ "$tauri_cli_version" != 'tauri-cli 2.11.4' ]]; then
+        printf 'unexpected Tauri CLI version: %s\n' "$tauri_cli_version" >&2
+        exit 1
+    fi
     npm run sync-engine
     npm test
     npx tsc --noEmit
     npm run build
     cargo test --locked --manifest-path src-tauri/Cargo.toml
+    python3 -I -S -B "$pinned_tools" prepare linux --target-directory "$cargo_target"
+    python3 -I -S -B "$pinned_tools" verify linux --target-directory "$cargo_target"
     npm run tauri -- build --ci --bundles appimage --config "$build_config" --verbose -- --locked
+    python3 -I -S -B "$pinned_tools" verify linux --target-directory "$cargo_target"
 )
 
 mapfile -t appimages < <(find "$app_root/src-tauri/target/release/bundle/appimage" -maxdepth 1 -type f -name '*.AppImage' -print)

--- a/ports/tauri/packaging/linux/verify-bundle.sh
+++ b/ports/tauri/packaging/linux/verify-bundle.sh
@@ -56,6 +56,42 @@ else
     failures=$((failures + 1))
 fi
 
+# The source lock, target selectors, hashed requirements, exact filenames,
+# and committed checksum ledger must remain internally identical. Assembly
+# verifies the downloaded bytes against this lock before extraction; this gate
+# additionally requires the exact distribution identities in the staged tree.
+artifact_verifier="$script_dir/../verify_python_artifact_lock.py"
+artifact_lock="$script_dir/../python-artifacts-linux-cp313-x86_64.lock.json"
+artifact_sha256="$script_dir/../python-artifacts-linux-cp313-x86_64.sha256"
+wheel_requirements="$script_dir/../python-wheels-linux-cp313-x86_64.requirements.txt"
+sane_requirements="$script_dir/../python-sane-linux-cp313-x86_64.requirements.txt"
+if "$HOST_PYTHON" -I -B "$artifact_verifier" \
+    --lock "$artifact_lock" \
+    --wheel-requirements "$wheel_requirements" \
+    --sdist-requirements "$sane_requirements" \
+    --sha256sums "$artifact_sha256"; then
+    printf 'PASS  exact Linux Python artifact lock\n'
+else
+    printf 'FAIL  exact Linux Python artifact lock\n' >&2
+    failures=$((failures + 1))
+fi
+
+for distribution in \
+    'numpy-2.5.1.dist-info' \
+    'tifffile-2026.7.31.dist-info' \
+    'imagecodecs-2026.6.26.dist-info' \
+    'opencv_python_headless-4.14.0.94.dist-info' \
+    'pyusb-1.3.1.dist-info' \
+    'jinja2-3.1.6.dist-info' \
+    'markupsafe-3.0.3.dist-info'; do
+    if [[ -d "$root/BridgeRuntime/site-packages/$distribution" ]]; then
+        printf 'PASS  exact Python distribution %s\n' "$distribution"
+    else
+        printf 'FAIL  exact Python distribution %s\n' "$distribution" >&2
+        failures=$((failures + 1))
+    fi
+done
+
 identity_verifier="$script_dir/../../../../scripts/verify_coolscanpy_source.py"
 if "$HOST_PYTHON" -I -B "$identity_verifier" \
     "$root/CorrespondingSource/coolscanpy" \

--- a/ports/tauri/packaging/python-artifacts-linux-cp313-x86_64.lock.json
+++ b/ports/tauri/packaging/python-artifacts-linux-cp313-x86_64.lock.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": 1,
+  "target": {
+    "implementation": "cp",
+    "pythonVersion": "313",
+    "abi": "cp313",
+    "platform": "manylinux_2_28_x86_64"
+  },
+  "artifacts": [
+    {
+      "name": "setuptools",
+      "version": "83.0.0",
+      "kind": "wheel",
+      "roles": ["build"],
+      "filename": "setuptools-83.0.0-py3-none-any.whl",
+      "size": 1008090,
+      "sha256": "29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3"
+    },
+    {
+      "name": "numpy",
+      "version": "2.5.1",
+      "kind": "wheel",
+      "roles": ["runtime"],
+      "filename": "numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "size": 16661440,
+      "sha256": "9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a"
+    },
+    {
+      "name": "tifffile",
+      "version": "2026.7.31",
+      "kind": "wheel",
+      "roles": ["runtime"],
+      "filename": "tifffile-2026.7.31-py3-none-any.whl",
+      "size": 271576,
+      "sha256": "81adfa08012be1c478f99b83cda2f529eef8620cfbdf94fc41eef6f1d7b47dc5"
+    },
+    {
+      "name": "imagecodecs",
+      "version": "2026.6.26",
+      "kind": "wheel",
+      "roles": ["runtime"],
+      "filename": "imagecodecs-2026.6.26-cp312-abi3-manylinux_2_28_x86_64.whl",
+      "size": 28855566,
+      "sha256": "6e9e57171ce7cdf884e7d45d25427f77275321a0ddbd26941c5c90b242d2b597"
+    },
+    {
+      "name": "opencv-python-headless",
+      "version": "4.14.0.94",
+      "kind": "wheel",
+      "roles": ["runtime"],
+      "filename": "opencv_python_headless-4.14.0.94-cp37-abi3-manylinux_2_28_x86_64.whl",
+      "size": 61960165,
+      "sha256": "211e581f5a4670acbbe08fff36a35e9946039d2eea28b80394632d036d1be527"
+    },
+    {
+      "name": "pyusb",
+      "version": "1.3.1",
+      "kind": "wheel",
+      "roles": ["runtime"],
+      "filename": "pyusb-1.3.1-py3-none-any.whl",
+      "size": 58465,
+      "sha256": "bf9b754557af4717fe80c2b07cc2b923a9151f5c08d17bdb5345dac09d6a0430"
+    },
+    {
+      "name": "Jinja2",
+      "version": "3.1.6",
+      "kind": "wheel",
+      "roles": ["runtime"],
+      "filename": "jinja2-3.1.6-py3-none-any.whl",
+      "size": 134899,
+      "sha256": "85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
+    },
+    {
+      "name": "MarkupSafe",
+      "version": "3.0.3",
+      "kind": "wheel",
+      "roles": ["runtime"],
+      "filename": "markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+      "size": 22980,
+      "sha256": "ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676"
+    },
+    {
+      "name": "python-sane",
+      "version": "2.9.2",
+      "kind": "sdist",
+      "roles": ["build", "runtime"],
+      "filename": "python_sane-2.9.2.tar.gz",
+      "size": 22513,
+      "sha256": "50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe"
+    }
+  ]
+}

--- a/ports/tauri/packaging/python-artifacts-linux-cp313-x86_64.sha256
+++ b/ports/tauri/packaging/python-artifacts-linux-cp313-x86_64.sha256
@@ -1,0 +1,9 @@
+6e9e57171ce7cdf884e7d45d25427f77275321a0ddbd26941c5c90b242d2b597  imagecodecs-2026.6.26-cp312-abi3-manylinux_2_28_x86_64.whl
+85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67  jinja2-3.1.6-py3-none-any.whl
+ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676  markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a  numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+211e581f5a4670acbbe08fff36a35e9946039d2eea28b80394632d036d1be527  opencv_python_headless-4.14.0.94-cp37-abi3-manylinux_2_28_x86_64.whl
+50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe  python_sane-2.9.2.tar.gz
+bf9b754557af4717fe80c2b07cc2b923a9151f5c08d17bdb5345dac09d6a0430  pyusb-1.3.1-py3-none-any.whl
+29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3  setuptools-83.0.0-py3-none-any.whl
+81adfa08012be1c478f99b83cda2f529eef8620cfbdf94fc41eef6f1d7b47dc5  tifffile-2026.7.31-py3-none-any.whl

--- a/ports/tauri/packaging/python-sane-linux-cp313-x86_64.requirements.txt
+++ b/ports/tauri/packaging/python-sane-linux-cp313-x86_64.requirements.txt
@@ -1,0 +1,4 @@
+# python-sane has no CPython 3.13 wheel. The reviewed sdist is downloaded by
+# exact HTTPS URL, bounded, and verified against this requirement and the
+# shared artifact lock before it is compiled against the bundled interpreter.
+python-sane==2.9.2 --hash=sha256:50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe

--- a/ports/tauri/packaging/python-wheels-linux-cp313-x86_64.requirements.txt
+++ b/ports/tauri/packaging/python-wheels-linux-cp313-x86_64.requirements.txt
@@ -1,0 +1,12 @@
+# Wheels used by the Linux bundle and the Windows/WSL bridge lane.
+# Keep one requirement and one reviewed artifact hash per line. The staging
+# assemblers invoke pip with --require-hashes, --no-deps, --only-binary=:all:,
+# and the exact CPython 3.13 / manylinux_2_28_x86_64 target selectors.
+setuptools==83.0.0 --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3
+numpy==2.5.1 --hash=sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a
+tifffile==2026.7.31 --hash=sha256:81adfa08012be1c478f99b83cda2f529eef8620cfbdf94fc41eef6f1d7b47dc5
+imagecodecs==2026.6.26 --hash=sha256:6e9e57171ce7cdf884e7d45d25427f77275321a0ddbd26941c5c90b242d2b597
+opencv-python-headless==4.14.0.94 --hash=sha256:211e581f5a4670acbbe08fff36a35e9946039d2eea28b80394632d036d1be527
+pyusb==1.3.1 --hash=sha256:bf9b754557af4717fe80c2b07cc2b923a9151f5c08d17bdb5345dac09d6a0430
+jinja2==3.1.6 --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
+MarkupSafe==3.0.3 --hash=sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676

--- a/ports/tauri/packaging/tests/test_python_artifact_lock.py
+++ b/ports/tauri/packaging/tests/test_python_artifact_lock.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import tarfile
+import tempfile
+import unittest
+from unittest import mock
+import zipfile
+
+
+PACKAGING_ROOT = Path(__file__).resolve().parents[1]
+VERIFIER_PATH = PACKAGING_ROOT / "verify_python_artifact_lock.py"
+SPEC = importlib.util.spec_from_file_location(
+    "verify_python_artifact_lock", VERIFIER_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+VERIFIER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VERIFIER)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class PythonArtifactLockTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.artifacts = self.root / "artifacts"
+        self.artifacts.mkdir()
+        self.wheel = self.artifacts / "demo-1.0-py3-none-any.whl"
+        with zipfile.ZipFile(
+            self.wheel, "w", compression=zipfile.ZIP_DEFLATED
+        ) as archive:
+            archive.writestr("demo/__init__.py", "VALUE = 1\n")
+            archive.writestr(
+                "demo-1.0.dist-info/METADATA", "Name: demo\nVersion: 1.0\n"
+            )
+        self.sdist = self.artifacts / "python_sane-2.9.2.tar.gz"
+        self._write_sdist()
+        self.lock = self.root / "lock.json"
+        self.wheel_requirements = self.root / "wheels.txt"
+        self.sdist_requirements = self.root / "sdist.txt"
+        self.combined_requirements = self.root / "combined.txt"
+        self.ledger = self.root / "SHA256SUMS"
+        self._write_lock()
+
+    def _write_sdist(
+        self, unsafe_name: str | None = None, symlink: bool = False
+    ) -> None:
+        with tarfile.open(self.sdist, "w:gz") as archive:
+            root = tarfile.TarInfo("python_sane-2.9.2")
+            root.type = tarfile.DIRTYPE
+            root.mode = 0o755
+            archive.addfile(root)
+            payload = b"GPL fixture\n"
+            member = tarfile.TarInfo(unsafe_name or "python_sane-2.9.2/COPYING")
+            if symlink:
+                member.type = tarfile.SYMTYPE
+                member.linkname = "../outside"
+                archive.addfile(member)
+            else:
+                member.size = len(payload)
+                member.mode = 0o644
+                archive.addfile(member, io.BytesIO(payload))
+            metadata = b"Name: python-sane\nVersion: 2.9.2\n"
+            member = tarfile.TarInfo("python_sane-2.9.2/PKG-INFO")
+            member.size = len(metadata)
+            member.mode = 0o644
+            archive.addfile(member, io.BytesIO(metadata))
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _write_lock(self) -> None:
+        wheel_hash = sha256(self.wheel)
+        sdist_hash = sha256(self.sdist)
+        payload = {
+            "schemaVersion": 1,
+            "target": {
+                "implementation": "cp",
+                "pythonVersion": "313",
+                "abi": "cp313",
+                "platform": "manylinux_2_28_x86_64",
+            },
+            "artifacts": [
+                {
+                    "name": "demo",
+                    "version": "1.0",
+                    "kind": "wheel",
+                    "roles": ["runtime"],
+                    "filename": self.wheel.name,
+                    "size": self.wheel.stat().st_size,
+                    "sha256": wheel_hash,
+                },
+                {
+                    "name": "python-sane",
+                    "version": "2.9.2",
+                    "kind": "sdist",
+                    "roles": ["build", "runtime"],
+                    "filename": self.sdist.name,
+                    "size": self.sdist.stat().st_size,
+                    "sha256": sdist_hash,
+                },
+            ],
+        }
+        self.lock.write_text(json.dumps(payload), encoding="utf-8")
+        wheel_line = f"demo==1.0 --hash=sha256:{wheel_hash}\n"
+        sdist_line = f"python-sane==2.9.2 --hash=sha256:{sdist_hash}\n"
+        self.wheel_requirements.write_text(wheel_line, encoding="utf-8")
+        self.sdist_requirements.write_text(sdist_line, encoding="utf-8")
+        self.combined_requirements.write_text(wheel_line + sdist_line, encoding="utf-8")
+        entries = sorted(((self.wheel.name, wheel_hash), (self.sdist.name, sdist_hash)))
+        self.ledger.write_text(
+            "".join(f"{digest}  {filename}\n" for filename, digest in entries),
+            encoding="ascii",
+        )
+
+    def args(self, *extra: str) -> list[str]:
+        return [
+            "--lock",
+            str(self.lock),
+            "--wheel-requirements",
+            str(self.wheel_requirements),
+            "--sdist-requirements",
+            str(self.sdist_requirements),
+            "--combined-requirements",
+            str(self.combined_requirements),
+            "--sha256sums",
+            str(self.ledger),
+            "--directory",
+            str(self.artifacts),
+            *extra,
+        ]
+
+    def test_accepts_exact_set_and_extracts_bounded_regular_files(self) -> None:
+        destination = self.root / "extracted"
+        self.assertEqual(
+            VERIFIER.main(
+                self.args(
+                    "--extract-wheels", str(destination), "--wheel-role", "runtime"
+                )
+            ),
+            0,
+        )
+        self.assertEqual(
+            (destination / "demo" / "__init__.py").read_text(), "VALUE = 1\n"
+        )
+        self.assertFalse((destination / "demo" / "__init__.py").is_symlink())
+        sdist_destination = self.root / "sdist-extracted"
+        self.assertEqual(
+            VERIFIER.main(self.args("--extract-sdist", str(sdist_destination))),
+            0,
+        )
+        self.assertEqual(
+            (sdist_destination / "python_sane-2.9.2" / "COPYING").read_text(),
+            "GPL fixture\n",
+        )
+
+    def test_rejects_tampered_artifact(self) -> None:
+        self.wheel.write_bytes(self.wheel.read_bytes() + b"tamper")
+        self.assertEqual(VERIFIER.main(self.args()), 1)
+
+    def test_bounded_reader_rejects_different_second_held_read(self) -> None:
+        path = self.root / "bounded.txt"
+        path.write_bytes(b"first")
+        real_read = VERIFIER.os.read
+        calls = 0
+
+        def changing_read(descriptor: int, size: int) -> bytes:
+            nonlocal calls
+            calls += 1
+            chunk = real_read(descriptor, size)
+            # Each five-byte pass is followed by its EOF read. Return different
+            # bytes on the second pass while preserving the snapshotted size.
+            if calls == 3 and chunk == b"first":
+                return b"other"
+            return chunk
+
+        with mock.patch.object(VERIFIER.os, "read", side_effect=changing_read):
+            with self.assertRaisesRegex(VERIFIER.LockError, "changed while"):
+                VERIFIER.bounded_bytes(path, 64, "fixture")
+
+    def test_bounded_reader_ignores_unstable_windows_fstat_identity_fields(
+        self,
+    ) -> None:
+        path = self.root / "bounded-windows.txt"
+        path.write_bytes(b"stable")
+        real_fstat = VERIFIER.os.fstat
+        calls = 0
+
+        def windows_style_fstat(descriptor: int) -> os.stat_result:
+            nonlocal calls
+            calls += 1
+            value = list(real_fstat(descriptor))
+            # Windows hosted runners can expose different synthetic st_dev and
+            # st_ino values for repeated fstat calls on the same held handle.
+            value[1] = calls
+            value[2] = calls + 100
+            return os.stat_result(value)
+
+        with mock.patch.object(VERIFIER.os, "fstat", side_effect=windows_style_fstat):
+            self.assertEqual(VERIFIER.bounded_bytes(path, 64, "fixture"), b"stable")
+
+    def test_all_low_level_artifact_io_requests_windows_binary_mode(self) -> None:
+        source = VERIFIER_PATH.read_text(encoding="utf-8")
+        self.assertEqual(source.count('getattr(os, "O_BINARY", 0)'), 5)
+        self.assertNotRegex(
+            source,
+            r"os\.open\([^\n]+os\.O_RDONLY\s*\|\s*nofollow\s*\)",
+        )
+        self.assertNotIn("st_mtime_ns", source)
+
+    def test_rejects_unexpected_artifact(self) -> None:
+        (self.artifacts / "surprise.whl").write_bytes(b"unexpected")
+        self.assertEqual(VERIFIER.main(self.args()), 1)
+
+    def test_rejects_wrong_combined_requirement_hash(self) -> None:
+        self.combined_requirements.write_text(
+            "demo==1.0 --hash=sha256:"
+            + "0" * 64
+            + "\n"
+            + self.sdist_requirements.read_text(),
+            encoding="utf-8",
+        )
+        self.assertEqual(VERIFIER.main(self.args()), 1)
+
+    def test_rejects_traversal_before_extraction(self) -> None:
+        with zipfile.ZipFile(self.wheel, "w") as archive:
+            archive.writestr("../outside", "escape")
+        self._write_lock()
+        destination = self.root / "extract-traversal"
+        self.assertEqual(
+            VERIFIER.main(self.args("--extract-wheels", str(destination))),
+            1,
+        )
+        self.assertFalse((self.root / "outside").exists())
+
+    def test_rejects_sdist_traversal_before_extraction(self) -> None:
+        self._write_sdist("../outside")
+        self._write_lock()
+        destination = self.root / "extract-sdist-traversal"
+        self.assertEqual(
+            VERIFIER.main(self.args("--extract-sdist", str(destination))),
+            1,
+        )
+        self.assertFalse((self.root / "outside").exists())
+
+    def test_rejects_sdist_links(self) -> None:
+        self._write_sdist(symlink=True)
+        self._write_lock()
+        destination = self.root / "extract-sdist-link"
+        self.assertEqual(
+            VERIFIER.main(self.args("--extract-sdist", str(destination))),
+            1,
+        )
+        self.assertFalse((self.root / "outside").exists())
+
+    def test_committed_lock_and_requirements_are_coherent(self) -> None:
+        self.assertEqual(
+            VERIFIER.main(
+                [
+                    "--lock",
+                    str(
+                        PACKAGING_ROOT / "python-artifacts-linux-cp313-x86_64.lock.json"
+                    ),
+                    "--wheel-requirements",
+                    str(
+                        PACKAGING_ROOT
+                        / "python-wheels-linux-cp313-x86_64.requirements.txt"
+                    ),
+                    "--sdist-requirements",
+                    str(
+                        PACKAGING_ROOT
+                        / "python-sane-linux-cp313-x86_64.requirements.txt"
+                    ),
+                    "--sha256sums",
+                    str(PACKAGING_ROOT / "python-artifacts-linux-cp313-x86_64.sha256"),
+                ]
+            ),
+            0,
+        )
+
+    def test_both_assemblers_use_one_exact_hash_required_target_download(self) -> None:
+        for relative in ("windows/assemble-staging.sh", "linux/assemble-staging.sh"):
+            source = (PACKAGING_ROOT / relative).read_text(encoding="utf-8")
+            self.assertEqual(
+                source.count("--no-cache-dir download --require-hashes"), 1, relative
+            )
+            self.assertIn("--no-deps --only-binary=:all:", source, relative)
+            self.assertIn(
+                "--python-version 313 --implementation cp --abi cp313", source, relative
+            )
+            self.assertIn("--platform manylinux_2_28_x86_64", source, relative)
+            self.assertIn("--index-url https://pypi.org/simple", source, relative)
+            self.assertIn(
+                '--directory "$python_artifacts"',
+                source.replace("$wheelhouse", "$python_artifacts"),
+                relative,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ports/tauri/packaging/verify_python_artifact_lock.py
+++ b/ports/tauri/packaging/verify_python_artifact_lock.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python3
+"""Validate and safely unpack ScanStudio's pinned CPython package artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import stat
+import sys
+import tarfile
+import zipfile
+
+
+MAX_LOCK_BYTES = 64 * 1024
+MAX_REQUIREMENTS_BYTES = 64 * 1024
+MAX_LEDGER_BYTES = 64 * 1024
+MAX_WHEEL_MEMBERS = 25_000
+MAX_WHEEL_FILE_BYTES = 512 * 1024 * 1024
+MAX_WHEEL_TOTAL_BYTES = 2 * 1024 * 1024 * 1024
+MAX_SDIST_MEMBERS = 10_000
+MAX_SDIST_FILE_BYTES = 64 * 1024 * 1024
+MAX_SDIST_TOTAL_BYTES = 256 * 1024 * 1024
+READ_CHUNK = 1024 * 1024
+HASH_RE = re.compile(r"[0-9a-f]{64}")
+REQUIREMENT_RE = re.compile(
+    r"(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)==(?P<version>[^\s]+) "
+    r"--hash=sha256:(?P<sha256>[0-9a-f]{64})"
+)
+LEDGER_RE = re.compile(r"(?P<sha256>[0-9a-f]{64})  (?P<filename>[^/\\\r\n]+)")
+
+
+class LockError(RuntimeError):
+    """The committed lock or downloaded artifact set is invalid."""
+
+
+def bounded_bytes(path: Path, limit: int, label: str) -> bytes:
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    binary = getattr(os, "O_BINARY", 0)
+    try:
+        descriptor = os.open(path, os.O_RDONLY | nofollow | binary)
+    except OSError as error:
+        raise LockError(
+            f"cannot open {label} without following links {path}: {error}"
+        ) from error
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise LockError(f"{label} must be a regular non-symlink file: {path}")
+        if before.st_size > limit:
+            raise LockError(f"{label} exceeds {limit} bytes: {path}")
+
+        def held_read() -> bytes:
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                chunk = os.read(descriptor, min(READ_CHUNK, limit + 1 - total))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                total += len(chunk)
+                if total > limit:
+                    raise LockError(f"{label} exceeds {limit} bytes: {path}")
+            return b"".join(chunks)
+
+        # Windows can report different nanosecond timestamp representations
+        # for successive fstat calls on the same untouched handle. Two full
+        # bounded reads through that already-held handle give the portable
+        # mutation proof we need without trusting timestamp normalization.
+        first = held_read()
+        second = held_read()
+        after = os.fstat(descriptor)
+        if (
+            len(first) != before.st_size
+            or first != second
+            or before.st_size != after.st_size
+            or not stat.S_ISREG(after.st_mode)
+        ):
+            raise LockError(f"{label} changed while it was read: {path}")
+        return first
+    finally:
+        os.close(descriptor)
+
+
+def normalize_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+def load_lock(path: Path) -> list[dict[str, object]]:
+    try:
+        payload = json.loads(bounded_bytes(path, MAX_LOCK_BYTES, "lock"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise LockError(f"invalid JSON lock {path}: {error}") from error
+    if not isinstance(payload, dict) or set(payload) != {
+        "schemaVersion",
+        "target",
+        "artifacts",
+    }:
+        raise LockError(
+            "artifact lock must contain exactly schemaVersion, target, artifacts"
+        )
+    if payload["schemaVersion"] != 1:
+        raise LockError("unsupported artifact-lock schema")
+    if payload["target"] != {
+        "implementation": "cp",
+        "pythonVersion": "313",
+        "abi": "cp313",
+        "platform": "manylinux_2_28_x86_64",
+    }:
+        raise LockError(
+            "artifact lock target is not exact CPython 3.13 manylinux x86_64"
+        )
+    artifacts = payload["artifacts"]
+    if not isinstance(artifacts, list) or not artifacts:
+        raise LockError("artifact lock has no artifacts")
+
+    names: set[str] = set()
+    filenames: set[str] = set()
+    hashes: set[str] = set()
+    validated: list[dict[str, object]] = []
+    required_keys = {"name", "version", "kind", "roles", "filename", "size", "sha256"}
+    for index, raw in enumerate(artifacts):
+        if not isinstance(raw, dict) or set(raw) != required_keys:
+            raise LockError(f"artifact {index} has unexpected fields")
+        name = raw["name"]
+        version = raw["version"]
+        kind = raw["kind"]
+        roles = raw["roles"]
+        filename = raw["filename"]
+        size = raw["size"]
+        sha256 = raw["sha256"]
+        if not isinstance(name, str) or not re.fullmatch(
+            r"[A-Za-z0-9][A-Za-z0-9._-]*", name
+        ):
+            raise LockError(f"artifact {index} has invalid package name")
+        if (
+            not isinstance(version, str)
+            or not version
+            or any(c.isspace() for c in version)
+        ):
+            raise LockError(f"artifact {index} has invalid version")
+        if kind not in {"wheel", "sdist"}:
+            raise LockError(f"artifact {index} has invalid kind")
+        if (
+            not isinstance(roles, list)
+            or not roles
+            or any(role not in {"build", "runtime"} for role in roles)
+            or len(set(roles)) != len(roles)
+        ):
+            raise LockError(f"artifact {index} has invalid roles")
+        if (
+            not isinstance(filename, str)
+            or filename in {"", ".", "..", "SHA256SUMS"}
+            or Path(filename).name != filename
+            or "/" in filename
+            or "\\" in filename
+        ):
+            raise LockError(f"artifact {index} has unsafe filename")
+        if kind == "wheel" and not filename.endswith(".whl"):
+            raise LockError(f"wheel artifact {index} has a non-wheel filename")
+        if kind == "sdist" and not filename.endswith(".tar.gz"):
+            raise LockError(f"sdist artifact {index} has an unexpected filename")
+        if (
+            not isinstance(size, int)
+            or isinstance(size, bool)
+            or not 0 < size <= 256 * 1024 * 1024
+        ):
+            raise LockError(f"artifact {index} has invalid size")
+        if not isinstance(sha256, str) or not HASH_RE.fullmatch(sha256):
+            raise LockError(f"artifact {index} has invalid SHA-256")
+        normalized = normalize_name(name)
+        if normalized in names:
+            raise LockError(f"duplicate normalized package name: {name}")
+        if filename.casefold() in filenames:
+            raise LockError(f"duplicate/case-colliding artifact filename: {filename}")
+        if sha256 in hashes:
+            raise LockError(f"duplicate artifact digest: {sha256}")
+        names.add(normalized)
+        filenames.add(filename.casefold())
+        hashes.add(sha256)
+        validated.append(raw)
+
+    if sum(artifact["kind"] == "sdist" for artifact in validated) != 1:
+        raise LockError("artifact lock must contain exactly one source distribution")
+    return validated
+
+
+def parse_requirements(path: Path) -> dict[str, tuple[str, str]]:
+    try:
+        text = bounded_bytes(path, MAX_REQUIREMENTS_BYTES, "requirements").decode(
+            "utf-8"
+        )
+    except UnicodeDecodeError as error:
+        raise LockError(f"requirements are not UTF-8: {path}") from error
+    requirements: dict[str, tuple[str, str]] = {}
+    for line_number, raw_line in enumerate(text.splitlines(), 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = REQUIREMENT_RE.fullmatch(line)
+        if match is None:
+            raise LockError(f"non-canonical requirement at {path}:{line_number}")
+        name = normalize_name(match.group("name"))
+        if name in requirements:
+            raise LockError(f"duplicate requirement for {name}: {path}")
+        requirements[name] = (match.group("version"), match.group("sha256"))
+    return requirements
+
+
+def validate_requirements(
+    artifacts: list[dict[str, object]],
+    wheel_path: Path,
+    sdist_path: Path,
+    combined_path: Path | None = None,
+) -> None:
+    wheel_requirements = parse_requirements(wheel_path)
+    sdist_requirements = parse_requirements(sdist_path)
+    if set(wheel_requirements) & set(sdist_requirements):
+        raise LockError("wheel and sdist requirements overlap")
+    expected_wheels = {
+        normalize_name(str(artifact["name"])): (artifact["version"], artifact["sha256"])
+        for artifact in artifacts
+        if artifact["kind"] == "wheel"
+    }
+    expected_sdists = {
+        normalize_name(str(artifact["name"])): (artifact["version"], artifact["sha256"])
+        for artifact in artifacts
+        if artifact["kind"] == "sdist"
+    }
+    if wheel_requirements != expected_wheels:
+        raise LockError("wheel requirements do not exactly match the artifact lock")
+    if sdist_requirements != expected_sdists:
+        raise LockError("sdist requirements do not exactly match the artifact lock")
+    if combined_path is not None:
+        combined_requirements = parse_requirements(combined_path)
+        expected_combined = expected_wheels | expected_sdists
+        if combined_requirements != expected_combined:
+            raise LockError(
+                "combined requirements do not exactly match the artifact lock"
+            )
+
+
+def parse_ledger(path: Path) -> dict[str, str]:
+    try:
+        text = bounded_bytes(path, MAX_LEDGER_BYTES, "SHA256 ledger").decode("ascii")
+    except UnicodeDecodeError as error:
+        raise LockError(f"SHA256 ledger is not ASCII: {path}") from error
+    entries: dict[str, str] = {}
+    previous = ""
+    for line_number, line in enumerate(text.splitlines(), 1):
+        match = LEDGER_RE.fullmatch(line)
+        if match is None:
+            raise LockError(f"non-canonical SHA256 ledger line at {path}:{line_number}")
+        filename = match.group("filename")
+        if filename <= previous:
+            raise LockError(
+                "SHA256 ledger filenames must be unique and bytewise sorted"
+            )
+        previous = filename
+        entries[filename] = match.group("sha256")
+    return entries
+
+
+def validate_ledger(artifacts: list[dict[str, object]], ledger_path: Path) -> None:
+    expected = {
+        str(artifact["filename"]): str(artifact["sha256"]) for artifact in artifacts
+    }
+    if parse_ledger(ledger_path) != dict(sorted(expected.items())):
+        raise LockError("SHA256 ledger does not exactly match the artifact lock")
+
+
+def digest_regular_file(path: Path, expected_size: int) -> str:
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    binary = getattr(os, "O_BINARY", 0)
+    flags = os.O_RDONLY | nofollow | binary
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise LockError(
+            f"cannot open artifact without following links: {path}: {error}"
+        ) from error
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_size != expected_size:
+            raise LockError(f"artifact is not the expected regular file/size: {path}")
+        value = hashlib.sha256()
+        total = 0
+        while True:
+            chunk = os.read(descriptor, READ_CHUNK)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > expected_size:
+                raise LockError(f"artifact grew while hashing: {path}")
+            value.update(chunk)
+        after = os.fstat(descriptor)
+        if (
+            total != expected_size
+            or before.st_size != after.st_size
+            or not stat.S_ISREG(after.st_mode)
+        ):
+            raise LockError(f"artifact changed while hashing: {path}")
+        return value.hexdigest()
+    finally:
+        os.close(descriptor)
+
+
+def open_verified_artifact(path: Path, expected_size: int, expected_sha256: str) -> int:
+    """Return a held descriptor after hashing the exact regular file through it."""
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    binary = getattr(os, "O_BINARY", 0)
+    try:
+        descriptor = os.open(path, os.O_RDONLY | nofollow | binary)
+    except OSError as error:
+        raise LockError(
+            f"cannot open artifact without following links: {path}: {error}"
+        ) from error
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_size != expected_size:
+            raise LockError(f"artifact is not the expected regular file/size: {path}")
+        value = hashlib.sha256()
+        total = 0
+        while True:
+            chunk = os.read(descriptor, READ_CHUNK)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > expected_size:
+                raise LockError(f"artifact grew while hashing: {path}")
+            value.update(chunk)
+        after = os.fstat(descriptor)
+        if (
+            total != expected_size
+            or before.st_size != after.st_size
+            or not stat.S_ISREG(after.st_mode)
+        ):
+            raise LockError(f"artifact changed while hashing: {path}")
+        actual_sha256 = value.hexdigest()
+        if actual_sha256 != expected_sha256:
+            raise LockError(
+                f"SHA-256 mismatch for {path.name}: expected {expected_sha256}, got {actual_sha256}"
+            )
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def validate_directory(
+    artifacts: list[dict[str, object]], directory: Path, allow_ledger: bool
+) -> None:
+    try:
+        root_info = directory.lstat()
+    except OSError as error:
+        raise LockError(
+            f"cannot inspect artifact directory {directory}: {error}"
+        ) from error
+    if not stat.S_ISDIR(root_info.st_mode) or directory.is_symlink():
+        raise LockError(
+            f"artifact directory must be a non-symlink directory: {directory}"
+        )
+    expected = {str(artifact["filename"]): artifact for artifact in artifacts}
+    permitted = set(expected)
+    if allow_ledger:
+        permitted.add("SHA256SUMS")
+    actual = {entry.name for entry in directory.iterdir()}
+    if actual != permitted:
+        missing = sorted(permitted - actual)
+        unexpected = sorted(actual - permitted)
+        raise LockError(
+            f"artifact directory mismatch; missing={missing}, unexpected={unexpected}"
+        )
+    for filename, artifact in expected.items():
+        path = directory / filename
+        digest = digest_regular_file(path, int(artifact["size"]))
+        if digest != artifact["sha256"]:
+            raise LockError(
+                f"SHA-256 mismatch for {filename}: expected {artifact['sha256']}, got {digest}"
+            )
+    if allow_ledger:
+        expected_ledger = {
+            str(artifact["filename"]): str(artifact["sha256"]) for artifact in artifacts
+        }
+        if parse_ledger(directory / "SHA256SUMS") != dict(
+            sorted(expected_ledger.items())
+        ):
+            raise LockError(
+                "artifact-directory SHA256SUMS does not exactly match the lock"
+            )
+
+
+def safe_member_parts(name: str) -> tuple[str, ...]:
+    if not name or "\x00" in name or "\\" in name:
+        raise LockError(f"archive has an unsafe member name: {name!r}")
+    path = PurePosixPath(name)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise LockError(f"archive member escapes extraction root: {name!r}")
+    return path.parts
+
+
+def ensure_parent_directories(root: Path, parts: tuple[str, ...]) -> None:
+    current = root
+    for part in parts:
+        current = current / part
+        try:
+            current.mkdir(mode=0o755)
+        except FileExistsError:
+            info = current.lstat()
+            if not stat.S_ISDIR(info.st_mode) or current.is_symlink():
+                raise LockError(
+                    f"archive extraction parent is not a safe directory: {current}"
+                )
+
+
+def extract_wheels(
+    artifacts: list[dict[str, object]], directory: Path, destination: Path, role: str
+) -> None:
+    try:
+        destination.mkdir(parents=True, mode=0o755, exist_ok=True)
+        destination_info = destination.lstat()
+    except OSError as error:
+        raise LockError(
+            f"cannot create wheel extraction root {destination}: {error}"
+        ) from error
+    if not stat.S_ISDIR(destination_info.st_mode) or destination.is_symlink():
+        raise LockError(
+            f"wheel extraction root must be a non-symlink directory: {destination}"
+        )
+
+    selected = [
+        artifact
+        for artifact in artifacts
+        if artifact["kind"] == "wheel" and (role == "all" or role in artifact["roles"])
+    ]
+    if not selected:
+        raise LockError(f"no wheels selected for role {role}")
+
+    seen_casefold: set[str] = set()
+    total_uncompressed = 0
+    for artifact in selected:
+        path = directory / str(artifact["filename"])
+        nofollow = getattr(os, "O_NOFOLLOW", 0)
+        binary = getattr(os, "O_BINARY", 0)
+        descriptor = open_verified_artifact(
+            path, int(artifact["size"]), str(artifact["sha256"])
+        )
+        try:
+            with os.fdopen(descriptor, "rb", closefd=False) as handle:
+                with zipfile.ZipFile(handle) as archive:
+                    members = archive.infolist()
+                    if len(members) > MAX_WHEEL_MEMBERS:
+                        raise LockError(f"wheel has too many members: {path.name}")
+                    prepared: list[tuple[zipfile.ZipInfo, tuple[str, ...], bool]] = []
+                    for member in members:
+                        parts = safe_member_parts(member.filename)
+                        unix_mode = member.external_attr >> 16
+                        file_type = stat.S_IFMT(unix_mode)
+                        is_directory = member.is_dir()
+                        if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+                            raise LockError(
+                                f"wheel contains a link or special file: {path.name}:{member.filename}"
+                            )
+                        if member.flag_bits & 0x1:
+                            raise LockError(
+                                f"wheel contains an encrypted member: {path.name}:{member.filename}"
+                            )
+                        if member.file_size > MAX_WHEEL_FILE_BYTES:
+                            raise LockError(
+                                f"wheel member exceeds size bound: {path.name}:{member.filename}"
+                            )
+                        total_uncompressed += member.file_size
+                        if total_uncompressed > MAX_WHEEL_TOTAL_BYTES:
+                            raise LockError("wheel extraction exceeds total size bound")
+                        normalized = "/".join(parts).casefold()
+                        if normalized in seen_casefold:
+                            raise LockError(
+                                f"wheels contain a duplicate/case-colliding path: {member.filename}"
+                            )
+                        seen_casefold.add(normalized)
+                        prepared.append((member, parts, is_directory))
+
+                    for member, parts, is_directory in prepared:
+                        if is_directory:
+                            ensure_parent_directories(destination, parts)
+                            continue
+                        ensure_parent_directories(destination, parts[:-1])
+                        target = destination.joinpath(*parts)
+                        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow | binary
+                        descriptor_out = os.open(target, flags, 0o644)
+                        written = 0
+                        try:
+                            with os.fdopen(
+                                descriptor_out, "wb", closefd=False
+                            ) as output:
+                                with archive.open(member, "r") as source:
+                                    while True:
+                                        chunk = source.read(READ_CHUNK)
+                                        if not chunk:
+                                            break
+                                        written += len(chunk)
+                                        if written > member.file_size:
+                                            raise LockError(
+                                                f"wheel member expanded beyond declared size: {member.filename}"
+                                            )
+                                        output.write(chunk)
+                                output.flush()
+                                os.fsync(output.fileno())
+                        finally:
+                            os.close(descriptor_out)
+                        if written != member.file_size:
+                            raise LockError(
+                                f"wheel member was truncated: {member.filename}"
+                            )
+                        if unix_mode & 0o111:
+                            target.chmod(0o755)
+        finally:
+            os.close(descriptor)
+
+
+def extract_sdist(
+    artifacts: list[dict[str, object]], directory: Path, destination: Path
+) -> None:
+    matches = [artifact for artifact in artifacts if artifact["kind"] == "sdist"]
+    if len(matches) != 1:
+        raise LockError("expected exactly one locked source distribution")
+    artifact = matches[0]
+    path = directory / str(artifact["filename"])
+    descriptor = open_verified_artifact(
+        path, int(artifact["size"]), str(artifact["sha256"])
+    )
+    try:
+        try:
+            destination.mkdir(parents=True, mode=0o755, exist_ok=True)
+            destination_info = destination.lstat()
+        except OSError as error:
+            raise LockError(
+                f"cannot create sdist extraction root {destination}: {error}"
+            ) from error
+        if not stat.S_ISDIR(destination_info.st_mode) or destination.is_symlink():
+            raise LockError(
+                f"sdist extraction root must be a non-symlink directory: {destination}"
+            )
+
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            with tarfile.open(fileobj=handle, mode="r:gz") as archive:
+                members = archive.getmembers()
+                if len(members) > MAX_SDIST_MEMBERS:
+                    raise LockError(f"sdist has too many members: {path.name}")
+                seen_casefold: set[str] = set()
+                total_uncompressed = 0
+                prepared: list[tuple[tarfile.TarInfo, tuple[str, ...]]] = []
+                for member in members:
+                    parts = safe_member_parts(member.name)
+                    if not (member.isfile() or member.isdir()):
+                        raise LockError(
+                            f"sdist contains a link or special file: {path.name}:{member.name}"
+                        )
+                    if member.size < 0 or member.size > MAX_SDIST_FILE_BYTES:
+                        raise LockError(
+                            f"sdist member exceeds size bound: {path.name}:{member.name}"
+                        )
+                    total_uncompressed += member.size
+                    if total_uncompressed > MAX_SDIST_TOTAL_BYTES:
+                        raise LockError("sdist extraction exceeds total size bound")
+                    normalized = "/".join(parts).casefold()
+                    if normalized in seen_casefold:
+                        raise LockError(
+                            f"sdist contains a duplicate/case-colliding path: {member.name}"
+                        )
+                    seen_casefold.add(normalized)
+                    prepared.append((member, parts))
+
+                nofollow = getattr(os, "O_NOFOLLOW", 0)
+                binary = getattr(os, "O_BINARY", 0)
+                for member, parts in prepared:
+                    if member.isdir():
+                        ensure_parent_directories(destination, parts)
+                        continue
+                    ensure_parent_directories(destination, parts[:-1])
+                    target = destination.joinpath(*parts)
+                    descriptor_out = os.open(
+                        target,
+                        os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow | binary,
+                        0o644,
+                    )
+                    written = 0
+                    try:
+                        source = archive.extractfile(member)
+                        if source is None:
+                            raise LockError(
+                                f"sdist regular member has no data: {member.name}"
+                            )
+                        with source:
+                            with os.fdopen(
+                                descriptor_out, "wb", closefd=False
+                            ) as output:
+                                while True:
+                                    chunk = source.read(READ_CHUNK)
+                                    if not chunk:
+                                        break
+                                    written += len(chunk)
+                                    if written > member.size:
+                                        raise LockError(
+                                            f"sdist member expanded beyond declared size: {member.name}"
+                                        )
+                                    output.write(chunk)
+                                output.flush()
+                                os.fsync(output.fileno())
+                    finally:
+                        os.close(descriptor_out)
+                    if written != member.size:
+                        raise LockError(f"sdist member was truncated: {member.name}")
+                    if member.mode & 0o111:
+                        target.chmod(0o755)
+    finally:
+        os.close(descriptor)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lock", required=True, type=Path)
+    parser.add_argument("--wheel-requirements", required=True, type=Path)
+    parser.add_argument("--sdist-requirements", required=True, type=Path)
+    parser.add_argument("--combined-requirements", type=Path)
+    parser.add_argument("--sha256sums", required=True, type=Path)
+    parser.add_argument("--directory", type=Path)
+    parser.add_argument("--allow-ledger", action="store_true")
+    parser.add_argument("--extract-wheels", type=Path)
+    parser.add_argument("--extract-sdist", type=Path)
+    parser.add_argument(
+        "--wheel-role", choices=("all", "build", "runtime"), default="all"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        artifacts = load_lock(args.lock)
+        validate_requirements(
+            artifacts,
+            args.wheel_requirements,
+            args.sdist_requirements,
+            args.combined_requirements,
+        )
+        validate_ledger(artifacts, args.sha256sums)
+        if args.directory is not None:
+            validate_directory(artifacts, args.directory, args.allow_ledger)
+        elif args.extract_wheels is not None or args.extract_sdist is not None:
+            raise LockError("artifact extraction requires --directory")
+        if args.extract_wheels is not None:
+            extract_wheels(
+                artifacts, args.directory, args.extract_wheels, args.wheel_role
+            )
+        if args.extract_sdist is not None:
+            extract_sdist(artifacts, args.directory, args.extract_sdist)
+    except (LockError, OSError, tarfile.TarError, zipfile.BadZipFile) as error:
+        print(f"python artifact lock verification failed: {error}", file=sys.stderr)
+        return 1
+    print("python artifact lock verification passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ports/tauri/packaging/windows/assemble-staging.sh
+++ b/ports/tauri/packaging/windows/assemble-staging.sh
@@ -26,21 +26,16 @@ CPYTHON_URL="https://github.com/astral-sh/python-build-standalone/releases/downl
 CPYTHON_SHA256="6734c3e643c75e860c36ee3a7904e8e6bafbf3232d89b17ffd5fbfa72ab2816c"
 CPYTHON_ARCHIVE="cpython-3.13.14+20260728-x86_64-unknown-linux-gnu.tar.gz"
 
-# Exact versions compatible with the shipped source declarations. Packages
-# are downloaded at build time and installed with --no-index at user install
-# time. python-sane ships as its source archive and is compiled inside WSL
-# against Ubuntu's libsane-dev for CPython 3.13.
-WSL_REQUIREMENTS=(
-    "setuptools==83.0.0"
-    "numpy==2.5.1"
-    "tifffile==2026.7.31"
-    "imagecodecs==2026.6.26"
-    "opencv-python-headless==4.14.0.94"
-    "pyusb==1.3.1"
-    "jinja2==3.1.6"
-    "MarkupSafe==3.0.3"
-    "python-sane==2.9.2"
-)
+# Every package artifact is bound before use to a committed package/version,
+# target ABI, exact filename, size, and SHA-256. python-sane has no CPython
+# 3.13 wheel, so its reviewed sdist is compiled inside WSL against
+# Ubuntu's libsane-dev.
+PYTHON_ARTIFACT_LOCK="$repo_root/packaging/python-artifacts-linux-cp313-x86_64.lock.json"
+PYTHON_ARTIFACT_SHA256="$repo_root/packaging/python-artifacts-linux-cp313-x86_64.sha256"
+PYTHON_WHEEL_REQUIREMENTS="$repo_root/packaging/python-wheels-linux-cp313-x86_64.requirements.txt"
+PYTHON_SANE_REQUIREMENTS="$repo_root/packaging/python-sane-linux-cp313-x86_64.requirements.txt"
+PYTHON_ARTIFACT_VERIFIER="$repo_root/packaging/verify_python_artifact_lock.py"
+PYTHON_SANE_URL="https://files.pythonhosted.org/packages/source/p/python-sane/python_sane-2.9.2.tar.gz"
 
 # GPL corresponding source + license preconditions. The source trees are
 # copied (never edited) from the port/cross-platform branches at build time.
@@ -57,6 +52,17 @@ require_file "Windows hardware-session double-click launcher" \
 require_file "Windows hardware-session WSL latch helper" \
     "$script_dir/scanstudio-hardware-session-latch.sh"
 require_file "Windows hardware-session NSIS hooks" "$script_dir/installer-hooks.nsh"
+require_file "Python artifact lock" "$PYTHON_ARTIFACT_LOCK"
+require_file "Python artifact checksum ledger" "$PYTHON_ARTIFACT_SHA256"
+require_file "Python wheel requirements" "$PYTHON_WHEEL_REQUIREMENTS"
+require_file "python-sane requirements" "$PYTHON_SANE_REQUIREMENTS"
+require_file "Python artifact verifier" "$PYTHON_ARTIFACT_VERIFIER"
+
+"$HOST_PYTHON" -I -B "$PYTHON_ARTIFACT_VERIFIER" \
+    --lock "$PYTHON_ARTIFACT_LOCK" \
+    --wheel-requirements "$PYTHON_WHEEL_REQUIREMENTS" \
+    --sdist-requirements "$PYTHON_SANE_REQUIREMENTS" \
+    --sha256sums "$PYTHON_ARTIFACT_SHA256"
 
 COOLSCANPY_IDENTITY_VERIFIER="$repo_root/../../scripts/verify_coolscanpy_source.py"
 require_file "CoolscanPy package identity verifier" "$COOLSCANPY_IDENTITY_VERIFIER"
@@ -80,76 +86,49 @@ license_extract="$(mktemp -d)"
 trap 'rm -rf "$download_dir" "$license_extract"' EXIT
 mkdir -p "$STAGING_ROOT/BridgeRuntime" "$STAGING_ROOT/Wheelhouse"
 cpython_tarball="$STAGING_ROOT/BridgeRuntime/$CPYTHON_ARCHIVE"
-curl -fL --retry 3 -o "$cpython_tarball" "$CPYTHON_URL"
+curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+    --connect-timeout 20 --max-time 600 --speed-limit 1024 --speed-time 60 \
+    --max-filesize 268435456 --retry 3 --retry-delay 1 --retry-all-errors \
+    --output "$cpython_tarball" "$CPYTHON_URL"
 verify_sha256 "$CPYTHON_SHA256" "$cpython_tarball"
 printf '%s  %s\n' "$CPYTHON_SHA256" "$CPYTHON_ARCHIVE" \
     > "$STAGING_ROOT/BridgeRuntime/SHA256SUMS"
 
 wheelhouse="$STAGING_ROOT/Wheelhouse"
-wheel_args=(download --no-deps --only-binary=:all: --python-version 313 \
-    --implementation cp --abi cp313 --platform manylinux_2_28_x86_64 \
-    --dest "$wheelhouse")
-for requirement in "${WSL_REQUIREMENTS[@]:0:8}"; do
-    "$HOST_PYTHON" -m pip "${wheel_args[@]}" "$requirement"
-done
+"$HOST_PYTHON" -I -B -m pip --isolated --disable-pip-version-check \
+    --no-cache-dir download --require-hashes --no-deps --only-binary=:all: \
+    --python-version 313 --implementation cp --abi cp313 \
+    --platform manylinux_2_28_x86_64 --index-url https://pypi.org/simple \
+    --dest "$wheelhouse" --requirement "$PYTHON_WHEEL_REQUIREMENTS"
 python_sane_sdist="$wheelhouse/python_sane-2.9.2.tar.gz"
-curl -fL --retry 3 -o "$python_sane_sdist" \
-    "https://files.pythonhosted.org/packages/source/p/python-sane/python_sane-2.9.2.tar.gz"
-verify_sha256 \
-    "50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe" \
-    "$python_sane_sdist"
+curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+    --connect-timeout 20 --max-time 180 --speed-limit 1024 --speed-time 30 \
+    --max-filesize 1048576 --retry 3 --retry-delay 1 --retry-all-errors \
+    --output "$python_sane_sdist" "$PYTHON_SANE_URL"
 
-# A wheelhouse checksum ledger makes offline installation fail closed on any
-# corruption after packaging. The requirements file also pins every identity
-# and hash consumed by pip; no transitive or floating resolution remains.
-"$HOST_PYTHON" - "$wheelhouse" "$STAGING_ROOT/wsl-requirements.txt" <<'PYTHON'
-import hashlib
-import re
-import sys
-from pathlib import Path
+"$HOST_PYTHON" -I -B "$PYTHON_ARTIFACT_VERIFIER" \
+    --lock "$PYTHON_ARTIFACT_LOCK" \
+    --wheel-requirements "$PYTHON_WHEEL_REQUIREMENTS" \
+    --sdist-requirements "$PYTHON_SANE_REQUIREMENTS" \
+    --sha256sums "$PYTHON_ARTIFACT_SHA256" \
+    --directory "$wheelhouse"
 
-wheelhouse = Path(sys.argv[1])
-requirements_path = Path(sys.argv[2])
-artifacts = sorted(p for p in wheelhouse.iterdir() if p.is_file())
-
-def digest(path: Path) -> str:
-    value = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            value.update(chunk)
-    return value.hexdigest()
-
-(wheelhouse / "SHA256SUMS").write_text(
-    "".join(f"{digest(path)}  {path.name}\n" for path in artifacts)
-)
-
-pins = {
-    "setuptools": "83.0.0",
-    "numpy": "2.5.1",
-    "tifffile": "2026.7.31",
-    "imagecodecs": "2026.6.26",
-    "opencv-python-headless": "4.14.0.94",
-    "pyusb": "1.3.1",
-    "jinja2": "3.1.6",
-    "MarkupSafe": "3.0.3",
-    "python-sane": "2.9.2",
-}
-
-def normalized(name: str) -> str:
-    return re.sub(r"[-_.]+", "-", name).lower()
-
-lines = []
-for name, version in pins.items():
-    prefix = normalized(name).replace("-", "_")
-    matches = [
-        path for path in artifacts
-        if normalized(path.name).startswith(normalized(prefix + "-" + version))
-    ]
-    if len(matches) != 1:
-        raise SystemExit(f"expected one wheelhouse artifact for {name}=={version}, got {matches}")
-    lines.append(f"{name}=={version} --hash=sha256:{digest(matches[0])}\n")
-requirements_path.write_text("".join(lines))
-PYTHON
+# The runtime ledger is the reviewed committed ledger, not a build-generated
+# description of whatever the package index happened to return. The combined
+# requirements file remains usable by pip --require-hashes inside WSL.
+install -m 644 "$PYTHON_ARTIFACT_SHA256" "$wheelhouse/SHA256SUMS"
+{
+    cat "$PYTHON_WHEEL_REQUIREMENTS"
+    printf '\n'
+    cat "$PYTHON_SANE_REQUIREMENTS"
+} > "$STAGING_ROOT/wsl-requirements.txt"
+"$HOST_PYTHON" -I -B "$PYTHON_ARTIFACT_VERIFIER" \
+    --lock "$PYTHON_ARTIFACT_LOCK" \
+    --wheel-requirements "$PYTHON_WHEEL_REQUIREMENTS" \
+    --sdist-requirements "$PYTHON_SANE_REQUIREMENTS" \
+    --combined-requirements "$STAGING_ROOT/wsl-requirements.txt" \
+    --sha256sums "$PYTHON_ARTIFACT_SHA256" \
+    --directory "$wheelhouse" --allow-ledger
 
 # (4) the WSL2-side bridge installer and user-facing setup material, shipped
 # together so an extracted portable zip is self-explanatory offline.
@@ -182,12 +161,22 @@ tar -xOf "$cpython_tarball" python/lib/python3.13/LICENSE.txt \
     > "$STAGING_ROOT/Licenses/CPython-3.13.txt"
 
 mkdir -p "$license_extract/site-packages"
-while IFS= read -r -d '' wheel; do
-    "$HOST_PYTHON" -m zipfile -e "$wheel" "$license_extract/site-packages"
-done < <(find "$wheelhouse" -maxdepth 1 -type f -name '*.whl' -print0)
+"$HOST_PYTHON" -I -B "$PYTHON_ARTIFACT_VERIFIER" \
+    --lock "$PYTHON_ARTIFACT_LOCK" \
+    --wheel-requirements "$PYTHON_WHEEL_REQUIREMENTS" \
+    --sdist-requirements "$PYTHON_SANE_REQUIREMENTS" \
+    --sha256sums "$PYTHON_ARTIFACT_SHA256" \
+    --directory "$wheelhouse" --allow-ledger \
+    --extract-wheels "$license_extract/site-packages" --wheel-role all
 collect_python_wheel_licenses \
     "$license_extract/site-packages" "$STAGING_ROOT/Licenses/python-wheelhouse"
-tar -xzf "$python_sane_sdist" -C "$license_extract"
+"$HOST_PYTHON" -I -B "$PYTHON_ARTIFACT_VERIFIER" \
+    --lock "$PYTHON_ARTIFACT_LOCK" \
+    --wheel-requirements "$PYTHON_WHEEL_REQUIREMENTS" \
+    --sdist-requirements "$PYTHON_SANE_REQUIREMENTS" \
+    --sha256sums "$PYTHON_ARTIFACT_SHA256" \
+    --directory "$wheelhouse" --allow-ledger \
+    --extract-sdist "$license_extract"
 python_sane_source="$(find "$license_extract" -maxdepth 1 -type d -name 'python_sane-*' -print -quit)"
 mkdir -p "$STAGING_ROOT/Licenses/python-wheelhouse/python_sane-2.9.2"
 install -m 644 "$python_sane_source/COPYING" \

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -25,6 +25,16 @@ $stagingRoot = Join-Path $portRoot 'packaging\.staging\windows'
 $verifier = Join-Path $PSScriptRoot 'verify-bundle.ps1'
 $launcherBlackBox = Join-Path $PSScriptRoot 'tests\test-hardware-session-launcher.ps1'
 $windowsPowerShell = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+$pinnedToolsInstaller = Join-Path $portRoot 'packaging\install_pinned_tauri_tools.py'
+$cargoTarget = Join-Path $appRoot 'src-tauri\target'
+$tauriToolsRoot = Join-Path $cargoTarget '.tauri'
+$webViewGuid = 'e4dd9b83-b7e3-4d17-8d7c-e14cdd7c3a51'
+$webViewFileName = 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe'
+$webViewSha256 = 'f8d4ab074c22a0cd136434f37c6b34dfb64ebf8a32ce42e03bd8f2a6b51a3892'
+$nsisPluginSha256 = '5ba143b5db4a87d32d6e7802e033330aae56cbceabe0d1e3ba41948385ad4709'
+$pinnedWebView = Join-Path $tauriToolsRoot "x64\$webViewGuid\$webViewFileName"
+$pinnedMakensis = Join-Path $tauriToolsRoot 'NSIS\makensis.exe'
+$pinnedNsisPlugin = Join-Path $tauriToolsRoot 'NSIS\Plugins\x86-unicode\additional\nsis_tauri_utils.dll'
 
 if (-not (Test-Path $stagingRoot -PathType Container)) {
     throw "Windows staging is missing: $stagingRoot"
@@ -177,6 +187,132 @@ function Test-RegistryValueExists {
 
     $properties = Get-ItemProperty -LiteralPath $Path -ErrorAction SilentlyContinue
     return $null -ne $properties -and $null -ne $properties.PSObject.Properties[$Name]
+}
+
+function Invoke-PinnedTauriToolCheck {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('prepare', 'verify')]
+        [string]$Operation
+    )
+
+    & python `
+        -I `
+        -S `
+        -B `
+        $pinnedToolsInstaller `
+        $Operation `
+        windows `
+        --target-directory `
+        $cargoTarget
+    if ($LASTEXITCODE -ne 0) {
+        throw "Pinned Tauri tool $Operation failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Get-HeldStreamSha256 {
+    param([Parameter(Mandatory = $true)][System.IO.FileStream]$Stream)
+
+    $Stream.Position = 0
+    $algorithm = [Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = $algorithm.ComputeHash($Stream)
+    }
+    finally {
+        $algorithm.Dispose()
+        $Stream.Position = 0
+    }
+    return ([BitConverter]::ToString($bytes)).Replace('-', '').ToLowerInvariant()
+}
+
+function Assert-HeldPinnedFile {
+    param(
+        [Parameter(Mandatory = $true)][System.IO.FileStream]$Stream,
+        [Parameter(Mandatory = $true)][string]$ExpectedSha256,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+
+    $actual = Get-HeldStreamSha256 -Stream $Stream
+    if ($actual -cne $ExpectedSha256) {
+        throw "$Description held-file SHA-256 mismatch: expected $ExpectedSha256, got $actual"
+    }
+}
+
+function Assert-PinnedWebViewAuthenticode {
+    if (-not (Test-Path -LiteralPath $pinnedWebView -PathType Leaf)) {
+        throw "Pinned WebView2 offline installer is missing: $pinnedWebView"
+    }
+    $attributes = (Get-Item -LiteralPath $pinnedWebView -Force).Attributes
+    if (($attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Pinned WebView2 offline installer is a reparse point: $pinnedWebView"
+    }
+    $actualHash = (Get-FileHash -LiteralPath $pinnedWebView -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualHash -cne $webViewSha256) {
+        throw "Pinned WebView2 SHA-256 mismatch: expected $webViewSha256, got $actualHash"
+    }
+
+    $signature = Get-AuthenticodeSignature -LiteralPath $pinnedWebView
+    if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+        throw "Pinned WebView2 Authenticode status is $($signature.Status): $($signature.StatusMessage)"
+    }
+    if ($null -eq $signature.SignerCertificate -or
+        $signature.SignerCertificate.Subject -notmatch '(^|, )O=Microsoft Corporation(,|$)') {
+        throw "Pinned WebView2 signer is not Microsoft Corporation: $($signature.SignerCertificate.Subject)"
+    }
+    if ($null -eq $signature.TimeStamperCertificate) {
+        throw 'Pinned WebView2 Authenticode signature has no timestamp certificate.'
+    }
+    Write-Host "WebView2 Authenticode valid: $($signature.SignerCertificate.Subject)"
+}
+
+function Assert-GeneratedNsisUsesPinnedWebView {
+    $expectedNsi = Join-Path $cargoTarget 'release\nsis\x64\installer.nsi'
+    if (-not (Test-Path -LiteralPath $expectedNsi -PathType Leaf)) {
+        throw "Generated NSIS source is missing from its exact path: $expectedNsi"
+    }
+    $attributes = (Get-Item -LiteralPath $expectedNsi -Force).Attributes
+    if (($attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Generated NSIS source is a reparse point: $expectedNsi"
+    }
+    $allNsi = @(
+        Get-ChildItem -LiteralPath (Join-Path $cargoTarget 'release\nsis') `
+            -Recurse `
+            -File `
+            -Filter 'installer.nsi'
+    )
+    if ($allNsi.Count -ne 1 -or
+        [IO.Path]::GetFullPath($allNsi[0].FullName) -ine [IO.Path]::GetFullPath($expectedNsi)) {
+        throw "Expected exactly one generated installer.nsi at $expectedNsi, found: $($allNsi.FullName)"
+    }
+
+    $source = [IO.File]::ReadAllText($expectedNsi)
+    $pathMatches = [regex]::Matches(
+        $source,
+        '(?m)^!define WEBVIEW2INSTALLERPATH "([^"\r\n]+)"\r?$'
+    )
+    if ($pathMatches.Count -ne 1) {
+        throw "Generated NSIS source must define WEBVIEW2INSTALLERPATH exactly once; found $($pathMatches.Count)"
+    }
+    $generatedWebViewPath = $pathMatches[0].Groups[1].Value
+    if (-not (Test-SameFileSystemPath -Left $generatedWebViewPath -Right $pinnedWebView)) {
+        throw "Generated NSIS source names '$generatedWebViewPath', expected held file '$pinnedWebView'"
+    }
+    $modeMatches = [regex]::Matches(
+        $source,
+        '(?m)^!define INSTALLWEBVIEW2MODE "offlineInstaller"\r?$'
+    )
+    if ($modeMatches.Count -ne 1) {
+        throw "Generated NSIS source must select offlineInstaller exactly once; found $($modeMatches.Count)"
+    }
+    $fileUses = [regex]::Matches(
+        $source,
+        '(?m)^\s*File "/oname=\$TEMP\\MicrosoftEdgeWebView2RuntimeInstaller\.exe" "\$\{WEBVIEW2INSTALLERPATH\}"\r?$'
+    )
+    if ($fileUses.Count -ne 1) {
+        throw "Generated NSIS source must embed the pinned WebView2 define exactly once; found $($fileUses.Count)"
+    }
+    $nsiHash = (Get-FileHash -LiteralPath $expectedNsi -Algorithm SHA256).Hash.ToLowerInvariant()
+    Write-Host "Generated NSIS source verified: $expectedNsi SHA-256 $nsiHash"
 }
 
 function Assert-NoExistingScanStudioInstall {
@@ -631,19 +767,67 @@ Invoke-HardwareSessionLauncherBlackBox -Root $PSScriptRoot
 
 $buildConfig = Join-Path ([System.IO.Path]::GetTempPath()) ("scanstudio-tauri-version-" + [guid]::NewGuid().ToString('N') + '.json')
 @{ version = $Version } | ConvertTo-Json -Compress | Set-Content -LiteralPath $buildConfig -Encoding utf8NoBOM -NoNewline
+$pinnedToolHandles = [Collections.Generic.List[System.IO.FileStream]]::new()
+$heldMakensisSha256 = ''
 
 Push-Location $appRoot
 try {
     npm ci
+    $tauriCli = Join-Path $appRoot 'node_modules\.bin\tauri.cmd'
+    $tauriCliVersion = (& $tauriCli --version | Out-String).Trim()
+    if ($tauriCliVersion -cne 'tauri-cli 2.11.4') {
+        throw "Unexpected Tauri CLI version: $tauriCliVersion"
+    }
     npm run sync-engine
     npm test
     npx tsc --noEmit
     npm run build
     cargo test --locked --manifest-path src-tauri\Cargo.toml
+    Invoke-PinnedTauriToolCheck -Operation prepare
+    Invoke-PinnedTauriToolCheck -Operation verify
+    Assert-PinnedWebViewAuthenticode
+
+    foreach ($pinnedToolPath in @($pinnedWebView, $pinnedMakensis, $pinnedNsisPlugin)) {
+        $held = [IO.File]::Open(
+            $pinnedToolPath,
+            [IO.FileMode]::Open,
+            [IO.FileAccess]::Read,
+            [IO.FileShare]::Read
+        )
+        $pinnedToolHandles.Add($held)
+    }
+    Assert-HeldPinnedFile `
+        -Stream $pinnedToolHandles[0] `
+        -ExpectedSha256 $webViewSha256 `
+        -Description 'WebView2 offline installer'
+    $heldMakensisSha256 = Get-HeldStreamSha256 -Stream $pinnedToolHandles[1]
+    Assert-HeldPinnedFile `
+        -Stream $pinnedToolHandles[2] `
+        -ExpectedSha256 $nsisPluginSha256 `
+        -Description 'NSIS Tauri plugin'
+
     npm run tauri -- build --ci --bundles nsis --config $buildConfig -- --locked
+    Invoke-PinnedTauriToolCheck -Operation verify
+    Assert-HeldPinnedFile `
+        -Stream $pinnedToolHandles[0] `
+        -ExpectedSha256 $webViewSha256 `
+        -Description 'WebView2 offline installer'
+    Assert-HeldPinnedFile `
+        -Stream $pinnedToolHandles[1] `
+        -ExpectedSha256 $heldMakensisSha256 `
+        -Description 'NSIS compiler'
+    Assert-HeldPinnedFile `
+        -Stream $pinnedToolHandles[2] `
+        -ExpectedSha256 $nsisPluginSha256 `
+        -Description 'NSIS Tauri plugin'
+    Assert-PinnedWebViewAuthenticode
+    Assert-GeneratedNsisUsesPinnedWebView
 }
 finally {
     Pop-Location
+    foreach ($handle in $pinnedToolHandles) {
+        $handle.Dispose()
+    }
     Remove-Item -LiteralPath $buildConfig -Force -ErrorAction SilentlyContinue
 }
 

--- a/ports/tauri/packaging/windows/verify-bundle.ps1
+++ b/ports/tauri/packaging/windows/verify-bundle.ps1
@@ -68,6 +68,28 @@ $requirementsPath = Join-Path $Root 'wsl-requirements.txt'
 $requirementsText = if (Test-Path $requirementsPath -PathType Leaf) {
     Get-Content -Raw -Path $requirementsPath
 } else { '' }
+$packagingRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$artifactVerifier = Join-Path $packagingRoot 'verify_python_artifact_lock.py'
+$artifactLock = Join-Path $packagingRoot 'python-artifacts-linux-cp313-x86_64.lock.json'
+$artifactSha256 = Join-Path $packagingRoot 'python-artifacts-linux-cp313-x86_64.sha256'
+$wheelRequirements = Join-Path $packagingRoot 'python-wheels-linux-cp313-x86_64.requirements.txt'
+$saneRequirements = Join-Path $packagingRoot 'python-sane-linux-cp313-x86_64.requirements.txt'
+$wheelhouse = Join-Path $Root 'Wheelhouse'
+& python -I -B $artifactVerifier `
+    --lock $artifactLock `
+    --wheel-requirements $wheelRequirements `
+    --sdist-requirements $saneRequirements `
+    --combined-requirements $requirementsPath `
+    --sha256sums $artifactSha256 `
+    --directory $wheelhouse `
+    --allow-ledger
+if ($LASTEXITCODE -eq 0) {
+    Write-Host 'PASS  exact locked WSL Python artifact set'
+}
+else {
+    Write-Host 'FAIL  exact locked WSL Python artifact set' -ForegroundColor Red
+    $failures += 1
+}
 $pins = @(
     'setuptools==83.0.0',
     'numpy==2.5.1',
@@ -80,7 +102,7 @@ $pins = @(
     'python-sane==2.9.2'
 )
 foreach ($pin in $pins) {
-    if ($requirementsText.Contains("$pin --hash=sha256:")) {
+    if ($requirementsText.IndexOf("$pin --hash=sha256:", [StringComparison]::OrdinalIgnoreCase) -ge 0) {
         Write-Host "PASS  pinned offline requirement $pin"
     }
     else {

--- a/ports/tauri/packaging/windows/verify-bundle.sh
+++ b/ports/tauri/packaging/windows/verify-bundle.sh
@@ -143,6 +143,23 @@ fi
 # The offline wheelhouse must contain every pinned requirement, and its
 # installer must preserve the local-project ordering and fail-closed flags.
 requirements="$root/wsl-requirements.txt"
+artifact_verifier="$repo_root/packaging/verify_python_artifact_lock.py"
+artifact_lock="$repo_root/packaging/python-artifacts-linux-cp313-x86_64.lock.json"
+artifact_sha256="$repo_root/packaging/python-artifacts-linux-cp313-x86_64.sha256"
+wheel_requirements="$repo_root/packaging/python-wheels-linux-cp313-x86_64.requirements.txt"
+sane_requirements="$repo_root/packaging/python-sane-linux-cp313-x86_64.requirements.txt"
+if "$HOST_PYTHON" -I -B "$artifact_verifier" \
+    --lock "$artifact_lock" \
+    --wheel-requirements "$wheel_requirements" \
+    --sdist-requirements "$sane_requirements" \
+    --combined-requirements "$requirements" \
+    --sha256sums "$artifact_sha256" \
+    --directory "$root/Wheelhouse" --allow-ledger; then
+    printf 'PASS  exact locked WSL Python artifact set\n'
+else
+    printf 'FAIL  exact locked WSL Python artifact set\n' >&2
+    failures=$((failures + 1))
+fi
 for requirement in \
     'setuptools==83.0.0' \
     'numpy==2.5.1' \
@@ -153,7 +170,7 @@ for requirement in \
     'jinja2==3.1.6' \
     'MarkupSafe==3.0.3' \
     'python-sane==2.9.2'; do
-    if [[ -f "$requirements" ]] && grep -Fq "$requirement --hash=sha256:" "$requirements"; then
+    if [[ -f "$requirements" ]] && grep -Fiq "$requirement --hash=sha256:" "$requirements"; then
         printf 'PASS  pinned offline requirement %s\n' "$requirement"
     else
         printf 'FAIL  pinned offline requirement %s\n' "$requirement" >&2

--- a/scripts/check_coolscanpy_pypi_sync.sh
+++ b/scripts/check_coolscanpy_pypi_sync.sh
@@ -6,7 +6,7 @@
 # debugging confusion the instrumented-refusal work exists to prevent
 # (owner policy, 2026-08-08: "keep them in sync so there's no delta").
 #
-# Mechanics: download the latest published coolscanpy sdist and compare its
+# Mechanics: download the exact authenticated coolscanpy 0.7.1 sdist and compare its
 # src/coolscanpy tree byte-for-byte against this repo's vendored
 # coolscanpy/src/coolscanpy. Version strings are NOT trusted as the primary
 # signal (an unbumped version with changed code is precisely the failure
@@ -49,30 +49,12 @@ KNOWN_VENDORED_DIVERGENCE=(
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
-echo "fetching latest published coolscanpy from PyPI..."
-meta="$workdir/meta.json"
-curl --fail --silent --show-error --location \
-  https://pypi.org/pypi/coolscanpy/json > "$meta"
-
-pypi_version="$(python3 -c "import json;print(json.load(open('$meta'))['info']['version'])")"
-sdist_url="$(python3 - "$meta" <<'PY'
-import json, sys
-data = json.load(open(sys.argv[1]))
-for f in data["urls"]:
-    if f["packagetype"] == "sdist":
-        print(f["url"]); break
-else:
-    raise SystemExit("no sdist on the latest PyPI release")
-PY
-)"
-
-curl --fail --silent --show-error --location "$sdist_url" > "$workdir/sdist.tar.gz"
-tar -xzf "$workdir/sdist.tar.gz" -C "$workdir"
-published_src="$(find "$workdir" -type d -path '*/src/coolscanpy' | head -1)"
-if [ -z "$published_src" ]; then
-  echo "::error::coolscanpy PyPI sync gate: sdist layout unexpected (no src/coolscanpy)"
-  exit 1
-fi
+echo "fetching authenticated coolscanpy 0.7.1 source from PyPI..."
+published_root="$(python3 -I -S -B scripts/fetch_pinned_coolscanpy_sdist.py \
+  --destination "$workdir/published")"
+published_src="$published_root/src/coolscanpy"
+test -d "$published_src"
+pypi_version="0.7.1"
 
 printf '%s\n' "${KNOWN_VENDORED_DIVERGENCE[@]}" > "$workdir/exemptions"
 if PUBLISHED_SRC="$published_src" VENDORED_DIR="$VENDORED_DIR" \

--- a/scripts/check_github_action_pins.py
+++ b/scripts/check_github_action_pins.py
@@ -1,75 +1,733 @@
 #!/usr/bin/env python3
-"""Fail when a workflow executes an external action without a full SHA pin."""
+"""Enforce a small, fail-closed GitHub workflow action policy.
+
+This checker intentionally does not import a YAML implementation.  Workflow files are
+security inputs, and a permissive parser (or regexes that merely find text resembling
+``uses``) makes it too easy for YAML aliases, duplicate keys, block scalars, or alternate
+node spellings to create a different document than the policy reviewed.  Instead, the
+checker accepts only the canonical YAML subset used by this repository, builds its
+structure, and then inspects executable action locations.
+"""
 
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
 import re
+import stat
 import sys
+import unicodedata
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_ROOT = REPOSITORY_ROOT / ".github" / "workflows"
-USES_RE = re.compile(r"^(?P<indent>\s*)(?:-\s*)?uses:\s*(?P<value>.+?)\s*$")
-EXTERNAL_RE = re.compile(r"^[^\s@]+@(?P<ref>[0-9a-f]{40})$")
+MAX_WORKFLOW_BYTES = 1024 * 1024
+MAX_WORKFLOW_FILES = 128
+MAX_NESTING = 64
+
+EXTERNAL_ACTION_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9_.-]+"
+    r"(?:/[A-Za-z0-9_.-]+)*@[0-9a-f]{40}$"
+)
+KEY_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.-]*")
+PROPERTY_RE = re.compile(r"(?:^|\s)[&*][A-Za-z0-9_.-]+(?:\s|$)|(?:^|\s)![^\s]+")
+
+FORBIDDEN_SETUP_ACTIONS = {
+    "actions/setup-node",
+    "actions/setup-python",
+    "astral-sh/setup-uv",
+}
+RUST_TOOLCHAIN_VERSION = "1.97.1"
+REVIEWED_UV_ENVIRONMENT = {
+    "UV_PYTHON_PREFERENCE": "only-managed",
+    "UV_PYTHON_CPYTHON_BUILD": "20260718",
+}
 
 
-def _uses_value(raw: str) -> str:
-    value = raw.split("#", 1)[0].strip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
-        value = value[1:-1]
-    return value
+class PolicyError(Exception):
+    """A source file is outside the accepted canonical workflow subset."""
+
+    def __init__(self, message: str, line: int | None = None):
+        super().__init__(message)
+        self.message = message
+        self.line = line
+
+
+class _Line:
+    __slots__ = ("indent", "number", "text")
+
+    def __init__(self, indent: int, number: int, text: str):
+        self.indent = indent
+        self.number = number
+        self.text = text
+
+
+class _Node:
+    __slots__ = ("kind", "line", "style", "value")
+
+    def __init__(
+        self,
+        kind: str,
+        value: object,
+        line: int,
+        style: str | None = None,
+    ):
+        self.kind = kind
+        self.value = value
+        self.line = line
+        self.style = style
+
+
+def _strip_comment(text: str, line: int) -> str:
+    """Strip a YAML comment while validating scalar quote balance."""
+
+    quote: str | None = None
+    index = 0
+    while index < len(text):
+        character = text[index]
+        if quote == "'":
+            if character == "'":
+                if index + 1 < len(text) and text[index + 1] == "'":
+                    index += 2
+                    continue
+                quote = None
+        elif quote == '"':
+            if character == "\\":
+                index += 2
+                continue
+            if character == '"':
+                quote = None
+        elif character in "'\"" and (
+            index == 0 or text[index - 1].isspace() or text[index - 1] in "[:,"
+        ):
+            quote = character
+        elif character == "#" and (index == 0 or text[index - 1].isspace()):
+            return text[:index].rstrip()
+        index += 1
+    if quote is not None:
+        raise PolicyError("unterminated quoted scalar", line)
+    return text.rstrip()
+
+
+def _mapping_parts(text: str, line: int) -> tuple[str, str]:
+    if text.startswith(("?", "'", '"')) or text.startswith("<<"):
+        raise PolicyError(
+            "quoted, explicit, and merge mapping keys are forbidden", line
+        )
+    match = re.fullmatch(r"([^:]+):(?:\s+(.*))?", text)
+    if match is None:
+        raise PolicyError("expected a canonical block mapping entry", line)
+    key = match.group(1)
+    if KEY_RE.fullmatch(key) is None:
+        raise PolicyError(f"non-canonical mapping key: {key}", line)
+    return key, match.group(2) or ""
+
+
+def _decode_quoted_scalar(value: str, line: int) -> str:
+    if value.startswith("'"):
+        if len(value) < 2 or not value.endswith("'"):
+            raise PolicyError("unterminated single-quoted scalar", line)
+        inner = value[1:-1]
+        index = 0
+        while index < len(inner):
+            if inner[index] == "'":
+                if index + 1 >= len(inner) or inner[index + 1] != "'":
+                    raise PolicyError("invalid single-quoted scalar", line)
+                index += 2
+            else:
+                index += 1
+        decoded = inner.replace("''", "'")
+        if any(
+            unicodedata.category(character) in {"Cc", "Cf", "Cs"}
+            for character in decoded
+        ):
+            raise PolicyError("decoded scalar contains a control character", line)
+        return decoded
+    try:
+        decoded = json.loads(value)
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise PolicyError(
+            "double-quoted scalars must use JSON-compatible escapes", line
+        ) from error
+    if not isinstance(decoded, str):
+        raise PolicyError("expected a quoted string scalar", line)
+    if any(
+        unicodedata.category(character) in {"Cc", "Cf", "Cs"} for character in decoded
+    ):
+        raise PolicyError("decoded scalar contains a control character", line)
+    return decoded
+
+
+def _plain_scalar(value: str, line: int) -> _Node:
+    if value.startswith(("- ", "? ", ": ", "#", "]", "}", ",", "%", "@", "`")):
+        raise PolicyError("plain scalar starts with a reserved YAML indicator", line)
+    if re.search(r":(?:\s|$)", value):
+        raise PolicyError("plain scalar contains a colon followed by whitespace", line)
+    if value[0] in "&*!":
+        raise PolicyError("YAML anchors, aliases, and tags are forbidden", line)
+    if PROPERTY_RE.search(value):
+        raise PolicyError("YAML anchors, aliases, and tags are forbidden", line)
+    if value.startswith(("|", ">")):
+        raise PolicyError("folded and unexpected block scalars are forbidden", line)
+    if value.startswith("{") or value.endswith("}") and value.startswith("{"):
+        raise PolicyError("flow mappings are forbidden", line)
+    return _Node("scalar", value, line, "plain")
+
+
+def _quoted_scalar(value: str, line: int) -> _Node:
+    quote = value[0]
+    index = 1
+    while index < len(value):
+        if quote == "'" and value[index] == "'":
+            if index + 1 < len(value) and value[index + 1] == "'":
+                index += 2
+                continue
+            break
+        if quote == '"' and value[index] == "\\":
+            index += 2
+            continue
+        if value[index] == quote:
+            break
+        index += 1
+    if index >= len(value) or value[index + 1 :].strip():
+        raise PolicyError("quoted scalar must occupy the complete value", line)
+    return _Node("scalar", _decode_quoted_scalar(value, line), line, "quoted")
+
+
+def _flow_items(value: str, line: int) -> list[str]:
+    if not value.endswith("]"):
+        raise PolicyError("unterminated flow sequence", line)
+    body = value[1:-1]
+    items: list[str] = []
+    start = 0
+    quote: str | None = None
+    index = 0
+    while index < len(body):
+        character = body[index]
+        if quote == "'":
+            if character == "'":
+                if index + 1 < len(body) and body[index + 1] == "'":
+                    index += 2
+                    continue
+                quote = None
+        elif quote == '"':
+            if character == "\\":
+                index += 2
+                continue
+            if character == '"':
+                quote = None
+        elif character in "'\"":
+            quote = character
+        elif character == ",":
+            items.append(body[start:index].strip())
+            start = index + 1
+        elif character in "[]{}":
+            raise PolicyError(
+                "nested flow collections and flow mappings are forbidden", line
+            )
+        index += 1
+    if quote is not None:
+        raise PolicyError("unterminated quoted flow-sequence item", line)
+    tail = body[start:].strip()
+    if tail:
+        items.append(tail)
+    elif body.strip():
+        raise PolicyError("trailing flow-sequence commas are forbidden", line)
+    if any(not item for item in items):
+        raise PolicyError("empty flow-sequence items are forbidden", line)
+    return items
+
+
+def _inline_node(value: str, key: str | None, line: int) -> _Node:
+    if value == "|":
+        if key not in {"run", "path"}:
+            raise PolicyError("block scalars are allowed only for run and path", line)
+        return _Node("block", None, line, "literal")
+    if value.startswith(("|", ">")):
+        raise PolicyError(
+            "only exact run: | and path: | literal blocks are allowed", line
+        )
+    if value.startswith("{"):
+        raise PolicyError("flow mappings are forbidden", line)
+    if value.startswith("["):
+        nodes = [_inline_node(item, None, line) for item in _flow_items(value, line)]
+        if any(node.kind != "scalar" for node in nodes):
+            raise PolicyError("flow sequences may contain only scalars", line)
+        return _Node("list", nodes, line, "flow")
+    if value.startswith(("'", '"')):
+        return _quoted_scalar(value, line)
+    return _plain_scalar(value, line)
+
+
+def _logical_lines(source: str) -> list[_Line]:
+    physical = source.split("\n")[:-1]
+    logical: list[_Line] = []
+    index = 0
+    while index < len(physical):
+        raw = physical[index]
+        number = index + 1
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            index += 1
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        if indent % 2:
+            raise PolicyError("indentation must use two-space increments", number)
+        text = _strip_comment(raw[indent:], number)
+        if not text:
+            index += 1
+            continue
+        if text.startswith("%") or text in {"---", "..."}:
+            raise PolicyError(
+                "YAML directives and document markers are forbidden", number
+            )
+        logical.append(_Line(indent, number, text))
+
+        block_match = re.fullmatch(r"([^:]+):\s*(\|[^\s]*)", text)
+        if block_match is not None and block_match.group(2) == "|":
+            block_key = block_match.group(1)
+            if block_key in {"run", "path"}:
+                index += 1
+                while index < len(physical):
+                    body_line = physical[index]
+                    if not body_line.strip():
+                        index += 1
+                        continue
+                    body_indent = len(body_line) - len(body_line.lstrip(" "))
+                    if body_indent <= indent:
+                        break
+                    index += 1
+                continue
+        index += 1
+    return logical
+
+
+class _Parser:
+    def __init__(self, lines: list[_Line]):
+        self.lines = lines
+
+    def parse(self) -> _Node:
+        if not self.lines:
+            raise PolicyError("workflow document is empty")
+        if self.lines[0].indent != 0:
+            raise PolicyError(
+                "root mapping must start at column one", self.lines[0].number
+            )
+        node, index = self._block(0, 0, 0)
+        if index != len(self.lines):
+            raise PolicyError("unexpected trailing YAML node", self.lines[index].number)
+        if node.kind != "map":
+            raise PolicyError("workflow root must be a mapping", node.line)
+        return node
+
+    def _block(self, index: int, indent: int, depth: int) -> tuple[_Node, int]:
+        if depth > MAX_NESTING:
+            raise PolicyError(
+                f"workflow nesting exceeds {MAX_NESTING} levels",
+                self.lines[index].number,
+            )
+        if self.lines[index].indent != indent:
+            raise PolicyError(
+                "nested blocks must increase indentation by two spaces",
+                self.lines[index].number,
+            )
+        if self.lines[index].text == "-" or self.lines[index].text.startswith("- "):
+            return self._sequence(index, indent, depth)
+        return self._mapping(index, indent, depth)
+
+    def _entry(
+        self, text: str, line: int, indent: int, next_index: int, depth: int
+    ) -> tuple[str, _Node, int]:
+        key, raw_value = _mapping_parts(text, line)
+        if raw_value:
+            node = _inline_node(raw_value, key, line)
+            if next_index < len(self.lines) and self.lines[next_index].indent > indent:
+                raise PolicyError(
+                    "a scalar mapping value cannot also own a nested block",
+                    self.lines[next_index].number,
+                )
+            return key, node, next_index
+        if next_index < len(self.lines) and self.lines[next_index].indent > indent:
+            if self.lines[next_index].indent != indent + 2:
+                raise PolicyError(
+                    "nested blocks must increase indentation by two spaces",
+                    self.lines[next_index].number,
+                )
+            node, next_index = self._block(next_index, indent + 2, depth + 1)
+            return key, node, next_index
+        return key, _Node("null", None, line), next_index
+
+    def _mapping(self, index: int, indent: int, depth: int) -> tuple[_Node, int]:
+        entries: dict[str, _Node] = {}
+        start_line = self.lines[index].number
+        while index < len(self.lines) and self.lines[index].indent == indent:
+            current = self.lines[index]
+            if current.text == "-" or current.text.startswith("- "):
+                raise PolicyError(
+                    "cannot mix block mappings and sequences", current.number
+                )
+            key, node, index = self._entry(
+                current.text, current.number, indent, index + 1, depth
+            )
+            if key in entries:
+                raise PolicyError(f"duplicate mapping key: {key}", current.number)
+            entries[key] = node
+        return _Node("map", entries, start_line), index
+
+    def _sequence(self, index: int, indent: int, depth: int) -> tuple[_Node, int]:
+        items: list[_Node] = []
+        start_line = self.lines[index].number
+        while index < len(self.lines) and self.lines[index].indent == indent:
+            current = self.lines[index]
+            if current.text != "-" and not current.text.startswith("- "):
+                raise PolicyError(
+                    "cannot mix block sequences and mappings", current.number
+                )
+            item_text = current.text[1:].lstrip()
+            index += 1
+            if not item_text:
+                if index >= len(self.lines) or self.lines[index].indent != indent + 2:
+                    raise PolicyError(
+                        "empty sequence item must own a nested block", current.number
+                    )
+                item, index = self._block(index, indent + 2, depth + 1)
+                items.append(item)
+                continue
+
+            try:
+                _mapping_parts(item_text, current.number)
+            except PolicyError:
+                item = _inline_node(item_text, None, current.number)
+                if index < len(self.lines) and self.lines[index].indent > indent:
+                    raise PolicyError(
+                        "a scalar sequence item cannot own a nested block",
+                        self.lines[index].number,
+                    )
+                items.append(item)
+                continue
+
+            mapping_indent = indent + 2
+            entries: dict[str, _Node] = {}
+            key, node, index = self._entry(
+                item_text, current.number, mapping_indent, index, depth + 1
+            )
+            entries[key] = node
+            while index < len(self.lines) and self.lines[index].indent > indent:
+                following = self.lines[index]
+                if following.indent != mapping_indent:
+                    raise PolicyError(
+                        "sequence mappings use one two-space indentation level",
+                        following.number,
+                    )
+                key, node, index = self._entry(
+                    following.text,
+                    following.number,
+                    mapping_indent,
+                    index + 1,
+                    depth + 1,
+                )
+                if key in entries:
+                    raise PolicyError(f"duplicate mapping key: {key}", following.number)
+                entries[key] = node
+            items.append(_Node("map", entries, current.number))
+        return _Node("list", items, start_line), index
+
+
+def _read_workflow(path: Path) -> str:
+    expected = os.lstat(path)
+    if not stat.S_ISREG(expected.st_mode):
+        raise PolicyError("workflow path is not a regular file")
+    flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    descriptor = os.open(path, flags)
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise PolicyError("workflow path is not a regular file")
+        if (expected.st_dev, expected.st_ino) != (before.st_dev, before.st_ino):
+            raise PolicyError("workflow identity changed while opening it")
+        if before.st_size > MAX_WORKFLOW_BYTES:
+            raise PolicyError(f"workflow exceeds {MAX_WORKFLOW_BYTES} bytes")
+        chunks: list[bytes] = []
+        total = 0
+        while total <= MAX_WORKFLOW_BYTES:
+            chunk = os.read(descriptor, min(65536, MAX_WORKFLOW_BYTES + 1 - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+        data = b"".join(chunks)
+        after = os.fstat(descriptor)
+        identity_before = (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+        )
+        identity_after = (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+        if identity_before != identity_after or len(data) != before.st_size:
+            raise PolicyError("workflow changed during the bounded read")
+        if len(data) > MAX_WORKFLOW_BYTES:
+            raise PolicyError(f"workflow exceeds {MAX_WORKFLOW_BYTES} bytes")
+    finally:
+        os.close(descriptor)
+
+    if data.startswith(b"\xef\xbb\xbf"):
+        raise PolicyError("UTF-8 BOM is forbidden")
+    try:
+        source = data.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise PolicyError("workflow is not strict UTF-8") from error
+    if not source.endswith("\n"):
+        raise PolicyError("workflow must end with an LF")
+    for index, character in enumerate(source):
+        if character == "\n":
+            continue
+        if character in {"\r", "\t", "\x00"} or unicodedata.category(character) in {
+            "Cc",
+            "Cf",
+            "Cs",
+        }:
+            line = source.count("\n", 0, index) + 1
+            raise PolicyError(
+                "BOM, NUL, CR, tabs, and control characters are forbidden", line
+            )
+    return source
+
+
+def _map(node: _Node, description: str) -> dict[str, _Node]:
+    if node.kind != "map":
+        raise PolicyError(f"{description} must be a block mapping", node.line)
+    return node.value  # type: ignore[return-value]
+
+
+def _scalar(node: _Node, description: str, *, plain: bool = False) -> str:
+    if node.kind != "scalar" or plain and node.style != "plain":
+        suffix = " plain scalar" if plain else " scalar"
+        raise PolicyError(f"{description} must be a{suffix}", node.line)
+    return node.value  # type: ignore[return-value]
+
+
+def _check_uv_environment(node: _Node, location: str, violations: list[str]) -> None:
+    try:
+        environment = _map(node, f"{location} env")
+    except PolicyError as error:
+        violations.append(f"{location}:{error.line}: {error.message}")
+        return
+    for key, value_node in environment.items():
+        if not key.casefold().startswith("uv_"):
+            continue
+        expected = REVIEWED_UV_ENVIRONMENT.get(key)
+        if expected is None:
+            violations.append(
+                f"{location}:{value_node.line}: unreviewed uv environment key: {key}"
+            )
+            continue
+        try:
+            actual = _scalar(value_node, f"env.{key}")
+        except PolicyError as error:
+            violations.append(f"{location}:{error.line}: {error.message}")
+            continue
+        if actual != expected:
+            violations.append(
+                f"{location}:{value_node.line}: env.{key} must equal {expected}"
+            )
+
+
+def _check_rust_toolchain(
+    owner: dict[str, _Node],
+    location: str,
+    uses_line: int,
+    violations: list[str],
+) -> None:
+    with_node = owner.get("with")
+    if with_node is None:
+        violations.append(
+            f"{location}:{uses_line}: dtolnay/rust-toolchain requires an exact with mapping"
+        )
+        return
+    try:
+        inputs = _map(with_node, "dtolnay/rust-toolchain with")
+    except PolicyError as error:
+        violations.append(f"{location}:{error.line}: {error.message}")
+        return
+    if set(inputs) != {"toolchain"}:
+        violations.append(
+            f"{location}:{with_node.line}: dtolnay/rust-toolchain must have only "
+            "the reviewed toolchain input"
+        )
+    toolchain = inputs.get("toolchain")
+    if toolchain is not None:
+        try:
+            actual = _scalar(toolchain, "dtolnay/rust-toolchain input toolchain")
+        except PolicyError as error:
+            violations.append(f"{location}:{error.line}: {error.message}")
+        else:
+            if actual != RUST_TOOLCHAIN_VERSION:
+                violations.append(
+                    f"{location}:{toolchain.line}: dtolnay/rust-toolchain input "
+                    f"toolchain must equal {RUST_TOOLCHAIN_VERSION}"
+                )
+
+
+def _check_uses(
+    node: _Node,
+    owner: dict[str, _Node],
+    location: str,
+    violations: list[str],
+) -> int:
+    try:
+        action = _scalar(node, "uses", plain=True)
+    except PolicyError as error:
+        violations.append(f"{location}:{error.line}: {error.message}")
+        return 0
+    if action.startswith("./"):
+        violations.append(
+            f"{location}:{node.line}: local action wrappers are forbidden: {action}"
+        )
+        return 0
+    if action.startswith("docker://"):
+        violations.append(
+            f"{location}:{node.line}: docker action wrappers are forbidden: {action}"
+        )
+        return 0
+
+    count = 1
+    action_path = action.rsplit("@", 1)[0]
+    if EXTERNAL_ACTION_RE.fullmatch(action) is None or any(
+        segment in {".", ".."} for segment in action_path.split("/")
+    ):
+        violations.append(
+            f"{location}:{node.line}: external action is not pinned to a full "
+            f"lowercase commit SHA: {action}"
+        )
+        return count
+
+    action_name = action.split("@", 1)[0].casefold()
+    if any(
+        action_name == forbidden or action_name.startswith(f"{forbidden}/")
+        for forbidden in FORBIDDEN_SETUP_ACTIONS
+    ):
+        violations.append(
+            f"{location}:{node.line}: {action_name} is forbidden; use the "
+            "repository-owned hash-verified tool installer"
+        )
+    elif action_name == "dtolnay/rust-toolchain":
+        _check_rust_toolchain(owner, location, node.line, violations)
+    elif action_name == "actions/checkout":
+        with_node = owner.get("with")
+        try:
+            inputs = _map(with_node, "actions/checkout with") if with_node else {}
+            persisted = inputs.get("persist-credentials")
+            if (
+                persisted is None
+                or _scalar(persisted, "persist-credentials", plain=True) != "false"
+            ):
+                raise PolicyError(
+                    "actions/checkout must set persist-credentials: false", node.line
+                )
+        except PolicyError as error:
+            violations.append(f"{location}:{error.line}: {error.message}")
+    return count
+
+
+def _inspect_workflow(root: _Node, relative: Path) -> tuple[int, list[str]]:
+    violations: list[str] = []
+    count = 0
+    root_map = _map(root, "workflow root")
+    if "env" in root_map:
+        _check_uv_environment(root_map["env"], str(relative), violations)
+    jobs_node = root_map.get("jobs")
+    if jobs_node is None:
+        return 0, [f"{relative}: workflow must contain a jobs mapping"]
+    jobs = _map(jobs_node, "jobs")
+    for job_name, job_node in jobs.items():
+        location = f"{relative}:jobs.{job_name}"
+        try:
+            job = _map(job_node, location)
+        except PolicyError as error:
+            violations.append(f"{relative}:{error.line}: {error.message}")
+            continue
+        if "env" in job:
+            _check_uv_environment(job["env"], location, violations)
+        has_job_uses = "uses" in job
+        has_steps = "steps" in job
+        if has_job_uses == has_steps:
+            violations.append(
+                f"{location}:{job_node.line}: job must define exactly one of uses or steps"
+            )
+            continue
+        if has_job_uses:
+            count += _check_uses(job["uses"], job, location, violations)
+            continue
+        steps_node = job["steps"]
+        if steps_node.kind != "list" or steps_node.style == "flow":
+            violations.append(
+                f"{location}:{steps_node.line}: steps must be a block sequence of mappings"
+            )
+            continue
+        for step_index, step_node in enumerate(steps_node.value, 1):
+            step_location = f"{location}.steps[{step_index}]"
+            if step_node.kind != "map":
+                violations.append(
+                    f"{step_location}:{step_node.line}: each step must be a block mapping"
+                )
+                continue
+            step = step_node.value
+            if "env" in step:
+                _check_uv_environment(step["env"], step_location, violations)
+            if "uses" in step:
+                count += _check_uses(step["uses"], step, step_location, violations)
+    return count, violations
 
 
 def main() -> int:
     violations: list[str] = []
     external_count = 0
-    workflow_paths = sorted(WORKFLOW_ROOT.glob("*.yml")) + sorted(
-        WORKFLOW_ROOT.glob("*.yaml")
+    try:
+        entries = list(WORKFLOW_ROOT.iterdir())
+    except OSError as error:
+        print(
+            f"GitHub Actions pin policy failed: cannot enumerate workflows: {error}",
+            file=sys.stderr,
+        )
+        return 1
+    workflow_paths = sorted(
+        path for path in entries if path.suffix in {".yml", ".yaml"}
     )
+    if len(workflow_paths) > MAX_WORKFLOW_FILES:
+        violations.append(f"workflow directory exceeds {MAX_WORKFLOW_FILES} YAML files")
+        workflow_paths = workflow_paths[:MAX_WORKFLOW_FILES]
     for path in workflow_paths:
-        lines = path.read_text(encoding="utf-8").splitlines()
-        for index, line in enumerate(lines):
-            match = USES_RE.match(line)
-            if match is None:
-                continue
-            value = _uses_value(match.group("value"))
-            if value.startswith("./") or value.startswith("docker://"):
-                continue
-            external_count += 1
-            if EXTERNAL_RE.fullmatch(value) is None:
-                violations.append(
-                    f"{path.relative_to(REPOSITORY_ROOT)}:{index + 1}: "
-                    f"external action is not pinned to a full lowercase commit SHA: {value}"
-                )
-                continue
-
-            if value.startswith("actions/checkout@"):
-                step_indent = len(match.group("indent"))
-                persists_credentials = False
-                for following in lines[index + 1 :]:
-                    if not following.strip() or following.lstrip().startswith("#"):
-                        continue
-                    following_indent = len(following) - len(following.lstrip())
-                    if following_indent <= step_indent:
-                        break
-                    if re.match(r"^\s*persist-credentials:\s*false\s*(?:#.*)?$", following):
-                        persists_credentials = True
-                if not persists_credentials:
-                    violations.append(
-                        f"{path.relative_to(REPOSITORY_ROOT)}:{index + 1}: "
-                        "actions/checkout must set persist-credentials: false"
-                    )
-
+        relative = path.relative_to(REPOSITORY_ROOT)
+        try:
+            source = _read_workflow(path)
+            root = _Parser(_logical_lines(source)).parse()
+            count, path_violations = _inspect_workflow(root, relative)
+            external_count += count
+            violations.extend(path_violations)
+        except (OSError, PolicyError) as error:
+            if isinstance(error, PolicyError):
+                line = f":{error.line}" if error.line is not None else ""
+                message = error.message
+            else:
+                line = ""
+                message = str(error)
+            violations.append(f"{relative}{line}: {message}")
     if external_count == 0:
-        violations.append("no external workflow actions were found")
+        violations.append(
+            "no external workflow actions were found in executable job locations"
+        )
     if violations:
         print("GitHub Actions pin policy failed:", file=sys.stderr)
         print("\n".join(f"  {violation}" for violation in violations), file=sys.stderr)
         return 1
-    print(
-        f"GitHub Actions pin policy passed: {external_count} external uses entries"
-    )
+    print(f"GitHub Actions pin policy passed: {external_count} external uses entries")
     return 0
 
 

--- a/scripts/fetch_pinned_coolscanpy_sdist.py
+++ b/scripts/fetch_pinned_coolscanpy_sdist.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Fetch and safely extract the exact CoolScanPy sdist accepted for release."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path, PurePosixPath
+import stat
+import sys
+import tarfile
+import time
+import tomllib
+import unicodedata
+import urllib.request
+
+
+VERSION = "0.7.1"
+FILENAME = f"coolscanpy-{VERSION}.tar.gz"
+URL = (
+    "https://files.pythonhosted.org/packages/12/d2/"
+    "0af2aaa7810adf016987c380f642835cd95eaef0dc50f7a51b0b85bf1d98/"
+    f"{FILENAME}"
+)
+SIZE = 531_413
+SHA256 = "ae089ee7dca40f38ed72217f8a6d2eeda17433b34f31c207ee18b7c3af40b34e"
+ROOT = f"coolscanpy-{VERSION}"
+ENTRY_COUNT = 103
+FILE_COUNT = 88
+DIRECTORY_COUNT = 15
+EXPANDED_FILE_BYTES = 2_353_965
+
+
+class FetchError(RuntimeError):
+    """The published source cannot be authenticated or safely extracted."""
+
+
+def download(destination: Path) -> None:
+    request = urllib.request.Request(
+        URL,
+        headers={"Accept-Encoding": "identity", "User-Agent": "ScanStudio-release"},
+    )
+    deadline = time.monotonic() + 180
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+        if response.geturl() != URL:
+            raise FetchError(f"unexpected CoolScanPy redirect: {response.geturl()}")
+        if response.headers.get("Content-Encoding") not in (None, "identity"):
+            raise FetchError("compressed HTTP transfer is not allowed")
+        if response.headers.get("Content-Length") != str(SIZE):
+            raise FetchError("CoolScanPy sdist Content-Length changed")
+        received = 0
+        digest = hashlib.sha256()
+        with destination.open("xb") as output:
+            while chunk := response.read(min(1024 * 1024, SIZE - received + 1)):
+                if time.monotonic() > deadline:
+                    raise FetchError("CoolScanPy sdist download exceeded its deadline")
+                received += len(chunk)
+                if received > SIZE:
+                    raise FetchError("CoolScanPy sdist exceeded its pinned size")
+                digest.update(chunk)
+                output.write(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        if received != SIZE or digest.hexdigest() != SHA256:
+            raise FetchError("CoolScanPy sdist size or SHA-256 mismatch")
+
+
+def member_path(name: str) -> PurePosixPath:
+    if not name or "\\" in name or "\x00" in name:
+        raise FetchError(f"unsafe CoolScanPy archive member: {name!r}")
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts or path.parts[0] != ROOT:
+        raise FetchError(f"CoolScanPy archive member escaped its root: {name!r}")
+    if any(part in ("", ".") for part in path.parts):
+        raise FetchError(f"ambiguous CoolScanPy archive member: {name!r}")
+    return path
+
+
+def extract(archive: Path, destination: Path) -> Path:
+    destination.mkdir(mode=0o700)
+    with tarfile.open(archive, mode="r:gz") as bundle:
+        members = bundle.getmembers()
+        files = sum(member.isfile() for member in members)
+        directories = sum(member.isdir() for member in members)
+        total = sum(member.size for member in members if member.isfile())
+        actual_shape = (len(members), files, directories, total)
+        expected_shape = (
+            ENTRY_COUNT,
+            FILE_COUNT,
+            DIRECTORY_COUNT,
+            EXPANDED_FILE_BYTES,
+        )
+        if actual_shape != expected_shape:
+            raise FetchError(
+                f"CoolScanPy archive shape changed: {actual_shape} != {expected_shape}"
+            )
+        validated: list[tuple[tarfile.TarInfo, PurePosixPath]] = []
+        seen: set[str] = set()
+        for member in members:
+            path = member_path(member.name)
+            key = unicodedata.normalize("NFC", path.as_posix()).casefold()
+            if key in seen:
+                raise FetchError(
+                    f"colliding CoolScanPy archive member: {member.name!r}"
+                )
+            seen.add(key)
+            if not member.isfile() and not member.isdir():
+                raise FetchError(
+                    f"CoolScanPy archive contains a link or special entry: {member.name!r}"
+                )
+            validated.append((member, path))
+
+        for member, path in validated:
+            output = destination.joinpath(*path.parts)
+            if member.isdir():
+                output.mkdir(mode=0o700, parents=True, exist_ok=True)
+                continue
+            output.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            source = bundle.extractfile(member)
+            if source is None:
+                raise FetchError(f"could not open CoolScanPy member: {member.name!r}")
+            copied = 0
+            with source, output.open("xb") as target:
+                while chunk := source.read(1024 * 1024):
+                    copied += len(chunk)
+                    if copied > member.size:
+                        raise FetchError(
+                            f"CoolScanPy member exceeded its size: {member.name!r}"
+                        )
+                    target.write(chunk)
+                target.flush()
+                os.fsync(target.fileno())
+            if copied != member.size:
+                raise FetchError(f"short CoolScanPy member: {member.name!r}")
+
+    source_root = destination / ROOT
+    pyproject = source_root / "pyproject.toml"
+    metadata = pyproject.lstat()
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+        raise FetchError("published CoolScanPy pyproject is not a plain file")
+    with pyproject.open("rb") as handle:
+        published_version = tomllib.load(handle)["project"]["version"]
+    if published_version != VERSION:
+        raise FetchError(f"published CoolScanPy version changed: {published_version!r}")
+    return source_root
+
+
+def fetch(destination: Path, repository_root: Path) -> Path:
+    with (repository_root / "coolscanpy" / "pyproject.toml").open("rb") as handle:
+        vendored_version = tomllib.load(handle)["project"]["version"]
+    if vendored_version != VERSION:
+        raise FetchError(
+            f"vendored CoolScanPy version {vendored_version!r} is not pinned {VERSION!r}"
+        )
+    try:
+        destination.mkdir(mode=0o700)
+    except FileExistsError as error:
+        raise FetchError(f"source destination already exists: {destination}") from error
+    archive = destination / FILENAME
+    download(archive)
+    source = extract(archive, destination / "extracted")
+    print(source)
+    return source
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--destination", required=True, type=Path)
+    parser.add_argument(
+        "--repository-root", type=Path, default=Path(__file__).resolve().parents[1]
+    )
+    args = parser.parse_args()
+    try:
+        fetch(args.destination, args.repository_root)
+    except (FetchError, OSError, KeyError, tarfile.TarError) as error:
+        print(f"Pinned CoolScanPy source fetch failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_pinned_cargo_about.py
+++ b/scripts/install_pinned_cargo_about.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Build cargo-about 0.9.1 from its authenticated crate archive and lock."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import time
+import urllib.request
+
+
+VERSION = "0.9.1"
+ASSET_URL = "https://static.crates.io/crates/cargo-about/cargo-about-0.9.1.crate"
+ASSET_SIZE = 96_994
+ASSET_SHA256 = "4d62bfc04a579b87777727b0f5f389f72bdeb1c6cc8fbcf1c0e0c736c9b5b7a4"
+ARCHIVE_ROOT = f"cargo-about-{VERSION}"
+ARCHIVE_ENTRIES = 77
+MAX_EXPANDED_BYTES = 2 * 1024 * 1024
+
+
+class InstallError(RuntimeError):
+    """The authenticated cargo-about installation cannot proceed safely."""
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download(destination: Path) -> None:
+    request = urllib.request.Request(
+        ASSET_URL,
+        headers={"Accept-Encoding": "identity", "User-Agent": "ScanStudio-release"},
+    )
+    deadline = time.monotonic() + 180
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+        if response.geturl() != ASSET_URL:
+            raise InstallError(f"unexpected cargo-about redirect: {response.geturl()}")
+        if response.headers.get("Content-Encoding") not in (None, "identity"):
+            raise InstallError("compressed HTTP transfer is not allowed")
+        length = response.headers.get("Content-Length")
+        if length != str(ASSET_SIZE):
+            raise InstallError(
+                f"cargo-about Content-Length mismatch: expected {ASSET_SIZE}, got {length!r}"
+            )
+        received = 0
+        digest = hashlib.sha256()
+        with destination.open("xb") as output:
+            while chunk := response.read(min(1024 * 1024, ASSET_SIZE - received + 1)):
+                if time.monotonic() > deadline:
+                    raise InstallError("cargo-about download exceeded its deadline")
+                received += len(chunk)
+                if received > ASSET_SIZE:
+                    raise InstallError("cargo-about download exceeded its pinned size")
+                digest.update(chunk)
+                output.write(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        if received != ASSET_SIZE:
+            raise InstallError(
+                f"cargo-about download was short: expected {ASSET_SIZE}, got {received}"
+            )
+        if digest.hexdigest() != ASSET_SHA256:
+            raise InstallError("cargo-about crate SHA-256 mismatch")
+
+
+def member_path(name: str) -> PurePosixPath:
+    if not name or "\\" in name or "\x00" in name:
+        raise InstallError(f"unsafe cargo-about archive member: {name!r}")
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts or path.parts[0] != ARCHIVE_ROOT:
+        raise InstallError(f"cargo-about archive member escaped its root: {name!r}")
+    return path
+
+
+def extract(archive: Path, destination: Path) -> Path:
+    destination.mkdir(mode=0o700)
+    with tarfile.open(archive, mode="r:gz") as bundle:
+        members = bundle.getmembers()
+        if len(members) != ARCHIVE_ENTRIES:
+            raise InstallError(
+                f"cargo-about archive entry count changed: {len(members)}"
+            )
+        total = 0
+        seen: set[str] = set()
+        for member in members:
+            path = member_path(member.name)
+            key = path.as_posix().casefold()
+            if key in seen:
+                raise InstallError(f"colliding cargo-about member: {member.name!r}")
+            seen.add(key)
+            if member.isfile():
+                total += member.size
+                if member.size < 0 or total > MAX_EXPANDED_BYTES:
+                    raise InstallError("cargo-about archive exceeds its expanded bound")
+            elif not member.isdir():
+                raise InstallError(
+                    f"cargo-about archive contains a link or special entry: {member.name!r}"
+                )
+        bundle.extractall(destination, members=members, filter="data")
+    source = destination / ARCHIVE_ROOT
+    for required in ("Cargo.toml", "Cargo.lock", "src/cargo-about/main.rs"):
+        path = source / required
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise InstallError(f"cargo-about source input is not a plain file: {path}")
+    return source
+
+
+def clean_cargo_environment(root: Path) -> dict[str, str]:
+    forbidden = (
+        "CARGO_REGISTRIES_",
+        "CARGO_SOURCE_",
+        "CARGO_HTTP_",
+        "CARGO_NET_",
+        "RUSTC_WRAPPER",
+        "RUSTFLAGS",
+    )
+    inherited = [
+        key for key in os.environ if any(key.startswith(prefix) for prefix in forbidden)
+    ]
+    if inherited:
+        raise InstallError(
+            "refusing inherited Cargo source/tool overrides: " + ", ".join(inherited)
+        )
+    environment = os.environ.copy()
+    cargo_home = root / "cargo-home"
+    cargo_home.mkdir(mode=0o700)
+    environment.update(
+        {
+            "CARGO_HOME": str(cargo_home),
+            "CARGO_NET_GIT_FETCH_WITH_CLI": "false",
+            "CARGO_HTTP_TIMEOUT": "60",
+            "CARGO_TERM_COLOR": "never",
+        }
+    )
+    return environment
+
+
+def append_github_path(path: Path | None, value: Path) -> None:
+    if path is None:
+        return
+    if "\n" in str(value) or "\r" in str(value):
+        raise InstallError("refusing a multiline GitHub PATH entry")
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(f"{value}\n")
+
+
+def install(root: Path, github_path: Path | None) -> Path:
+    try:
+        root.mkdir(mode=0o700)
+    except FileExistsError as error:
+        raise InstallError(
+            f"cargo-about install root already exists: {root}"
+        ) from error
+    archive = root / f"cargo-about-{VERSION}.crate"
+    download(archive)
+    if sha256_file(archive) != ASSET_SHA256:
+        raise InstallError("cargo-about crate changed after download")
+    source = extract(archive, root / "source")
+    cargo = shutil.which("cargo")
+    if cargo is None:
+        raise InstallError("verified Cargo is unavailable")
+    install_root = root / "installed"
+    environment = clean_cargo_environment(root)
+    subprocess.run(
+        [
+            cargo,
+            "install",
+            "--path",
+            str(source),
+            "--locked",
+            "--features",
+            "cli",
+            "--root",
+            str(install_root),
+        ],
+        check=True,
+        timeout=900,
+        env=environment,
+    )
+    executable = (
+        install_root / "bin" / ("cargo-about.exe" if os.name == "nt" else "cargo-about")
+    )
+    metadata = executable.lstat()
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+        raise InstallError("built cargo-about is not a plain regular file")
+    version = subprocess.run(
+        [executable, "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=environment,
+    ).stdout.strip()
+    if version != f"cargo-about {VERSION}":
+        raise InstallError(f"unexpected cargo-about version: {version!r}")
+    append_github_path(github_path, executable.parent)
+    print(
+        f"Pinned cargo-about verified: version={version} crate={ASSET_SHA256} "
+        f"binary_sha256={sha256_file(executable)}"
+    )
+    return executable
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--install-root", required=True, type=Path)
+    parser.add_argument(
+        "--github-path",
+        type=Path,
+        default=Path(os.environ["GITHUB_PATH"])
+        if "GITHUB_PATH" in os.environ
+        else None,
+    )
+    args = parser.parse_args()
+    try:
+        install(args.install_root, args.github_path)
+    except (
+        InstallError,
+        OSError,
+        subprocess.SubprocessError,
+        tarfile.TarError,
+    ) as error:
+        print(f"Pinned cargo-about installation failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_pinned_node.py
+++ b/scripts/install_pinned_node.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Install the exact Node.js build used by ScanStudio packaging workflows."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path, PurePosixPath
+import platform
+import stat
+import subprocess
+import sys
+import tarfile
+import time
+import urllib.request
+import zipfile
+
+VERSION = "22.23.2"
+MAX_ARCHIVE_BYTES = 128 * 1024 * 1024
+MAX_EXTRACTED_BYTES = 768 * 1024 * 1024
+MAX_ARCHIVE_ENTRIES = 100_000
+
+PLATFORMS = {
+    ("Darwin", "arm64"): {
+        "asset": f"node-v{VERSION}-darwin-arm64.tar.gz",
+        "archive_sha256": "61130f394c1630d211dd50aecc4353d379480f36d3ac913cd85dbba1aed585c6",
+        "executable": f"node-v{VERSION}-darwin-arm64/bin/node",
+        "executable_sha256": "18e387c90ab8a8400183e8bdd396376e1e875b91b4c874b894dcade7b35bf572",
+        "path": f"node-v{VERSION}-darwin-arm64/bin",
+        "npm_cli": f"node-v{VERSION}-darwin-arm64/lib/node_modules/npm/bin/npm-cli.js",
+        "node_arch": "arm64",
+        "kind": "tar",
+    },
+    ("Darwin", "x86_64"): {
+        "asset": f"node-v{VERSION}-darwin-x64.tar.gz",
+        "archive_sha256": "58e99022c2ff89395576cc7fd4d98cea24bb68081475d5f88b801ee8729fb026",
+        "executable": f"node-v{VERSION}-darwin-x64/bin/node",
+        "executable_sha256": "0b4f059915f3bf3c6cbb02422f4a529bfb21cbbec2d29851c9a5d833f78a04f6",
+        "path": f"node-v{VERSION}-darwin-x64/bin",
+        "npm_cli": f"node-v{VERSION}-darwin-x64/lib/node_modules/npm/bin/npm-cli.js",
+        "node_arch": "x64",
+        "kind": "tar",
+    },
+    ("Linux", "x86_64"): {
+        "asset": f"node-v{VERSION}-linux-x64.tar.xz",
+        "archive_sha256": "d60acfe00a2932254bb0ad20e01b0d74397a0875595de719654b214f4b03f307",
+        "executable": f"node-v{VERSION}-linux-x64/bin/node",
+        "executable_sha256": "3517c2df0b2f8cd7f422b4b8450ef81c6889f08eb03e281d6de9079b15e6a327",
+        "path": f"node-v{VERSION}-linux-x64/bin",
+        "npm_cli": f"node-v{VERSION}-linux-x64/lib/node_modules/npm/bin/npm-cli.js",
+        "node_arch": "x64",
+        "kind": "tar",
+    },
+    ("Windows", "AMD64"): {
+        "asset": f"node-v{VERSION}-win-x64.zip",
+        "archive_sha256": "1177b4137ba5adaa56354ae40f1080c7450e8ae09cecb47da459d1c52ac99f97",
+        "executable": f"node-v{VERSION}-win-x64/node.exe",
+        "executable_sha256": "0d0f5e39f9f3d9587bc19f73eab3c2c9c4903fd02d6dbf9c853dd81b3d95fad4",
+        "path": f"node-v{VERSION}-win-x64",
+        "npm_cli": f"node-v{VERSION}-win-x64/node_modules/npm/bin/npm-cli.js",
+        "node_arch": "x64",
+        "kind": "zip",
+    },
+}
+
+
+class InstallError(RuntimeError):
+    pass
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validated_member_path(name: str, expected_root: str) -> PurePosixPath:
+    if not name or "\\" in name or "\x00" in name:
+        raise InstallError(f"unsafe archive member name: {name!r}")
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts or path.parts[0] != expected_root:
+        raise InstallError(f"archive member escapes the expected root: {name!r}")
+    return path
+
+
+def validated_link_target(
+    member: PurePosixPath, target: str, expected_root: str
+) -> None:
+    if not target or "\\" in target or "\x00" in target:
+        raise InstallError(f"unsafe archive link target: {target!r}")
+    target_path = PurePosixPath(target)
+    if target_path.is_absolute():
+        raise InstallError(f"absolute archive link target: {target!r}")
+    combined: list[str] = []
+    for component in (*member.parent.parts, *target_path.parts):
+        if component in ("", "."):
+            continue
+        if component == "..":
+            if not combined:
+                raise InstallError(f"archive link escapes root: {target!r}")
+            combined.pop()
+        else:
+            combined.append(component)
+    if not combined or combined[0] != expected_root:
+        raise InstallError(f"archive link escapes root: {target!r}")
+
+
+def ensure_directory_chain(root: Path, parts: tuple[str, ...]) -> Path:
+    current = root
+    for part in parts:
+        current /= part
+        try:
+            current.mkdir(mode=0o755)
+        except FileExistsError:
+            metadata = current.lstat()
+            if not stat.S_ISDIR(metadata.st_mode) or current.is_symlink():
+                raise InstallError(
+                    f"Node extraction parent is not a safe directory: {current}"
+                )
+    return current
+
+
+def download(url: str, destination: Path) -> None:
+    deadline = time.monotonic() + 180
+    request = urllib.request.Request(url, headers={"Accept-Encoding": "identity"})
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+        if response.geturl() != url:
+            raise InstallError(
+                f"unexpected Node download redirect: {response.geturl()}"
+            )
+        if response.headers.get("Content-Encoding") not in (None, "identity"):
+            raise InstallError("compressed HTTP transfer is not allowed")
+        length_header = response.headers.get("Content-Length")
+        if length_header is None or not length_header.isdecimal():
+            raise InstallError("Node download omitted a valid Content-Length")
+        expected_length = int(length_header)
+        if expected_length <= 0 or expected_length > MAX_ARCHIVE_BYTES:
+            raise InstallError("Node download length is outside the allowed bound")
+        received = 0
+        with destination.open("xb") as output:
+            while chunk := response.read(
+                min(1024 * 1024, expected_length - received + 1)
+            ):
+                if time.monotonic() > deadline:
+                    raise InstallError("Node download exceeded its total deadline")
+                received += len(chunk)
+                if received > expected_length or received > MAX_ARCHIVE_BYTES:
+                    raise InstallError("Node download exceeded its declared length")
+                output.write(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        if received != expected_length:
+            raise InstallError(
+                f"Node download length mismatch: expected {expected_length}, got {received}"
+            )
+
+
+def extract_tar(archive: Path, destination: Path, expected_root: str) -> None:
+    mode = "r:gz" if archive.name.endswith(".tar.gz") else "r:xz"
+    with tarfile.open(archive, mode=mode) as bundle:
+        members = bundle.getmembers()
+        if not members or len(members) > MAX_ARCHIVE_ENTRIES:
+            raise InstallError("Node tar entry count is outside the allowed bound")
+        total = 0
+        seen: set[str] = set()
+        prepared: list[tuple[tarfile.TarInfo, PurePosixPath]] = []
+        for member in members:
+            path = validated_member_path(member.name, expected_root)
+            key = path.as_posix().rstrip("/").casefold()
+            if key in seen:
+                raise InstallError(
+                    f"duplicate/colliding Node tar member: {member.name!r}"
+                )
+            seen.add(key)
+            if member.isfile():
+                total += member.size
+                if member.size < 0 or total > MAX_EXTRACTED_BYTES:
+                    raise InstallError("Node tar payload exceeds the allowed bound")
+            elif member.issym():
+                validated_link_target(path, member.linkname, expected_root)
+            elif member.islnk():
+                raise InstallError(f"Node tar contains a hard link: {member.name!r}")
+            elif not member.isdir():
+                raise InstallError(f"unsupported Node tar entry type: {member.name!r}")
+            prepared.append((member, path))
+
+        # Python 3.10's backported ``data`` filter rejects Node's legitimate
+        # ``bin/npm -> ../lib/...`` link on Ubuntu 22.04 by resolving it from
+        # the extraction root instead of the link's parent. Extract the fully
+        # prevalidated archive ourselves so the same create-only containment
+        # policy works on every declared build host.
+        nofollow = getattr(os, "O_NOFOLLOW", 0)
+        for member, path in prepared:
+            parent = ensure_directory_chain(destination, path.parts[:-1])
+            target = parent / path.name
+            if member.isdir():
+                ensure_directory_chain(destination, path.parts)
+                continue
+            if member.issym():
+                os.symlink(member.linkname, target)
+                continue
+
+            source = bundle.extractfile(member)
+            if source is None:
+                raise InstallError(f"could not open Node tar member: {member.name!r}")
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow
+            descriptor = os.open(target, flags, member.mode & 0o777)
+            written = 0
+            try:
+                with source, os.fdopen(descriptor, "wb", closefd=False) as output:
+                    while chunk := source.read(1024 * 1024):
+                        written += len(chunk)
+                        if written > member.size:
+                            raise InstallError(
+                                f"Node tar member exceeded its size: {member.name!r}"
+                            )
+                        output.write(chunk)
+                    output.flush()
+                    os.fsync(output.fileno())
+            finally:
+                os.close(descriptor)
+            if written != member.size:
+                raise InstallError(f"short Node tar member: {member.name!r}")
+
+
+def extract_zip(archive: Path, destination: Path, expected_root: str) -> None:
+    with zipfile.ZipFile(archive) as bundle:
+        members = bundle.infolist()
+        if not members or len(members) > MAX_ARCHIVE_ENTRIES:
+            raise InstallError("Node zip entry count is outside the allowed bound")
+        total = 0
+        seen: set[str] = set()
+        for member in members:
+            path = validated_member_path(member.filename, expected_root)
+            key = path.as_posix().rstrip("/").casefold()
+            if key in seen:
+                raise InstallError(
+                    f"duplicate/colliding Node zip member: {member.filename!r}"
+                )
+            seen.add(key)
+            mode = member.external_attr >> 16
+            if stat.S_ISLNK(mode):
+                raise InstallError(
+                    f"Node zip contains a symbolic link: {member.filename!r}"
+                )
+            file_type = stat.S_IFMT(mode)
+            if file_type not in (0, stat.S_IFREG, stat.S_IFDIR):
+                raise InstallError(
+                    f"Node zip contains a special entry: {member.filename!r}"
+                )
+            total += member.file_size
+            if total > MAX_EXTRACTED_BYTES:
+                raise InstallError("Node zip payload exceeds the allowed bound")
+        bundle.extractall(destination)
+
+
+def install(
+    install_root: Path, github_path: Path | None, github_env: Path | None
+) -> Path:
+    platform_key = (platform.system(), platform.machine())
+    details = PLATFORMS.get(platform_key)
+    if details is None:
+        raise InstallError(f"unsupported Node build host: {platform_key!r}")
+    try:
+        install_root.mkdir(mode=0o700)
+    except FileExistsError as error:
+        raise InstallError(
+            f"Node install root already exists: {install_root}"
+        ) from error
+
+    asset = str(details["asset"])
+    archive = install_root / asset
+    url = f"https://nodejs.org/dist/v{VERSION}/{asset}"
+    download(url, archive)
+    actual_archive_sha = sha256_file(archive)
+    if actual_archive_sha != details["archive_sha256"]:
+        raise InstallError(
+            f"Node archive digest mismatch: expected {details['archive_sha256']}, "
+            f"got {actual_archive_sha}"
+        )
+
+    expected_root = (
+        asset.removesuffix(".tar.gz").removesuffix(".tar.xz").removesuffix(".zip")
+    )
+    if details["kind"] == "tar":
+        extract_tar(archive, install_root, expected_root)
+    else:
+        extract_zip(archive, install_root, expected_root)
+
+    executable = install_root / str(details["executable"])
+    if executable.is_symlink() or not executable.is_file():
+        raise InstallError("Node executable is not a regular non-link file")
+    actual_executable_sha = sha256_file(executable)
+    if actual_executable_sha != details["executable_sha256"]:
+        raise InstallError(
+            f"Node executable digest mismatch: expected {details['executable_sha256']}, "
+            f"got {actual_executable_sha}"
+        )
+    version = subprocess.run(
+        [executable, "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    ).stdout.strip()
+    if version != f"v{VERSION}":
+        raise InstallError(f"unexpected Node runtime version: {version!r}")
+
+    node_arch = subprocess.run(
+        [executable, "-p", "process.arch"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    ).stdout.strip()
+    if node_arch != details["node_arch"]:
+        raise InstallError(f"unexpected Node architecture: {node_arch!r}")
+    npm_cli = install_root / str(details["npm_cli"])
+    if npm_cli.is_symlink() or not npm_cli.is_file():
+        raise InstallError("npm CLI is not a regular non-link file")
+    npm_version = subprocess.run(
+        [executable, npm_cli, "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    ).stdout.strip()
+    if npm_version != "10.9.8":
+        raise InstallError(f"unexpected npm version: {npm_version!r}")
+
+    bin_path = install_root / str(details["path"])
+    if github_path is not None:
+        with github_path.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(f"{bin_path}\n")
+    if github_env is not None:
+        with github_env.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(f"SCANSTUDIO_NODE_BIN={bin_path}\n")
+    print(
+        f"Pinned Node verified: version={version} archive={actual_archive_sha} "
+        f"executable={actual_executable_sha} npm={npm_version} arch={node_arch} "
+        f"path={bin_path}"
+    )
+    return bin_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--install-root", type=Path, required=True)
+    parser.add_argument(
+        "--github-path",
+        type=Path,
+        default=Path(os.environ["GITHUB_PATH"])
+        if "GITHUB_PATH" in os.environ
+        else None,
+    )
+    parser.add_argument(
+        "--github-env",
+        type=Path,
+        default=Path(os.environ["GITHUB_ENV"]) if "GITHUB_ENV" in os.environ else None,
+    )
+    args = parser.parse_args()
+    try:
+        install(args.install_root, args.github_path, args.github_env)
+    except (
+        InstallError,
+        OSError,
+        subprocess.SubprocessError,
+        tarfile.TarError,
+        zipfile.BadZipFile,
+    ) as error:
+        print(f"Pinned Node installation failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_pinned_uv_python.py
+++ b/scripts/install_pinned_uv_python.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Install hash-pinned uv and its exact managed CPython build for CI/release."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import platform
+import stat
+import subprocess
+import sys
+import tarfile
+import time
+import urllib.request
+import zipfile
+
+UV_VERSION = "0.11.30"
+PYTHON_VERSION = "3.13.14"
+PYTHON_BUILD = "20260718"
+ENSUREPIP_VERSION = "26.1.2"
+PYTHON_MIRROR = "https://github.com/astral-sh/python-build-standalone/releases/download"
+MAX_ARCHIVE_BYTES = 64 * 1024 * 1024
+MAX_EXTRACTED_BYTES = 256 * 1024 * 1024
+MAX_ARCHIVE_ENTRIES = 128
+
+PLATFORMS = {
+    ("Darwin", "arm64"): {
+        "asset": "uv-aarch64-apple-darwin.tar.gz",
+        "archive_sha256": "9bed3567d496d8dab84ecf7a1247551ac94ef1baaebb7b65df008dd93e9dc357",
+        "executable": "uv-aarch64-apple-darwin/uv",
+        "executable_sha256": "254a9afbcd66edd329a1a00ad5b0142c3285e6b354461800211ecffab74167fe",
+        "python_machine": "arm64",
+        "kind": "tar",
+    },
+    ("Darwin", "x86_64"): {
+        "asset": "uv-x86_64-apple-darwin.tar.gz",
+        "archive_sha256": "ce285fbbfbe294b1e1bc6c87c8b59d9622b85383b88b2b132a2df5c73e83d7c1",
+        "executable": "uv-x86_64-apple-darwin/uv",
+        "executable_sha256": "81ef2b6fb3e9959034393d1b55c7b0cca34be0fbaf8e2dac56a996d366c9c120",
+        "python_machine": "x86_64",
+        "kind": "tar",
+    },
+    ("Linux", "x86_64"): {
+        "asset": "uv-x86_64-unknown-linux-gnu.tar.gz",
+        "archive_sha256": "04bc7d180d6138bf6dc08387acf507a823f397a98fea55da36b0ccc7fbce3b68",
+        "executable": "uv-x86_64-unknown-linux-gnu/uv",
+        "executable_sha256": "9a4299a0c3bcc01012acbcdae7b5655e5087e0e5d87459306736a1420a902b81",
+        "python_machine": "x86_64",
+        "kind": "tar",
+    },
+    ("Windows", "AMD64"): {
+        "asset": "uv-x86_64-pc-windows-msvc.zip",
+        "archive_sha256": "be8d78c992312212e5cc05e9f9de3fa996db73b7c86a186dfb9231eb9f91d33e",
+        # The authenticated Windows ZIP has exactly three root-level
+        # executables, unlike the Unix archives' single directory root.
+        "archive_root": None,
+        "executable": "uv.exe",
+        "executable_sha256": "2773193ff0f378c8b0c7e1417fb35f63a50dbd9fa9a09174aef7cce313e7789e",
+        "python_machine": "AMD64",
+        "kind": "zip",
+    },
+}
+
+
+class InstallError(RuntimeError):
+    pass
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validated_member_path(name: str, expected_root: str | None) -> PurePosixPath:
+    if not name or "\\" in name or "\x00" in name:
+        raise InstallError(f"unsafe archive member name: {name!r}")
+    path = PurePosixPath(name)
+    if (
+        path.is_absolute()
+        or ".." in path.parts
+        or any(part in {"", "."} for part in path.parts)
+        or expected_root is not None
+        and path.parts[0] != expected_root
+    ):
+        raise InstallError(f"archive member escapes the expected root: {name!r}")
+    return path
+
+
+def download(url: str, destination: Path) -> None:
+    deadline = time.monotonic() + 180
+    request = urllib.request.Request(url, headers={"Accept-Encoding": "identity"})
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+        final_url = response.geturl()
+        if not final_url.startswith("https://"):
+            raise InstallError(f"uv download left HTTPS: {final_url}")
+        if response.headers.get("Content-Encoding") not in (None, "identity"):
+            raise InstallError("compressed HTTP transfer is not allowed")
+        length_header = response.headers.get("Content-Length")
+        if length_header is None or not length_header.isdecimal():
+            raise InstallError("uv download omitted a valid Content-Length")
+        expected_length = int(length_header)
+        if expected_length <= 0 or expected_length > MAX_ARCHIVE_BYTES:
+            raise InstallError("uv download length is outside the allowed bound")
+        received = 0
+        with destination.open("xb") as output:
+            while chunk := response.read(
+                min(1024 * 1024, expected_length - received + 1)
+            ):
+                if time.monotonic() > deadline:
+                    raise InstallError("uv download exceeded its total deadline")
+                received += len(chunk)
+                if received > expected_length or received > MAX_ARCHIVE_BYTES:
+                    raise InstallError("uv download exceeded its declared length")
+                output.write(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        if received != expected_length:
+            raise InstallError(
+                f"uv download length mismatch: expected {expected_length}, got {received}"
+            )
+
+
+def extract_tar(archive: Path, destination: Path, expected_root: str) -> None:
+    with tarfile.open(archive, mode="r:gz") as bundle:
+        members = bundle.getmembers()
+        if not members or len(members) > MAX_ARCHIVE_ENTRIES:
+            raise InstallError("uv tar entry count is outside the allowed bound")
+        total = 0
+        seen: set[str] = set()
+        for member in members:
+            path = validated_member_path(member.name, expected_root)
+            key = path.as_posix().rstrip("/").casefold()
+            if key in seen:
+                raise InstallError(
+                    f"duplicate/colliding uv tar member: {member.name!r}"
+                )
+            seen.add(key)
+            if member.isfile():
+                total += member.size
+                if member.size < 0 or total > MAX_EXTRACTED_BYTES:
+                    raise InstallError("uv tar payload exceeds the allowed bound")
+            elif not member.isdir():
+                raise InstallError(f"unsupported uv tar entry type: {member.name!r}")
+        bundle.extractall(destination, members=members, filter="data")
+
+
+def extract_zip(archive: Path, destination: Path, expected_root: str | None) -> None:
+    with zipfile.ZipFile(archive) as bundle:
+        members = bundle.infolist()
+        if not members or len(members) > MAX_ARCHIVE_ENTRIES:
+            raise InstallError("uv zip entry count is outside the allowed bound")
+        total = 0
+        seen: set[str] = set()
+        for member in members:
+            path = validated_member_path(member.filename, expected_root)
+            key = path.as_posix().rstrip("/").casefold()
+            if key in seen:
+                raise InstallError(
+                    f"duplicate/colliding uv zip member: {member.filename!r}"
+                )
+            seen.add(key)
+            mode = member.external_attr >> 16
+            if stat.S_ISLNK(mode):
+                raise InstallError(
+                    f"uv zip contains a symbolic link: {member.filename!r}"
+                )
+            file_type = stat.S_IFMT(mode)
+            if file_type not in (0, stat.S_IFREG, stat.S_IFDIR):
+                raise InstallError(
+                    f"uv zip contains a special entry: {member.filename!r}"
+                )
+            total += member.file_size
+            if total > MAX_EXTRACTED_BYTES:
+                raise InstallError("uv zip payload exceeds the allowed bound")
+        bundle.extractall(destination)
+
+
+def clean_uv_environment(install_root: Path) -> dict[str, str]:
+    allowed_parent_keys = {
+        "COMSPEC",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "PATH",
+        "PATHEXT",
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+        "SYSTEMROOT",
+        "SystemRoot",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "USERPROFILE",
+        "WINDIR",
+    }
+    environment = {
+        key: value for key, value in os.environ.items() if key in allowed_parent_keys
+    }
+    config = install_root / "empty-uv.toml"
+    with config.open("xb") as handle:
+        handle.flush()
+        os.fsync(handle.fileno())
+    environment.update(
+        {
+            "UV_NO_CONFIG": "1",
+            "UV_CONFIG_FILE": str(config),
+            "UV_PYTHON": PYTHON_VERSION,
+            "UV_PYTHON_PREFERENCE": "only-managed",
+            "UV_PYTHON_DOWNLOADS": "automatic",
+            "UV_PYTHON_CPYTHON_BUILD": PYTHON_BUILD,
+            "UV_PYTHON_DOWNLOADS_JSON_URL": "",
+            "UV_PYTHON_INSTALL_MIRROR": PYTHON_MIRROR,
+            "UV_ASTRAL_MIRROR_URL": "",
+            "UV_PYTHON_NO_REGISTRY": "1",
+            "UV_PYTHON_INSTALL_REGISTRY": "0",
+            "UV_PYTHON_INSTALL_DIR": str(install_root / "python"),
+            "UV_PYTHON_CACHE_DIR": str(install_root / "python-cache"),
+            "UV_CACHE_DIR": str(install_root / "uv-cache"),
+            "UV_NO_PROGRESS": "1",
+            "UV_NO_MODIFY_PATH": "1",
+        }
+    )
+    if platform.system() == "Linux":
+        environment["UV_LIBC"] = "gnu"
+    return environment
+
+
+def append_github_file(path: Path | None, lines: list[str]) -> None:
+    if path is None:
+        return
+    for line in lines:
+        if "\n" in line or "\r" in line:
+            raise InstallError("refusing a multiline GitHub environment value")
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        for line in lines:
+            handle.write(f"{line}\n")
+
+
+def install(
+    install_root: Path, github_path: Path | None, github_env: Path | None
+) -> None:
+    platform_key = (platform.system(), platform.machine())
+    details = PLATFORMS.get(platform_key)
+    if details is None:
+        raise InstallError(f"unsupported uv build host: {platform_key!r}")
+    try:
+        install_root.mkdir(mode=0o700)
+    except FileExistsError as error:
+        raise InstallError(
+            f"toolchain install root already exists: {install_root}"
+        ) from error
+
+    asset = str(details["asset"])
+    archive = install_root / asset
+    url = f"https://github.com/astral-sh/uv/releases/download/{UV_VERSION}/{asset}"
+    download(url, archive)
+    archive_sha = sha256_file(archive)
+    if archive_sha != details["archive_sha256"]:
+        raise InstallError(
+            f"uv archive digest mismatch: expected {details['archive_sha256']}, got {archive_sha}"
+        )
+    expected_root = details.get(
+        "archive_root", asset.removesuffix(".tar.gz").removesuffix(".zip")
+    )
+    if details["kind"] == "tar":
+        extract_tar(archive, install_root, expected_root)
+    else:
+        extract_zip(archive, install_root, expected_root)
+
+    uv = install_root / str(details["executable"])
+    if uv.is_symlink() or not uv.is_file():
+        raise InstallError("uv executable is not a regular non-link file")
+    executable_sha = sha256_file(uv)
+    if executable_sha != details["executable_sha256"]:
+        raise InstallError(
+            f"uv executable digest mismatch: expected {details['executable_sha256']}, "
+            f"got {executable_sha}"
+        )
+    environment = clean_uv_environment(install_root)
+    uv_version = subprocess.run(
+        [uv, "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=environment,
+    ).stdout.strip()
+    if uv_version.split()[:2] != ["uv", UV_VERSION]:
+        raise InstallError(f"unexpected uv version: {uv_version!r}")
+
+    venv = install_root / "venv"
+    subprocess.run(
+        [
+            uv,
+            "venv",
+            str(venv),
+            "--python",
+            PYTHON_VERSION,
+            "--no-project",
+            "--clear",
+        ],
+        check=True,
+        timeout=300,
+        cwd=install_root,
+        env=environment,
+    )
+    venv_bin = venv / ("Scripts" if platform.system() == "Windows" else "bin")
+    python = venv_bin / ("python.exe" if platform.system() == "Windows" else "python3")
+    # The exact PBS archive carries CPython's bundled ensurepip wheel. Use that
+    # already-authenticated byte source instead of resolving a mutable pip from
+    # an index; packaging helpers legitimately need ``python -m pip download``.
+    subprocess.run(
+        [python, "-I", "-B", "-m", "ensurepip", "--default-pip"],
+        check=True,
+        timeout=120,
+        cwd=install_root,
+        env=environment,
+    )
+    pip_probe = subprocess.run(
+        [
+            python,
+            "-I",
+            "-B",
+            "-c",
+            (
+                "import json,pip; "
+                "print(json.dumps({'version': pip.__version__, 'file': pip.__file__}))"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=environment,
+    )
+    pip_identity = json.loads(pip_probe.stdout)
+    if pip_identity["version"] != ENSUREPIP_VERSION:
+        raise InstallError(f"unexpected ensurepip version: {pip_identity['version']!r}")
+    if not Path(pip_identity["file"]).resolve().is_relative_to(venv.resolve()):
+        raise InstallError("ensurepip package escaped the private venv")
+    probe = subprocess.run(
+        [
+            python,
+            "-I",
+            "-B",
+            "-c",
+            (
+                "import json,platform,sys; "
+                "print(json.dumps({'version': list(sys.version_info[:3]), "
+                "'machine': platform.machine(), 'executable': sys.executable, "
+                "'prefix': sys.prefix, 'base_prefix': sys.base_prefix}))"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=environment,
+    )
+    identity = json.loads(probe.stdout)
+    if identity["version"] != [3, 13, 14]:
+        raise InstallError(
+            f"unexpected managed Python version: {identity['version']!r}"
+        )
+    if identity["machine"].casefold() != str(details["python_machine"]).casefold():
+        raise InstallError(
+            f"unexpected managed Python architecture: {identity['machine']!r}"
+        )
+    if not Path(identity["prefix"]).resolve().is_relative_to(venv.resolve()):
+        raise InstallError("managed Python prefix escaped the private venv")
+    python_root = (install_root / "python").resolve()
+    base_prefix = Path(identity["base_prefix"]).resolve()
+    if not base_prefix.is_relative_to(python_root):
+        raise InstallError(
+            "managed Python base prefix escaped the private install root"
+        )
+    if base_prefix.parent != python_root:
+        raise InstallError("managed Python base prefix was not an exact private child")
+    build_file = base_prefix / "BUILD"
+    if (
+        build_file.is_symlink()
+        or not build_file.is_file()
+        or build_file.read_bytes() != PYTHON_BUILD.encode("ascii")
+    ):
+        raise InstallError("managed Python did not carry the exact PBS build identity")
+
+    uv_dir = uv.parent
+    append_github_file(github_path, [str(uv_dir), str(venv_bin)])
+    exported_environment = {
+        key: value for key, value in environment.items() if key.startswith("UV_")
+    }
+    exported_environment["VIRTUAL_ENV"] = str(venv)
+    append_github_file(
+        github_env,
+        [f"{key}={value}" for key, value in sorted(exported_environment.items())],
+    )
+    print(
+        f"Pinned uv/Python verified: uv={uv_version} uv_archive={archive_sha} "
+        f"uv_executable={executable_sha} python={identity['version']} "
+        f"pbs_build={PYTHON_BUILD} pip={pip_identity['version']} "
+        f"machine={identity['machine']}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--install-root", type=Path, required=True)
+    parser.add_argument(
+        "--github-path",
+        type=Path,
+        default=Path(os.environ["GITHUB_PATH"])
+        if "GITHUB_PATH" in os.environ
+        else None,
+    )
+    parser.add_argument(
+        "--github-env",
+        type=Path,
+        default=Path(os.environ["GITHUB_ENV"]) if "GITHUB_ENV" in os.environ else None,
+    )
+    args = parser.parse_args()
+    try:
+        install(args.install_root, args.github_path, args.github_env)
+    except (
+        InstallError,
+        OSError,
+        ValueError,
+        subprocess.SubprocessError,
+        tarfile.TarError,
+        zipfile.BadZipFile,
+    ) as error:
+        print(f"Pinned uv/Python installation failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_ubuntu_build_prerequisites.sh
+++ b/scripts/install_ubuntu_build_prerequisites.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Release/preview Linux packages must not change merely because an Ubuntu
+# mirror advanced between two runs.  This timestamped Ubuntu snapshot is an
+# immutable, archive-signed resolution boundary for every apt input below.
+readonly SNAPSHOT_STAMP="20260811T000000Z"
+readonly SNAPSHOT_BASE="https://snapshot.ubuntu.com/ubuntu/${SNAPSHOT_STAMP}"
+
+if [[ "$(uname -s)" != "Linux" ]] || [[ "$(dpkg --print-architecture)" != "amd64" ]]; then
+  echo "Pinned Ubuntu prerequisites require Linux amd64" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+source /etc/os-release
+if [[ "${ID:-}" != "ubuntu" ]] || [[ "${VERSION_ID:-}" != "22.04" ]]; then
+  echo "Pinned Ubuntu prerequisites require Ubuntu 22.04" >&2
+  exit 1
+fi
+
+task_root="$(mktemp -d "${RUNNER_TEMP:-/tmp}/scanstudio-ubuntu-snapshot.XXXXXX")"
+readonly task_root
+readonly sources_file="${task_root}/sources.list"
+readonly apt_lists="${task_root}/apt-lists"
+readonly apt_archives="${task_root}/apt-archives"
+mkdir -p "${apt_lists}/partial" "${apt_archives}/partial"
+chmod 0755 "${task_root}" "${apt_lists}" "${apt_lists}/partial" \
+  "${apt_archives}" "${apt_archives}/partial"
+
+cat >"${sources_file}" <<EOF
+deb [check-valid-until=no signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] ${SNAPSHOT_BASE} jammy main restricted universe multiverse
+deb [check-valid-until=no signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] ${SNAPSHOT_BASE} jammy-updates main restricted universe multiverse
+deb [check-valid-until=no signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] ${SNAPSHOT_BASE} jammy-security main restricted universe multiverse
+deb [check-valid-until=no signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] ${SNAPSHOT_BASE} jammy-backports main restricted universe multiverse
+EOF
+
+readonly expected_inrelease_hashes="${task_root}/expected-inrelease-hashes"
+cat >"${expected_inrelease_hashes}" <<'EOF'
+57600aafd922b5b4fd99f6cf3246ccd4f8cf61d5b1caccec6eec1ad2fe8abe23
+98c8715a56c88b08479728c388fdc9854cfd6473e208fb18d75505e3dafc30c7
+c14060cd8c6d625874dfcb9523a35a395bf4865c28b6b6a82569ef326fe92dc6
+dd1338c7614fc1d0cf40e310ef2d1a8a88c7659e13d46420e5040abdd53e1148
+EOF
+
+apt_options=(
+  -o "Dir::Etc::sourcelist=${sources_file}"
+  -o "Dir::Etc::sourceparts=-"
+  -o "Dir::State::lists=${apt_lists}"
+  -o "Dir::Cache::archives=${apt_archives}"
+  -o "Acquire::Check-Valid-Until=false"
+  -o "Acquire::Retries=3"
+  -o "Acquire::http::Timeout=30"
+  -o "Acquire::https::Timeout=30"
+)
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  apt_command=(apt-get)
+else
+  apt_command=(sudo apt-get)
+fi
+
+verify_consumed_inrelease() {
+  local actual_hashes="${task_root}/actual-inrelease-hashes"
+  mapfile -t inrelease_files < <(
+    find "${apt_lists}" -maxdepth 1 -type f -name '*_InRelease' -print | LC_ALL=C sort
+  )
+  if [[ "${#inrelease_files[@]}" -ne 4 ]]; then
+    echo "Expected exactly four apt InRelease files, got ${#inrelease_files[@]}" >&2
+    return 1
+  fi
+  sha256sum "${inrelease_files[@]}" | awk '{print $1}' | LC_ALL=C sort >"${actual_hashes}"
+  cmp "${expected_inrelease_hashes}" "${actual_hashes}"
+}
+
+# The immutable Ubuntu base image intentionally does not ship a CA bundle.
+# Bootstrap HTTPS using archive-signed metadata with peer validation disabled,
+# prove those exact InRelease bytes, then install CA/Python and immediately
+# discard/re-fetch all indexes with normal HTTPS peer verification enabled.
+"${apt_command[@]}" "${apt_options[@]}" \
+  -o "Acquire::https::Verify-Peer=false" update
+verify_consumed_inrelease
+"${apt_command[@]}" "${apt_options[@]}" \
+  -o "Acquire::https::Verify-Peer=false" install -y --no-install-recommends \
+  --allow-downgrades --reinstall ca-certificates curl python3
+find "${apt_lists}" -mindepth 1 -maxdepth 1 -type f -delete
+"${apt_command[@]}" "${apt_options[@]}" update
+verify_consumed_inrelease
+
+"${apt_command[@]}" "${apt_options[@]}" install -y --no-install-recommends \
+  --allow-downgrades --reinstall \
+  build-essential ca-certificates curl file libayatana-appindicator3-dev libfuse2 libgtk-3-dev \
+  libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev librsvg2-dev \
+  libsane-dev libssl-dev libusb-1.0-0 libwebkit2gtk-4.1-dev squashfs-tools \
+  libxdo-dev patchelf pkg-config python3 sane-utils wget
+
+echo "Ubuntu build prerequisites installed from ${SNAPSHOT_BASE}"
+readonly installed_manifest="${task_root}/installed-dpkg-manifest.tsv"
+dpkg-query -W -f='${binary:Package}\t${Version}\n' | LC_ALL=C sort >"${installed_manifest}"
+cat "${installed_manifest}"
+sha256sum "${installed_manifest}"

--- a/scripts/tests/test_check_github_action_pins.py
+++ b/scripts/tests/test_check_github_action_pins.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import os
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 import tempfile
@@ -10,10 +11,20 @@ import unittest
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 CHECKER_PATH = REPOSITORY_ROOT / "scripts" / "check_github_action_pins.py"
+GENERIC_ACTION = "owner/action@0123456789abcdef0123456789abcdef01234567"
+CHECKOUT_ACTION = "actions/checkout@11d5960a326750d5838078e36cf38b85af677262"
+SETUP_UV_ACTION = "astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9"
+SETUP_PYTHON_ACTION = "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
+SETUP_NODE_ACTION = "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020"
+RUST_TOOLCHAIN_ACTION = (
+    "dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c"
+)
 
 
 def load_checker():
-    spec = importlib.util.spec_from_file_location("check_github_action_pins", CHECKER_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "check_github_action_pins", CHECKER_PATH
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -21,12 +32,12 @@ def load_checker():
 
 
 class GitHubActionPinPolicyTests(unittest.TestCase):
-    def run_policy(self, workflow: str) -> tuple[int, str]:
+    def run_policy_data(self, workflow: bytes) -> tuple[int, str]:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             workflow_root = root / ".github" / "workflows"
             workflow_root.mkdir(parents=True)
-            (workflow_root / "test.yml").write_text(workflow, encoding="utf-8")
+            (workflow_root / "test.yml").write_bytes(workflow)
             checker = load_checker()
             checker.REPOSITORY_ROOT = root
             checker.WORKFLOW_ROOT = workflow_root
@@ -35,48 +46,552 @@ class GitHubActionPinPolicyTests(unittest.TestCase):
                 result = checker.main()
             return result, output.getvalue()
 
-    def test_full_sha_and_checkout_credential_fence_pass(self) -> None:
+    def run_policy(self, workflow: str) -> tuple[int, str]:
+        return self.run_policy_data(workflow.encode("utf-8"))
+
+    def assert_rejected(self, workflow: str, expected: str) -> None:
+        result, output = self.run_policy(workflow)
+        self.assertEqual(result, 1, output)
+        self.assertIn(expected, output)
+
+    def test_canonical_checkout_rust_and_literal_path_pass(self) -> None:
         result, output = self.run_policy(
-            """jobs:
+            f"""name: Canonical
+on:
+  push:
+jobs:
   test:
+    env:
+      UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: {CHECKOUT_ACTION}
         with:
           persist-credentials: false
-      - uses: owner/action@0123456789abcdef0123456789abcdef01234567
+      - uses: {RUST_TOOLCHAIN_ACTION}
+        with:
+          toolchain: '1.97.1'
+      - uses: {GENERIC_ACTION}
+        with:
+          path: |
+            first artifact
+            second artifact
 """
         )
         self.assertEqual(result, 0, output)
+        self.assertIn("3 external uses entries", output)
 
-    def test_every_mutable_or_abbreviated_ref_is_rejected(self) -> None:
+    def test_every_mutable_abbreviated_or_uppercase_sha_ref_is_rejected(self) -> None:
         for unsafe_ref in (
             "v4",
             "main",
             "release",
             "v4.2.2",
             "0123456789abcdef0123456789abcdef0123456",
+            "0123456789ABCDEF0123456789ABCDEF01234567",
         ):
             with self.subTest(unsafe_ref=unsafe_ref):
-                result, output = self.run_policy(
+                self.assert_rejected(
                     f"""jobs:
   test:
     steps:
       - uses: owner/action@{unsafe_ref}
-"""
+""",
+                    "not pinned to a full lowercase commit SHA",
                 )
-                self.assertEqual(result, 1)
-                self.assertIn("not pinned to a full lowercase commit SHA", output)
 
-    def test_checkout_must_disable_persisted_credentials(self) -> None:
+    def test_reusable_job_uses_is_structurally_inspected(self) -> None:
         result, output = self.run_policy(
+            """jobs:
+  delegated:
+    uses: owner/repository/.github/workflows/build.yml@0123456789abcdef0123456789abcdef01234567
+"""
+        )
+        self.assertEqual(result, 0, output)
+        self.assert_rejected(
+            """jobs:
+  delegated:
+    uses: owner/repository/.github/workflows/build.yml@main
+""",
+            "not pinned to a full lowercase commit SHA",
+        )
+
+    def test_literal_run_block_cannot_create_a_uses_decoy(self) -> None:
+        result, output = self.run_policy(
+            f"""jobs:
+  test:
+    steps:
+      - name: Text that resembles workflow YAML
+        run: |
+          - uses: attacker/action@main
+          uses: attacker/action@0123456789abcdef0123456789abcdef01234567
+          with:
+            persist-credentials: false
+      - uses: {GENERIC_ACTION}
+"""
+        )
+        self.assertEqual(result, 0, output)
+        self.assertIn("1 external uses entries", output)
+
+    def test_literal_block_decoy_does_not_satisfy_action_requirement(self) -> None:
+        self.assert_rejected(
             """jobs:
   test:
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - run: |
+          uses: owner/action@0123456789abcdef0123456789abcdef01234567
+""",
+            "no external workflow actions were found",
+        )
+
+    def test_quoted_uses_and_quoted_mapping_key_are_rejected(self) -> None:
+        for workflow in (
+            f"""jobs:
+  test:
+    steps:
+      - uses: "{GENERIC_ACTION}"
+""",
+            f"""jobs:
+  test:
+    steps:
+      - 'uses': {GENERIC_ACTION}
+""",
+        ):
+            with self.subTest(workflow=workflow):
+                self.assert_rejected(workflow, "policy failed")
+
+    def test_flow_mapping_and_flow_steps_cannot_hide_actions(self) -> None:
+        self.assert_rejected(
+            f"""jobs:
+  test:
+    steps:
+      - {{uses: {GENERIC_ACTION}}}
+""",
+            "flow mappings are forbidden",
+        )
+        self.assert_rejected(
+            f"""jobs:
+  test:
+    steps: ["uses: {GENERIC_ACTION}"]
+""",
+            "steps must be a block sequence of mappings",
+        )
+
+    def test_folded_and_unexpected_block_scalars_are_rejected(self) -> None:
+        for indicator in (">", ">-", "|-"):
+            with self.subTest(indicator=indicator):
+                self.assert_rejected(
+                    f"""jobs:
+  test:
+    steps:
+      - run: {indicator}
+          uses: {GENERIC_ACTION}
+""",
+                    "block",
+                )
+        self.assert_rejected(
+            f"""jobs:
+  test:
+    steps:
+      - uses: {GENERIC_ACTION}
+        with:
+          manifest: |
+            unreviewed
+""",
+            "block scalars are allowed only for run and path",
+        )
+
+    def test_yaml_invalid_plain_scalar_indicators_are_rejected(self) -> None:
+        for value, expected in (
+            ("python -c release: 1.97.1", "colon followed by whitespace"),
+            ("@mutable", "reserved YAML indicator"),
+            ("`mutable`", "reserved YAML indicator"),
+        ):
+            with self.subTest(value=value):
+                self.assert_rejected(
+                    f"""jobs:
+  test:
+    steps:
+      - run: {value}
+      - uses: {GENERIC_ACTION}
+""",
+                    expected,
+                )
+
+    def test_local_and_docker_action_wrappers_are_forbidden(self) -> None:
+        for action, expected in (
+            ("./.github/actions/wrapper", "local action wrappers are forbidden"),
+            ("docker://alpine:3.22", "docker action wrappers are forbidden"),
+        ):
+            with self.subTest(action=action):
+                self.assert_rejected(
+                    f"""jobs:
+  test:
+    steps:
+      - uses: {action}
+""",
+                    expected,
+                )
+
+    def test_duplicate_keys_are_rejected_at_every_security_boundary(self) -> None:
+        for duplicate_fragment, expected in (
+            (
+                f"""      - uses: {GENERIC_ACTION}
+        uses: owner/other@fedcba9876543210fedcba9876543210fedcba98
+""",
+                "duplicate mapping key: uses",
+            ),
+            (
+                f"""      - uses: {SETUP_UV_ACTION}
+        with:
+          version: "0.11.30"
+          version: "0.12.3"
+          python-version: "3.13.14"
+          enable-cache: false
+""",
+                "duplicate mapping key: version",
+            ),
+            (
+                f"""      - uses: {GENERIC_ACTION}
+        with:
+          name: first
+        with:
+          name: second
+""",
+                "duplicate mapping key: with",
+            ),
+        ):
+            with self.subTest(expected=expected):
+                self.assert_rejected(
+                    "jobs:\n  test:\n    steps:\n" + duplicate_fragment,
+                    expected,
+                )
+        self.assert_rejected(
+            f"""jobs:
+  first:
+    steps:
+      - uses: {GENERIC_ACTION}
+jobs:
+  second:
+    steps:
+      - uses: {GENERIC_ACTION}
+""",
+            "duplicate mapping key: jobs",
+        )
+        self.assert_rejected(
+            f"""jobs:
+  test:
+    steps:
+      - uses: {GENERIC_ACTION}
+  test:
+    steps:
+      - uses: {GENERIC_ACTION}
+""",
+            "duplicate mapping key: test",
+        )
+
+    def test_yaml_directives_documents_properties_and_special_keys_fail_closed(
+        self,
+    ) -> None:
+        base = f"""jobs:
+  test:
+    steps:
+      - uses: {GENERIC_ACTION}
+"""
+        cases = (
+            ("---\n" + base, "document markers"),
+            ("%YAML 1.2\n" + base, "directives"),
+            ("jobs: &shared\n", "anchors"),
+            ("jobs: *shared\n", "aliases"),
+            ("jobs: !custom value\n", "tags"),
+            ("? jobs\n: value\n", "explicit"),
+            ("jobs:\n  <<: *shared\n", "merge"),
+        )
+        for workflow, expected in cases:
+            with self.subTest(expected=expected):
+                self.assert_rejected(workflow, expected)
+
+    def test_noncanonical_bytes_and_line_endings_fail_closed(self) -> None:
+        canonical = (
+            f"jobs:\n  test:\n    steps:\n      - uses: {GENERIC_ACTION}\n"
+        ).encode()
+        cases = (
+            (b"\xef\xbb\xbf" + canonical, "BOM"),
+            (canonical.replace(b"\n", b"\r\n"), "control characters"),
+            (canonical.replace(b"  test", b"\ttest"), "tabs"),
+            (canonical.replace(b"jobs", b"jo\x00bs"), "NUL"),
+            (canonical[:-1], "end with an LF"),
+            (b"\xff\n", "strict UTF-8"),
+        )
+        for workflow, expected in cases:
+            with self.subTest(expected=expected):
+                result, output = self.run_policy_data(workflow)
+                self.assertEqual(result, 1, output)
+                self.assertIn(expected, output)
+
+    def test_checkout_requires_direct_plain_false_not_a_block_decoy(self) -> None:
+        self.assert_rejected(
+            f"""jobs:
+  test:
+    steps:
+      - uses: {CHECKOUT_ACTION}
+        with:
+          persist-credentials: true
+        run: |
+          persist-credentials: false
+""",
+            "actions/checkout must set persist-credentials: false",
+        )
+        self.assert_rejected(
+            f"""jobs:
+  test:
+    steps:
+      - uses: {CHECKOUT_ACTION}
+        with:
+          persist-credentials: "false"
+""",
+            "plain scalar",
+        )
+
+    def test_external_setup_actions_are_categorically_forbidden(self) -> None:
+        cases = (
+            (
+                SETUP_UV_ACTION,
+                """          version: "0.11.30"
+          python-version: "3.13.14"
+          activate-environment: true
+          enable-cache: false
+""",
+            ),
+            (SETUP_PYTHON_ACTION, "          python-version: '3.13.14'\n"),
+            (
+                SETUP_NODE_ACTION,
+                """          node-version: '22.23.2'
+          cache: npm
+          cache-dependency-path: ports/tauri/app/package-lock.json
+""",
+            ),
+        )
+        for action, inputs in cases:
+            with self.subTest(action=action):
+                action_name = action.split("@", 1)[0]
+                self.assert_rejected(
+                    f"""jobs:
+  test:
+    steps:
+      - uses: {action}
+        with:
+{inputs}""",
+                    f"{action_name} is forbidden",
+                )
+        self.assert_rejected(
+            """jobs:
+  test:
+    steps:
+      - uses: actions/setup-node/internal@0123456789abcdef0123456789abcdef01234567
+""",
+            "actions/setup-node/internal is forbidden",
+        )
+        self.assert_rejected(
+            f"""jobs:
+  test:
+    steps:
+      - uses: {SETUP_PYTHON_ACTION}
+        with:
+          python-version: '3.13'
+""",
+            "actions/setup-python is forbidden",
+        )
+
+    def test_setup_action_input_variants_cannot_restore_a_forbidden_action(
+        self,
+    ) -> None:
+        cases = (
+            (SETUP_UV_ACTION, "manifest-file"),
+            (SETUP_UV_ACTION, "checksum"),
+            (SETUP_UV_ACTION, "version-file"),
+            (SETUP_UV_ACTION, "download-url"),
+            (SETUP_UV_ACTION, "custom-input"),
+            (SETUP_PYTHON_ACTION, "check-latest"),
+            (SETUP_PYTHON_ACTION, "python-version-file"),
+            (SETUP_NODE_ACTION, "mirror"),
+            (SETUP_NODE_ACTION, "mirror-token"),
+            (SETUP_NODE_ACTION, "node-version-file"),
+        )
+        for action, input_name in cases:
+            with self.subTest(action=action, input_name=input_name):
+                self.assert_rejected(
+                    f"""jobs:
+  test:
+    steps:
+      - uses: {action}
+        with:
+          {input_name}: attacker-controlled
+""",
+                    "is forbidden",
+                )
+
+    def test_rust_toolchain_requires_exact_patch_and_reviewed_inputs(self) -> None:
+        result, output = self.run_policy(
+            f"""jobs:
+  test:
+    steps:
+      - uses: {RUST_TOOLCHAIN_ACTION}
+        with:
+          toolchain: '1.97.1'
 """
         )
-        self.assertEqual(result, 1)
-        self.assertIn("persist-credentials: false", output)
+        self.assertEqual(result, 0, output)
+        for inputs, expected in (
+            ("          toolchain: stable\n", "must equal 1.97.1"),
+            ("          toolchain: '1.97'\n", "must equal 1.97.1"),
+            ("          profile: minimal\n", "only the reviewed toolchain input"),
+            (
+                "          toolchain: '1.97.1'\n          override: true\n",
+                "only the reviewed toolchain input",
+            ),
+            (
+                "          toolchain: '1.97.1'\n          targets: x86_64-pc-windows-gnu\n",
+                "only the reviewed toolchain input",
+            ),
+            (
+                "          toolchain: '1.97.1'\n          components: clippy\n",
+                "only the reviewed toolchain input",
+            ),
+        ):
+            with self.subTest(inputs=inputs):
+                self.assert_rejected(
+                    f"""jobs:
+  test:
+    steps:
+      - uses: {RUST_TOOLCHAIN_ACTION}
+        with:
+{inputs}""",
+                    expected,
+                )
+
+    def test_only_exact_reviewed_uv_environment_is_allowed(self) -> None:
+        approved_env = """    env:
+      UV_PYTHON_PREFERENCE: only-managed
+      UV_PYTHON_CPYTHON_BUILD: "20260718"
+"""
+        result, output = self.run_policy(
+            f"""jobs:
+  test:
+{approved_env}    steps:
+      - uses: {GENERIC_ACTION}
+"""
+        )
+        self.assertEqual(result, 0, output)
+        for key in (
+            "UV_PYTHON_DOWNLOADS_JSON_URL",
+            "UV_PYTHON_INSTALL_MIRROR",
+            "UV_ASTRAL_MIRROR_URL",
+            "UV_CACHE_DIR",
+            "uv_python_preference",
+        ):
+            with self.subTest(key=key):
+                self.assert_rejected(
+                    f"""jobs:
+  test:
+    env:
+      {key}: https://attacker.invalid/input
+    steps:
+      - uses: {GENERIC_ACTION}
+""",
+                    "unreviewed uv environment key",
+                )
+        self.assert_rejected(
+            f"""jobs:
+  test:
+    env:
+      UV_PYTHON_CPYTHON_BUILD: latest
+    steps:
+      - uses: {GENERIC_ACTION}
+""",
+            "UV_PYTHON_CPYTHON_BUILD must equal 20260718",
+        )
+
+    def test_step_level_uv_environment_is_inspected(self) -> None:
+        self.assert_rejected(
+            f"""jobs:
+  test:
+    steps:
+      - uses: {GENERIC_ACTION}
+        env:
+          UV_PYTHON_DOWNLOADS_JSON_URL: https://attacker.invalid/manifest.json
+""",
+            "unreviewed uv environment key",
+        )
+
+    def test_workflow_level_uv_environment_is_inspected(self) -> None:
+        self.assert_rejected(
+            f"""env:
+  UV_ASTRAL_MIRROR_URL: https://attacker.invalid
+jobs:
+  test:
+    steps:
+      - uses: {GENERIC_ACTION}
+""",
+            "unreviewed uv environment key",
+        )
+
+    def test_decoded_control_characters_and_excessive_nesting_are_rejected(
+        self,
+    ) -> None:
+        self.assert_rejected(
+            f"""name: "bad\\u0000value"
+jobs:
+  test:
+    steps:
+      - uses: {GENERIC_ACTION}
+""",
+            "decoded scalar contains a control character",
+        )
+        nested = ""
+        for depth in range(66):
+            nested += "  " * depth + f"level{depth}:\n"
+        self.assert_rejected(nested, "nesting exceeds")
+
+    def test_oversize_and_nonregular_workflow_inputs_fail_closed(self) -> None:
+        checker = load_checker()
+        result, output = self.run_policy_data(
+            b"#" * (checker.MAX_WORKFLOW_BYTES + 1) + b"\n"
+        )
+        self.assertEqual(result, 1, output)
+        self.assertIn("exceeds", output)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            target = Path(temporary_directory) / "target.yml"
+            target.write_text("jobs:\n", encoding="utf-8")
+            link = Path(temporary_directory) / "link.yml"
+            link.symlink_to(target)
+            with self.assertRaises(checker.PolicyError):
+                checker._read_workflow(link)
+
+            if not hasattr(os, "mkfifo"):
+                return
+            fifo = Path(temporary_directory) / "workflow.yml"
+            os.mkfifo(fifo)
+            with self.assertRaises(checker.PolicyError):
+                checker._read_workflow(fifo)
+
+    def test_steps_and_step_items_must_have_canonical_structure(self) -> None:
+        self.assert_rejected(
+            f"""jobs:
+  test:
+    steps: {GENERIC_ACTION}
+""",
+            "steps must be a block sequence of mappings",
+        )
+        self.assert_rejected(
+            f"""jobs:
+  test:
+    steps:
+      - {GENERIC_ACTION}
+""",
+            "each step must be a block mapping",
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_pinned_release_fetchers.py
+++ b/scripts/tests/test_pinned_release_fetchers.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+from pathlib import Path
+import sys
+import tarfile
+import tempfile
+from types import ModuleType
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+COOLSCANPY = load(
+    "test_pinned_coolscanpy_sdist",
+    ROOT / "scripts" / "fetch_pinned_coolscanpy_sdist.py",
+)
+CARGO_ABOUT = load(
+    "test_pinned_cargo_about",
+    ROOT / "scripts" / "install_pinned_cargo_about.py",
+)
+
+
+class FakeResponse:
+    def __init__(self, payload: bytes, url: str, length: str | None = None) -> None:
+        self.payload = io.BytesIO(payload)
+        self.url = url
+        self.headers = {"Content-Length": length} if length is not None else {}
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def geturl(self) -> str:
+        return self.url
+
+    def read(self, size: int = -1) -> bytes:
+        return self.payload.read(size)
+
+
+def tar_payload(entries: list[tuple[str, bytes | None, bytes]]) -> bytes:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as bundle:
+        for name, link, payload in entries:
+            member = tarfile.TarInfo(name)
+            if link is not None:
+                member.type = link[:1]
+                member.linkname = link[1:].decode()
+            elif name.endswith("/"):
+                member.type = tarfile.DIRTYPE
+            else:
+                member.type = tarfile.REGTYPE
+                member.size = len(payload)
+            bundle.addfile(member, io.BytesIO(payload) if member.isfile() else None)
+    return output.getvalue()
+
+
+class DownloadTests(unittest.TestCase):
+    def test_coolscanpy_download_rejects_redirect_length_and_digest(self) -> None:
+        payload = b"payload"
+        cases = (
+            FakeResponse(payload, "https://attacker.invalid/x", str(len(payload))),
+            FakeResponse(payload, COOLSCANPY.URL, str(len(payload) + 1)),
+            FakeResponse(payload, COOLSCANPY.URL, str(len(payload))),
+        )
+        with (
+            mock.patch.object(COOLSCANPY, "SIZE", len(payload)),
+            mock.patch.object(
+                COOLSCANPY, "SHA256", hashlib.sha256(b"other").hexdigest()
+            ),
+        ):
+            for response in cases:
+                with self.subTest(url=response.url, headers=response.headers):
+                    with tempfile.TemporaryDirectory() as temporary:
+                        path = Path(temporary) / "archive"
+                        with mock.patch.object(
+                            COOLSCANPY.urllib.request, "urlopen", return_value=response
+                        ):
+                            with self.assertRaises(COOLSCANPY.FetchError):
+                                COOLSCANPY.download(path)
+
+    def test_cargo_about_download_accepts_only_exact_bytes(self) -> None:
+        payload = b"authenticated crate"
+        response = FakeResponse(payload, CARGO_ABOUT.ASSET_URL, str(len(payload)))
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "crate"
+            with (
+                mock.patch.object(CARGO_ABOUT, "ASSET_SIZE", len(payload)),
+                mock.patch.object(
+                    CARGO_ABOUT, "ASSET_SHA256", hashlib.sha256(payload).hexdigest()
+                ),
+                mock.patch.object(
+                    CARGO_ABOUT.urllib.request, "urlopen", return_value=response
+                ),
+            ):
+                CARGO_ABOUT.download(path)
+            self.assertEqual(path.read_bytes(), payload)
+
+
+class ArchiveTests(unittest.TestCase):
+    def test_member_paths_reject_escape_and_ambiguity(self) -> None:
+        for module, function, root, error in (
+            (
+                COOLSCANPY,
+                COOLSCANPY.member_path,
+                COOLSCANPY.ROOT,
+                COOLSCANPY.FetchError,
+            ),
+            (
+                CARGO_ABOUT,
+                CARGO_ABOUT.member_path,
+                CARGO_ABOUT.ARCHIVE_ROOT,
+                CARGO_ABOUT.InstallError,
+            ),
+        ):
+            for name in ("", f"{root}/../outside", f"{root}\\outside", "/outside"):
+                with self.subTest(module=module.__name__, name=name):
+                    with self.assertRaises(error):
+                        function(name)
+
+    def test_coolscanpy_extract_rejects_links_before_writing_outside(self) -> None:
+        payload = tar_payload(
+            [
+                (f"{COOLSCANPY.ROOT}/", None, b""),
+                (
+                    f"{COOLSCANPY.ROOT}/link",
+                    tarfile.SYMTYPE + b"../../outside",
+                    b"",
+                ),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            archive = root / "source.tar.gz"
+            archive.write_bytes(payload)
+            with (
+                mock.patch.object(COOLSCANPY, "ENTRY_COUNT", 2),
+                mock.patch.object(COOLSCANPY, "FILE_COUNT", 0),
+                mock.patch.object(COOLSCANPY, "DIRECTORY_COUNT", 1),
+                mock.patch.object(COOLSCANPY, "EXPANDED_FILE_BYTES", 0),
+                self.assertRaisesRegex(COOLSCANPY.FetchError, "link or special"),
+            ):
+                COOLSCANPY.extract(archive, root / "extract")
+            self.assertFalse((root / "outside").exists())
+
+    def test_cargo_about_extract_rejects_link_or_special_entry(self) -> None:
+        payload = tar_payload(
+            [
+                (f"{CARGO_ABOUT.ARCHIVE_ROOT}/", None, b""),
+                (
+                    f"{CARGO_ABOUT.ARCHIVE_ROOT}/link",
+                    tarfile.SYMTYPE + b"outside",
+                    b"",
+                ),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            archive = root / "source.crate"
+            archive.write_bytes(payload)
+            with (
+                mock.patch.object(CARGO_ABOUT, "ARCHIVE_ENTRIES", 2),
+                self.assertRaisesRegex(CARGO_ABOUT.InstallError, "link or special"),
+            ):
+                CARGO_ABOUT.extract(archive, root / "extract")
+
+
+class WiringTests(unittest.TestCase):
+    def test_release_workflow_uses_authenticated_cargo_about(self) -> None:
+        for workflow in ("ports.yml", "release.yml"):
+            text = (ROOT / ".github" / "workflows" / workflow).read_text()
+            self.assertNotIn("cargo install --locked --version 0.9.1", text)
+            self.assertIn("scripts/install_pinned_cargo_about.py", text)
+
+    def test_coolscanpy_gate_uses_exact_fetcher_not_latest_metadata(self) -> None:
+        text = (ROOT / "scripts" / "check_coolscanpy_pypi_sync.sh").read_text()
+        self.assertIn("scripts/fetch_pinned_coolscanpy_sdist.py", text)
+        self.assertNotIn("pypi/coolscanpy/json", text)
+        self.assertNotIn("tar -xzf", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_pinned_tauri_tools.py
+++ b/scripts/tests/test_pinned_tauri_tools.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+import tempfile
+from types import ModuleType, SimpleNamespace
+import unittest
+from unittest import mock
+import zipfile
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER_PATH = (
+    REPOSITORY_ROOT / "ports" / "tauri" / "packaging" / "install_pinned_tauri_tools.py"
+)
+
+
+def load_installer() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "test_pinned_tauri_installer", INSTALLER_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+INSTALLER = load_installer()
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        payload: bytes,
+        url: str,
+        *,
+        content_length: str | None = None,
+        content_encoding: str | None = None,
+    ) -> None:
+        self._payload = payload
+        self._offset = 0
+        self._url = url
+        self.headers: dict[str, str] = {}
+        if content_length is not None:
+            self.headers["Content-Length"] = content_length
+        if content_encoding is not None:
+            self.headers["Content-Encoding"] = content_encoding
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def geturl(self) -> str:
+        return self._url
+
+    def read(self, size: int = -1) -> bytes:
+        if self._offset >= len(self._payload):
+            return b""
+        end = len(self._payload) if size < 0 else self._offset + size
+        chunk = self._payload[self._offset : end]
+        self._offset += len(chunk)
+        return chunk
+
+
+def make_zip(entries: list[tuple[str, int, bytes]]) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, mode="w") as bundle:
+        for name, mode, payload in entries:
+            member = zipfile.ZipInfo(name)
+            member.create_system = 3
+            member.external_attr = mode << 16
+            bundle.writestr(member, payload)
+    return output.getvalue()
+
+
+def sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def write_exclusive(path: Path, payload: bytes) -> None:
+    with path.open("xb") as output:
+        output.write(payload)
+
+
+class DownloadBoundaryTests(unittest.TestCase):
+    def test_exact_https_download_is_accepted(self) -> None:
+        payload = b"exact pinned payload"
+        asset = {
+            "url": "https://example.invalid/tool",
+            "size": len(payload),
+            "sha256": sha256(payload),
+        }
+        response = FakeResponse(
+            payload,
+            str(asset["url"]),
+            content_length=str(len(payload)),
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            destination = Path(temporary_directory).resolve() / "tool"
+            with mock.patch.object(
+                INSTALLER.urllib.request, "urlopen", return_value=response
+            ):
+                INSTALLER.download_asset(asset, destination)
+            self.assertEqual(destination.read_bytes(), payload)
+
+    def test_download_rejects_bad_length_encoding_redirect_and_digest(self) -> None:
+        payload = b"payload"
+        good_asset = {
+            "url": "https://example.invalid/tool",
+            "size": len(payload),
+            "sha256": sha256(payload),
+        }
+        cases = (
+            FakeResponse(payload, str(good_asset["url"])),
+            FakeResponse(
+                payload,
+                str(good_asset["url"]),
+                content_length=str(len(payload) + 1),
+            ),
+            FakeResponse(
+                payload,
+                str(good_asset["url"]),
+                content_length=str(len(payload)),
+                content_encoding="gzip",
+            ),
+            FakeResponse(
+                payload,
+                "http://example.invalid/tool",
+                content_length=str(len(payload)),
+            ),
+        )
+        for index, response in enumerate(cases):
+            with (
+                self.subTest(case=index),
+                tempfile.TemporaryDirectory() as temporary_directory,
+            ):
+                destination = Path(temporary_directory).resolve() / "tool"
+                with mock.patch.object(
+                    INSTALLER.urllib.request, "urlopen", return_value=response
+                ):
+                    with self.assertRaises(INSTALLER.ToolError):
+                        INSTALLER.download_asset(good_asset, destination)
+
+        wrong_digest_asset = dict(good_asset, sha256="0" * 64)
+        response = FakeResponse(
+            payload,
+            str(good_asset["url"]),
+            content_length=str(len(payload)),
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            destination = Path(temporary_directory).resolve() / "tool"
+            with mock.patch.object(
+                INSTALLER.urllib.request, "urlopen", return_value=response
+            ):
+                with self.assertRaisesRegex(INSTALLER.ToolError, "digest mismatch"):
+                    INSTALLER.download_asset(wrong_digest_asset, destination)
+
+
+class ArchiveBoundaryTests(unittest.TestCase):
+    def test_member_names_reject_traversal_and_windows_ambiguity(self) -> None:
+        unsafe = (
+            "",
+            "nsis-3.11",
+            "/nsis-3.11/file",
+            "other/file",
+            "nsis-3.11/../outside",
+            "nsis-3.11\\file",
+            "nsis-3.11/C:/file",
+            "nsis-3.11/CON.txt",
+            "nsis-3.11/trailing. ",
+        )
+        for name in unsafe:
+            with self.subTest(name=name):
+                with self.assertRaises(INSTALLER.ToolError):
+                    INSTALLER.validated_zip_member(name, "nsis-3.11")
+
+    def test_traversal_is_rejected_before_extraction(self) -> None:
+        archive_payload = make_zip(
+            [("nsis-3.11/../../outside", stat.S_IFREG | 0o600, b"outside")]
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            archive = root / "nsis.zip"
+            archive.write_bytes(archive_payload)
+            destination = root / "NSIS"
+            with (
+                mock.patch.object(INSTALLER, "NSIS_BASE_FILE_COUNT", 1),
+                mock.patch.object(INSTALLER, "NSIS_BASE_EXPANDED_BYTES", 7),
+                self.assertRaises(INSTALLER.ToolError),
+            ):
+                INSTALLER.extract_nsis_archive(archive, destination)
+            self.assertFalse((root / "outside").exists())
+
+    def test_links_special_files_and_case_collisions_are_rejected(self) -> None:
+        cases = (
+            [
+                (
+                    "nsis-3.11/link",
+                    stat.S_IFLNK | 0o777,
+                    b"../../outside",
+                )
+            ],
+            [("nsis-3.11/device", stat.S_IFCHR | 0o600, b"device")],
+            [
+                ("nsis-3.11/File", stat.S_IFREG | 0o600, b"one"),
+                ("nsis-3.11/file", stat.S_IFREG | 0o600, b"two"),
+            ],
+        )
+        for index, entries in enumerate(cases):
+            payload = make_zip(entries)
+            expanded = sum(len(entry[2]) for entry in entries)
+            with (
+                self.subTest(case=index),
+                tempfile.TemporaryDirectory() as temporary_directory,
+            ):
+                root = Path(temporary_directory).resolve()
+                archive = root / "nsis.zip"
+                archive.write_bytes(payload)
+                with (
+                    mock.patch.object(INSTALLER, "NSIS_BASE_FILE_COUNT", len(entries)),
+                    mock.patch.object(INSTALLER, "NSIS_BASE_EXPANDED_BYTES", expanded),
+                    self.assertRaises(INSTALLER.ToolError),
+                ):
+                    INSTALLER.extract_nsis_archive(archive, root / "NSIS")
+
+
+class ToolTreeTests(unittest.TestCase):
+    def test_held_hash_ignores_windows_synthetic_identity_metadata(self) -> None:
+        payload = b"stable pinned bytes"
+        original_fstat = INSTALLER.os.fstat
+        call_count = 0
+
+        def synthetic_fstat(descriptor: int) -> SimpleNamespace:
+            nonlocal call_count
+            actual = original_fstat(descriptor)
+            call_count += 1
+            return SimpleNamespace(
+                st_mode=actual.st_mode,
+                st_size=actual.st_size,
+                st_nlink=actual.st_nlink,
+                st_dev=10_000 + call_count,
+                st_ino=20_000 + call_count,
+                st_mtime_ns=30_000 + call_count,
+            )
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            tool = Path(temporary_directory).resolve() / "tool"
+            tool.write_bytes(payload)
+            with mock.patch.object(INSTALLER.os, "fstat", side_effect=synthetic_fstat):
+                self.assertEqual(
+                    INSTALLER.hash_regular_file(tool, expected_size=len(payload)),
+                    sha256(payload),
+                )
+
+    def test_held_hash_rejects_content_changed_between_reads(self) -> None:
+        payload = b"stable pinned bytes"
+        replacement = b"changed pinned byte"
+        self.assertEqual(len(payload), len(replacement))
+        original_read = INSTALLER.os.read
+        first_pass_complete = False
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            tool = Path(temporary_directory).resolve() / "tool"
+            tool.write_bytes(payload)
+
+            def mutate_after_first_pass(descriptor: int, size: int) -> bytes:
+                nonlocal first_pass_complete
+                chunk = original_read(descriptor, size)
+                if not chunk and not first_pass_complete:
+                    first_pass_complete = True
+                    tool.write_bytes(replacement)
+                return chunk
+
+            with (
+                mock.patch.object(
+                    INSTALLER.os, "read", side_effect=mutate_after_first_pass
+                ),
+                self.assertRaisesRegex(INSTALLER.ToolError, "changed while hashing"),
+            ):
+                INSTALLER.hash_regular_file(tool, expected_size=len(payload))
+
+    def test_linux_prepare_applies_exact_patch_and_rejects_tampering(self) -> None:
+        source = b"0123456789abcdef"
+        installed = source[:8] + b"\0\0\0" + source[11:]
+        asset = {
+            "name": "linuxdeploy-x86_64.AppImage",
+            "url": "https://example.invalid/linuxdeploy",
+            "size": len(source),
+            "sha256": sha256(source),
+            "installed_sha256": sha256(installed),
+            "zero_range": (8, 11),
+        }
+
+        def fake_download(_asset: dict[str, object], destination: Path) -> None:
+            write_exclusive(destination, source)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            tools_root = Path(temporary_directory).resolve() / ".tauri"
+            tools_root.mkdir()
+            with (
+                mock.patch.object(INSTALLER, "LINUX_ASSETS", (asset,)),
+                mock.patch.object(
+                    INSTALLER, "download_asset", side_effect=fake_download
+                ),
+            ):
+                INSTALLER.prepare_linux(tools_root)
+                tool = tools_root / str(asset["name"])
+                self.assertEqual(tool.read_bytes(), installed)
+                INSTALLER.verify_linux(tools_root)
+                tool.chmod(0o755)
+                with self.assertRaisesRegex(INSTALLER.ToolError, "exactly 0700"):
+                    INSTALLER.verify_linux(tools_root)
+                tool.chmod(0o700)
+                tool.write_bytes(b"X" * len(installed))
+                with self.assertRaisesRegex(INSTALLER.ToolError, "digest mismatch"):
+                    INSTALLER.verify_linux(tools_root)
+
+    def test_windows_prepare_commits_full_tree_plugin_and_webview(self) -> None:
+        base_entries = [
+            ("nsis-3.11/makensis.exe", stat.S_IFREG | 0o600, b"compiler"),
+            (
+                "nsis-3.11/Plugins/x86-unicode/System.dll",
+                stat.S_IFREG | 0o600,
+                b"system-plugin",
+            ),
+        ]
+        archive_payload = make_zip(base_entries)
+        plugin_payload = b"tauri-plugin"
+        webview_payload = b"signed-webview-fixture"
+        archive_asset = {
+            "name": "nsis.zip",
+            "url": "https://example.invalid/nsis",
+            "size": len(archive_payload),
+            "sha256": sha256(archive_payload),
+        }
+        plugin_asset = {
+            "name": "nsis_tauri_utils.dll",
+            "url": "https://example.invalid/plugin",
+            "size": len(plugin_payload),
+            "sha256": sha256(plugin_payload),
+        }
+        webview_asset = {
+            "name": "MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
+            "url": "https://example.invalid/webview",
+            "size": len(webview_payload),
+            "sha256": sha256(webview_payload),
+        }
+        payloads = {
+            str(archive_asset["url"]): archive_payload,
+            str(plugin_asset["url"]): plugin_payload,
+            str(webview_asset["url"]): webview_payload,
+        }
+
+        def fake_download(asset: dict[str, object], destination: Path) -> None:
+            write_exclusive(destination, payloads[str(asset["url"])])
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            expected_base = root / "expected-base"
+            (expected_base / "Plugins" / "x86-unicode").mkdir(parents=True)
+            (expected_base / "makensis.exe").write_bytes(b"compiler")
+            (expected_base / "Plugins" / "x86-unicode" / "System.dll").write_bytes(
+                b"system-plugin"
+            )
+            tree_sha, file_count, directory_count, expanded = INSTALLER._tree_commit(
+                expected_base
+            )
+            tools_root = root / ".tauri"
+            tools_root.mkdir()
+            with (
+                mock.patch.object(INSTALLER, "NSIS_ARCHIVE", archive_asset),
+                mock.patch.object(INSTALLER, "NSIS_PLUGIN", plugin_asset),
+                mock.patch.object(INSTALLER, "WEBVIEW2_ASSET", webview_asset),
+                mock.patch.object(INSTALLER, "NSIS_BASE_TREE_SHA256", tree_sha),
+                mock.patch.object(INSTALLER, "NSIS_BASE_FILE_COUNT", file_count),
+                mock.patch.object(
+                    INSTALLER, "NSIS_BASE_DIRECTORY_COUNT", directory_count
+                ),
+                mock.patch.object(INSTALLER, "NSIS_BASE_EXPANDED_BYTES", expanded),
+                mock.patch.object(
+                    INSTALLER, "download_asset", side_effect=fake_download
+                ),
+            ):
+                INSTALLER.prepare_windows(tools_root)
+                INSTALLER.verify_windows(tools_root)
+                webview = (
+                    tools_root
+                    / "x64"
+                    / INSTALLER.WEBVIEW2_GUID
+                    / str(webview_asset["name"])
+                )
+                webview.write_bytes(b"X" * len(webview_payload))
+                with self.assertRaisesRegex(INSTALLER.ToolError, "digest mismatch"):
+                    INSTALLER.verify_windows(tools_root)
+
+    def test_overrides_and_preexisting_cache_fail_before_download(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            target = Path(temporary_directory).resolve() / "target"
+            with mock.patch.dict(os.environ, {"NSIS_PATH": "attacker"}, clear=True):
+                with self.assertRaisesRegex(INSTALLER.ToolError, "overrides"):
+                    INSTALLER.prepare("linux", target)
+            self.assertFalse(target.exists())
+
+            target.mkdir()
+            tools_root = target / ".tauri"
+            tools_root.mkdir()
+            sentinel = tools_root / "sentinel"
+            sentinel.write_text("preserve me")
+            with mock.patch.dict(os.environ, {}, clear=True):
+                with self.assertRaisesRegex(INSTALLER.ToolError, "pre-existing"):
+                    INSTALLER.prepare("linux", target)
+            self.assertEqual(sentinel.read_text(), "preserve me")
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symlinks unavailable")
+    def test_verifier_rejects_symlinked_tool(self) -> None:
+        payload = b"tool"
+        asset = {
+            "name": "tool",
+            "url": "https://example.invalid/tool",
+            "size": len(payload),
+            "sha256": sha256(payload),
+        }
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            outside = root / "outside"
+            outside.write_bytes(payload)
+            tools_root = root / ".tauri"
+            tools_root.mkdir()
+            (tools_root / "tool").symlink_to(outside)
+            with mock.patch.object(INSTALLER, "LINUX_ASSETS", (asset,)):
+                with self.assertRaisesRegex(
+                    INSTALLER.ToolError, "link or reparse point"
+                ):
+                    INSTALLER.verify_linux(tools_root)
+
+    @unittest.skipUnless(hasattr(os, "link"), "hard links unavailable")
+    def test_verifier_rejects_hard_linked_tool(self) -> None:
+        payload = b"tool"
+        asset = {
+            "name": "tool",
+            "url": "https://example.invalid/tool",
+            "size": len(payload),
+            "sha256": sha256(payload),
+        }
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            outside = root / "outside"
+            outside.write_bytes(payload)
+            tools_root = root / ".tauri"
+            tools_root.mkdir()
+            os.link(outside, tools_root / "tool")
+            with mock.patch.object(INSTALLER, "LINUX_ASSETS", (asset,)):
+                with self.assertRaisesRegex(INSTALLER.ToolError, "hard link"):
+                    INSTALLER.verify_linux(tools_root)
+
+
+class PackagingWiringTests(unittest.TestCase):
+    def test_tauri_and_package_builds_use_the_private_pinned_tree(self) -> None:
+        config = json.loads(
+            (
+                REPOSITORY_ROOT
+                / "ports"
+                / "tauri"
+                / "app"
+                / "src-tauri"
+                / "tauri.conf.json"
+            ).read_text()
+        )
+        self.assertIs(config["bundle"]["useLocalToolsDir"], True)
+
+        linux = (
+            REPOSITORY_ROOT
+            / "ports"
+            / "tauri"
+            / "packaging"
+            / "linux"
+            / "build-and-verify.sh"
+        ).read_text()
+        self.assertIn("prepare linux --target-directory", linux)
+        self.assertGreaterEqual(linux.count("verify linux --target-directory"), 2)
+        self.assertIn("tauri-cli 2.11.4", linux)
+        self.assertLess(linux.index("prepare linux"), linux.index("npm run tauri"))
+
+        windows = (
+            REPOSITORY_ROOT
+            / "ports"
+            / "tauri"
+            / "packaging"
+            / "windows"
+            / "build-and-verify.ps1"
+        ).read_text()
+        for required in (
+            "Invoke-PinnedTauriToolCheck -Operation prepare",
+            "Invoke-PinnedTauriToolCheck -Operation verify",
+            "Get-AuthenticodeSignature",
+            "WEBVIEW2INSTALLERPATH",
+            "FileShare]::Read",
+            "Assert-GeneratedNsisUsesPinnedWebView",
+            "tauri-cli 2.11.4",
+        ):
+            self.assertIn(required, windows)
+        self.assertLess(
+            windows.rindex("Assert-GeneratedNsisUsesPinnedWebView"),
+            windows.rindex("Publish-VerifiedOutputs"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_pinned_toolchain_installers.py
+++ b/scripts/tests/test_pinned_toolchain_installers.py
@@ -1,0 +1,612 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+from pathlib import Path
+import stat
+import tarfile
+import tempfile
+from types import ModuleType
+import unittest
+from unittest import mock
+import zipfile
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_installer(name: str) -> ModuleType:
+    path = REPOSITORY_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"test_{name}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+NODE = load_installer("install_pinned_node")
+UV_PYTHON = load_installer("install_pinned_uv_python")
+INSTALLERS = (("node", NODE), ("uv", UV_PYTHON))
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        body: bytes,
+        url: str,
+        *,
+        content_length: str | None = None,
+        content_encoding: str | None = None,
+    ) -> None:
+        self._body = body
+        self._offset = 0
+        self._url = url
+        self.headers: dict[str, str] = {}
+        if content_length is not None:
+            self.headers["Content-Length"] = content_length
+        if content_encoding is not None:
+            self.headers["Content-Encoding"] = content_encoding
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def geturl(self) -> str:
+        return self._url
+
+    def read(self, size: int = -1) -> bytes:
+        if self._offset >= len(self._body):
+            return b""
+        if size < 0:
+            end = len(self._body)
+        else:
+            end = min(self._offset + size, len(self._body))
+        chunk = self._body[self._offset : end]
+        self._offset = end
+        return chunk
+
+
+def add_tar_entry(
+    bundle: tarfile.TarFile,
+    name: str,
+    *,
+    kind: bytes = tarfile.REGTYPE,
+    data: bytes = b"payload",
+    linkname: str = "",
+) -> None:
+    member = tarfile.TarInfo(name)
+    member.type = kind
+    member.linkname = linkname
+    if kind == tarfile.REGTYPE:
+        member.size = len(data)
+        bundle.addfile(member, io.BytesIO(data))
+    else:
+        bundle.addfile(member)
+
+
+def make_tar(path: Path, entries: list[dict[str, object]]) -> None:
+    with tarfile.open(path, mode="w:gz") as bundle:
+        for entry in entries:
+            add_tar_entry(bundle, **entry)
+
+
+def make_zip(path: Path, entries: list[tuple[str, int, bytes]]) -> None:
+    with zipfile.ZipFile(path, mode="w") as bundle:
+        for name, mode, data in entries:
+            member = zipfile.ZipInfo(name)
+            member.create_system = 3
+            member.external_attr = mode << 16
+            bundle.writestr(member, data)
+
+
+def fake_response_for(
+    installer: ModuleType,
+    url: str,
+    body: bytes,
+    *,
+    content_length: str | None = None,
+    content_encoding: str | None = None,
+    final_url: str | None = None,
+) -> FakeResponse:
+    del installer
+    return FakeResponse(
+        body,
+        final_url or url,
+        content_length=content_length,
+        content_encoding=content_encoding,
+    )
+
+
+def test_platform_details(
+    installer: ModuleType,
+    archive_sha256: str,
+    executable_sha256: str,
+) -> dict[str, str]:
+    details = {
+        "asset": "tool.tar.gz",
+        "archive_sha256": archive_sha256,
+        "executable": "tool/bin/tool",
+        "executable_sha256": executable_sha256,
+        "kind": "tar",
+    }
+    if installer is NODE:
+        details.update(
+            {
+                "path": "tool/bin",
+                "npm_cli": "tool/lib/npm-cli.js",
+                "node_arch": "unit-test-arch",
+            }
+        )
+    else:
+        details["python_machine"] = "unit-test-arch"
+    return details
+
+
+class ArchiveBoundaryTests(unittest.TestCase):
+    def test_member_paths_reject_traversal_and_ambiguous_names(self) -> None:
+        unsafe_names = (
+            "",
+            "/tool/bin/tool",
+            "other/bin/tool",
+            "tool/../escape",
+            "../tool/bin/tool",
+            "tool\\bin\\tool",
+            "tool/bin/\x00tool",
+        )
+        for installer_name, installer in INSTALLERS:
+            for name in unsafe_names:
+                with self.subTest(installer=installer_name, name=name):
+                    with self.assertRaises(installer.InstallError):
+                        installer.validated_member_path(name, "tool")
+
+    def test_node_link_targets_remain_inside_the_expected_root(self) -> None:
+        member = NODE.validated_member_path("tool/lib/node", "tool")
+        NODE.validated_link_target(member, "../bin/node", "tool")
+        for target in ("", "/outside", "../../outside", "..\\..\\outside"):
+            with self.subTest(target=target):
+                with self.assertRaises(NODE.InstallError):
+                    NODE.validated_link_target(member, target, "tool")
+
+    def test_node_tar_extracts_its_contained_relative_npm_link(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            archive = root / "fixture.tar.gz"
+            make_tar(
+                archive,
+                [
+                    {
+                        "name": "tool/lib/node_modules/npm/bin/npm-cli.js",
+                        "data": b"console.log('10.9.8')\n",
+                    },
+                    {
+                        "name": "tool/bin/npm",
+                        "kind": tarfile.SYMTYPE,
+                        "linkname": "../lib/node_modules/npm/bin/npm-cli.js",
+                    },
+                ],
+            )
+            destination = root / "destination"
+            destination.mkdir()
+            NODE.extract_tar(archive, destination, "tool")
+            npm = destination / "tool/bin/npm"
+            self.assertTrue(npm.is_symlink())
+            self.assertEqual(
+                npm.readlink().as_posix(), "../lib/node_modules/npm/bin/npm-cli.js"
+            )
+            self.assertEqual(npm.read_bytes(), b"console.log('10.9.8')\n")
+
+    def test_tar_traversal_is_rejected_before_extraction(self) -> None:
+        for installer_name, installer in INSTALLERS:
+            with self.subTest(installer=installer_name):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    root = Path(temporary_directory)
+                    archive = root / "fixture.tar.gz"
+                    make_tar(archive, [{"name": "tool/../outside"}])
+                    destination = root / "destination"
+                    destination.mkdir()
+                    with self.assertRaises(installer.InstallError):
+                        installer.extract_tar(archive, destination, "tool")
+                    self.assertFalse((root / "outside").exists())
+
+    def test_zip_traversal_is_rejected_before_extraction(self) -> None:
+        regular_mode = stat.S_IFREG | 0o600
+        for installer_name, installer in INSTALLERS:
+            with self.subTest(installer=installer_name):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    root = Path(temporary_directory)
+                    archive = root / "fixture.zip"
+                    make_zip(
+                        archive,
+                        [("tool/../outside", regular_mode, b"outside")],
+                    )
+                    destination = root / "destination"
+                    destination.mkdir()
+                    with self.assertRaises(installer.InstallError):
+                        installer.extract_zip(archive, destination, "tool")
+                    self.assertFalse((root / "outside").exists())
+
+    def test_uv_zip_accepts_its_authenticated_windows_root_shape(self) -> None:
+        regular_mode = stat.S_IFREG | 0o755
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            archive = root / "fixture.zip"
+            make_zip(
+                archive,
+                [
+                    ("uv.exe", regular_mode, b"uv"),
+                    ("uvw.exe", regular_mode, b"uvw"),
+                    ("uvx.exe", regular_mode, b"uvx"),
+                ],
+            )
+            destination = root / "destination"
+            destination.mkdir()
+            UV_PYTHON.extract_zip(archive, destination, None)
+            self.assertEqual((destination / "uv.exe").read_bytes(), b"uv")
+
+            traversal = root / "traversal.zip"
+            make_zip(traversal, [("../outside", regular_mode, b"outside")])
+            with self.assertRaises(UV_PYTHON.InstallError):
+                UV_PYTHON.extract_zip(traversal, destination, None)
+            self.assertFalse((root / "outside").exists())
+
+    def test_tar_case_collisions_are_rejected(self) -> None:
+        entries = [{"name": "tool/File"}, {"name": "tool/file"}]
+        for installer_name, installer in INSTALLERS:
+            with self.subTest(installer=installer_name):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    root = Path(temporary_directory)
+                    archive = root / "fixture.tar.gz"
+                    make_tar(archive, entries)
+                    destination = root / "destination"
+                    destination.mkdir()
+                    with self.assertRaisesRegex(
+                        installer.InstallError, "duplicate/colliding"
+                    ):
+                        installer.extract_tar(archive, destination, "tool")
+
+    def test_zip_case_collisions_are_rejected(self) -> None:
+        regular_mode = stat.S_IFREG | 0o600
+        entries = [
+            ("tool/File", regular_mode, b"one"),
+            ("tool/file", regular_mode, b"two"),
+        ]
+        for installer_name, installer in INSTALLERS:
+            with self.subTest(installer=installer_name):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    root = Path(temporary_directory)
+                    archive = root / "fixture.zip"
+                    make_zip(archive, entries)
+                    destination = root / "destination"
+                    destination.mkdir()
+                    with self.assertRaisesRegex(
+                        installer.InstallError, "duplicate/colliding"
+                    ):
+                        installer.extract_zip(archive, destination, "tool")
+
+    def test_tar_links_and_special_entries_are_rejected(self) -> None:
+        cases = (
+            (NODE, tarfile.SYMTYPE, "../../outside"),
+            (NODE, tarfile.LNKTYPE, "tool/file"),
+            (NODE, tarfile.CHRTYPE, ""),
+            (UV_PYTHON, tarfile.SYMTYPE, "tool/file"),
+            (UV_PYTHON, tarfile.LNKTYPE, "tool/file"),
+            (UV_PYTHON, tarfile.CHRTYPE, ""),
+        )
+        for installer, kind, linkname in cases:
+            with self.subTest(installer=installer.__name__, kind=kind):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    root = Path(temporary_directory)
+                    archive = root / "fixture.tar.gz"
+                    make_tar(
+                        archive,
+                        [
+                            {
+                                "name": "tool/entry",
+                                "kind": kind,
+                                "linkname": linkname,
+                            }
+                        ],
+                    )
+                    destination = root / "destination"
+                    destination.mkdir()
+                    with self.assertRaises(installer.InstallError):
+                        installer.extract_tar(archive, destination, "tool")
+
+    def test_zip_links_and_special_entries_are_rejected(self) -> None:
+        cases = (
+            (stat.S_IFLNK | 0o777, b"tool/target"),
+            (stat.S_IFIFO | 0o600, b""),
+            (stat.S_IFCHR | 0o600, b""),
+        )
+        for installer_name, installer in INSTALLERS:
+            for mode, data in cases:
+                with self.subTest(installer=installer_name, mode=oct(mode)):
+                    with tempfile.TemporaryDirectory() as temporary_directory:
+                        root = Path(temporary_directory)
+                        archive = root / "fixture.zip"
+                        make_zip(archive, [("tool/entry", mode, data)])
+                        destination = root / "destination"
+                        destination.mkdir()
+                        with self.assertRaises(installer.InstallError):
+                            installer.extract_zip(archive, destination, "tool")
+
+
+class DownloadBoundaryTests(unittest.TestCase):
+    def run_download(
+        self,
+        installer: ModuleType,
+        response: FakeResponse,
+        destination: Path,
+    ) -> None:
+        with mock.patch.object(
+            installer.urllib.request, "urlopen", return_value=response
+        ):
+            installer.download(response.geturl(), destination)
+
+    def test_declared_length_overrun_and_truncation_are_rejected(self) -> None:
+        for installer_name, installer in INSTALLERS:
+            for body, declared_length, expected_message in (
+                (b"four", "3", "declared length"),
+                (b"two", "4", "length mismatch"),
+            ):
+                with self.subTest(
+                    installer=installer_name,
+                    body=body,
+                    declared_length=declared_length,
+                ):
+                    with tempfile.TemporaryDirectory() as temporary_directory:
+                        destination = Path(temporary_directory) / "archive"
+                        url = "https://example.invalid/archive"
+                        response = fake_response_for(
+                            installer,
+                            url,
+                            body,
+                            content_length=declared_length,
+                        )
+                        with self.assertRaisesRegex(
+                            installer.InstallError, expected_message
+                        ):
+                            self.run_download(installer, response, destination)
+
+    def test_invalid_or_out_of_bounds_lengths_are_rejected(self) -> None:
+        for installer_name, installer in INSTALLERS:
+            invalid_lengths = (None, "not-a-number", "0", "-1")
+            for content_length in invalid_lengths:
+                with self.subTest(
+                    installer=installer_name, content_length=content_length
+                ):
+                    with tempfile.TemporaryDirectory() as temporary_directory:
+                        destination = Path(temporary_directory) / "archive"
+                        url = "https://example.invalid/archive"
+                        response = fake_response_for(
+                            installer,
+                            url,
+                            b"payload",
+                            content_length=content_length,
+                        )
+                        with self.assertRaises(installer.InstallError):
+                            self.run_download(installer, response, destination)
+
+            with self.subTest(installer=installer_name, content_length="oversized"):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    destination = Path(temporary_directory) / "archive"
+                    url = "https://example.invalid/archive"
+                    response = fake_response_for(
+                        installer,
+                        url,
+                        b"payload",
+                        content_length=str(installer.MAX_ARCHIVE_BYTES + 1),
+                    )
+                    with self.assertRaisesRegex(
+                        installer.InstallError, "outside the allowed bound"
+                    ):
+                        self.run_download(installer, response, destination)
+
+    def test_total_deadline_is_enforced_before_writing_late_data(self) -> None:
+        for installer_name, installer in INSTALLERS:
+            with self.subTest(installer=installer_name):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    destination = Path(temporary_directory) / "archive"
+                    url = "https://example.invalid/archive"
+                    response = fake_response_for(
+                        installer,
+                        url,
+                        b"payload",
+                        content_length="7",
+                    )
+                    with mock.patch.object(
+                        installer.time, "monotonic", side_effect=(0.0, 181.0)
+                    ):
+                        with self.assertRaisesRegex(
+                            installer.InstallError, "total deadline"
+                        ):
+                            self.run_download(installer, response, destination)
+                    self.assertEqual(destination.read_bytes(), b"")
+
+    def test_existing_archive_destination_is_never_replaced(self) -> None:
+        for installer_name, installer in INSTALLERS:
+            with self.subTest(installer=installer_name):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    destination = Path(temporary_directory) / "archive"
+                    destination.write_bytes(b"sentinel")
+                    url = "https://example.invalid/archive"
+                    response = fake_response_for(
+                        installer,
+                        url,
+                        b"payload",
+                        content_length="7",
+                    )
+                    with self.assertRaises(FileExistsError):
+                        self.run_download(installer, response, destination)
+                    self.assertEqual(destination.read_bytes(), b"sentinel")
+
+    def test_compressed_transfer_and_insecure_final_url_are_rejected(self) -> None:
+        for installer_name, installer in INSTALLERS:
+            with self.subTest(installer=installer_name, boundary="encoding"):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    destination = Path(temporary_directory) / "archive"
+                    url = "https://example.invalid/archive"
+                    response = fake_response_for(
+                        installer,
+                        url,
+                        b"payload",
+                        content_length="7",
+                        content_encoding="gzip",
+                    )
+                    with self.assertRaisesRegex(
+                        installer.InstallError, "compressed HTTP transfer"
+                    ):
+                        self.run_download(installer, response, destination)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            destination = Path(temporary_directory) / "archive"
+            url = "https://example.invalid/archive"
+            response = fake_response_for(
+                NODE,
+                url,
+                b"payload",
+                content_length="7",
+                final_url="https://cdn.example.invalid/archive",
+            )
+            with mock.patch.object(
+                NODE.urllib.request, "urlopen", return_value=response
+            ):
+                with self.assertRaisesRegex(
+                    NODE.InstallError, "unexpected Node download redirect"
+                ):
+                    NODE.download(url, destination)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            destination = Path(temporary_directory) / "archive"
+            url = "https://example.invalid/archive"
+            response = fake_response_for(
+                UV_PYTHON,
+                url,
+                b"payload",
+                content_length="7",
+                final_url="http://example.invalid/archive",
+            )
+            with mock.patch.object(
+                UV_PYTHON.urllib.request, "urlopen", return_value=response
+            ):
+                with self.assertRaisesRegex(UV_PYTHON.InstallError, "left HTTPS"):
+                    UV_PYTHON.download(url, destination)
+
+
+class InstallBoundaryTests(unittest.TestCase):
+    def install_patches(
+        self,
+        installer: ModuleType,
+        details: dict[str, str],
+    ) -> tuple[object, object, object]:
+        platform_key = ("UnitTestOS", "UnitTestMachine")
+        return (
+            mock.patch.object(installer, "PLATFORMS", {platform_key: details}),
+            mock.patch.object(
+                installer.platform, "system", return_value=platform_key[0]
+            ),
+            mock.patch.object(
+                installer.platform, "machine", return_value=platform_key[1]
+            ),
+        )
+
+    def test_existing_install_root_fails_before_download(self) -> None:
+        for installer_name, installer in INSTALLERS:
+            details = test_platform_details(installer, "0" * 64, "0" * 64)
+            with self.subTest(installer=installer_name):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    install_root = Path(temporary_directory) / "existing"
+                    install_root.mkdir()
+                    platform_table, system, machine = self.install_patches(
+                        installer, details
+                    )
+                    with (
+                        platform_table,
+                        system,
+                        machine,
+                        mock.patch.object(installer, "download") as download,
+                    ):
+                        with self.assertRaisesRegex(
+                            installer.InstallError, "install root already exists"
+                        ):
+                            installer.install(install_root, None, None)
+                    download.assert_not_called()
+
+    def test_archive_digest_mismatch_stops_before_extraction(self) -> None:
+        archive_payload = b"tampered archive"
+        for installer_name, installer in INSTALLERS:
+            details = test_platform_details(installer, "0" * 64, "0" * 64)
+            with self.subTest(installer=installer_name):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    install_root = Path(temporary_directory) / "install"
+
+                    def fake_download(_url: str, destination: Path) -> None:
+                        destination.write_bytes(archive_payload)
+
+                    platform_table, system, machine = self.install_patches(
+                        installer, details
+                    )
+                    with (
+                        platform_table,
+                        system,
+                        machine,
+                        mock.patch.object(
+                            installer, "download", side_effect=fake_download
+                        ),
+                        mock.patch.object(installer, "extract_tar") as extract,
+                    ):
+                        with self.assertRaisesRegex(
+                            installer.InstallError, "archive digest mismatch"
+                        ):
+                            installer.install(install_root, None, None)
+                    extract.assert_not_called()
+
+    def test_executable_digest_mismatch_stops_before_execution(self) -> None:
+        archive_payload = b"authenticated archive fixture"
+        executable_payload = b"tampered executable"
+        archive_sha256 = hashlib.sha256(archive_payload).hexdigest()
+        for installer_name, installer in INSTALLERS:
+            details = test_platform_details(installer, archive_sha256, "0" * 64)
+            with self.subTest(installer=installer_name):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    install_root = Path(temporary_directory) / "install"
+
+                    def fake_download(_url: str, destination: Path) -> None:
+                        destination.write_bytes(archive_payload)
+
+                    def fake_extract(
+                        _archive: Path,
+                        destination: Path,
+                        _expected_root: str,
+                    ) -> None:
+                        executable = destination / str(details["executable"])
+                        executable.parent.mkdir(parents=True)
+                        executable.write_bytes(executable_payload)
+
+                    platform_table, system, machine = self.install_patches(
+                        installer, details
+                    )
+                    with (
+                        platform_table,
+                        system,
+                        machine,
+                        mock.patch.object(
+                            installer, "download", side_effect=fake_download
+                        ),
+                        mock.patch.object(
+                            installer, "extract_tar", side_effect=fake_extract
+                        ),
+                        mock.patch.object(installer.subprocess, "run") as run,
+                    ):
+                        with self.assertRaisesRegex(
+                            installer.InstallError, "executable digest mismatch"
+                        ):
+                            installer.install(install_root, None, None)
+                    run.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_verify_release_notes.py
+++ b/scripts/tests/test_verify_release_notes.py
@@ -10,9 +10,9 @@ import unittest
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 VERIFIER_PATH = REPOSITORY_ROOT / "scripts" / "verify_release_notes.py"
-COMMITTED_NOTES = REPOSITORY_ROOT / "docs" / "releases" / "v0.7.0-beta.6.md"
-TAG = "v0.7.0-beta.6"
-VERSION = "0.7.0-beta.6"
+COMMITTED_NOTES = REPOSITORY_ROOT / "docs" / "releases" / "v0.7.0-beta.7.md"
+TAG = "v0.7.0-beta.7"
+VERSION = "0.7.0-beta.7"
 
 _SPEC = importlib.util.spec_from_file_location("verify_release_notes", VERIFIER_PATH)
 assert _SPEC is not None and _SPEC.loader is not None
@@ -50,7 +50,7 @@ class VerifyReleaseNotesTests(unittest.TestCase):
             repository_root=root,
         )
 
-    def test_committed_beta6_notes_pass_cli_verification(self) -> None:
+    def test_committed_beta7_notes_pass_cli_verification(self) -> None:
         completed = subprocess.run(
             [
                 sys.executable,
@@ -68,6 +68,20 @@ class VerifyReleaseNotesTests(unittest.TestCase):
         )
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertIn(f"tag={TAG}", completed.stdout)
+
+    def test_committed_notes_bind_cancelled_beta6_and_release_toolchain(self) -> None:
+        self.assertIn("The `v0.7.0-beta.6` tag build was cancelled", self.valid_text)
+        self.assertIn("no release assets were created", self.valid_text)
+        self.assertIn(
+            "`v0.7.0-beta.7` is therefore the first published artifact set",
+            self.valid_text,
+        )
+        self.assertIn("hash-pinned `uv` 0.11.30", self.valid_text)
+        self.assertIn("Node.js 22.23.2", self.valid_text)
+        self.assertIn("managed CPython 3.13.14 build 20260718", self.valid_text)
+        self.assertIn("exact Rust 1.97.1", self.valid_text)
+        self.assertIn("hash-pinned sane-backends 1.4.0", self.valid_text)
+        self.assertIn("private Tauri tools tree", self.valid_text)
 
     def test_release_workflow_binds_draft_and_published_bodies(self) -> None:
         workflow = (
@@ -92,7 +106,7 @@ class VerifyReleaseNotesTests(unittest.TestCase):
             with self.assertRaisesRegex(
                 _VERIFIER.ReleaseNotesError, "tag/version mismatch"
             ):
-                self.verify(notes, root, tag="v0.7.0-beta.7")
+                self.verify(notes, root, tag="v0.7.0-beta.8")
 
     def test_version_must_use_the_release_filename_grammar(self) -> None:
         temporary, root, notes = self.make_repository()
@@ -100,7 +114,7 @@ class VerifyReleaseNotesTests(unittest.TestCase):
             with self.assertRaisesRegex(
                 _VERIFIER.ReleaseNotesError, "invalid release version"
             ):
-                self.verify(notes, root, tag="v../../beta.6", version="../../beta.6")
+                self.verify(notes, root, tag="v../../beta.7", version="../../beta.7")
 
     def test_filename_is_derived_from_the_validated_tag(self) -> None:
         temporary, root, notes = self.make_repository()

--- a/scripts/verify_pinned_rust.py
+++ b/scripts/verify_pinned_rust.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Verify the exact rustup-managed Rust toolchain used by CI and releases."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import platform
+import subprocess
+import sys
+
+VERSION = "1.97.1"
+RUSTC_COMMIT = "8bab26f4f68e0e26f0bb7960be334d5b520ea452"
+CARGO_COMMIT = "c980f4866141969fab6254a680546a277789d6f0"
+
+HOSTS = {
+    ("Darwin", "arm64"): "aarch64-apple-darwin",
+    ("Darwin", "x86_64"): "x86_64-apple-darwin",
+    ("Linux", "x86_64"): "x86_64-unknown-linux-gnu",
+    ("Windows", "AMD64"): "x86_64-pc-windows-msvc",
+}
+
+
+def output(*command: str) -> str:
+    return subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    ).stdout.strip()
+
+
+def parse_verbose(text: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for line in text.splitlines()[1:]:
+        if ": " in line:
+            key, value = line.split(": ", 1)
+            fields[key] = value
+    return fields
+
+
+def main() -> int:
+    expected_host = HOSTS.get((platform.system(), platform.machine()))
+    if expected_host is None:
+        print("Unsupported Rust build host", file=sys.stderr)
+        return 1
+
+    rustc = parse_verbose(output("rustc", "-Vv"))
+    cargo = parse_verbose(output("cargo", "-Vv"))
+    expected = {
+        "rustc": (rustc, RUSTC_COMMIT),
+        "cargo": (cargo, CARGO_COMMIT),
+    }
+    for name, (fields, commit) in expected.items():
+        if fields.get("release") != VERSION:
+            raise RuntimeError(f"unexpected {name} release: {fields.get('release')!r}")
+        if fields.get("commit-hash") != commit:
+            raise RuntimeError(
+                f"unexpected {name} commit: {fields.get('commit-hash')!r}"
+            )
+        if fields.get("host") != expected_host:
+            raise RuntimeError(f"unexpected {name} host: {fields.get('host')!r}")
+
+    active = output("rustup", "show", "active-toolchain").split()[0]
+    expected_active = f"{VERSION}-{expected_host}"
+    if active != expected_active:
+        raise RuntimeError(f"unexpected active Rust toolchain: {active!r}")
+    rustc_path = Path(
+        output("rustup", "which", "--toolchain", expected_active, "rustc")
+    ).resolve()
+    cargo_path = Path(
+        output("rustup", "which", "--toolchain", expected_active, "cargo")
+    ).resolve()
+    expected_component = f"toolchains/{expected_active}/bin"
+    for name, path in (("rustc", rustc_path), ("cargo", cargo_path)):
+        if expected_component not in path.as_posix():
+            raise RuntimeError(f"{name} escaped the exact rustup toolchain: {path}")
+
+    print(
+        f"Pinned Rust verified: toolchain={expected_active} "
+        f"rustc={RUSTC_COMMIT} cargo={CARGO_COMMIT}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- authenticate every release build tool and Python artifact before use
- build the optional python-sane binding against an exact private SANE link SDK
- pin and preverify Tauri NSIS, WebView2, and Linux AppImage inputs
- require tag containment in reviewed main history and complete tag-bound beta.7 notes
- replace the line-oriented action pin checker with a fail-closed structural workflow policy

## Local verification

- senior-security final verdict: GO; no remaining P1/P2 blocker
- scripts: 76/76
- Python artifact adversarial tests: 9/9
- Tauri tool adversarial tests: 11/11
- Windows staging verifier: 51 passed, 1 expected WSL-only skip
- Linux staging verifier: 43 passed, 2 expected native-Linux skips
- workflow action policy: 39 exact external references
- actionlint, Ruff, shell syntax, vendor sync, CoolScanPy PyPI/source identity, release-note verifier, and diff checks passed
- exact cargo-about 0.9.1 installer completed successfully
- fresh Node 22.23.2/npm 10.9.8 installation passed with exact archive and executable hashes

## Boundaries

- Windows PowerShell/NSIS and strict native Linux runtime checks remain CI-hosted gates
- no Windows scanner runtime test or scanner operation was performed
- Apple Developer ID/notarization credentials remain absent; automatic installation stays fail-closed and beta.7 is documented as a manual, checksum-verified install
- v0.7.0-beta.6 remains an immutable cancelled-build tag with no release or assets; v0.7.0-beta.7 is the intended first published artifact set
