### PR TITLE
mac: reach manual placement from any refeed, surface scan refusals, record adapter

### DIFF
--- a/app/ScanStudio/Sources/ScanStudio/BatchInspectorView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/BatchInspectorView.swift
@@ -565,6 +565,18 @@ struct BatchInspectorView: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .padding(.top, 4)
                 }
+                // Issue #76/#24: a whole-batch refusal (e.g. the unattended
+                // binding confidence gate) can fail every frame for the same
+                // one reason before any capture is attempted, leaving
+                // "Completed: 0" with nothing explaining why. Smallest
+                // honest surfacing of that reason, not a redesign.
+                if let batchFailureReason {
+                    Label(batchFailureReason.guidance, systemImage: "info.circle")
+                        .font(.system(size: 10))
+                        .foregroundStyle(Color.scanStudioSecondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 4)
+                }
             }
         }
     }
@@ -579,6 +591,24 @@ struct BatchInspectorView: View {
         (sessionModel.scanSummary?.failed ?? []).filter {
             sessionModel.frameErrors[$0]?.code != FrameFailureLabel.manualReviewCode
         }
+    }
+
+    /// The scanner's own explanation for a batch that finished without
+    /// completing a single frame -- distinct from `needsReviewFrames`/
+    /// `failedFrames` (which list WHICH frames failed): a whole-batch
+    /// refusal fails every frame for the same one reason before any capture
+    /// is attempted. `nil` whenever the batch completed at least one frame,
+    /// or no failed frame carries a real (non-review) error detail.
+    private var batchFailureReason: ErrorPresentation? {
+        guard let summary = sessionModel.scanSummary, summary.completed.isEmpty else {
+            return nil
+        }
+        guard let error = summary.failed.lazy.compactMap({ sessionModel.frameErrors[$0] }).first(where: {
+            $0.code != FrameFailureLabel.manualReviewCode
+        }) else {
+            return nil
+        }
+        return ErrorPresentationPolicy.make(lastErrorMessage: "\(error.code): \(error.message)")
     }
 
     private func frameList(_ frames: [Int]) -> String {

--- a/app/ScanStudio/Sources/ScanStudio/ContentView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ContentView.swift
@@ -458,7 +458,12 @@ private struct WorkspaceErrorBanner: View {
                 // engine attached that plain-English diagnosis, show it
                 // prominently -- never the raw JSON it was extracted from
                 // (`ProbableCauseExtractor`) -- right above the button.
-                if showsManualPlacementAction {
+                // The two are independent: the sentence renders on its own
+                // when `refeedRequired` has since cleared (a disconnect
+                // composes NOT_CONNECTED over the old message), and the
+                // button renders without a sentence for undiagnosed
+                // refeeds.
+                if showsManualPlacementAction || presentation.probableCause != nil {
                     VStack(alignment: .leading, spacing: 8) {
                         if let probableCause = presentation.probableCause {
                             Text(probableCause)
@@ -468,28 +473,30 @@ private struct WorkspaceErrorBanner: View {
                                 .textSelection(.enabled)
                         }
 
-                        Button {
-                            Task {
-                                await sessionModel.beginManualFramePlacement()
-                            }
-                        } label: {
-                            if isLoadingManualPlacement {
-                                HStack(spacing: 6) {
-                                    ProgressView().controlSize(.small)
-                                    Text("Loading Film Strip…")
+                        if showsManualPlacementAction {
+                            Button {
+                                Task {
+                                    await sessionModel.beginManualFramePlacement()
                                 }
-                            } else {
-                                Label(
-                                    "Place frames manually",
-                                    systemImage: "rectangle.and.hand.point.up.left"
-                                )
+                            } label: {
+                                if isLoadingManualPlacement {
+                                    HStack(spacing: 6) {
+                                        ProgressView().controlSize(.small)
+                                        Text("Loading Film Strip…")
+                                    }
+                                } else {
+                                    Label(
+                                        "Place frames manually",
+                                        systemImage: "rectangle.and.hand.point.up.left"
+                                    )
+                                }
                             }
+                            .buttonStyle(.bordered)
+                            .tint(.scanStudioAmber)
+                            .font(.system(size: 11, weight: .medium))
+                            .disabled(isLoadingManualPlacement)
+                            .help("Draw your own frame boundaries on the captured film strip")
                         }
-                        .buttonStyle(.bordered)
-                        .tint(.scanStudioAmber)
-                        .font(.system(size: 11, weight: .medium))
-                        .disabled(isLoadingManualPlacement)
-                        .help("Draw your own frame boundaries on the captured film strip")
                     }
                     .padding(10)
                     .background(Color.scanStudioRaised, in: RoundedRectangle(cornerRadius: 6))

--- a/app/ScanStudio/Sources/ScanStudio/ContentView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ContentView.swift
@@ -404,6 +404,15 @@ private struct WorkspaceErrorBanner: View {
         sessionModel.manualPlacementStripState == .loading
     }
 
+    /// Rung 4 is reachable whenever this refusal classifies as
+    /// `REFEED_REQUIRED` (`ErrorPresentation.canPlaceFramesManually`) and
+    /// the session is still in the "current physical registration cannot be
+    /// trusted" state `beginManualFramePlacement()` depends on -- the same
+    /// `refeedRequired` flag that gates `DeviceBarView`'s Eject affordance.
+    private var showsManualPlacementAction: Bool {
+        presentation.canPlaceFramesManually && sessionModel.refeedRequired
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 10) {
@@ -441,19 +450,23 @@ private struct WorkspaceErrorBanner: View {
                 }
 
                 // Rung 3 + Rung 4 of the feeding UX ladder
-                // (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): when the
-                // engine attached a plain-English diagnosis to this
-                // refusal, show it prominently -- never the raw JSON it
-                // was extracted from (`ProbableCauseExtractor`) -- and
-                // offer the manual-placement recovery path right beside
-                // it.
-                if let probableCause = presentation.probableCause {
+                // (FEEDING-UX-LADDER-OVERNIGHT-20260807.md): the
+                // manual-placement action is offered for every
+                // REFEED_REQUIRED this session can actually recover from
+                // (`showsManualPlacementAction`), not only the minority
+                // that also carry a Rung-3 diagnosis (issue #16). When the
+                // engine attached that plain-English diagnosis, show it
+                // prominently -- never the raw JSON it was extracted from
+                // (`ProbableCauseExtractor`) -- right above the button.
+                if showsManualPlacementAction {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text(probableCause)
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(Color.scanStudioPrimaryText)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .textSelection(.enabled)
+                        if let probableCause = presentation.probableCause {
+                            Text(probableCause)
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(Color.scanStudioPrimaryText)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .textSelection(.enabled)
+                        }
 
                         Button {
                             Task {
@@ -481,7 +494,10 @@ private struct WorkspaceErrorBanner: View {
                     .padding(10)
                     .background(Color.scanStudioRaised, in: RoundedRectangle(cornerRadius: 6))
                     .accessibilityElement(children: .combine)
-                    .accessibilityLabel("Probable cause: \(probableCause)")
+                    .accessibilityLabel(
+                        presentation.probableCause.map { "Probable cause: \($0)" }
+                            ?? "Manual frame placement is available"
+                    )
                 }
 
                 HStack(spacing: 12) {

--- a/app/ScanStudio/Sources/ScanStudio/ScanPanelView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ScanPanelView.swift
@@ -111,6 +111,7 @@ struct ScanPanelView: View {
                 )
                 .font(.system(size: 11))
                 .foregroundStyle(summary.stopped ? Color.scanStudioAmber : (summary.failed.isEmpty ? Color.scanStudioCyan : Color.scanStudioRed))
+                .help(batchSummaryHelp(summary))
             }
 
             Spacer()
@@ -307,6 +308,25 @@ struct ScanPanelView: View {
             return "Paused · \(sessionModel.selectedFrameCount) remaining"
         }
         return "Last batch: \(summary.completed.count) completed"
+    }
+
+    /// Issue #76/#24: "Last batch: 0 completed" alone hid the driver's own
+    /// refusal reason (e.g. the unattended-binding confidence gate failing
+    /// every frame before any capture). This footer label has no room for a
+    /// second line, so the reason surfaces as a tooltip instead --
+    /// `BatchInspectorView.batchResultSummary` shows the same reason inline
+    /// for the fuller Batch inspector. Falls back to the visible label text
+    /// when the batch did complete frames or no failed frame carries a real
+    /// (non-review) error detail.
+    private func batchSummaryHelp(_ summary: ScanSummary) -> String {
+        guard summary.completed.isEmpty,
+              let error = summary.failed.lazy.compactMap({ sessionModel.frameErrors[$0] }).first(where: {
+                  $0.code != FrameFailureLabel.manualReviewCode
+              })
+        else {
+            return batchSummary(summary)
+        }
+        return ErrorPresentationPolicy.make(lastErrorMessage: "\(error.code): \(error.message)").guidance
     }
 
     private var skipFrameHelpText: String {

--- a/app/ScanStudio/Sources/ScanStudio/ScanPanelView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ScanPanelView.swift
@@ -315,9 +315,10 @@ struct ScanPanelView: View {
     /// every frame before any capture). This footer label has no room for a
     /// second line, so the reason surfaces as a tooltip instead --
     /// `BatchInspectorView.batchResultSummary` shows the same reason inline
-    /// for the fuller Batch inspector. Falls back to the visible label text
-    /// when the batch did complete frames or no failed frame carries a real
-    /// (non-review) error detail.
+    /// for the fuller Batch inspector. The reason is appended after the
+    /// visible label text, never substituted for it: a reason no curated
+    /// matcher recognizes still gets its generic guidance, and the count
+    /// stays visible either way.
     private func batchSummaryHelp(_ summary: ScanSummary) -> String {
         guard summary.completed.isEmpty,
               let error = summary.failed.lazy.compactMap({ sessionModel.frameErrors[$0] }).first(where: {
@@ -326,7 +327,10 @@ struct ScanPanelView: View {
         else {
             return batchSummary(summary)
         }
-        return ErrorPresentationPolicy.make(lastErrorMessage: "\(error.code): \(error.message)").guidance
+        let guidance = ErrorPresentationPolicy.make(
+            lastErrorMessage: "\(error.code): \(error.message)"
+        ).guidance
+        return "\(batchSummary(summary)) — \(guidance)"
     }
 
     private var skipFrameHelpText: String {

--- a/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
@@ -78,21 +78,31 @@ public struct ErrorPresentation: Equatable, Sendable {
     /// never the surrounding diagnostic prose. `nil` for the common case
     /// (most errors, including most REFEED_REQUIREDs, carry no Rung-3
     /// diagnosis). When present, the workspace error card shows it
-    /// prominently and offers "Place frames manually" alongside it.
+    /// prominently alongside "Place frames manually".
     public let probableCause: String?
+    /// True whenever this refusal classifies as `REFEED_REQUIRED` -- Rung 4
+    /// of the feeding UX ladder's manual-placement recovery is reachable for
+    /// every REFEED_REQUIRED, not only the minority that also carry a
+    /// Rung-3 `probableCause` (issue #16: a preview that returns with low
+    /// confidence but no diagnosis sentence still needs "Place frames
+    /// manually" offered). Drives the workspace error card's button on its
+    /// own; the diagnosis sentence next to it stays gated on `probableCause`.
+    public let canPlaceFramesManually: Bool
 
     public init(
         title: String,
         guidance: String,
         technicalDetails: String,
         issueURL: URL,
-        probableCause: String? = nil
+        probableCause: String? = nil,
+        canPlaceFramesManually: Bool = false
     ) {
         self.title = title
         self.guidance = guidance
         self.technicalDetails = technicalDetails
         self.issueURL = issueURL
         self.probableCause = probableCause
+        self.canPlaceFramesManually = canPlaceFramesManually
     }
 }
 
@@ -223,13 +233,15 @@ public enum ErrorPresentationPolicy {
             // REFEED_REQUIRED -- never merely because the raw text happens
             // to contain a probable_cause-shaped fragment. An INTERNAL (or
             // any other) error carrying an embedded, coincidental, or
-            // adversarial-looking fragment must never surface a sentence or
-            // the "Place frames manually" action; `copy.code` is this
-            // policy's own already-computed classification, not a second,
-            // independent guess.
+            // adversarial-looking fragment must never surface a sentence.
+            // `copy.code` is this policy's own already-computed
+            // classification, not a second, independent guess --
+            // `canPlaceFramesManually` below reuses the exact same gate, so
+            // an unclassified error cannot offer manual placement either.
             probableCause: copy.code == "REFEED_REQUIRED"
                 ? ProbableCauseExtractor.extract(from: lastErrorMessage)
-                : nil
+                : nil,
+            canPlaceFramesManually: copy.code == "REFEED_REQUIRED"
         )
     }
 

--- a/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
@@ -208,6 +208,7 @@ public enum ErrorPresentationPolicy {
         let copy = leadingFrameClippedCopy(in: lastErrorMessage)
             ?? filmFeedInterruptedCopy(in: lastErrorMessage)
             ?? filmTransportSlipCopy(in: lastErrorMessage)
+            ?? unattendedBindingConfidenceCopy(in: lastErrorMessage)
             ?? previewReadinessTimeoutCopy(in: lastErrorMessage)
             ?? knownCopy.first { containsCode($0.code, in: normalizedMessage) }
             ?? Copy(
@@ -291,6 +292,31 @@ public enum ErrorPresentationPolicy {
             guidance: "The scanner lost the film’s position. Remove and firmly reinsert "
                 + "the strip, then acquire a fresh preview. Do not retry Capture with "
                 + "the current preview."
+        )
+    }
+
+    /// The bridge's unattended-binding confidence gate (coolscanpy
+    /// `ls5000_single_pass/worker.py`): every frame in the batch refuses
+    /// before any motion because the roll's boundary-detection confidence
+    /// measured below what unattended scanning requires. Matched on this
+    /// phrase alone, not a `ROLL_MISMATCH` code prefix -- the engine wraps
+    /// the same wording differently depending on whether it surfaces from a
+    /// synchronous refusal or a per-frame scan failure, but the phrase
+    /// itself is unique to this one gate.
+    private static func unattendedBindingConfidenceCopy(in message: String) -> Copy? {
+        guard message.range(
+            of: "unattended frame binding requires",
+            options: .caseInsensitive
+        ) != nil else {
+            return nil
+        }
+        return Copy(
+            code: "ROLL_MISMATCH",
+            title: "This roll previewed with low confidence",
+            guidance: "This roll previewed below the confidence the unattended scanner "
+                + "binding requires. Refeeding the strip or previewing it again may raise "
+                + "that confidence. A future release is expected to widen what the "
+                + "detector accepts here."
         )
     }
 

--- a/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
@@ -4548,6 +4548,8 @@ public final class SessionModel {
             "filmPresent": status.filmPresent.map(String.init) ?? "unknown",
             "mediaLoaded": String(status.mediaLoaded),
             "transport": status.transport,
+            "adapter": status.adapter ?? "unknown",
+            "carrier": status.carrier ?? "unknown",
         ]
     }
 

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
@@ -570,4 +570,44 @@ struct ErrorPresentationPolicyTests {
             #expect(!presentation.canPlaceFramesManually, "expected false for: \(rawMessage)")
         }
     }
+
+    // MARK: - Unattended-binding confidence refusal (issue #76/#24)
+
+    @Test("the unattended-binding confidence gate gets calm, factual copy of its own")
+    func unattendedBindingConfidenceCopy() {
+        let rawMessage = "ROLL_MISMATCH: roll boundary lattice confidence is 'low'; "
+            + "unattended frame binding requires 'high'"
+
+        let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+
+        #expect(presentation.title == "This roll previewed with low confidence")
+        #expect(
+            presentation.guidance
+                == "This roll previewed below the confidence the unattended scanner binding requires. Refeeding the strip or previewing it again may raise that confidence. A future release is expected to widen what the detector accepts here."
+        )
+        #expect(presentation.technicalDetails == rawMessage)
+        // Deliberately its own code, distinct from REFEED_REQUIRED: this is
+        // a scan-time capture refusal, not a preview failure, and no
+        // manual-placement raster is guaranteed to exist for it.
+        #expect(!presentation.canPlaceFramesManually)
+    }
+
+    @Test("the unattended-binding phrase is recognized regardless of how the engine wraps the code")
+    func unattendedBindingConfidenceCopyMatchesWrappedForm() {
+        let rawMessage = "INTERNAL: bridge scan.frameFailed (ROLL_MISMATCH): roll boundary lattice "
+            + "confidence is 'low'; unattended frame binding requires 'high'"
+
+        let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+
+        #expect(presentation.title == "This roll previewed with low confidence")
+    }
+
+    @Test("an ordinary roll mismatch without the confidence phrase keeps its own fallback")
+    func rollMismatchWithoutConfidencePhraseUsesFallback() {
+        let rawMessage = "INTERNAL: bridge scan.frameFailed (ROLL_MISMATCH): calibration signature changed"
+        let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+
+        #expect(presentation.title != "This roll previewed with low confidence")
+        #expect(presentation.title == "ScanStudio could not complete that action")
+    }
 }

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
@@ -498,6 +498,10 @@ struct ErrorPresentationPolicyTests {
         let rawMessage = "REFEED_REQUIRED: preview could not establish a usable roll session"
         let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
         #expect(presentation.probableCause == nil)
+        // Issue #16: a preview that returns REFEED_REQUIRED with low
+        // confidence but no Rung-3 diagnosis is the common case, not the
+        // exception -- manual placement must still be reachable here.
+        #expect(presentation.canPlaceFramesManually)
     }
 
     @Test("a completely unrelated error never fabricates a probableCause")
@@ -506,6 +510,7 @@ struct ErrorPresentationPolicyTests {
             lastErrorMessage: "NOT_CONNECTED: scanner is not connected"
         )
         #expect(presentation.probableCause == nil)
+        #expect(!presentation.canPlaceFramesManually)
     }
 
     /// S8 (adversarial review round 2, 2026-08-08): extraction must be
@@ -525,5 +530,44 @@ struct ErrorPresentationPolicyTests {
         #expect(presentation.probableCause == nil)
         #expect(presentation.title != "Film shifted—refeed required")
         #expect(presentation.title != "Film needs to be reloaded")
+        #expect(!presentation.canPlaceFramesManually)
+    }
+
+    // MARK: - canPlaceFramesManually (issue #16)
+
+    @Test("every REFEED_REQUIRED-classified refusal offers manual placement, with or without a probable cause")
+    func canPlaceFramesManuallyCoversEveryReclassifiedRefeed() {
+        let messages = [
+            // Plain known-code REFEED_REQUIRED (noProbableCauseWhenAbsent
+            // covers this one too; repeated here alongside its siblings for
+            // one place that documents the full REFEED_REQUIRED family).
+            "REFEED_REQUIRED: the transport index no longer matches",
+            // leadingFrameClippedCopy's reclassification.
+            "REFEED_REQUIRED: the first frame begins 17 preview rows before "
+                + "the captured preview area (88.1% remains); refeed the film slightly deeper "
+                + "and acquire a fresh preview. ScanStudio did not expose the cropped frame for scanning",
+            // filmTransportSlipCopy's reclassification -- raw code is
+            // INTERNAL, not REFEED_REQUIRED, and still qualifies.
+            "INTERNAL: bridge scan.frameFailed (ROLL_MISMATCH): SynchronizedProtocolError: "
+                + "command 124: sense 045300 not in accepted ['000000']",
+        ]
+        for rawMessage in messages {
+            let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+            #expect(presentation.canPlaceFramesManually, "expected true for: \(rawMessage)")
+        }
+    }
+
+    @Test("codes that never resolve to REFEED_REQUIRED never offer manual placement")
+    func canPlaceFramesManuallyFalseForOtherCodes() {
+        let messages = [
+            "NOT_CONNECTED: scanner is not connected",
+            "FEEDER_PARKED: transport parked at end-stop",
+            "INVALID_PARAMS: frame selection was empty",
+            "BRIDGE_TIMEOUT: no terminal event arrived",
+        ]
+        for rawMessage in messages {
+            let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+            #expect(!presentation.canPlaceFramesManually, "expected false for: \(rawMessage)")
+        }
     }
 }

--- a/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
@@ -2046,6 +2046,11 @@ struct SessionEventPolicyTests {
         )
         model.handle(event: EngineEvent(name: "scanner.status", rawLine: notLoaded))
         #expect(model.refeedRequired)
+        // Issue #16: with no adapter identified, the diagnostic trail must
+        // say so honestly instead of omitting the field entirely.
+        let statusDetails = try? #require(model.errorPresentation?.technicalDetails)
+        #expect(statusDetails?.contains("adapter=unknown") == true)
+        #expect(statusDetails?.contains("carrier=unknown") == true)
     }
 
     @Test("a scan-time roll slip invalidates the preview and requires a refeed before another capture")
@@ -2130,6 +2135,11 @@ struct SessionEventPolicyTests {
             let statusDetails = try? #require(model.errorPresentation?.technicalDetails)
             #expect(statusDetails?.contains("filmPresent=false") == true)
             #expect(statusDetails?.contains("mediaLoaded=false") == true)
+            // Issue #16: "Adapter: unknown / Holder: unknown" left the three
+            // possible causes indistinguishable. The diagnostic trail must
+            // record the scanner's own adapter/carrier strings once known.
+            #expect(statusDetails?.contains("adapter=SA-21") == true)
+            #expect(statusDetails?.contains("carrier=strip6") == true)
         }
     }
 


### PR DESCRIPTION
Refs #16 #76 #24.

Three mac-app fixes from the same field reports:

- Manual frame placement was unreachable exactly when needed (#16): the button only rendered when a Rung-3 probable-cause sentence existed, which a returned-low-confidence detection structurally never gets (the raise carries diagnostics but RollSessionError cannot carry a probable_cause). The button now renders for any REFEED_REQUIRED the session can actually recover from, and the sentence renders independently whenever a diagnosis exists. The backend path (roll.previewStrip from a refused preview, motion-free) already supported this entry per its own doc comments.
- The unattended-binding scan refusal was invisible (#76, #24): a batch that completes with zero frames now surfaces the driver's reason ("roll boundary lattice confidence ... unattended frame binding requires 'high'") with honest copy -- appended to the batch summary, inline in the Batch inspector. No threshold changes: the confidence gate itself is untouched pending the feed-detector round.
- Error reports print "Adapter: unknown" with no way to tell why (#16): every applied scanner.status diagnostic event now records adapter and carrier, so the next report distinguishes "never refreshed" from "refreshed but unreadable".

swift test: 480 tests in 50 suites, 0 failures; every commit built and tested in isolation. Two independent adversarial review passes ran against the root cause and this diff; the one caught regression (the probable-cause sentence briefly nested under the button's condition, which a NOT_CONNECTED-over-REFEED composed message would hide) is fixed in the last commit.