### PR TITLE
Eject after a failed preview: vendor fallback, confirmed, typed end-to-end

### DIFF
--- a/app/ScanStudio/engine/src/protocol.rs
+++ b/app/ScanStudio/engine/src/protocol.rs
@@ -116,6 +116,14 @@ pub enum ErrorCode {
     /// A recognized-but-unsupported Nikon model (Lane D, #14): discovery
     /// lists it by name, but connect is refused. Fail-closed.
     NotSupported,
+    /// The bridge's eject could not run or could not confirm the film
+    /// left the transport. Previously flattened to `Internal`, which made
+    /// the #16/#68/#76 eject failures undiagnosable client-side.
+    EjectFailed,
+    /// The driver's typed accepted-without-progress eject outcome
+    /// (INCIDENT-20260719-eject-from-park): the transport never actuated
+    /// and a power cycle is the only demonstrated recovery.
+    FeederParked,
 }
 
 // ---------------------------------------------------------------------
@@ -858,6 +866,8 @@ mod tests {
             (ErrorCode::ManualReviewRequired, "MANUAL_REVIEW_REQUIRED"),
             (ErrorCode::HwMotionNotArmed, "HW_MOTION_NOT_ARMED"),
             (ErrorCode::NotSupported, "NOT_SUPPORTED"),
+            (ErrorCode::EjectFailed, "EJECT_FAILED"),
+            (ErrorCode::FeederParked, "FEEDER_PARKED"),
         ] {
             assert_eq!(serde_json::to_value(code).unwrap(), json!(wire));
             let decoded: ErrorCode = serde_json::from_value(json!(wire)).unwrap();

--- a/app/ScanStudio/engine/src/real_backend.rs
+++ b/app/ScanStudio/engine/src/real_backend.rs
@@ -4509,6 +4509,8 @@ fn map_bridge_error_code_str(code: &str) -> ErrorCode {
         "FILM_FEED_INTERRUPTED" => ErrorCode::FilmFeedInterrupted,
         "HW_MOTION_NOT_ARMED" => ErrorCode::HwMotionNotArmed,
         "UNKNOWN_JOB" => ErrorCode::UnknownJob,
+        "EJECT_FAILED" => ErrorCode::EjectFailed,
+        "FEEDER_PARKED" => ErrorCode::FeederParked,
         _ => ErrorCode::Internal,
     }
 }

--- a/bridge/src/scanstudio_bridge/service.py
+++ b/bridge/src/scanstudio_bridge/service.py
@@ -623,6 +623,26 @@ class BridgeService:
                     "device.eject", "error", code=exc.code.value, message=str(exc)
                 )
                 raise
+            except Exception as exc:
+                # Wire-contract boundary: BRIDGE.md documents EJECT_FAILED
+                # as "the eject could not run", which is true for any
+                # unmapped transport/driver exception. Left alone these
+                # fall through to cli.py's catch-all and reach the client
+                # as a bare INTERNAL with no telemetry line -- the shape
+                # that made the #16/#68/#76 field reports undiagnosable.
+                # The original type rides in the message so a driver
+                # defect still reads as one.
+                message = (
+                    f"eject failed before completion "
+                    f"({type(exc).__name__}: {exc})"
+                )
+                self._telemetry.record(
+                    "device.eject",
+                    "error",
+                    code=ErrorCode.EJECT_FAILED.value,
+                    message=message,
+                )
+                raise BridgeError(ErrorCode.EJECT_FAILED, message) from exc
             finally:
                 self._lane_held = False
         if not ejected:

--- a/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -1565,14 +1565,11 @@ class CoolscanPyTransport:
     def eject(self) -> bool:
         if self._device is None:
             raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
-        # Route through the open Roll when one exists. On the pinned
-        # coolscanpy `Roll.eject()` is a plain passthrough to
-        # `Device.eject()`, so behavior is identical today -- but the
-        # vendor-traced held-session eject (RESERVE_UNIT before the eject
-        # CDB, proven live 2026-07-20 from a normal post-traversal state)
-        # lands on `Roll` first (see coolscanpy's capture branch), so this
-        # routing picks it up with zero bridge changes the day the pin
-        # advances. The callable guard keeps duck-typed Roll doubles
+        # Route through the open Roll when one exists: on the current pin
+        # `Roll.eject()` replays the vendor-traced held-session eject
+        # sequence (RESERVE_UNIT before the eject CDB, proven live
+        # 2026-07-20), which is only valid while a preview's reservation
+        # is still held. The callable guard keeps duck-typed Roll doubles
         # without an eject method on the device route instead of dying
         # with an AttributeError.
         roll = self._roll
@@ -1580,11 +1577,16 @@ class CoolscanPyTransport:
             target = roll
         else:
             target = self._device
-        # Future-pin exception (capture branch): Roll.eject() with no held
-        # reservation raises EjectNotAvailable, which is NOT an EjectFailed
-        # subclass. Resolved per call so the editable pin advancing is
-        # picked up without a bridge restart ordering hazard; the empty
-        # tuple makes the except clause match nothing on today's pin.
+        # True whenever the eject that produced `ejected` ran through the
+        # vendor Device route (directly, or as the fallback below) -- that
+        # route reports acceptance, not actuation, so its success must be
+        # confirmed before it is reported (see _require_vendor_eject_confirmed).
+        vendor_route = target is self._device
+        # Roll.eject() with no held reservation raises EjectNotAvailable,
+        # which is NOT an EjectFailed subclass. Exported by the pinned
+        # coolscanpy since 2026-08-07; still resolved per call so a pin
+        # without the symbol degrades to an empty tuple (matching nothing)
+        # instead of an AttributeError at import order.
         eject_not_available: tuple[type[BaseException], ...] = tuple(
             cls
             for cls in (getattr(coolscanpy, "EjectNotAvailable", None),)
@@ -1609,7 +1611,42 @@ class CoolscanPyTransport:
         except coolscanpy.EjectFailed as exc:
             raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
         except eject_not_available as exc:
-            raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
+            if target is not roll:
+                # Defensive, should be unreachable: EjectNotAvailable is
+                # raised only by Roll.eject(), never by Device.eject().
+                raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
+            # A failed preview's fail-closed teardown already released the
+            # held reservation (coolscanpy 0.2.0), so Roll.eject() refuses
+            # here WITHOUT having sent any command -- the film is still
+            # physically inside (field reports #16 #68 #76: power cycle was
+            # the only way out). No eject has been attempted yet, so fall
+            # back to the capability-gated vendor eject on Device before
+            # giving up. Every fallback outcome keeps the direct device
+            # route's typed mapping, and success below still requires a
+            # confirmed ejected=True -- the fallback adds a second attempt,
+            # never a weaker acceptance.
+            vendor_route = True
+            try:
+                ejected = bool(self._device.eject())
+            except ImportError as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.EJECT_FAILED,
+                    "real eject requires the coolscanpy[scanner] extra and SANE installed -- see README",
+                ) from fallback_exc
+            except coolscanpy.DeviceBusy as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.DEVICE_BUSY, str(fallback_exc)
+                ) from fallback_exc
+            except coolscanpy.FeederParked as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.FEEDER_PARKED, str(fallback_exc)
+                ) from fallback_exc
+            except coolscanpy.EjectFailed as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.EJECT_FAILED, str(fallback_exc)
+                ) from fallback_exc
+        if ejected and vendor_route:
+            self._require_vendor_eject_confirmed()
         if not ejected:
             # A capability-gated no-op is NOT an eject: the film is still
             # inside the feeder. Returning success here would be exactly
@@ -1621,12 +1658,53 @@ class CoolscanPyTransport:
             )
         # The strip is out: the roll session and preview no longer
         # describe loaded film. Close-first ordering on purpose -- if
-        # close() raises (surfaced as INTERNAL by service.py's boundary),
-        # `self._roll` stays set so `device.close` can still close
-        # Roll-then-Device in the order coolscanpy requires.
+        # close() raises, `self._roll` stays set so `device.close` can
+        # still close Roll-then-Device in the order coolscanpy requires.
+        # The failure is raised typed as INTERNAL with a message that says
+        # the film IS out: letting it reach service.py's generic eject
+        # boundary would report "eject failed" for a completed eject.
         if self._roll is not None:
-            self._roll.close()
+            try:
+                self._roll.close()
+            except Exception as exc:
+                raise BridgeError(
+                    ErrorCode.INTERNAL,
+                    "the film was ejected, but closing the roll session "
+                    f"afterwards failed ({type(exc).__name__}: {exc}); "
+                    "disconnect and reconnect before the next preview",
+                ) from exc
             self._roll = None
         self._material = None
         self._preview_established = False
         return True
+
+    def _require_vendor_eject_confirmed(self) -> None:
+        # The vendor eject reports acceptance, not actuation: the LS-5000
+        # can accept the eject CDB with clean sense and never move
+        # (INCIDENT-20260719-eject-from-park, reconfirmed 2026-07-24 from
+        # the 022b4b wedge). The Roll route confirms actuation through the
+        # worker journal; the Device route must confirm through the
+        # motion-free film-presence probe before any success is reported.
+        # The probe's None means "could not determine" -- per its own
+        # contract it must never be read as film-absent -- so anything
+        # short of a definite False fails closed.
+        probe = getattr(self._device, "film_present", None)
+        present: bool | None = None
+        if callable(probe):
+            try:
+                present = probe()
+            except Exception:
+                present = None
+        if present is True:
+            raise BridgeError(
+                ErrorCode.FEEDER_PARKED,
+                "the vendor eject was accepted but the film is still "
+                "present; the transport did not actuate -- a power cycle "
+                "is the only demonstrated recovery",
+            )
+        if present is not False:
+            raise BridgeError(
+                ErrorCode.EJECT_FAILED,
+                "the vendor eject was accepted but film presence could "
+                "not be confirmed clear; treat the film as still loaded",
+            )

--- a/bridge/tests/test_service_dispatch.py
+++ b/bridge/tests/test_service_dispatch.py
@@ -592,6 +592,38 @@ def test_device_eject_bridge_error_from_transport_records_error_telemetry(
     assert "power cycle" in error_entry["message"]
 
 
+def test_device_eject_unmapped_transport_exception_is_eject_failed_not_internal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transport/driver exception outside the transport's mapped ladder
+    must reach the wire as a typed EJECT_FAILED with a code+message
+    telemetry line -- not fall through to cli.py's catch-all INTERNAL,
+    which is how the #16/#68/#76 eject failures shipped undiagnosable."""
+
+    class _ExplodingTransport(_StubTransport):
+        def eject(self) -> bool:
+            raise RuntimeError("capture worker reaped mid-eject")
+
+    svc = _opened_service(tmp_path, _ExplodingTransport())
+    _arm(monkeypatch, tmp_path)
+    emit = _RecordingEmit()
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch({"id": 2, "method": "device.eject"}, emit)
+
+    assert excinfo.value.code == ErrorCode.EJECT_FAILED
+    assert "RuntimeError" in str(excinfo.value)
+    assert "capture worker reaped mid-eject" in str(excinfo.value)
+    assert not emit.has("device.status")
+    error_entry = next(
+        e
+        for e in _telemetry_entries(tmp_path)
+        if e["method"] == "device.eject" and e["outcome"] == "error"
+    )
+    assert error_entry["code"] == ErrorCode.EJECT_FAILED.value
+    assert "RuntimeError" in error_entry["message"]
+
+
 def test_device_eject_success_clears_preview_material_so_scan_start_is_no_preview(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/bridge/tests/test_transport_coolscanpy.py
+++ b/bridge/tests/test_transport_coolscanpy.py
@@ -201,6 +201,11 @@ class _FakeDevice:
     def __init__(self, roll: _FakeRoll | None = None) -> None:
         self._roll = roll
         self.eject_effect: object = True
+        # The vendor-eject confirmation probe (Device.film_present): None
+        # (undetermined) mirrors the pre-probe default; vendor-route eject
+        # success tests set False (confirmed-out) explicitly, and the
+        # accepted-without-progress / unconfirmable shapes set True/None.
+        self.film_present_result: object = None
         self.closed = False
         self.capabilities = _fake_capabilities()
         # Plan 10-09 (attempts-root persistence): records exactly what
@@ -218,6 +223,11 @@ class _FakeDevice:
         if isinstance(self.eject_effect, BaseException):
             raise self.eject_effect
         return self.eject_effect
+
+    def film_present(self) -> bool | None:
+        if isinstance(self.film_present_result, BaseException):
+            raise self.film_present_result
+        return self.film_present_result
 
     def close(self) -> None:
         self.closed = True
@@ -3091,6 +3101,7 @@ def test_eject_raises_eject_failed_on_coolscanpy_eject_failed(
 def test_eject_returns_true_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
     transport, device = _opened_transport(monkeypatch, _FakeRoll())
     device.eject_effect = True
+    device.film_present_result = False
     assert transport.eject() is True
 
 
@@ -3156,6 +3167,7 @@ def test_eject_falls_back_to_device_when_roll_lacks_eject(
     roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)])
     transport, device = _opened_transport(monkeypatch, roll)
     device.eject_effect = True
+    device.film_present_result = False
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
 
     assert transport.eject() is True
@@ -3187,30 +3199,182 @@ def test_eject_maps_feeder_parked_stall_and_preserves_session_state(
     assert transport.status().preview_established is True
 
 
-def test_eject_maps_future_pin_eject_not_available_to_eject_failed(
+def test_eject_not_available_falls_back_to_device_eject(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The capture branch's Roll.eject() raises EjectNotAvailable (not an
-    EjectFailed subclass) when no held reservation exists. The pinned
-    coolscanpy does not export it yet; the transport resolves it by name at
-    call time so the mapping is already correct the day the pin advances."""
-
-    class _EjectNotAvailable(Exception):
-        pass
-
-    monkeypatch.setattr(coolscanpy, "EjectNotAvailable", _EjectNotAvailable, raising=False)
+    """Roll.eject() with no held reservation (the state every failed
+    preview's fail-closed teardown leaves behind) raises the REAL exported
+    coolscanpy.EjectNotAvailable without sending any command -- so the
+    transport must try the capability-gated vendor eject on Device instead
+    of refusing outright (#16 #68 #76: the refusal used to strand the film
+    until a power cycle). Uses the real exception class on purpose: the
+    old fake-substitute version of this test could not catch a
+    class-identity regression."""
     roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
-    roll.eject_effect = _EjectNotAvailable(
+    roll.eject_effect = coolscanpy.EjectNotAvailable(
         "no held reservation to eject: call preview() first"
     )
-    transport, _device = _opened_transport(monkeypatch, roll)
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = True
+    device.film_present_result = False
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    assert transport.eject() is True
+
+    assert roll.eject_calls == 1
+    assert roll.closed is True
+    assert transport.status().preview_established is False
+
+
+def test_eject_fallback_failure_stays_typed_and_preserves_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the Device fallback also fails, the error stays the typed
+    EJECT_FAILED of the direct device route -- and the roll session is
+    preserved exactly as the FeederParked case preserves it, because the
+    film did not come out."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.EjectFailed("vendor eject command failed")
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
 
     with pytest.raises(BridgeError) as excinfo:
         transport.eject()
 
     assert excinfo.value.code == ErrorCode.EJECT_FAILED
-    assert "no held reservation" in str(excinfo.value)
+    assert "vendor eject command failed" in str(excinfo.value)
+    assert roll.closed is False
+    assert transport.status().preview_established is True
+
+
+def test_eject_fallback_feeder_parked_maps_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked transport reported by the fallback vendor eject keeps the
+    FEEDER_PARKED taxonomy (never a silent success, never a retry)."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.FeederParked(
+        "eject accepted without confirmed clear; power cycle required"
+    )
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.FEEDER_PARKED
+    assert roll.closed is False
+
+
+def test_eject_fallback_device_busy_maps_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DeviceBusy from the fallback vendor eject is a retry-later state,
+    not an eject failure -- it must keep its own taxonomy instead of
+    collapsing into EJECT_FAILED."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.DeviceBusy("io lock is held")
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.DEVICE_BUSY
+    assert roll.closed is False
+
+
+def test_vendor_eject_still_present_after_accept_is_feeder_parked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The vendor eject reports acceptance, not actuation
+    (INCIDENT-20260719-eject-from-park): a clean scanimage exit with film
+    still present is the accepted-without-progress wedge and must surface
+    as FEEDER_PARKED, never as success."""
+    transport, device = _opened_transport(monkeypatch, _FakeRoll())
+    device.eject_effect = True
+    device.film_present_result = True
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.FEEDER_PARKED
+    assert "still present" in str(excinfo.value)
+
+
+def test_vendor_eject_unconfirmable_presence_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """film_present() -> None means undetermined -- per its contract it
+    must never be read as film-absent, so an unconfirmable vendor eject
+    fails closed as EJECT_FAILED."""
+    transport, device = _opened_transport(monkeypatch, _FakeRoll())
+    device.eject_effect = True
+    device.film_present_result = None
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.EJECT_FAILED
+    assert "could not be confirmed" in str(excinfo.value)
+
+
+def test_eject_roll_close_failure_reports_film_out_not_eject_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-eject Roll.close() failure happens AFTER the film is
+    physically out: it must surface as INTERNAL with a message saying so,
+    never as an eject failure -- and `_roll` stays set so device.close can
+    still run the Roll-then-Device teardown order."""
+
+    class _CloseFailingRoll(_EjectRecordingRoll):
+        def close(self) -> None:
+            raise RuntimeError("batch worker still reporting")
+
+    roll = _CloseFailingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = True
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.INTERNAL
+    assert "the film was ejected" in str(excinfo.value)
+    assert roll.closed is False
+
+
+def test_eject_after_failed_preview_ejects_via_device_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end regression for the #16/#68/#76 shape: preview fails, the
+    operator clicks Eject, and the film must come out through the Device
+    fallback instead of the guaranteed EjectNotAvailable refusal."""
+
+    class _RefusedPreviewRoll(_EjectRecordingRoll):
+        def preview(self, slots: list[int] | None = None) -> list["coolscanpy.Thumbnail"]:
+            raise coolscanpy.RefeedRequired(
+                "preview could not establish a usable roll session"
+            )
+
+    roll = _RefusedPreviewRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable(
+        "no held reservation to eject: call preview() first"
+    )
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = True
+    device.film_present_result = False
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert excinfo.value.code == ErrorCode.REFEED_REQUIRED
+
+    assert transport.eject() is True
+    assert roll.eject_calls == 1
+    assert roll.closed is True
 
 
 # -- coolscanpy_provenance (Plan 10-09) ---------------------------------------------

--- a/ports/tauri/vendor/engine/src/protocol.rs
+++ b/ports/tauri/vendor/engine/src/protocol.rs
@@ -116,6 +116,14 @@ pub enum ErrorCode {
     /// A recognized-but-unsupported Nikon model (Lane D, #14): discovery
     /// lists it by name, but connect is refused. Fail-closed.
     NotSupported,
+    /// The bridge's eject could not run or could not confirm the film
+    /// left the transport. Previously flattened to `Internal`, which made
+    /// the #16/#68/#76 eject failures undiagnosable client-side.
+    EjectFailed,
+    /// The driver's typed accepted-without-progress eject outcome
+    /// (INCIDENT-20260719-eject-from-park): the transport never actuated
+    /// and a power cycle is the only demonstrated recovery.
+    FeederParked,
 }
 
 // ---------------------------------------------------------------------
@@ -858,6 +866,8 @@ mod tests {
             (ErrorCode::ManualReviewRequired, "MANUAL_REVIEW_REQUIRED"),
             (ErrorCode::HwMotionNotArmed, "HW_MOTION_NOT_ARMED"),
             (ErrorCode::NotSupported, "NOT_SUPPORTED"),
+            (ErrorCode::EjectFailed, "EJECT_FAILED"),
+            (ErrorCode::FeederParked, "FEEDER_PARKED"),
         ] {
             assert_eq!(serde_json::to_value(code).unwrap(), json!(wire));
             let decoded: ErrorCode = serde_json::from_value(json!(wire)).unwrap();

--- a/ports/tauri/vendor/engine/src/real_backend.rs
+++ b/ports/tauri/vendor/engine/src/real_backend.rs
@@ -4595,6 +4595,8 @@ fn map_bridge_error_code_str(code: &str) -> ErrorCode {
         "FILM_FEED_INTERRUPTED" => ErrorCode::FilmFeedInterrupted,
         "HW_MOTION_NOT_ARMED" => ErrorCode::HwMotionNotArmed,
         "UNKNOWN_JOB" => ErrorCode::UnknownJob,
+        "EJECT_FAILED" => ErrorCode::EjectFailed,
+        "FEEDER_PARKED" => ErrorCode::FeederParked,
         _ => ErrorCode::Internal,
     }
 }

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
@@ -632,6 +632,26 @@ class BridgeService:
                     "device.eject", "error", code=exc.code.value, message=str(exc)
                 )
                 raise
+            except Exception as exc:
+                # Wire-contract boundary: BRIDGE.md documents EJECT_FAILED
+                # as "the eject could not run", which is true for any
+                # unmapped transport/driver exception. Left alone these
+                # fall through to cli.py's catch-all and reach the client
+                # as a bare INTERNAL with no telemetry line -- the shape
+                # that made the #16/#68/#76 field reports undiagnosable.
+                # The original type rides in the message so a driver
+                # defect still reads as one.
+                message = (
+                    f"eject failed before completion "
+                    f"({type(exc).__name__}: {exc})"
+                )
+                self._telemetry.record(
+                    "device.eject",
+                    "error",
+                    code=ErrorCode.EJECT_FAILED.value,
+                    message=message,
+                )
+                raise BridgeError(ErrorCode.EJECT_FAILED, message) from exc
             finally:
                 self._lane_held = False
         if not ejected:

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -1565,14 +1565,11 @@ class CoolscanPyTransport:
     def eject(self) -> bool:
         if self._device is None:
             raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
-        # Route through the open Roll when one exists. On the pinned
-        # coolscanpy `Roll.eject()` is a plain passthrough to
-        # `Device.eject()`, so behavior is identical today -- but the
-        # vendor-traced held-session eject (RESERVE_UNIT before the eject
-        # CDB, proven live 2026-07-20 from a normal post-traversal state)
-        # lands on `Roll` first (see coolscanpy's capture branch), so this
-        # routing picks it up with zero bridge changes the day the pin
-        # advances. The callable guard keeps duck-typed Roll doubles
+        # Route through the open Roll when one exists: on the current pin
+        # `Roll.eject()` replays the vendor-traced held-session eject
+        # sequence (RESERVE_UNIT before the eject CDB, proven live
+        # 2026-07-20), which is only valid while a preview's reservation
+        # is still held. The callable guard keeps duck-typed Roll doubles
         # without an eject method on the device route instead of dying
         # with an AttributeError.
         roll = self._roll
@@ -1580,11 +1577,16 @@ class CoolscanPyTransport:
             target = roll
         else:
             target = self._device
-        # Future-pin exception (capture branch): Roll.eject() with no held
-        # reservation raises EjectNotAvailable, which is NOT an EjectFailed
-        # subclass. Resolved per call so the editable pin advancing is
-        # picked up without a bridge restart ordering hazard; the empty
-        # tuple makes the except clause match nothing on today's pin.
+        # True whenever the eject that produced `ejected` ran through the
+        # vendor Device route (directly, or as the fallback below) -- that
+        # route reports acceptance, not actuation, so its success must be
+        # confirmed before it is reported (see _require_vendor_eject_confirmed).
+        vendor_route = target is self._device
+        # Roll.eject() with no held reservation raises EjectNotAvailable,
+        # which is NOT an EjectFailed subclass. Exported by the pinned
+        # coolscanpy since 2026-08-07; still resolved per call so a pin
+        # without the symbol degrades to an empty tuple (matching nothing)
+        # instead of an AttributeError at import order.
         eject_not_available: tuple[type[BaseException], ...] = tuple(
             cls
             for cls in (getattr(coolscanpy, "EjectNotAvailable", None),)
@@ -1609,7 +1611,42 @@ class CoolscanPyTransport:
         except coolscanpy.EjectFailed as exc:
             raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
         except eject_not_available as exc:
-            raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
+            if target is not roll:
+                # Defensive, should be unreachable: EjectNotAvailable is
+                # raised only by Roll.eject(), never by Device.eject().
+                raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
+            # A failed preview's fail-closed teardown already released the
+            # held reservation (coolscanpy 0.2.0), so Roll.eject() refuses
+            # here WITHOUT having sent any command -- the film is still
+            # physically inside (field reports #16 #68 #76: power cycle was
+            # the only way out). No eject has been attempted yet, so fall
+            # back to the capability-gated vendor eject on Device before
+            # giving up. Every fallback outcome keeps the direct device
+            # route's typed mapping, and success below still requires a
+            # confirmed ejected=True -- the fallback adds a second attempt,
+            # never a weaker acceptance.
+            vendor_route = True
+            try:
+                ejected = bool(self._device.eject())
+            except ImportError as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.EJECT_FAILED,
+                    "real eject requires the coolscanpy[scanner] extra and SANE installed -- see README",
+                ) from fallback_exc
+            except coolscanpy.DeviceBusy as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.DEVICE_BUSY, str(fallback_exc)
+                ) from fallback_exc
+            except coolscanpy.FeederParked as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.FEEDER_PARKED, str(fallback_exc)
+                ) from fallback_exc
+            except coolscanpy.EjectFailed as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.EJECT_FAILED, str(fallback_exc)
+                ) from fallback_exc
+        if ejected and vendor_route:
+            self._require_vendor_eject_confirmed()
         if not ejected:
             # A capability-gated no-op is NOT an eject: the film is still
             # inside the feeder. Returning success here would be exactly
@@ -1621,12 +1658,53 @@ class CoolscanPyTransport:
             )
         # The strip is out: the roll session and preview no longer
         # describe loaded film. Close-first ordering on purpose -- if
-        # close() raises (surfaced as INTERNAL by service.py's boundary),
-        # `self._roll` stays set so `device.close` can still close
-        # Roll-then-Device in the order coolscanpy requires.
+        # close() raises, `self._roll` stays set so `device.close` can
+        # still close Roll-then-Device in the order coolscanpy requires.
+        # The failure is raised typed as INTERNAL with a message that says
+        # the film IS out: letting it reach service.py's generic eject
+        # boundary would report "eject failed" for a completed eject.
         if self._roll is not None:
-            self._roll.close()
+            try:
+                self._roll.close()
+            except Exception as exc:
+                raise BridgeError(
+                    ErrorCode.INTERNAL,
+                    "the film was ejected, but closing the roll session "
+                    f"afterwards failed ({type(exc).__name__}: {exc}); "
+                    "disconnect and reconnect before the next preview",
+                ) from exc
             self._roll = None
         self._material = None
         self._preview_established = False
         return True
+
+    def _require_vendor_eject_confirmed(self) -> None:
+        # The vendor eject reports acceptance, not actuation: the LS-5000
+        # can accept the eject CDB with clean sense and never move
+        # (INCIDENT-20260719-eject-from-park, reconfirmed 2026-07-24 from
+        # the 022b4b wedge). The Roll route confirms actuation through the
+        # worker journal; the Device route must confirm through the
+        # motion-free film-presence probe before any success is reported.
+        # The probe's None means "could not determine" -- per its own
+        # contract it must never be read as film-absent -- so anything
+        # short of a definite False fails closed.
+        probe = getattr(self._device, "film_present", None)
+        present: bool | None = None
+        if callable(probe):
+            try:
+                present = probe()
+            except Exception:
+                present = None
+        if present is True:
+            raise BridgeError(
+                ErrorCode.FEEDER_PARKED,
+                "the vendor eject was accepted but the film is still "
+                "present; the transport did not actuate -- a power cycle "
+                "is the only demonstrated recovery",
+            )
+        if present is not False:
+            raise BridgeError(
+                ErrorCode.EJECT_FAILED,
+                "the vendor eject was accepted but film presence could "
+                "not be confirmed clear; treat the film as still loaded",
+            )

--- a/ports/tauri/vendor/scanstudio-bridge/tests/test_service_dispatch.py
+++ b/ports/tauri/vendor/scanstudio-bridge/tests/test_service_dispatch.py
@@ -592,6 +592,38 @@ def test_device_eject_bridge_error_from_transport_records_error_telemetry(
     assert "power cycle" in error_entry["message"]
 
 
+def test_device_eject_unmapped_transport_exception_is_eject_failed_not_internal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transport/driver exception outside the transport's mapped ladder
+    must reach the wire as a typed EJECT_FAILED with a code+message
+    telemetry line -- not fall through to cli.py's catch-all INTERNAL,
+    which is how the #16/#68/#76 eject failures shipped undiagnosable."""
+
+    class _ExplodingTransport(_StubTransport):
+        def eject(self) -> bool:
+            raise RuntimeError("capture worker reaped mid-eject")
+
+    svc = _opened_service(tmp_path, _ExplodingTransport())
+    _arm(monkeypatch, tmp_path)
+    emit = _RecordingEmit()
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch({"id": 2, "method": "device.eject"}, emit)
+
+    assert excinfo.value.code == ErrorCode.EJECT_FAILED
+    assert "RuntimeError" in str(excinfo.value)
+    assert "capture worker reaped mid-eject" in str(excinfo.value)
+    assert not emit.has("device.status")
+    error_entry = next(
+        e
+        for e in _telemetry_entries(tmp_path)
+        if e["method"] == "device.eject" and e["outcome"] == "error"
+    )
+    assert error_entry["code"] == ErrorCode.EJECT_FAILED.value
+    assert "RuntimeError" in error_entry["message"]
+
+
 def test_device_eject_success_clears_preview_material_so_scan_start_is_no_preview(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
+++ b/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
@@ -201,6 +201,11 @@ class _FakeDevice:
     def __init__(self, roll: _FakeRoll | None = None) -> None:
         self._roll = roll
         self.eject_effect: object = True
+        # The vendor-eject confirmation probe (Device.film_present): None
+        # (undetermined) mirrors the pre-probe default; vendor-route eject
+        # success tests set False (confirmed-out) explicitly, and the
+        # accepted-without-progress / unconfirmable shapes set True/None.
+        self.film_present_result: object = None
         self.closed = False
         self.capabilities = _fake_capabilities()
         # Plan 10-09 (attempts-root persistence): records exactly what
@@ -218,6 +223,11 @@ class _FakeDevice:
         if isinstance(self.eject_effect, BaseException):
             raise self.eject_effect
         return self.eject_effect
+
+    def film_present(self) -> bool | None:
+        if isinstance(self.film_present_result, BaseException):
+            raise self.film_present_result
+        return self.film_present_result
 
     def close(self) -> None:
         self.closed = True
@@ -3091,6 +3101,7 @@ def test_eject_raises_eject_failed_on_coolscanpy_eject_failed(
 def test_eject_returns_true_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
     transport, device = _opened_transport(monkeypatch, _FakeRoll())
     device.eject_effect = True
+    device.film_present_result = False
     assert transport.eject() is True
 
 
@@ -3156,6 +3167,7 @@ def test_eject_falls_back_to_device_when_roll_lacks_eject(
     roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)])
     transport, device = _opened_transport(monkeypatch, roll)
     device.eject_effect = True
+    device.film_present_result = False
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
 
     assert transport.eject() is True
@@ -3187,30 +3199,182 @@ def test_eject_maps_feeder_parked_stall_and_preserves_session_state(
     assert transport.status().preview_established is True
 
 
-def test_eject_maps_future_pin_eject_not_available_to_eject_failed(
+def test_eject_not_available_falls_back_to_device_eject(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The capture branch's Roll.eject() raises EjectNotAvailable (not an
-    EjectFailed subclass) when no held reservation exists. The pinned
-    coolscanpy does not export it yet; the transport resolves it by name at
-    call time so the mapping is already correct the day the pin advances."""
-
-    class _EjectNotAvailable(Exception):
-        pass
-
-    monkeypatch.setattr(coolscanpy, "EjectNotAvailable", _EjectNotAvailable, raising=False)
+    """Roll.eject() with no held reservation (the state every failed
+    preview's fail-closed teardown leaves behind) raises the REAL exported
+    coolscanpy.EjectNotAvailable without sending any command -- so the
+    transport must try the capability-gated vendor eject on Device instead
+    of refusing outright (#16 #68 #76: the refusal used to strand the film
+    until a power cycle). Uses the real exception class on purpose: the
+    old fake-substitute version of this test could not catch a
+    class-identity regression."""
     roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
-    roll.eject_effect = _EjectNotAvailable(
+    roll.eject_effect = coolscanpy.EjectNotAvailable(
         "no held reservation to eject: call preview() first"
     )
-    transport, _device = _opened_transport(monkeypatch, roll)
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = True
+    device.film_present_result = False
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    assert transport.eject() is True
+
+    assert roll.eject_calls == 1
+    assert roll.closed is True
+    assert transport.status().preview_established is False
+
+
+def test_eject_fallback_failure_stays_typed_and_preserves_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the Device fallback also fails, the error stays the typed
+    EJECT_FAILED of the direct device route -- and the roll session is
+    preserved exactly as the FeederParked case preserves it, because the
+    film did not come out."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.EjectFailed("vendor eject command failed")
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
 
     with pytest.raises(BridgeError) as excinfo:
         transport.eject()
 
     assert excinfo.value.code == ErrorCode.EJECT_FAILED
-    assert "no held reservation" in str(excinfo.value)
+    assert "vendor eject command failed" in str(excinfo.value)
+    assert roll.closed is False
+    assert transport.status().preview_established is True
+
+
+def test_eject_fallback_feeder_parked_maps_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked transport reported by the fallback vendor eject keeps the
+    FEEDER_PARKED taxonomy (never a silent success, never a retry)."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.FeederParked(
+        "eject accepted without confirmed clear; power cycle required"
+    )
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.FEEDER_PARKED
+    assert roll.closed is False
+
+
+def test_eject_fallback_device_busy_maps_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DeviceBusy from the fallback vendor eject is a retry-later state,
+    not an eject failure -- it must keep its own taxonomy instead of
+    collapsing into EJECT_FAILED."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.DeviceBusy("io lock is held")
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.DEVICE_BUSY
+    assert roll.closed is False
+
+
+def test_vendor_eject_still_present_after_accept_is_feeder_parked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The vendor eject reports acceptance, not actuation
+    (INCIDENT-20260719-eject-from-park): a clean scanimage exit with film
+    still present is the accepted-without-progress wedge and must surface
+    as FEEDER_PARKED, never as success."""
+    transport, device = _opened_transport(monkeypatch, _FakeRoll())
+    device.eject_effect = True
+    device.film_present_result = True
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.FEEDER_PARKED
+    assert "still present" in str(excinfo.value)
+
+
+def test_vendor_eject_unconfirmable_presence_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """film_present() -> None means undetermined -- per its contract it
+    must never be read as film-absent, so an unconfirmable vendor eject
+    fails closed as EJECT_FAILED."""
+    transport, device = _opened_transport(monkeypatch, _FakeRoll())
+    device.eject_effect = True
+    device.film_present_result = None
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.EJECT_FAILED
+    assert "could not be confirmed" in str(excinfo.value)
+
+
+def test_eject_roll_close_failure_reports_film_out_not_eject_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-eject Roll.close() failure happens AFTER the film is
+    physically out: it must surface as INTERNAL with a message saying so,
+    never as an eject failure -- and `_roll` stays set so device.close can
+    still run the Roll-then-Device teardown order."""
+
+    class _CloseFailingRoll(_EjectRecordingRoll):
+        def close(self) -> None:
+            raise RuntimeError("batch worker still reporting")
+
+    roll = _CloseFailingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = True
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.INTERNAL
+    assert "the film was ejected" in str(excinfo.value)
+    assert roll.closed is False
+
+
+def test_eject_after_failed_preview_ejects_via_device_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end regression for the #16/#68/#76 shape: preview fails, the
+    operator clicks Eject, and the film must come out through the Device
+    fallback instead of the guaranteed EjectNotAvailable refusal."""
+
+    class _RefusedPreviewRoll(_EjectRecordingRoll):
+        def preview(self, slots: list[int] | None = None) -> list["coolscanpy.Thumbnail"]:
+            raise coolscanpy.RefeedRequired(
+                "preview could not establish a usable roll session"
+            )
+
+    roll = _RefusedPreviewRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable(
+        "no held reservation to eject: call preview() first"
+    )
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = True
+    device.film_present_result = False
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert excinfo.value.code == ErrorCode.REFEED_REQUIRED
+
+    assert transport.eject() is True
+    assert roll.eject_calls == 1
+    assert roll.closed is True
 
 
 # -- coolscanpy_provenance (Plan 10-09) ---------------------------------------------

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -296,7 +296,7 @@ EOF
 check_pair "protocol" "app/ScanStudio/protocol" "ports/tauri/vendor/protocol" "55577442d8b6a23ddcd3cc191ebf41a8258004047bc075511a241fa72adb0b65" <<'EOF'
 EOF
 
-check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "981cef16af0b17ded9e38bd2ff0b6321cf57bf2355a5c3e3659206b55fa4f6aa" <<'EOF'
+check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "fe42a67e872346b94d34a49dc931cf8f64f4a2801d0c15fc407e5c64923daca6" <<'EOF'
 Files app/ScanStudio/engine/Cargo.lock and ports/tauri/vendor/engine/Cargo.lock differ
 Files app/ScanStudio/engine/Cargo.toml and ports/tauri/vendor/engine/Cargo.toml differ
 Files app/ScanStudio/engine/src/evidence_package.rs and ports/tauri/vendor/engine/src/evidence_package.rs differ
@@ -307,7 +307,7 @@ Files app/ScanStudio/engine/src/render.rs and ports/tauri/vendor/engine/src/rend
 Only in ports/tauri/vendor/engine/src: wsl_io.rs
 EOF
 
-check_pair "bridge" "bridge" "ports/tauri/vendor/scanstudio-bridge" "26bdde25a8a824ac512a94eef52cd53c2a02e7bc230c846534df42a4c89bc194" <<'EOF'
+check_pair "bridge" "bridge" "ports/tauri/vendor/scanstudio-bridge" "a5ce7bf643931229a66604487fe27c00865e7196a37f1c1985b9065b79447923" <<'EOF'
 Only in ports/tauri/vendor/scanstudio-bridge: .github
 Only in ports/tauri/vendor/scanstudio-bridge/scripts: probe-linux-env.py
 Only in ports/tauri/vendor/scanstudio-bridge/scripts: verify-bridge.sh


### PR DESCRIPTION
Refs #16 #68 #76 (the eject-wedge component: three reporters could not eject after a failed preview until a power cycle).

Root cause, confirmed by trace: a failed preview's fail-closed teardown releases the held reservation, so Roll.eject() refuses with EjectNotAvailable before sending any command; the bridge always routed eject through the Roll with no fallback, so eject after a failed preview was architecturally guaranteed to fail with zero USB commands sent. The bridge typed it EJECT_FAILED, but the engine's bridge-code mapping had no arm for it, so every field report shipped as bare INTERNAL.

One change per layer:

- Transport: when the roll route refuses without having attempted anything, fall back to the capability-gated vendor Device.eject(). Because the vendor eject reports acceptance rather than actuation (INCIDENT-20260719-eject-from-park), any vendor-route success must be confirmed by the motion-free film-presence probe first: film still present = FEEDER_PARKED, unconfirmable = EJECT_FAILED, only definite absence is success. DeviceBusy keeps its own taxonomy; a post-eject Roll.close() failure now says the film IS out instead of reading as a failed eject.
- Service: any unmapped transport/driver exception from device.eject becomes typed EJECT_FAILED with a code+message telemetry line instead of falling through the CLI catch-all as INTERNAL with no telemetry.
- Engine: EJECT_FAILED and FEEDER_PARKED join the wire ErrorCode vocabulary and the bridge-code mapping.

Honest scope note: the stock macOS bundle ships no SANE tools, so on the reporters' Macs the fallback surfaces as a typed EJECT_FAILED carrying the driver's refeed-and-repreview guidance -- the diagnosability is fixed there, the physical eject still needs a refeed. On rigs with sane-utils (the Linux runbook path) the fallback can actually free the strip, gated on the presence probe. Wiring ReturnToOrigin (81h) into any automatic path stays out of scope: it is live-validated on an empty transport only.

Verification: both bridge suites green (primary + vendored mirror), both engine suites green, vendor pair fingerprints re-pinned after review. Two independent adversarial review passes ran against the root cause and this diff; their findings (weaker fallback acceptance, DeviceBusy taxonomy, close-failure mislabeling, engine flattening) are all incorporated. The new tests were proven to pin behavior by running them against the pre-fix sources (5/5 fail there).