### PR TITLE
Tauri: device-aware multisample options and defaults (engine capability field)

### DIFF
--- a/app/ScanStudio/engine/src/domain.rs
+++ b/app/ScanStudio/engine/src/domain.rs
@@ -26,6 +26,21 @@ pub struct DeviceInfo {
     /// False for a recognized-but-unsupported Nikon model (Lane D): it is
     /// listed by name in ``scanner.list`` but is never connectable.
     pub supported: bool,
+    /// Device-sourced accepted set for `CaptureRecipe.multisample_passes`.
+    /// A real backend populates this from `RealLs5000::supported_multisample_passes`
+    /// (itself `derive_supported_multisample_passes`, read from BRIDGE.md's
+    /// `Capabilities.supportedMultisamplePasses` -- the same set `scan.start`
+    /// already validates `multisamplePasses` against, `real_backend.rs`'s
+    /// "multisamplePasses must be one of {:?} for this device"). The
+    /// simulator has no bridge-sourced capability list of its own and
+    /// leaves this `None` rather than fabricate one; a client with no value
+    /// (simulator, or an old engine build predating this field) keeps
+    /// offering its own historical `[1, 2, 4, 8, 16]` range. `#[serde(default)]`
+    /// makes an absent key on decode `None`, never a decode error --
+    /// forward- and backward-compatible with every engine build that does
+    /// not yet send it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supported_multisample_passes: Option<Vec<u32>>,
 }
 
 // ---------------------------------------------------------------------
@@ -1363,10 +1378,40 @@ mod tests {
             firmware: "1.03-sim".into(),
             connection: "USB (simulated)".into(),
             supported: true,
+            supported_multisample_passes: None,
         };
         let value = serde_json::to_value(&device).unwrap();
         assert_eq!(value["deviceId"], json!("sim-ls5000-0"));
         assert_eq!(value["supported"], json!(true));
+        // None-safe: skip_serializing_if omits the key entirely rather than
+        // emitting `"supportedMultisamplePasses": null` -- an older/simulator
+        // wire payload with no such key at all must decode back to None too
+        // (checked by round_trip below), not merely tolerate an explicit null.
+        assert!(
+            !value.as_object().unwrap().contains_key("supportedMultisamplePasses"),
+            "None must omit the key, not serialize it as null: {value}"
+        );
+        round_trip(&device);
+    }
+
+    #[test]
+    fn device_info_supported_multisample_passes_serializes_for_a_real_device() {
+        // Mirrors what RealLs5000::device_info() now sends: the device's own
+        // derive_supported_multisample_passes()-derived set, camelCase on
+        // the wire, exactly the key WireProtocol.swift's DeviceInfo already
+        // decodes (`supportedMultisamplePasses`, added ahead of the engine
+        // actually sending it).
+        let device = DeviceInfo {
+            device_id: "bridge-ls5000-0".into(),
+            model: "SUPER COOLSCAN 5000 ED".into(),
+            kind: "real".into(),
+            firmware: "bridge 0.7.0".into(),
+            connection: "USB (bridge)".into(),
+            supported: true,
+            supported_multisample_passes: Some(vec![4]),
+        };
+        let value = serde_json::to_value(&device).unwrap();
+        assert_eq!(value["supportedMultisamplePasses"], json!([4]));
         round_trip(&device);
     }
 

--- a/app/ScanStudio/engine/src/protocol.rs
+++ b/app/ScanStudio/engine/src/protocol.rs
@@ -116,6 +116,14 @@ pub enum ErrorCode {
     /// A recognized-but-unsupported Nikon model (Lane D, #14): discovery
     /// lists it by name, but connect is refused. Fail-closed.
     NotSupported,
+    /// The bridge's eject could not run or could not confirm the film
+    /// left the transport. Previously flattened to `Internal`, which made
+    /// the #16/#68/#76 eject failures undiagnosable client-side.
+    EjectFailed,
+    /// The driver's typed accepted-without-progress eject outcome
+    /// (INCIDENT-20260719-eject-from-park): the transport never actuated
+    /// and a power cycle is the only demonstrated recovery.
+    FeederParked,
 }
 
 // ---------------------------------------------------------------------
@@ -858,6 +866,8 @@ mod tests {
             (ErrorCode::ManualReviewRequired, "MANUAL_REVIEW_REQUIRED"),
             (ErrorCode::HwMotionNotArmed, "HW_MOTION_NOT_ARMED"),
             (ErrorCode::NotSupported, "NOT_SUPPORTED"),
+            (ErrorCode::EjectFailed, "EJECT_FAILED"),
+            (ErrorCode::FeederParked, "FEEDER_PARKED"),
         ] {
             assert_eq!(serde_json::to_value(code).unwrap(), json!(wire));
             let decoded: ErrorCode = serde_json::from_value(json!(wire)).unwrap();

--- a/app/ScanStudio/engine/src/real_backend.rs
+++ b/app/ScanStudio/engine/src/real_backend.rs
@@ -4509,6 +4509,8 @@ fn map_bridge_error_code_str(code: &str) -> ErrorCode {
         "FILM_FEED_INTERRUPTED" => ErrorCode::FilmFeedInterrupted,
         "HW_MOTION_NOT_ARMED" => ErrorCode::HwMotionNotArmed,
         "UNKNOWN_JOB" => ErrorCode::UnknownJob,
+        "EJECT_FAILED" => ErrorCode::EjectFailed,
+        "FEEDER_PARKED" => ErrorCode::FeederParked,
         _ => ErrorCode::Internal,
     }
 }

--- a/app/ScanStudio/engine/src/real_backend.rs
+++ b/app/ScanStudio/engine/src/real_backend.rs
@@ -2615,6 +2615,14 @@ impl RealLs5000 {
             firmware: self.firmware_label.clone(),
             connection: "USB (bridge)".to_string(),
             supported: self.supported,
+            // The same device-sourced set scan_start's own INVALID_PARAMS
+            // gate already validates multisamplePasses against (see the
+            // "multisamplePasses must be one of {:?} for this device"
+            // check below) -- always Some for a real backend, since
+            // derive_supported_multisample_passes always returns a
+            // concrete (if degenerate) Vec from the bridge's own
+            // Capabilities, never absent data.
+            supported_multisample_passes: Some(self.supported_multisample_passes.clone()),
         }
     }
 

--- a/app/ScanStudio/engine/src/sim.rs
+++ b/app/ScanStudio/engine/src/sim.rs
@@ -358,6 +358,20 @@ impl SimulatedLs5000 {
                 firmware: "1.03-sim".to_string(),
                 connection: "USB (simulated)".to_string(),
                 supported: true,
+                // No bridge to source a capability list from, and
+                // skip_serializing_if keeps this key off the wire entirely
+                // (byte-identical scanner.list/scanner.connect JSON to
+                // before this field existed) rather than advertise an
+                // arbitrary simulator-only list. Every client's own
+                // device-aware policy already treats an absent value the
+                // same as this device's "simulated" kind would anyway
+                // (TS's multisampleOptionsForDevice / Swift's
+                // MultisamplePassPolicy.supportedOptions(for:) both fall
+                // back to the fuller [1, 2, 4, 8, 16] range for a
+                // non-"real" kind), so None and a spelled-out
+                // Some([1, 2, 4, 8, 16]) are observably identical here --
+                // None is simply the smaller, zero-new-fixtures change.
+                supported_multisample_passes: None,
             },
             state: Mutex::new(State::default()),
             cancelled: AtomicBool::new(false),

--- a/app/ScanStudio/engine/tests/end_to_end_real_backend.rs
+++ b/app/ScanStudio/engine/tests/end_to_end_real_backend.rs
@@ -1715,6 +1715,27 @@ fn real_device_listed_and_connectable_when_bridge_cmd_set() {
         "exactly one listed device must have kind \"real\": {devices:?}"
     );
     assert_eq!(real_devices[0]["deviceId"], json!("bridge-ls5000-0"));
+    // The exact wire key WireProtocol.swift's DeviceInfo already decodes
+    // (added ahead of the engine actually sending it) and the TS wire
+    // client's DeviceInfo interface expects, carrying mock_bridge's fixed
+    // Capabilities.supportedMultisamplePasses verbatim through
+    // derive_supported_multisample_passes -- a real, over-the-wire,
+    // black-box proof of the key name, not just an in-process Rust struct
+    // assertion.
+    assert_eq!(
+        real_devices[0]["supportedMultisamplePasses"],
+        json!([4]),
+        "real device's scanner.list entry must forward the bridge's supported multisample passes: {devices:?}"
+    );
+    let sim_devices: Vec<&Value> = devices
+        .iter()
+        .filter(|device| device["kind"] == json!("simulated"))
+        .collect();
+    assert_eq!(sim_devices.len(), 1, "expected exactly one simulated device: {devices:?}");
+    assert!(
+        sim_devices[0].get("supportedMultisamplePasses").is_none(),
+        "the simulator has no bridge-sourced capability list and must omit the key entirely, not null: {devices:?}"
+    );
 
     send(
         &mut stdin,

--- a/app/ScanStudio/engine/tests/real_backend_mapping.rs
+++ b/app/ScanStudio/engine/tests/real_backend_mapping.rs
@@ -319,6 +319,25 @@ fn unsupported_bridge_device_is_listed_but_never_connectable() {
     assert_eq!(err.code, ErrorCode::NotSupported);
 }
 
+/// `device_info()` (which `scanner.list`/`scanner.connect` both build their
+/// `DeviceInfo` response from) now forwards the exact device-sourced set
+/// `scan_start`'s own gate validates against
+/// (`scan_start_rejects_multisample_passes_other_than_device_supported`
+/// above), instead of leaving the client to guess or hardcode it. Available
+/// independent of connection state, matching `device_info()`'s own doc
+/// comment.
+#[test]
+fn device_info_forwards_the_bridges_supported_multisample_passes() {
+    let backend = RealLs5000::new(mock_bridge_bin(), GENEROUS_TIMEOUT)
+        .expect("RealLs5000::new should succeed against a healthy mock bridge");
+
+    assert_eq!(
+        backend.device_info().supported_multisample_passes,
+        Some(vec![4]),
+        "must forward mock_bridge's fixed_device_info() Capabilities.supportedMultisamplePasses verbatim"
+    );
+}
+
 const UNSUPPORTED_DEVICE_ID: &str = "bridge-ls50-0";
 
 #[test]

--- a/bridge/src/scanstudio_bridge/service.py
+++ b/bridge/src/scanstudio_bridge/service.py
@@ -623,6 +623,26 @@ class BridgeService:
                     "device.eject", "error", code=exc.code.value, message=str(exc)
                 )
                 raise
+            except Exception as exc:
+                # Wire-contract boundary: BRIDGE.md documents EJECT_FAILED
+                # as "the eject could not run", which is true for any
+                # unmapped transport/driver exception. Left alone these
+                # fall through to cli.py's catch-all and reach the client
+                # as a bare INTERNAL with no telemetry line -- the shape
+                # that made the #16/#68/#76 field reports undiagnosable.
+                # The original type rides in the message so a driver
+                # defect still reads as one.
+                message = (
+                    f"eject failed before completion "
+                    f"({type(exc).__name__}: {exc})"
+                )
+                self._telemetry.record(
+                    "device.eject",
+                    "error",
+                    code=ErrorCode.EJECT_FAILED.value,
+                    message=message,
+                )
+                raise BridgeError(ErrorCode.EJECT_FAILED, message) from exc
             finally:
                 self._lane_held = False
         if not ejected:

--- a/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -1565,14 +1565,11 @@ class CoolscanPyTransport:
     def eject(self) -> bool:
         if self._device is None:
             raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
-        # Route through the open Roll when one exists. On the pinned
-        # coolscanpy `Roll.eject()` is a plain passthrough to
-        # `Device.eject()`, so behavior is identical today -- but the
-        # vendor-traced held-session eject (RESERVE_UNIT before the eject
-        # CDB, proven live 2026-07-20 from a normal post-traversal state)
-        # lands on `Roll` first (see coolscanpy's capture branch), so this
-        # routing picks it up with zero bridge changes the day the pin
-        # advances. The callable guard keeps duck-typed Roll doubles
+        # Route through the open Roll when one exists: on the current pin
+        # `Roll.eject()` replays the vendor-traced held-session eject
+        # sequence (RESERVE_UNIT before the eject CDB, proven live
+        # 2026-07-20), which is only valid while a preview's reservation
+        # is still held. The callable guard keeps duck-typed Roll doubles
         # without an eject method on the device route instead of dying
         # with an AttributeError.
         roll = self._roll
@@ -1580,11 +1577,16 @@ class CoolscanPyTransport:
             target = roll
         else:
             target = self._device
-        # Future-pin exception (capture branch): Roll.eject() with no held
-        # reservation raises EjectNotAvailable, which is NOT an EjectFailed
-        # subclass. Resolved per call so the editable pin advancing is
-        # picked up without a bridge restart ordering hazard; the empty
-        # tuple makes the except clause match nothing on today's pin.
+        # True whenever the eject that produced `ejected` ran through the
+        # vendor Device route (directly, or as the fallback below) -- that
+        # route reports acceptance, not actuation, so its success must be
+        # confirmed before it is reported (see _require_vendor_eject_confirmed).
+        vendor_route = target is self._device
+        # Roll.eject() with no held reservation raises EjectNotAvailable,
+        # which is NOT an EjectFailed subclass. Exported by the pinned
+        # coolscanpy since 2026-08-07; still resolved per call so a pin
+        # without the symbol degrades to an empty tuple (matching nothing)
+        # instead of an AttributeError at import order.
         eject_not_available: tuple[type[BaseException], ...] = tuple(
             cls
             for cls in (getattr(coolscanpy, "EjectNotAvailable", None),)
@@ -1609,7 +1611,42 @@ class CoolscanPyTransport:
         except coolscanpy.EjectFailed as exc:
             raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
         except eject_not_available as exc:
-            raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
+            if target is not roll:
+                # Defensive, should be unreachable: EjectNotAvailable is
+                # raised only by Roll.eject(), never by Device.eject().
+                raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
+            # A failed preview's fail-closed teardown already released the
+            # held reservation (coolscanpy 0.2.0), so Roll.eject() refuses
+            # here WITHOUT having sent any command -- the film is still
+            # physically inside (field reports #16 #68 #76: power cycle was
+            # the only way out). No eject has been attempted yet, so fall
+            # back to the capability-gated vendor eject on Device before
+            # giving up. Every fallback outcome keeps the direct device
+            # route's typed mapping, and success below still requires a
+            # confirmed ejected=True -- the fallback adds a second attempt,
+            # never a weaker acceptance.
+            vendor_route = True
+            try:
+                ejected = bool(self._device.eject())
+            except ImportError as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.EJECT_FAILED,
+                    "real eject requires the coolscanpy[scanner] extra and SANE installed -- see README",
+                ) from fallback_exc
+            except coolscanpy.DeviceBusy as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.DEVICE_BUSY, str(fallback_exc)
+                ) from fallback_exc
+            except coolscanpy.FeederParked as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.FEEDER_PARKED, str(fallback_exc)
+                ) from fallback_exc
+            except coolscanpy.EjectFailed as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.EJECT_FAILED, str(fallback_exc)
+                ) from fallback_exc
+        if ejected and vendor_route:
+            self._require_vendor_eject_confirmed()
         if not ejected:
             # A capability-gated no-op is NOT an eject: the film is still
             # inside the feeder. Returning success here would be exactly
@@ -1621,12 +1658,53 @@ class CoolscanPyTransport:
             )
         # The strip is out: the roll session and preview no longer
         # describe loaded film. Close-first ordering on purpose -- if
-        # close() raises (surfaced as INTERNAL by service.py's boundary),
-        # `self._roll` stays set so `device.close` can still close
-        # Roll-then-Device in the order coolscanpy requires.
+        # close() raises, `self._roll` stays set so `device.close` can
+        # still close Roll-then-Device in the order coolscanpy requires.
+        # The failure is raised typed as INTERNAL with a message that says
+        # the film IS out: letting it reach service.py's generic eject
+        # boundary would report "eject failed" for a completed eject.
         if self._roll is not None:
-            self._roll.close()
+            try:
+                self._roll.close()
+            except Exception as exc:
+                raise BridgeError(
+                    ErrorCode.INTERNAL,
+                    "the film was ejected, but closing the roll session "
+                    f"afterwards failed ({type(exc).__name__}: {exc}); "
+                    "disconnect and reconnect before the next preview",
+                ) from exc
             self._roll = None
         self._material = None
         self._preview_established = False
         return True
+
+    def _require_vendor_eject_confirmed(self) -> None:
+        # The vendor eject reports acceptance, not actuation: the LS-5000
+        # can accept the eject CDB with clean sense and never move
+        # (INCIDENT-20260719-eject-from-park, reconfirmed 2026-07-24 from
+        # the 022b4b wedge). The Roll route confirms actuation through the
+        # worker journal; the Device route must confirm through the
+        # motion-free film-presence probe before any success is reported.
+        # The probe's None means "could not determine" -- per its own
+        # contract it must never be read as film-absent -- so anything
+        # short of a definite False fails closed.
+        probe = getattr(self._device, "film_present", None)
+        present: bool | None = None
+        if callable(probe):
+            try:
+                present = probe()
+            except Exception:
+                present = None
+        if present is True:
+            raise BridgeError(
+                ErrorCode.FEEDER_PARKED,
+                "the vendor eject was accepted but the film is still "
+                "present; the transport did not actuate -- a power cycle "
+                "is the only demonstrated recovery",
+            )
+        if present is not False:
+            raise BridgeError(
+                ErrorCode.EJECT_FAILED,
+                "the vendor eject was accepted but film presence could "
+                "not be confirmed clear; treat the film as still loaded",
+            )

--- a/bridge/tests/test_service_dispatch.py
+++ b/bridge/tests/test_service_dispatch.py
@@ -592,6 +592,38 @@ def test_device_eject_bridge_error_from_transport_records_error_telemetry(
     assert "power cycle" in error_entry["message"]
 
 
+def test_device_eject_unmapped_transport_exception_is_eject_failed_not_internal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transport/driver exception outside the transport's mapped ladder
+    must reach the wire as a typed EJECT_FAILED with a code+message
+    telemetry line -- not fall through to cli.py's catch-all INTERNAL,
+    which is how the #16/#68/#76 eject failures shipped undiagnosable."""
+
+    class _ExplodingTransport(_StubTransport):
+        def eject(self) -> bool:
+            raise RuntimeError("capture worker reaped mid-eject")
+
+    svc = _opened_service(tmp_path, _ExplodingTransport())
+    _arm(monkeypatch, tmp_path)
+    emit = _RecordingEmit()
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch({"id": 2, "method": "device.eject"}, emit)
+
+    assert excinfo.value.code == ErrorCode.EJECT_FAILED
+    assert "RuntimeError" in str(excinfo.value)
+    assert "capture worker reaped mid-eject" in str(excinfo.value)
+    assert not emit.has("device.status")
+    error_entry = next(
+        e
+        for e in _telemetry_entries(tmp_path)
+        if e["method"] == "device.eject" and e["outcome"] == "error"
+    )
+    assert error_entry["code"] == ErrorCode.EJECT_FAILED.value
+    assert "RuntimeError" in error_entry["message"]
+
+
 def test_device_eject_success_clears_preview_material_so_scan_start_is_no_preview(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/bridge/tests/test_transport_coolscanpy.py
+++ b/bridge/tests/test_transport_coolscanpy.py
@@ -201,6 +201,11 @@ class _FakeDevice:
     def __init__(self, roll: _FakeRoll | None = None) -> None:
         self._roll = roll
         self.eject_effect: object = True
+        # The vendor-eject confirmation probe (Device.film_present): None
+        # (undetermined) mirrors the pre-probe default; vendor-route eject
+        # success tests set False (confirmed-out) explicitly, and the
+        # accepted-without-progress / unconfirmable shapes set True/None.
+        self.film_present_result: object = None
         self.closed = False
         self.capabilities = _fake_capabilities()
         # Plan 10-09 (attempts-root persistence): records exactly what
@@ -218,6 +223,11 @@ class _FakeDevice:
         if isinstance(self.eject_effect, BaseException):
             raise self.eject_effect
         return self.eject_effect
+
+    def film_present(self) -> bool | None:
+        if isinstance(self.film_present_result, BaseException):
+            raise self.film_present_result
+        return self.film_present_result
 
     def close(self) -> None:
         self.closed = True
@@ -3091,6 +3101,7 @@ def test_eject_raises_eject_failed_on_coolscanpy_eject_failed(
 def test_eject_returns_true_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
     transport, device = _opened_transport(monkeypatch, _FakeRoll())
     device.eject_effect = True
+    device.film_present_result = False
     assert transport.eject() is True
 
 
@@ -3156,6 +3167,7 @@ def test_eject_falls_back_to_device_when_roll_lacks_eject(
     roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)])
     transport, device = _opened_transport(monkeypatch, roll)
     device.eject_effect = True
+    device.film_present_result = False
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
 
     assert transport.eject() is True
@@ -3187,30 +3199,182 @@ def test_eject_maps_feeder_parked_stall_and_preserves_session_state(
     assert transport.status().preview_established is True
 
 
-def test_eject_maps_future_pin_eject_not_available_to_eject_failed(
+def test_eject_not_available_falls_back_to_device_eject(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The capture branch's Roll.eject() raises EjectNotAvailable (not an
-    EjectFailed subclass) when no held reservation exists. The pinned
-    coolscanpy does not export it yet; the transport resolves it by name at
-    call time so the mapping is already correct the day the pin advances."""
-
-    class _EjectNotAvailable(Exception):
-        pass
-
-    monkeypatch.setattr(coolscanpy, "EjectNotAvailable", _EjectNotAvailable, raising=False)
+    """Roll.eject() with no held reservation (the state every failed
+    preview's fail-closed teardown leaves behind) raises the REAL exported
+    coolscanpy.EjectNotAvailable without sending any command -- so the
+    transport must try the capability-gated vendor eject on Device instead
+    of refusing outright (#16 #68 #76: the refusal used to strand the film
+    until a power cycle). Uses the real exception class on purpose: the
+    old fake-substitute version of this test could not catch a
+    class-identity regression."""
     roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
-    roll.eject_effect = _EjectNotAvailable(
+    roll.eject_effect = coolscanpy.EjectNotAvailable(
         "no held reservation to eject: call preview() first"
     )
-    transport, _device = _opened_transport(monkeypatch, roll)
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = True
+    device.film_present_result = False
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    assert transport.eject() is True
+
+    assert roll.eject_calls == 1
+    assert roll.closed is True
+    assert transport.status().preview_established is False
+
+
+def test_eject_fallback_failure_stays_typed_and_preserves_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the Device fallback also fails, the error stays the typed
+    EJECT_FAILED of the direct device route -- and the roll session is
+    preserved exactly as the FeederParked case preserves it, because the
+    film did not come out."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.EjectFailed("vendor eject command failed")
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
 
     with pytest.raises(BridgeError) as excinfo:
         transport.eject()
 
     assert excinfo.value.code == ErrorCode.EJECT_FAILED
-    assert "no held reservation" in str(excinfo.value)
+    assert "vendor eject command failed" in str(excinfo.value)
+    assert roll.closed is False
+    assert transport.status().preview_established is True
+
+
+def test_eject_fallback_feeder_parked_maps_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked transport reported by the fallback vendor eject keeps the
+    FEEDER_PARKED taxonomy (never a silent success, never a retry)."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.FeederParked(
+        "eject accepted without confirmed clear; power cycle required"
+    )
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.FEEDER_PARKED
+    assert roll.closed is False
+
+
+def test_eject_fallback_device_busy_maps_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DeviceBusy from the fallback vendor eject is a retry-later state,
+    not an eject failure -- it must keep its own taxonomy instead of
+    collapsing into EJECT_FAILED."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.DeviceBusy("io lock is held")
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.DEVICE_BUSY
+    assert roll.closed is False
+
+
+def test_vendor_eject_still_present_after_accept_is_feeder_parked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The vendor eject reports acceptance, not actuation
+    (INCIDENT-20260719-eject-from-park): a clean scanimage exit with film
+    still present is the accepted-without-progress wedge and must surface
+    as FEEDER_PARKED, never as success."""
+    transport, device = _opened_transport(monkeypatch, _FakeRoll())
+    device.eject_effect = True
+    device.film_present_result = True
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.FEEDER_PARKED
+    assert "still present" in str(excinfo.value)
+
+
+def test_vendor_eject_unconfirmable_presence_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """film_present() -> None means undetermined -- per its contract it
+    must never be read as film-absent, so an unconfirmable vendor eject
+    fails closed as EJECT_FAILED."""
+    transport, device = _opened_transport(monkeypatch, _FakeRoll())
+    device.eject_effect = True
+    device.film_present_result = None
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.EJECT_FAILED
+    assert "could not be confirmed" in str(excinfo.value)
+
+
+def test_eject_roll_close_failure_reports_film_out_not_eject_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-eject Roll.close() failure happens AFTER the film is
+    physically out: it must surface as INTERNAL with a message saying so,
+    never as an eject failure -- and `_roll` stays set so device.close can
+    still run the Roll-then-Device teardown order."""
+
+    class _CloseFailingRoll(_EjectRecordingRoll):
+        def close(self) -> None:
+            raise RuntimeError("batch worker still reporting")
+
+    roll = _CloseFailingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = True
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.INTERNAL
+    assert "the film was ejected" in str(excinfo.value)
+    assert roll.closed is False
+
+
+def test_eject_after_failed_preview_ejects_via_device_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end regression for the #16/#68/#76 shape: preview fails, the
+    operator clicks Eject, and the film must come out through the Device
+    fallback instead of the guaranteed EjectNotAvailable refusal."""
+
+    class _RefusedPreviewRoll(_EjectRecordingRoll):
+        def preview(self, slots: list[int] | None = None) -> list["coolscanpy.Thumbnail"]:
+            raise coolscanpy.RefeedRequired(
+                "preview could not establish a usable roll session"
+            )
+
+    roll = _RefusedPreviewRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable(
+        "no held reservation to eject: call preview() first"
+    )
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = True
+    device.film_present_result = False
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert excinfo.value.code == ErrorCode.REFEED_REQUIRED
+
+    assert transport.eject() is True
+    assert roll.eject_calls == 1
+    assert roll.closed is True
 
 
 # -- coolscanpy_provenance (Plan 10-09) ---------------------------------------------

--- a/ports/tauri/app/src/__tests__/App.test.tsx
+++ b/ports/tauri/app/src/__tests__/App.test.tsx
@@ -116,8 +116,10 @@ describe("App release surfaces", () => {
 
   it("keeps real-hardware Stop controls visible by refusing Windows setup navigation", async () => {
     useUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+    const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
     const handle = createScriptedTransport({
-      onRequest: (method) => {
+      onRequest: (method, params) => {
+        calls.push({ method, params: params as Record<string, unknown> });
         if (method === "scanner.connect") {
           return {
             result: {
@@ -161,6 +163,14 @@ describe("App release surfaces", () => {
     });
 
     expect(await screen.findByTestId("stop-after-current")).toBeVisible();
+    // Issue: this real device reports no supportedMultisamplePasses wire
+    // field, so it falls back to real_backend.rs's documented [4]-only
+    // constraint -- the literal multisamplePasses: 1 requested above must
+    // reach scan.start already coerced to 4, proving the fix end to end
+    // through the full App shell (App -> SessionStore.startScan ->
+    // applyRecipeDefaults -> transport), not just the pure helpers.
+    const scanStartCall = calls.find((call) => call.method === "scan.start");
+    expect((scanStartCall?.params.recipe as { multisamplePasses?: number })?.multisamplePasses).toBe(4);
     const setup = screen.getByTestId("windows-setup-action");
     expect(setup).toBeDisabled();
     await user.click(setup);

--- a/ports/tauri/app/src/session/__tests__/alpha11-compatibility.test.ts
+++ b/ports/tauri/app/src/session/__tests__/alpha11-compatibility.test.ts
@@ -127,6 +127,32 @@ describe("alpha.11 wire compatibility", () => {
         connection: "USB",
       }),
     ).toBe(true);
+    // Forward compatibility: a future engine build sends DeviceInfo's new
+    // optional supportedMultisamplePasses key (engine domain.rs) exactly
+    // as WireProtocol.swift's DeviceInfo already decodes it -- accepted,
+    // not just tolerated as an unknown field.
+    expect(
+      isDeviceInfo({
+        deviceId: "real-ls5000-0",
+        model: "SUPER COOLSCAN 5000 ED",
+        kind: "real",
+        firmware: "1.02",
+        connection: "USB",
+        supportedMultisamplePasses: [4],
+      }),
+    ).toBe(true);
+    // A malformed value for the new field must still be rejected like any
+    // other typed field, not silently pass through.
+    expect(
+      isDeviceInfo({
+        deviceId: "real-ls5000-0",
+        model: "SUPER COOLSCAN 5000 ED",
+        kind: "real",
+        firmware: "1.02",
+        connection: "USB",
+        supportedMultisamplePasses: ["4"],
+      }),
+    ).toBe(false);
     expect(isOutputRecipe(projectWith().recipes)).toBe(true);
     expect(
       isFrameAlignment({

--- a/ports/tauri/app/src/session/__tests__/policy-recipe-mirroring.test.ts
+++ b/ports/tauri/app/src/session/__tests__/policy-recipe-mirroring.test.ts
@@ -195,6 +195,25 @@ describe("SessionStore recipe mirroring (pure helpers)", () => {
     ).toEqual({ valid: true });
   });
 
+  it("intersects the device's set with the protocol invariant instead of replacing it", () => {
+    // A device advertising a value outside {1,2,4,8,16} narrows nothing
+    // for that value: 3 stays invalid even when the wire claims it, and a
+    // protocol-valid value outside the (filtered) device set stays
+    // rejected on the device bound.
+    expectInvalid(
+      { capture: { ...VALID_CAPTURE, multisamplePasses: 3 }, processing: VALID_PROCESSING, output: VALID_OUTPUT },
+      { requestedFrames: [1], supportedMultisamplePasses: [3, 4] },
+      "capture.multisamplePasses",
+      /must be one of 4/,
+    );
+    expect(
+      validateRecipe(
+        { capture: { ...VALID_CAPTURE, multisamplePasses: 4 }, processing: VALID_PROCESSING, output: VALID_OUTPUT },
+        { requestedFrames: [1], supportedMultisamplePasses: [3, 4] },
+      ),
+    ).toEqual({ valid: true });
+  });
+
   it("forces channels to rgb and digitalIceEnabled to false for bwNegative", () => {
     const effective = resolveEffectiveProcessing({
       ...VALID_PROCESSING,

--- a/ports/tauri/app/src/session/__tests__/policy-recipe-mirroring.test.ts
+++ b/ports/tauri/app/src/session/__tests__/policy-recipe-mirroring.test.ts
@@ -10,11 +10,13 @@ import { describe, expect, it } from "vitest";
 import {
   SessionStore,
   applyRecipeDefaults,
+  coerceMultisamplePasses,
+  multisampleOptionsForDevice,
   resolveEffectiveProcessing,
   validateRecipe,
 } from "../store/session";
 import { createScriptedTransport } from "../testing/harness";
-import type { CaptureRecipe, OutputRecipe, ProcessingRecipe } from "../wire/types";
+import type { CaptureRecipe, DeviceInfo, OutputRecipe, ProcessingRecipe } from "../wire/types";
 
 const VALID_CAPTURE = {
   resolutionDpi: 4000,
@@ -56,6 +58,32 @@ const VALID_OUTPUT: OutputRecipe = {
 
 const EMPTY_CTX = { requestedFrames: [1] };
 
+// Issue: the Tauri client hardcoded [1,2,4,8,16]/multisamplePasses:1 with
+// zero device awareness, so a real LS-5000 scan.start got refused --
+// real_backend.rs's scan_start: "multisamplePasses must be one of [4] for
+// this device". These three DeviceInfo shapes are the exact ones
+// multisampleOptionsForDevice branches on.
+const REAL_DEVICE_NO_WIRE_FIELD: DeviceInfo = {
+  deviceId: "bridge-ls5000-0",
+  model: "SUPER COOLSCAN 5000 ED",
+  kind: "real",
+  firmware: "bridge 0.7.0",
+  connection: "USB (bridge)",
+};
+
+const REAL_DEVICE_WITH_WIRE_FIELD: DeviceInfo = {
+  ...REAL_DEVICE_NO_WIRE_FIELD,
+  supportedMultisamplePasses: [4, 8],
+};
+
+const SIMULATED_DEVICE: DeviceInfo = {
+  deviceId: "sim-ls5000-0",
+  model: "SUPER COOLSCAN 5000 ED",
+  kind: "simulated",
+  firmware: "1.03-sim",
+  connection: "USB (simulated)",
+};
+
 function expectInvalid(
   recipe: Parameters<typeof validateRecipe>[0],
   ctx: Parameters<typeof validateRecipe>[1],
@@ -93,6 +121,44 @@ describe("SessionStore recipe mirroring (pure helpers)", () => {
     expect(resolved.processing).toBeUndefined();
   });
 
+  describe("device-aware multisamplePasses (Issue: real LS-5000 refused scan.start)", () => {
+    it("defaults to [4] and coerces the PROTOCOL.md default of 1 to 4 for a real device with no wire field", () => {
+      expect(multisampleOptionsForDevice(REAL_DEVICE_NO_WIRE_FIELD)).toEqual([4]);
+      const resolved = applyRecipeDefaults(undefined, undefined, undefined, REAL_DEVICE_NO_WIRE_FIELD);
+      expect(resolved.capture.multisamplePasses).toBe(4);
+    });
+
+    it("honors the device's own wire-reported set when present, sorted", () => {
+      expect(multisampleOptionsForDevice(REAL_DEVICE_WITH_WIRE_FIELD)).toEqual([4, 8]);
+      // A caller-supplied value already valid for THIS device's own list
+      // (8) must be kept, not coerced away to the hardcoded [4] fallback --
+      // proves the wire field is actually consulted, not just kind==="real".
+      const resolved = applyRecipeDefaults(
+        { multisamplePasses: 8 },
+        undefined,
+        undefined,
+        REAL_DEVICE_WITH_WIRE_FIELD,
+      );
+      expect(resolved.capture.multisamplePasses).toBe(8);
+    });
+
+    it("keeps the simulator's fuller range and default of 1 unchanged", () => {
+      expect(multisampleOptionsForDevice(SIMULATED_DEVICE)).toEqual([1, 2, 4, 8, 16]);
+      expect(multisampleOptionsForDevice(null)).toEqual([1, 2, 4, 8, 16]);
+      expect(multisampleOptionsForDevice(undefined)).toEqual([1, 2, 4, 8, 16]);
+      const resolved = applyRecipeDefaults(undefined, undefined, undefined, SIMULATED_DEVICE);
+      expect(resolved.capture.multisamplePasses).toBe(1);
+    });
+
+    it("coerce prefers keeping a still-valid current value, else the nearest option (ties toward lower)", () => {
+      expect(coerceMultisamplePasses(4, [4])).toBe(4);
+      expect(coerceMultisamplePasses(2, [4])).toBe(4);
+      expect(coerceMultisamplePasses(6, [4, 8])).toBe(4);
+      expect(coerceMultisamplePasses(9, [4, 8])).toBe(8);
+      expect(coerceMultisamplePasses(2, [])).toBe(2);
+    });
+  });
+
   it("rejects bitDepth outside {8,16}", () => {
     expectInvalid(
       { capture: { ...VALID_CAPTURE, bitDepth: 12 }, processing: VALID_PROCESSING, output: VALID_OUTPUT },
@@ -107,6 +173,26 @@ describe("SessionStore recipe mirroring (pure helpers)", () => {
       EMPTY_CTX,
       "capture.multisamplePasses",
     );
+  });
+
+  it("rejects a multisamplePasses value valid historically but outside ctx.supportedMultisamplePasses", () => {
+    // 8 is a normal member of the historical {1,2,4,8,16} set (would pass
+    // the bare EMPTY_CTX check above) but is not one of this device's own
+    // accepted values -- validateRecipe must use the device-scoped bound
+    // when the caller supplies one, not silently fall back to the full set.
+    expectInvalid(
+      { capture: { ...VALID_CAPTURE, multisamplePasses: 8 }, processing: VALID_PROCESSING, output: VALID_OUTPUT },
+      { requestedFrames: [1], supportedMultisamplePasses: [4] },
+      "capture.multisamplePasses",
+      /must be one of 4/,
+    );
+    // The same value is accepted once it IS one of the device's own options.
+    expect(
+      validateRecipe(
+        { capture: { ...VALID_CAPTURE, multisamplePasses: 8 }, processing: VALID_PROCESSING, output: VALID_OUTPUT },
+        { requestedFrames: [1], supportedMultisamplePasses: [4, 8] },
+      ),
+    ).toEqual({ valid: true });
   });
 
   it("forces channels to rgb and digitalIceEnabled to false for bwNegative", () => {
@@ -245,6 +331,68 @@ describe("SessionStore recipe mirroring (wired into startScan)", () => {
       recoverable: false,
     });
     expect(calls.filter((call) => call.method === "scan.start")).toHaveLength(1);
+  });
+
+  // Connects the store to `device` via a scripted scanner.connect response,
+  // then asserts what multisamplePasses scan.start actually receives when
+  // startScan is called with `requested`. Isolates the three scenarios the
+  // defect fix must cover end to end, through the exact path a real UI
+  // startScan call takes (SessionStore.startScan -> applyRecipeDefaults ->
+  // validateRecipe -> transport.sendRequest("scan.start", ...)).
+  async function multisamplePassesSentToScanStart(
+    device: DeviceInfo,
+    requested: number,
+  ): Promise<unknown> {
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const handle = createScriptedTransport({
+      onRequest: (method, params) => {
+        calls.push({ method, params: params as Record<string, unknown> });
+        if (method === "scanner.connect") {
+          return {
+            result: {
+              device,
+              status: {
+                connected: true,
+                adapter: null,
+                mediaLoaded: false,
+                carrier: null,
+                frameCount: null,
+                lamp: "off",
+                transport: "idle",
+                activeJobId: null,
+              },
+            },
+          };
+        }
+        if (method === "scan.start") return { result: { jobId: "job-multisample" } };
+        return { result: undefined };
+      },
+    });
+    const store = new SessionStore(handle.transport);
+    await store.connect(device.deviceId);
+    await store.startScan([1], {
+      ...VALID_CAPTURE,
+      multisamplePasses: requested as CaptureRecipe["multisamplePasses"],
+    });
+    const scanCall = calls.find((call) => call.method === "scan.start");
+    const recipe = scanCall?.params.recipe as CaptureRecipe;
+    return recipe.multisamplePasses;
+  }
+
+  it("coerces multisamplePasses:1 to 4 for a real device reporting no wire field", async () => {
+    await expect(
+      multisamplePassesSentToScanStart(REAL_DEVICE_NO_WIRE_FIELD, 1),
+    ).resolves.toBe(4);
+  });
+
+  it("honors an already-valid multisamplePasses against the device's own wire-reported set", async () => {
+    await expect(
+      multisamplePassesSentToScanStart(REAL_DEVICE_WITH_WIRE_FIELD, 8),
+    ).resolves.toBe(8);
+  });
+
+  it("leaves multisamplePasses untouched for the simulator", async () => {
+    await expect(multisamplePassesSentToScanStart(SIMULATED_DEVICE, 8)).resolves.toBe(8);
   });
 
   it("the bwNegative forcing reaches the wire call (channels rgb, digitalIceEnabled false)", async () => {

--- a/ports/tauri/app/src/session/store/session.ts
+++ b/ports/tauri/app/src/session/store/session.ts
@@ -421,23 +421,108 @@ function isFilmFeedInterrupted(error: EngineError): boolean {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Multisample-pass device policy (defect fix: the picker and
+// applyRecipeDefaults used to hardcode [1,2,4,8,16]/1 with zero device
+// awareness, so a real LS-5000 scan.start got refused with INVALID_PARAMS --
+// "multisamplePasses must be one of [4] for this device", real_backend.rs's
+// scan_start). Mirrors Swift's MultisamplePassPolicy (SessionModel.swift)
+// exactly: a real LS-5000 only accepts the device's own bridge-reported set
+// (DeviceInfo.supportedMultisamplePasses, wired through engine domain.rs --
+// always [4] today per RealLs5000::supported_multisample_passes' own doc
+// comment); the simulator keeps the fuller historical [1,2,4,8,16] range.
+// ---------------------------------------------------------------------------
+
+/** The simulator's own fuller, historical range -- unchanged. */
+export const SIMULATED_MULTISAMPLE_PASSES: readonly number[] = [1, 2, 4, 8, 16];
+/**
+ * Matches real_backend.rs's derive_supported_multisample_passes /
+ * DeviceInfo.supportedMultisamplePasses today: always [4] for the LS-5000.
+ * Used only when a connected real device's own wire-reported value is
+ * absent (an older engine build predating that field) -- once every engine
+ * build forwards it, this fallback becomes unreachable but stays correct.
+ */
+export const REAL_DEVICE_MULTISAMPLE_PASSES_FALLBACK: readonly number[] = [4];
+
+/**
+ * The multisamplePasses options a picker should offer for `device` (`null`
+ * or `undefined` -- no device connected yet -- gets the fuller
+ * simulator-shaped range, matching this picker's own pre-existing behavior
+ * before any device connects). Mirrors Swift's
+ * `MultisamplePassPolicy.supportedOptions(for:)` exactly, including
+ * treating an empty wire-reported list as absent rather than offering zero
+ * options.
+ */
+export function multisampleOptionsForDevice(device?: DeviceInfo | null): number[] {
+  if (device === null || device === undefined) return [...SIMULATED_MULTISAMPLE_PASSES];
+  const supported = device.supportedMultisamplePasses;
+  if (supported !== undefined && supported.length > 0) {
+    return [...supported].sort((a, b) => a - b);
+  }
+  return device.kind === "real"
+    ? [...REAL_DEVICE_MULTISAMPLE_PASSES_FALLBACK]
+    : [...SIMULATED_MULTISAMPLE_PASSES];
+}
+
+/**
+ * The value a recipe should carry given `options`: `current` unchanged if
+ * it's still supported, otherwise coerced to the closest allowed value
+ * (nearest by absolute difference; ties break toward the lower value)
+ * rather than always snapping to the first/lowest entry -- mirrors Swift's
+ * `MultisamplePassPolicy.coerce(_:into:)` exactly, so a hypothetical future
+ * [4, 8]-only device coerces a stored 6 to 4 and a stored 9 to 8, never
+ * both to the same value. An empty `options` list is a no-op (returns
+ * `current` unchanged) rather than crashing or fabricating a value with no
+ * basis.
+ */
+export function coerceMultisamplePasses(current: number, options: readonly number[]): number {
+  if (options.length === 0) return current;
+  if (options.includes(current)) return current;
+  let best = options[0];
+  for (const candidate of options.slice(1)) {
+    const bestDistance = Math.abs(best - current);
+    const candidateDistance = Math.abs(candidate - current);
+    if (
+      candidateDistance < bestDistance ||
+      (candidateDistance === bestDistance && candidate < best)
+    ) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
 /**
  * Fills in the documented defaults from PROTOCOL.md: CaptureRecipe
  * resolutionDpi 4000, bitDepth 16, multisamplePasses 1, channels "rgbi";
  * ArchiveRecipe.enabled true and fullCapturePackage true. Preview/positive
  * have no PROTOCOL.md-documented default `enabled` value and are left as
  * given -- no invented defaults.
+ *
+ * multisamplePasses is additionally coerced into `device`'s own supported
+ * options (multisampleOptionsForDevice/coerceMultisamplePasses above): the
+ * PROTOCOL.md default of 1 is fed in as the "current" value when the caller
+ * supplied none, so a real LS-5000 (whose only accepted value is 4)
+ * resolves straight to 4 instead of the simulator-only default of 1 the
+ * engine's own scan.start gate would then reject with INVALID_PARAMS.
+ * `device` omitted (or null) -- any caller with no device context yet --
+ * keeps today's simulator/no-device behavior (default 1) unchanged.
  */
 export function applyRecipeDefaults(
   capture?: CaptureRecipe,
   processing?: ProcessingRecipe,
   output?: OutputRecipe,
+  device?: DeviceInfo | null,
 ): ResolvedRecipes {
+  const multisampleOptions = multisampleOptionsForDevice(device);
   return {
     capture: {
       resolutionDpi: capture?.resolutionDpi ?? 4000,
       bitDepth: capture?.bitDepth ?? 16,
-      multisamplePasses: capture?.multisamplePasses ?? 1,
+      multisamplePasses: coerceMultisamplePasses(
+        capture?.multisamplePasses ?? 1,
+        multisampleOptions,
+      ) as ResolvedCaptureRecipe["multisamplePasses"],
       channels: capture?.channels ?? "rgbi",
     },
     processing,
@@ -486,6 +571,15 @@ export interface RecipeValidationContext {
   frameProcessingOverrides?: Record<number, ProcessingRecipe>;
   excludedFrameIndices?: Set<number>;
   requestedFrames: number[];
+  // Device-aware multisamplePasses bound (multisampleOptionsForDevice
+  // above). Omitted, this keeps validating against the full historical
+  // {1,2,4,8,16} set, matching every caller that predates device
+  // awareness. startScan's own call site supplies the connected device's
+  // actual options so a value that reaches validateRecipe already
+  // out-of-range for THIS device (bypassing applyRecipeDefaults'
+  // coercion, or called directly as in the tests below) is still rejected
+  // locally instead of round-tripping to the engine's INVALID_PARAMS.
+  supportedMultisamplePasses?: number[];
 }
 
 export type RecipeValidationResult =
@@ -525,11 +619,12 @@ export function validateRecipe(
       message: `bitDepth must be 8 or 16 (got ${capture.bitDepth})`,
     };
   }
-  if (!VALID_MULTISAMPLE_PASSES.includes(capture.multisamplePasses)) {
+  const multisampleOptions = ctx.supportedMultisamplePasses ?? VALID_MULTISAMPLE_PASSES;
+  if (!multisampleOptions.includes(capture.multisamplePasses)) {
     return {
       valid: false,
       field: "capture.multisamplePasses",
-      message: `multisamplePasses must be one of 1, 2, 4, 8, 16 (got ${capture.multisamplePasses})`,
+      message: `multisamplePasses must be one of ${multisampleOptions.join(", ")} (got ${capture.multisamplePasses})`,
     };
   }
   if (!VALID_CHANNELS.includes(capture.channels)) {
@@ -2039,7 +2134,18 @@ export class SessionStore {
     // rejection is EngineError-shaped; if the wire call itself still fails
     // (a case this mirror does not model), the engine's own
     // code/message/recoverable reach the caller byte-for-byte unmodified.
-    const resolved = applyRecipeDefaults(recipe, processing, output);
+    //
+    // multisamplePasses is additionally resolved against the CONNECTED
+    // device (multisampleOptionsForDevice/applyRecipeDefaults above): the
+    // same guarantee Swift's coerceMultisamplePassesForConnectedDevice
+    // gives by construction (its scanMultisamplePasses is proactively kept
+    // valid for the connected device at every connect/project boundary
+    // before scan.start ever sees it) reached here as a final coercion
+    // pass at the one place every scan.start call funnels through,
+    // regardless of what the caller's own recipe draft happened to carry.
+    const connectedDevice = this.#state.connection.device;
+    const multisampleOptions = multisampleOptionsForDevice(connectedDevice);
+    const resolved = applyRecipeDefaults(recipe, processing, output, connectedDevice);
     const effectiveProcessing =
       resolved.processing !== undefined
         ? resolveEffectiveProcessing(resolved.processing, resolved.capture.channels)
@@ -2066,6 +2172,7 @@ export class SessionStore {
         frameProcessingOverrides,
         excludedFrameIndices,
         requestedFrames: frames,
+        supportedMultisamplePasses: multisampleOptions,
       },
     );
     if (!validation.valid) {

--- a/ports/tauri/app/src/session/store/session.ts
+++ b/ports/tauri/app/src/session/store/session.ts
@@ -619,7 +619,14 @@ export function validateRecipe(
       message: `bitDepth must be 8 or 16 (got ${capture.bitDepth})`,
     };
   }
-  const multisampleOptions = ctx.supportedMultisamplePasses ?? VALID_MULTISAMPLE_PASSES;
+  // Intersect, never replace: the device's advertised set narrows the
+  // protocol invariant {1,2,4,8,16}, but a device advertising a value
+  // outside it must not widen what this validator accepts.
+  const multisampleOptions = ctx.supportedMultisamplePasses
+    ? ctx.supportedMultisamplePasses.filter((passes) =>
+        VALID_MULTISAMPLE_PASSES.includes(passes),
+      )
+    : VALID_MULTISAMPLE_PASSES;
   if (!multisampleOptions.includes(capture.multisamplePasses)) {
     return {
       valid: false,

--- a/ports/tauri/app/src/session/wire/types.ts
+++ b/ports/tauri/app/src/session/wire/types.ts
@@ -11,6 +11,14 @@ export interface DeviceInfo {
   kind: "simulated" | "real";
   firmware: string;
   connection: string;
+  // Device-sourced accepted set for CaptureRecipe.multisamplePasses (engine
+  // domain.rs DeviceInfo.supportedMultisamplePasses, itself
+  // RealLs5000::supported_multisample_passes -- the same set scan.start's
+  // own INVALID_PARAMS gate validates multisamplePasses against). Absent
+  // for the simulator and for any older engine build that predates this
+  // field; store/session.ts's multisampleOptionsForDevice is the single
+  // place that interprets an absent value.
+  supportedMultisamplePasses?: number[];
 }
 
 export interface ScannerStatus {
@@ -398,6 +406,10 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string");
 }
 
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "number");
+}
+
 const CARRIERS = ["roll36", "strip6", "mounted"] as const;
 const FILM_PROCESSES = [
   "positive",
@@ -436,7 +448,8 @@ export function isDeviceInfo(value: unknown): value is DeviceInfo {
     typeof value.model === "string" &&
     isIn(value.kind, ["simulated", "real"] as const) &&
     typeof value.firmware === "string" &&
-    typeof value.connection === "string"
+    typeof value.connection === "string" &&
+    (!("supportedMultisamplePasses" in value) || isNumberArray(value.supportedMultisamplePasses))
   );
 }
 

--- a/ports/tauri/app/src/views/ScanRun/__tests__/ScanRunView.test.tsx
+++ b/ports/tauri/app/src/views/ScanRun/__tests__/ScanRunView.test.tsx
@@ -140,6 +140,13 @@ describe("ScanRunView", () => {
     expect(captureDurationLabel(0)).toBe("Capture timing not recorded");
   });
 
+  it("leaves multisamplePasses untouched for the simulated device (device-aware coercion is a no-op here)", async () => {
+    const fixture = await runFixture();
+    const scanStartCall = fixture.calls.find((call) => call.method === "scan.start");
+    const recipe = scanStartCall?.params.recipe as { multisamplePasses?: number } | undefined;
+    expect(recipe?.multisamplePasses).toBe(1);
+  });
+
   it("renders per-frame states and attempt counts", async () => {
     const fixture = await runFixture();
     mocks.sessionStore = fixture.store;

--- a/ports/tauri/app/src/views/ScanSetup/CaptureRecipeForm.tsx
+++ b/ports/tauri/app/src/views/ScanSetup/CaptureRecipeForm.tsx
@@ -4,14 +4,24 @@ import styles from "./ScanSetup.module.css";
 export interface CaptureRecipeFormProps {
   capture: ResolvedCaptureRecipe;
   filmProcess?: FilmProcess;
+  // Device-aware multisamplePasses options (session/store/session.ts's
+  // multisampleOptionsForDevice, computed by the caller from the connected
+  // DeviceInfo). Plain numbers, not the narrower ResolvedCaptureRecipe
+  // union: a real device's wire-reported set is open-ended data, not a
+  // client-side literal type. Not defaulted here: a real LS-5000 only
+  // accepts [4], and a component-local [1,2,4,8,16] fallback would
+  // silently re-introduce the defect this prop exists to fix (offering
+  // multisample counts the connected device's own scan.start gate
+  // rejects). Every render caller must pass the list it actually wants
+  // offered.
+  multisampleOptions: readonly number[];
   onChange: (next: ResolvedCaptureRecipe) => void;
 }
-
-const MULTISAMPLE_PASSES: Array<ResolvedCaptureRecipe["multisamplePasses"]> = [1, 2, 4, 8, 16];
 
 export default function CaptureRecipeForm({
   capture,
   filmProcess,
+  multisampleOptions,
   onChange,
 }: CaptureRecipeFormProps) {
   const isBwNegative = filmProcess === "bwNegative";
@@ -84,7 +94,7 @@ export default function CaptureRecipeForm({
               update({ multisamplePasses: Number(event.target.value) as ResolvedCaptureRecipe["multisamplePasses"] })
             }
           >
-            {MULTISAMPLE_PASSES.map((passes) => (
+            {multisampleOptions.map((passes) => (
               <option key={passes} value={passes}>
                 {passes}
               </option>

--- a/ports/tauri/app/src/views/ScanSetup/FrameOverrideEditor.tsx
+++ b/ports/tauri/app/src/views/ScanSetup/FrameOverrideEditor.tsx
@@ -19,6 +19,11 @@ export interface FrameOverrideEditorProps {
   rollCapture: ResolvedCaptureRecipe;
   rollProcessing?: ProcessingRecipe;
   rollOutput: OutputRecipe;
+  // Device-aware multisamplePasses options (session/store/session.ts's
+  // multisampleOptionsForDevice), forwarded verbatim to this editor's own
+  // per-frame CaptureRecipeForm so a frame override picker never offers a
+  // count the connected device's scan.start gate would reject either.
+  multisampleOptions: readonly number[];
   // The active project's frame set — used to read any existing override and
   // to detect a whole-object-swap save (never a merged payload).
   project: ScanProject | null;
@@ -39,6 +44,7 @@ export default function FrameOverrideEditor({
   rollCapture,
   rollProcessing,
   rollOutput,
+  multisampleOptions,
   project,
 }: FrameOverrideEditorProps) {
   const frame = project?.frames.find((f) => f.index === frameIndex) ?? null;
@@ -154,6 +160,7 @@ export default function FrameOverrideEditor({
                   <CaptureRecipeForm
                     capture={drafts.capture}
                     filmProcess={filmProcess}
+                    multisampleOptions={multisampleOptions}
                     onChange={(next) => setDrafts((d) => ({ ...d, capture: next }))}
                   />
                 )}

--- a/ports/tauri/app/src/views/ScanSetup/ScanSetupView.tsx
+++ b/ports/tauri/app/src/views/ScanSetup/ScanSetupView.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { useSyncExternalStore } from "react";
 import {
   applyRecipeDefaults,
+  coerceMultisamplePasses,
+  multisampleOptionsForDevice,
   type ResolvedCaptureRecipe,
   resolveEffectiveProcessing,
 } from "../../session/store/session";
@@ -79,11 +81,19 @@ export default function ScanSetupView({
   const state = useSyncExternalStore(stableSubscribe, stableGetSnapshot);
   const project = state.project;
   const filmProcess = project?.filmProcess ?? "c41ColorNegative";
+  const connectedDevice = state.connection.device;
 
   // Roll-wide recipes: resolved defaults for capture (the project manifest
   // does not carry a capture/processing recipe), and the project's stored
-  // output recipe for output.
-  const resolved = applyRecipeDefaults(undefined, undefined, undefined);
+  // output recipe for output. Seeded with whatever device is already
+  // connected at mount time -- a real LS-5000 connected before this view
+  // ever rendered must not seed the simulator-shaped default of 1 that its
+  // own scan.start gate would then reject with INVALID_PARAMS.
+  const resolved = applyRecipeDefaults(undefined, undefined, undefined, connectedDevice);
+  // Device-aware picker options (mirrors Swift's MultisamplePassPolicy);
+  // recomputed every render, cheap, and always in sync with the connected
+  // device -- no memoization needed for a five-element-at-most array.
+  const multisampleOptions = multisampleOptionsForDevice(connectedDevice);
   const initialOutput = project?.recipes;
   const [capture, setCapture] = useState(resolved.capture);
   const [processing, setProcessing] = useState<ProcessingRecipe>(() => {
@@ -115,6 +125,34 @@ export default function ScanSetupView({
       .then((result) => setExifToolDetection(result))
       .catch(() => setExifToolDetection(null));
   }, []);
+
+  // Coerce on connect (mirrors Swift's coerceMultisamplePassesForConnectedDevice,
+  // called after scanner.connect and again after createProject while
+  // already connected): a device change can make the CURRENT
+  // multisamplePasses value unsupported (a real LS-5000 accepts only [4]).
+  // TS has no single persistent recipe draft to re-coerce at those two
+  // Swift call sites directly -- capture is this view's own local state --
+  // so this effect re-derives the connected device's options and
+  // re-coerces whenever the device's identity or its own reported options
+  // change; a no-op transition (options unchanged, current value still
+  // valid) returns the same object from the updater, so React bails out
+  // without an extra render. The mount-time seed above already covers a
+  // device connected before this view ever rendered; this effect covers
+  // one connecting (or reporting a different capability list) while the
+  // view stays mounted.
+  useEffect(() => {
+    setCapture((current) => {
+      const coerced = coerceMultisamplePasses(current.multisamplePasses, multisampleOptions);
+      return coerced === current.multisamplePasses
+        ? current
+        : { ...current, multisamplePasses: coerced as ResolvedCaptureRecipe["multisamplePasses"] };
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    connectedDevice?.deviceId,
+    connectedDevice?.kind,
+    connectedDevice?.supportedMultisamplePasses?.join(","),
+  ]);
 
   // If a project loads after mount (or changes), adopt its output recipes as
   // the form's starting point instead of leaving stale defaults.
@@ -214,7 +252,12 @@ export default function ScanSetupView({
           {error.message}
         </p>
       )}
-      <CaptureRecipeForm capture={capture} filmProcess={filmProcess} onChange={setCapture} />
+      <CaptureRecipeForm
+        capture={capture}
+        filmProcess={filmProcess}
+        multisampleOptions={multisampleOptions}
+        onChange={setCapture}
+      />
       <ProcessingRecipeForm processing={processing} filmProcess={filmProcess} onChange={setProcessing} />
       {output && <OutputRecipeForm output={output} onChange={setOutput} />}
       {project && (
@@ -225,6 +268,7 @@ export default function ScanSetupView({
           rollCapture={capture}
           rollProcessing={processing}
           rollOutput={output ?? resolved.output}
+          multisampleOptions={multisampleOptions}
           project={project}
         />
       )}

--- a/ports/tauri/app/src/views/ScanSetup/__tests__/CaptureRecipeForm.test.tsx
+++ b/ports/tauri/app/src/views/ScanSetup/__tests__/CaptureRecipeForm.test.tsx
@@ -16,10 +16,18 @@ const DEFAULT_CAPTURE: ResolvedCaptureRecipe = {
   channels: "rgbi",
 };
 
+const SIMULATOR_OPTIONS = [1, 2, 4, 8, 16];
+const REAL_DEVICE_OPTIONS = [4];
+
 describe("CaptureRecipeForm", () => {
   it("renders every field with the PROTOCOL.md defaults", () => {
     render(
-      <CaptureRecipeForm capture={DEFAULT_CAPTURE} filmProcess="positive" onChange={() => {}} />,
+      <CaptureRecipeForm
+        capture={DEFAULT_CAPTURE}
+        filmProcess="positive"
+        multisampleOptions={SIMULATOR_OPTIONS}
+        onChange={() => {}}
+      />,
     );
     expect(screen.getByLabelText("Resolution (Dpi)")).toHaveValue(4000);
     expect(screen.getByLabelText("16 bits")).toBeChecked();
@@ -38,6 +46,7 @@ describe("CaptureRecipeForm", () => {
         <CaptureRecipeForm
           capture={capture}
           filmProcess="positive"
+          multisampleOptions={SIMULATOR_OPTIONS}
           onChange={(next) => {
             seen.push(next);
             setCapture(next);
@@ -56,7 +65,12 @@ describe("CaptureRecipeForm", () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
     render(
-      <CaptureRecipeForm capture={DEFAULT_CAPTURE} filmProcess="positive" onChange={onChange} />,
+      <CaptureRecipeForm
+        capture={DEFAULT_CAPTURE}
+        filmProcess="positive"
+        multisampleOptions={SIMULATOR_OPTIONS}
+        onChange={onChange}
+      />,
     );
     await user.click(screen.getByLabelText("8 bits"));
     expect(onChange).toHaveBeenLastCalledWith({ ...DEFAULT_CAPTURE, bitDepth: 8 });
@@ -66,7 +80,12 @@ describe("CaptureRecipeForm", () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
     render(
-      <CaptureRecipeForm capture={DEFAULT_CAPTURE} filmProcess="positive" onChange={onChange} />,
+      <CaptureRecipeForm
+        capture={DEFAULT_CAPTURE}
+        filmProcess="positive"
+        multisampleOptions={SIMULATOR_OPTIONS}
+        onChange={onChange}
+      />,
     );
     await user.selectOptions(screen.getByLabelText("Multisample passes"), "16");
     expect(onChange).toHaveBeenLastCalledWith({ ...DEFAULT_CAPTURE, multisamplePasses: 16 });
@@ -76,7 +95,12 @@ describe("CaptureRecipeForm", () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
     render(
-      <CaptureRecipeForm capture={DEFAULT_CAPTURE} filmProcess="positive" onChange={onChange} />,
+      <CaptureRecipeForm
+        capture={DEFAULT_CAPTURE}
+        filmProcess="positive"
+        multisampleOptions={SIMULATOR_OPTIONS}
+        onChange={onChange}
+      />,
     );
     await user.click(screen.getByLabelText("Rgb"));
     expect(onChange).toHaveBeenLastCalledWith({ ...DEFAULT_CAPTURE, channels: "rgb" });
@@ -87,6 +111,7 @@ describe("CaptureRecipeForm", () => {
       <CaptureRecipeForm
         capture={{ ...DEFAULT_CAPTURE, channels: "rgbi" }}
         filmProcess="bwNegative"
+        multisampleOptions={SIMULATOR_OPTIONS}
         onChange={() => {}}
       />,
     );
@@ -99,10 +124,47 @@ describe("CaptureRecipeForm", () => {
 
   it("keeps the channels control enabled (never forced) for a non-B&W process", () => {
     render(
-      <CaptureRecipeForm capture={DEFAULT_CAPTURE} filmProcess="c41ColorNegative" onChange={() => {}} />,
+      <CaptureRecipeForm
+        capture={DEFAULT_CAPTURE}
+        filmProcess="c41ColorNegative"
+        multisampleOptions={SIMULATOR_OPTIONS}
+        onChange={() => {}}
+      />,
     );
     expect(screen.getByLabelText("Rgb")).not.toBeDisabled();
     expect(screen.getByLabelText("Rgb + infrared (rgbi)")).not.toBeDisabled();
     expect(screen.queryByTestId("capture-bw-channels-note")).toBeNull();
+  });
+
+  describe("device-aware multisampleOptions (Issue: real LS-5000 offered 2x/8x/16x)", () => {
+    it("offers the full simulator range when no device is connected yet", () => {
+      render(
+        <CaptureRecipeForm
+          capture={DEFAULT_CAPTURE}
+          filmProcess="positive"
+          multisampleOptions={SIMULATOR_OPTIONS}
+          onChange={() => {}}
+        />,
+      );
+      const options = screen
+        .getAllByRole<HTMLOptionElement>("option")
+        .map((option) => option.value);
+      expect(options).toEqual(["1", "2", "4", "8", "16"]);
+    });
+
+    it("offers only the connected real device's own set, never the simulator's 2x/8x/16x", () => {
+      render(
+        <CaptureRecipeForm
+          capture={{ ...DEFAULT_CAPTURE, multisamplePasses: 4 }}
+          filmProcess="positive"
+          multisampleOptions={REAL_DEVICE_OPTIONS}
+          onChange={() => {}}
+        />,
+      );
+      const options = screen
+        .getAllByRole<HTMLOptionElement>("option")
+        .map((option) => option.value);
+      expect(options).toEqual(["4"]);
+    });
   });
 });

--- a/ports/tauri/app/src/views/ScanSetup/__tests__/FrameOverrideEditor.test.tsx
+++ b/ports/tauri/app/src/views/ScanSetup/__tests__/FrameOverrideEditor.test.tsx
@@ -97,6 +97,7 @@ describe("FrameOverrideEditor", () => {
         rollCapture={CAPTURE}
         rollProcessing={PROCESSING}
         rollOutput={OUTPUT}
+        multisampleOptions={[1, 2, 4, 8, 16]}
         project={PROJECT}
       />,
     );
@@ -125,6 +126,7 @@ describe("FrameOverrideEditor", () => {
         rollCapture={CAPTURE}
         rollProcessing={PROCESSING}
         rollOutput={OUTPUT}
+        multisampleOptions={[1, 2, 4, 8, 16]}
         project={projectWithOverride}
       />,
     );
@@ -155,10 +157,32 @@ describe("FrameOverrideEditor", () => {
         rollCapture={CAPTURE}
         rollProcessing={PROCESSING}
         rollOutput={OUTPUT}
+        multisampleOptions={[1, 2, 4, 8, 16]}
         project={projectWithOverride}
       />,
     );
     await user.click(screen.getByTestId("toggle-override-capture"));
     expect(screen.getByTestId("capture-res-dpi")).toHaveValue(2000);
+  });
+
+  it("forwards a device-constrained multisampleOptions to the per-frame capture picker", async () => {
+    fixture();
+    const user = userEvent.setup();
+    render(
+      <FrameOverrideEditor
+        frameIndex={1}
+        filmProcess="c41ColorNegative"
+        rollCapture={{ ...CAPTURE, multisamplePasses: 4 }}
+        rollProcessing={PROCESSING}
+        rollOutput={OUTPUT}
+        multisampleOptions={[4]}
+        project={PROJECT}
+      />,
+    );
+    await user.click(screen.getByTestId("toggle-override-capture"));
+    const options = screen
+      .getAllByRole<HTMLOptionElement>("option")
+      .map((option) => option.value);
+    expect(options).toEqual(["4"]);
   });
 });

--- a/ports/tauri/app/src/views/ScanSetup/__tests__/ScanSetupView.test.tsx
+++ b/ports/tauri/app/src/views/ScanSetup/__tests__/ScanSetupView.test.tsx
@@ -171,4 +171,82 @@ describe("ScanSetupView", () => {
     render(<ScanSetupView selectedFrames={[]} onScanStarted={onScanStarted} onRequestConnect={() => undefined} />);
     expect(screen.getByTestId("start-scan")).toBeDisabled();
   });
+
+  describe("device-aware multisamplePasses (Issue: real LS-5000 offered 2x/8x/16x)", () => {
+    async function connectedRealDeviceStore(
+      supportedMultisamplePasses: number[] | undefined,
+    ): Promise<SessionStore> {
+      const handle = createScriptedTransport({
+        onRequest: (method) => {
+          if (method === "scanner.connect") {
+            return {
+              result: {
+                device: {
+                  deviceId: "real-ls5000-0",
+                  model: "Nikon LS-5000",
+                  kind: "real" as const,
+                  firmware: "1.02",
+                  connection: "usb",
+                  ...(supportedMultisamplePasses ? { supportedMultisamplePasses } : {}),
+                },
+                status: {
+                  connected: true,
+                  adapter: null,
+                  mediaLoaded: false,
+                  carrier: null,
+                  frameCount: null,
+                  lamp: "off" as const,
+                  transport: "idle" as const,
+                  activeJobId: null,
+                },
+              },
+            };
+          }
+          if (method === "project.create") {
+            return { result: { project: PROJECT, directory: "/Users/test/projects/real-roll" } };
+          }
+          return { result: undefined };
+        },
+      });
+      const store = new SessionStore(handle.transport);
+      await act(async () => {
+        await store.connect("real-ls5000-0");
+        await store.createProject("Setup Roll", "roll36", 36, "c41ColorNegative");
+      });
+      mocks.sessionStore = store;
+      return store;
+    }
+
+    it("offers only [4] and coerces the default multisample select to 4 for a real device with no wire field", async () => {
+      await connectedRealDeviceStore(undefined);
+      render(
+        <ScanSetupView selectedFrames={[1]} onScanStarted={() => undefined} onRequestConnect={() => undefined} />,
+      );
+      const select = await screen.findByTestId("capture-multisample");
+      const options = Array.from(select.querySelectorAll("option")).map((option) => option.value);
+      expect(options).toEqual(["4"]);
+      expect(select).toHaveValue("4");
+    });
+
+    it("honors the device's own wire-reported set when scanner.connect sends supportedMultisamplePasses", async () => {
+      await connectedRealDeviceStore([4, 8]);
+      render(
+        <ScanSetupView selectedFrames={[1]} onScanStarted={() => undefined} onRequestConnect={() => undefined} />,
+      );
+      const select = await screen.findByTestId("capture-multisample");
+      const options = Array.from(select.querySelectorAll("option")).map((option) => option.value);
+      expect(options).toEqual(["4", "8"]);
+    });
+
+    it("keeps the simulator's full picker range unchanged", async () => {
+      await connectedStore({ result: { jobId: "job-1" } });
+      render(
+        <ScanSetupView selectedFrames={[1]} onScanStarted={() => undefined} onRequestConnect={() => undefined} />,
+      );
+      const select = await screen.findByTestId("capture-multisample");
+      const options = Array.from(select.querySelectorAll("option")).map((option) => option.value);
+      expect(options).toEqual(["1", "2", "4", "8", "16"]);
+      expect(select).toHaveValue("1");
+    });
+  });
 });

--- a/ports/tauri/vendor/engine/src/domain.rs
+++ b/ports/tauri/vendor/engine/src/domain.rs
@@ -26,6 +26,21 @@ pub struct DeviceInfo {
     /// False for a recognized-but-unsupported Nikon model (Lane D): it is
     /// listed by name in ``scanner.list`` but is never connectable.
     pub supported: bool,
+    /// Device-sourced accepted set for `CaptureRecipe.multisample_passes`.
+    /// A real backend populates this from `RealLs5000::supported_multisample_passes`
+    /// (itself `derive_supported_multisample_passes`, read from BRIDGE.md's
+    /// `Capabilities.supportedMultisamplePasses` -- the same set `scan.start`
+    /// already validates `multisamplePasses` against, `real_backend.rs`'s
+    /// "multisamplePasses must be one of {:?} for this device"). The
+    /// simulator has no bridge-sourced capability list of its own and
+    /// leaves this `None` rather than fabricate one; a client with no value
+    /// (simulator, or an old engine build predating this field) keeps
+    /// offering its own historical `[1, 2, 4, 8, 16]` range. `#[serde(default)]`
+    /// makes an absent key on decode `None`, never a decode error --
+    /// forward- and backward-compatible with every engine build that does
+    /// not yet send it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supported_multisample_passes: Option<Vec<u32>>,
 }
 
 // ---------------------------------------------------------------------
@@ -1363,10 +1378,40 @@ mod tests {
             firmware: "1.03-sim".into(),
             connection: "USB (simulated)".into(),
             supported: true,
+            supported_multisample_passes: None,
         };
         let value = serde_json::to_value(&device).unwrap();
         assert_eq!(value["deviceId"], json!("sim-ls5000-0"));
         assert_eq!(value["supported"], json!(true));
+        // None-safe: skip_serializing_if omits the key entirely rather than
+        // emitting `"supportedMultisamplePasses": null` -- an older/simulator
+        // wire payload with no such key at all must decode back to None too
+        // (checked by round_trip below), not merely tolerate an explicit null.
+        assert!(
+            !value.as_object().unwrap().contains_key("supportedMultisamplePasses"),
+            "None must omit the key, not serialize it as null: {value}"
+        );
+        round_trip(&device);
+    }
+
+    #[test]
+    fn device_info_supported_multisample_passes_serializes_for_a_real_device() {
+        // Mirrors what RealLs5000::device_info() now sends: the device's own
+        // derive_supported_multisample_passes()-derived set, camelCase on
+        // the wire, exactly the key WireProtocol.swift's DeviceInfo already
+        // decodes (`supportedMultisamplePasses`, added ahead of the engine
+        // actually sending it).
+        let device = DeviceInfo {
+            device_id: "bridge-ls5000-0".into(),
+            model: "SUPER COOLSCAN 5000 ED".into(),
+            kind: "real".into(),
+            firmware: "bridge 0.7.0".into(),
+            connection: "USB (bridge)".into(),
+            supported: true,
+            supported_multisample_passes: Some(vec![4]),
+        };
+        let value = serde_json::to_value(&device).unwrap();
+        assert_eq!(value["supportedMultisamplePasses"], json!([4]));
         round_trip(&device);
     }
 

--- a/ports/tauri/vendor/engine/src/protocol.rs
+++ b/ports/tauri/vendor/engine/src/protocol.rs
@@ -116,6 +116,14 @@ pub enum ErrorCode {
     /// A recognized-but-unsupported Nikon model (Lane D, #14): discovery
     /// lists it by name, but connect is refused. Fail-closed.
     NotSupported,
+    /// The bridge's eject could not run or could not confirm the film
+    /// left the transport. Previously flattened to `Internal`, which made
+    /// the #16/#68/#76 eject failures undiagnosable client-side.
+    EjectFailed,
+    /// The driver's typed accepted-without-progress eject outcome
+    /// (INCIDENT-20260719-eject-from-park): the transport never actuated
+    /// and a power cycle is the only demonstrated recovery.
+    FeederParked,
 }
 
 // ---------------------------------------------------------------------
@@ -858,6 +866,8 @@ mod tests {
             (ErrorCode::ManualReviewRequired, "MANUAL_REVIEW_REQUIRED"),
             (ErrorCode::HwMotionNotArmed, "HW_MOTION_NOT_ARMED"),
             (ErrorCode::NotSupported, "NOT_SUPPORTED"),
+            (ErrorCode::EjectFailed, "EJECT_FAILED"),
+            (ErrorCode::FeederParked, "FEEDER_PARKED"),
         ] {
             assert_eq!(serde_json::to_value(code).unwrap(), json!(wire));
             let decoded: ErrorCode = serde_json::from_value(json!(wire)).unwrap();

--- a/ports/tauri/vendor/engine/src/real_backend.rs
+++ b/ports/tauri/vendor/engine/src/real_backend.rs
@@ -4595,6 +4595,8 @@ fn map_bridge_error_code_str(code: &str) -> ErrorCode {
         "FILM_FEED_INTERRUPTED" => ErrorCode::FilmFeedInterrupted,
         "HW_MOTION_NOT_ARMED" => ErrorCode::HwMotionNotArmed,
         "UNKNOWN_JOB" => ErrorCode::UnknownJob,
+        "EJECT_FAILED" => ErrorCode::EjectFailed,
+        "FEEDER_PARKED" => ErrorCode::FeederParked,
         _ => ErrorCode::Internal,
     }
 }

--- a/ports/tauri/vendor/engine/src/real_backend.rs
+++ b/ports/tauri/vendor/engine/src/real_backend.rs
@@ -2695,6 +2695,14 @@ impl RealLs5000 {
             firmware: self.firmware_label.clone(),
             connection: "USB (bridge)".to_string(),
             supported: self.supported,
+            // The same device-sourced set scan_start's own INVALID_PARAMS
+            // gate already validates multisamplePasses against (see the
+            // "multisamplePasses must be one of {:?} for this device"
+            // check below) -- always Some for a real backend, since
+            // derive_supported_multisample_passes always returns a
+            // concrete (if degenerate) Vec from the bridge's own
+            // Capabilities, never absent data.
+            supported_multisample_passes: Some(self.supported_multisample_passes.clone()),
         }
     }
 

--- a/ports/tauri/vendor/engine/src/sim.rs
+++ b/ports/tauri/vendor/engine/src/sim.rs
@@ -358,6 +358,20 @@ impl SimulatedLs5000 {
                 firmware: "1.03-sim".to_string(),
                 connection: "USB (simulated)".to_string(),
                 supported: true,
+                // No bridge to source a capability list from, and
+                // skip_serializing_if keeps this key off the wire entirely
+                // (byte-identical scanner.list/scanner.connect JSON to
+                // before this field existed) rather than advertise an
+                // arbitrary simulator-only list. Every client's own
+                // device-aware policy already treats an absent value the
+                // same as this device's "simulated" kind would anyway
+                // (TS's multisampleOptionsForDevice / Swift's
+                // MultisamplePassPolicy.supportedOptions(for:) both fall
+                // back to the fuller [1, 2, 4, 8, 16] range for a
+                // non-"real" kind), so None and a spelled-out
+                // Some([1, 2, 4, 8, 16]) are observably identical here --
+                // None is simply the smaller, zero-new-fixtures change.
+                supported_multisample_passes: None,
             },
             state: Mutex::new(State::default()),
             cancelled: AtomicBool::new(false),

--- a/ports/tauri/vendor/engine/tests/end_to_end_real_backend.rs
+++ b/ports/tauri/vendor/engine/tests/end_to_end_real_backend.rs
@@ -1715,6 +1715,27 @@ fn real_device_listed_and_connectable_when_bridge_cmd_set() {
         "exactly one listed device must have kind \"real\": {devices:?}"
     );
     assert_eq!(real_devices[0]["deviceId"], json!("bridge-ls5000-0"));
+    // The exact wire key WireProtocol.swift's DeviceInfo already decodes
+    // (added ahead of the engine actually sending it) and the TS wire
+    // client's DeviceInfo interface expects, carrying mock_bridge's fixed
+    // Capabilities.supportedMultisamplePasses verbatim through
+    // derive_supported_multisample_passes -- a real, over-the-wire,
+    // black-box proof of the key name, not just an in-process Rust struct
+    // assertion.
+    assert_eq!(
+        real_devices[0]["supportedMultisamplePasses"],
+        json!([4]),
+        "real device's scanner.list entry must forward the bridge's supported multisample passes: {devices:?}"
+    );
+    let sim_devices: Vec<&Value> = devices
+        .iter()
+        .filter(|device| device["kind"] == json!("simulated"))
+        .collect();
+    assert_eq!(sim_devices.len(), 1, "expected exactly one simulated device: {devices:?}");
+    assert!(
+        sim_devices[0].get("supportedMultisamplePasses").is_none(),
+        "the simulator has no bridge-sourced capability list and must omit the key entirely, not null: {devices:?}"
+    );
 
     send(
         &mut stdin,

--- a/ports/tauri/vendor/engine/tests/real_backend_mapping.rs
+++ b/ports/tauri/vendor/engine/tests/real_backend_mapping.rs
@@ -319,6 +319,25 @@ fn unsupported_bridge_device_is_listed_but_never_connectable() {
     assert_eq!(err.code, ErrorCode::NotSupported);
 }
 
+/// `device_info()` (which `scanner.list`/`scanner.connect` both build their
+/// `DeviceInfo` response from) now forwards the exact device-sourced set
+/// `scan_start`'s own gate validates against
+/// (`scan_start_rejects_multisample_passes_other_than_device_supported`
+/// above), instead of leaving the client to guess or hardcode it. Available
+/// independent of connection state, matching `device_info()`'s own doc
+/// comment.
+#[test]
+fn device_info_forwards_the_bridges_supported_multisample_passes() {
+    let backend = RealLs5000::new(mock_bridge_bin(), GENEROUS_TIMEOUT)
+        .expect("RealLs5000::new should succeed against a healthy mock bridge");
+
+    assert_eq!(
+        backend.device_info().supported_multisample_passes,
+        Some(vec![4]),
+        "must forward mock_bridge's fixed_device_info() Capabilities.supportedMultisamplePasses verbatim"
+    );
+}
+
 const UNSUPPORTED_DEVICE_ID: &str = "bridge-ls50-0";
 
 #[test]

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
@@ -632,6 +632,26 @@ class BridgeService:
                     "device.eject", "error", code=exc.code.value, message=str(exc)
                 )
                 raise
+            except Exception as exc:
+                # Wire-contract boundary: BRIDGE.md documents EJECT_FAILED
+                # as "the eject could not run", which is true for any
+                # unmapped transport/driver exception. Left alone these
+                # fall through to cli.py's catch-all and reach the client
+                # as a bare INTERNAL with no telemetry line -- the shape
+                # that made the #16/#68/#76 field reports undiagnosable.
+                # The original type rides in the message so a driver
+                # defect still reads as one.
+                message = (
+                    f"eject failed before completion "
+                    f"({type(exc).__name__}: {exc})"
+                )
+                self._telemetry.record(
+                    "device.eject",
+                    "error",
+                    code=ErrorCode.EJECT_FAILED.value,
+                    message=message,
+                )
+                raise BridgeError(ErrorCode.EJECT_FAILED, message) from exc
             finally:
                 self._lane_held = False
         if not ejected:

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -1565,14 +1565,11 @@ class CoolscanPyTransport:
     def eject(self) -> bool:
         if self._device is None:
             raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
-        # Route through the open Roll when one exists. On the pinned
-        # coolscanpy `Roll.eject()` is a plain passthrough to
-        # `Device.eject()`, so behavior is identical today -- but the
-        # vendor-traced held-session eject (RESERVE_UNIT before the eject
-        # CDB, proven live 2026-07-20 from a normal post-traversal state)
-        # lands on `Roll` first (see coolscanpy's capture branch), so this
-        # routing picks it up with zero bridge changes the day the pin
-        # advances. The callable guard keeps duck-typed Roll doubles
+        # Route through the open Roll when one exists: on the current pin
+        # `Roll.eject()` replays the vendor-traced held-session eject
+        # sequence (RESERVE_UNIT before the eject CDB, proven live
+        # 2026-07-20), which is only valid while a preview's reservation
+        # is still held. The callable guard keeps duck-typed Roll doubles
         # without an eject method on the device route instead of dying
         # with an AttributeError.
         roll = self._roll
@@ -1580,11 +1577,16 @@ class CoolscanPyTransport:
             target = roll
         else:
             target = self._device
-        # Future-pin exception (capture branch): Roll.eject() with no held
-        # reservation raises EjectNotAvailable, which is NOT an EjectFailed
-        # subclass. Resolved per call so the editable pin advancing is
-        # picked up without a bridge restart ordering hazard; the empty
-        # tuple makes the except clause match nothing on today's pin.
+        # True whenever the eject that produced `ejected` ran through the
+        # vendor Device route (directly, or as the fallback below) -- that
+        # route reports acceptance, not actuation, so its success must be
+        # confirmed before it is reported (see _require_vendor_eject_confirmed).
+        vendor_route = target is self._device
+        # Roll.eject() with no held reservation raises EjectNotAvailable,
+        # which is NOT an EjectFailed subclass. Exported by the pinned
+        # coolscanpy since 2026-08-07; still resolved per call so a pin
+        # without the symbol degrades to an empty tuple (matching nothing)
+        # instead of an AttributeError at import order.
         eject_not_available: tuple[type[BaseException], ...] = tuple(
             cls
             for cls in (getattr(coolscanpy, "EjectNotAvailable", None),)
@@ -1609,7 +1611,42 @@ class CoolscanPyTransport:
         except coolscanpy.EjectFailed as exc:
             raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
         except eject_not_available as exc:
-            raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
+            if target is not roll:
+                # Defensive, should be unreachable: EjectNotAvailable is
+                # raised only by Roll.eject(), never by Device.eject().
+                raise BridgeError(ErrorCode.EJECT_FAILED, str(exc)) from exc
+            # A failed preview's fail-closed teardown already released the
+            # held reservation (coolscanpy 0.2.0), so Roll.eject() refuses
+            # here WITHOUT having sent any command -- the film is still
+            # physically inside (field reports #16 #68 #76: power cycle was
+            # the only way out). No eject has been attempted yet, so fall
+            # back to the capability-gated vendor eject on Device before
+            # giving up. Every fallback outcome keeps the direct device
+            # route's typed mapping, and success below still requires a
+            # confirmed ejected=True -- the fallback adds a second attempt,
+            # never a weaker acceptance.
+            vendor_route = True
+            try:
+                ejected = bool(self._device.eject())
+            except ImportError as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.EJECT_FAILED,
+                    "real eject requires the coolscanpy[scanner] extra and SANE installed -- see README",
+                ) from fallback_exc
+            except coolscanpy.DeviceBusy as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.DEVICE_BUSY, str(fallback_exc)
+                ) from fallback_exc
+            except coolscanpy.FeederParked as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.FEEDER_PARKED, str(fallback_exc)
+                ) from fallback_exc
+            except coolscanpy.EjectFailed as fallback_exc:
+                raise BridgeError(
+                    ErrorCode.EJECT_FAILED, str(fallback_exc)
+                ) from fallback_exc
+        if ejected and vendor_route:
+            self._require_vendor_eject_confirmed()
         if not ejected:
             # A capability-gated no-op is NOT an eject: the film is still
             # inside the feeder. Returning success here would be exactly
@@ -1621,12 +1658,53 @@ class CoolscanPyTransport:
             )
         # The strip is out: the roll session and preview no longer
         # describe loaded film. Close-first ordering on purpose -- if
-        # close() raises (surfaced as INTERNAL by service.py's boundary),
-        # `self._roll` stays set so `device.close` can still close
-        # Roll-then-Device in the order coolscanpy requires.
+        # close() raises, `self._roll` stays set so `device.close` can
+        # still close Roll-then-Device in the order coolscanpy requires.
+        # The failure is raised typed as INTERNAL with a message that says
+        # the film IS out: letting it reach service.py's generic eject
+        # boundary would report "eject failed" for a completed eject.
         if self._roll is not None:
-            self._roll.close()
+            try:
+                self._roll.close()
+            except Exception as exc:
+                raise BridgeError(
+                    ErrorCode.INTERNAL,
+                    "the film was ejected, but closing the roll session "
+                    f"afterwards failed ({type(exc).__name__}: {exc}); "
+                    "disconnect and reconnect before the next preview",
+                ) from exc
             self._roll = None
         self._material = None
         self._preview_established = False
         return True
+
+    def _require_vendor_eject_confirmed(self) -> None:
+        # The vendor eject reports acceptance, not actuation: the LS-5000
+        # can accept the eject CDB with clean sense and never move
+        # (INCIDENT-20260719-eject-from-park, reconfirmed 2026-07-24 from
+        # the 022b4b wedge). The Roll route confirms actuation through the
+        # worker journal; the Device route must confirm through the
+        # motion-free film-presence probe before any success is reported.
+        # The probe's None means "could not determine" -- per its own
+        # contract it must never be read as film-absent -- so anything
+        # short of a definite False fails closed.
+        probe = getattr(self._device, "film_present", None)
+        present: bool | None = None
+        if callable(probe):
+            try:
+                present = probe()
+            except Exception:
+                present = None
+        if present is True:
+            raise BridgeError(
+                ErrorCode.FEEDER_PARKED,
+                "the vendor eject was accepted but the film is still "
+                "present; the transport did not actuate -- a power cycle "
+                "is the only demonstrated recovery",
+            )
+        if present is not False:
+            raise BridgeError(
+                ErrorCode.EJECT_FAILED,
+                "the vendor eject was accepted but film presence could "
+                "not be confirmed clear; treat the film as still loaded",
+            )

--- a/ports/tauri/vendor/scanstudio-bridge/tests/test_service_dispatch.py
+++ b/ports/tauri/vendor/scanstudio-bridge/tests/test_service_dispatch.py
@@ -592,6 +592,38 @@ def test_device_eject_bridge_error_from_transport_records_error_telemetry(
     assert "power cycle" in error_entry["message"]
 
 
+def test_device_eject_unmapped_transport_exception_is_eject_failed_not_internal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transport/driver exception outside the transport's mapped ladder
+    must reach the wire as a typed EJECT_FAILED with a code+message
+    telemetry line -- not fall through to cli.py's catch-all INTERNAL,
+    which is how the #16/#68/#76 eject failures shipped undiagnosable."""
+
+    class _ExplodingTransport(_StubTransport):
+        def eject(self) -> bool:
+            raise RuntimeError("capture worker reaped mid-eject")
+
+    svc = _opened_service(tmp_path, _ExplodingTransport())
+    _arm(monkeypatch, tmp_path)
+    emit = _RecordingEmit()
+
+    with pytest.raises(BridgeError) as excinfo:
+        svc.dispatch({"id": 2, "method": "device.eject"}, emit)
+
+    assert excinfo.value.code == ErrorCode.EJECT_FAILED
+    assert "RuntimeError" in str(excinfo.value)
+    assert "capture worker reaped mid-eject" in str(excinfo.value)
+    assert not emit.has("device.status")
+    error_entry = next(
+        e
+        for e in _telemetry_entries(tmp_path)
+        if e["method"] == "device.eject" and e["outcome"] == "error"
+    )
+    assert error_entry["code"] == ErrorCode.EJECT_FAILED.value
+    assert "RuntimeError" in error_entry["message"]
+
+
 def test_device_eject_success_clears_preview_material_so_scan_start_is_no_preview(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
+++ b/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
@@ -201,6 +201,11 @@ class _FakeDevice:
     def __init__(self, roll: _FakeRoll | None = None) -> None:
         self._roll = roll
         self.eject_effect: object = True
+        # The vendor-eject confirmation probe (Device.film_present): None
+        # (undetermined) mirrors the pre-probe default; vendor-route eject
+        # success tests set False (confirmed-out) explicitly, and the
+        # accepted-without-progress / unconfirmable shapes set True/None.
+        self.film_present_result: object = None
         self.closed = False
         self.capabilities = _fake_capabilities()
         # Plan 10-09 (attempts-root persistence): records exactly what
@@ -218,6 +223,11 @@ class _FakeDevice:
         if isinstance(self.eject_effect, BaseException):
             raise self.eject_effect
         return self.eject_effect
+
+    def film_present(self) -> bool | None:
+        if isinstance(self.film_present_result, BaseException):
+            raise self.film_present_result
+        return self.film_present_result
 
     def close(self) -> None:
         self.closed = True
@@ -3091,6 +3101,7 @@ def test_eject_raises_eject_failed_on_coolscanpy_eject_failed(
 def test_eject_returns_true_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
     transport, device = _opened_transport(monkeypatch, _FakeRoll())
     device.eject_effect = True
+    device.film_present_result = False
     assert transport.eject() is True
 
 
@@ -3156,6 +3167,7 @@ def test_eject_falls_back_to_device_when_roll_lacks_eject(
     roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)])
     transport, device = _opened_transport(monkeypatch, roll)
     device.eject_effect = True
+    device.film_present_result = False
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
 
     assert transport.eject() is True
@@ -3187,30 +3199,182 @@ def test_eject_maps_feeder_parked_stall_and_preserves_session_state(
     assert transport.status().preview_established is True
 
 
-def test_eject_maps_future_pin_eject_not_available_to_eject_failed(
+def test_eject_not_available_falls_back_to_device_eject(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The capture branch's Roll.eject() raises EjectNotAvailable (not an
-    EjectFailed subclass) when no held reservation exists. The pinned
-    coolscanpy does not export it yet; the transport resolves it by name at
-    call time so the mapping is already correct the day the pin advances."""
-
-    class _EjectNotAvailable(Exception):
-        pass
-
-    monkeypatch.setattr(coolscanpy, "EjectNotAvailable", _EjectNotAvailable, raising=False)
+    """Roll.eject() with no held reservation (the state every failed
+    preview's fail-closed teardown leaves behind) raises the REAL exported
+    coolscanpy.EjectNotAvailable without sending any command -- so the
+    transport must try the capability-gated vendor eject on Device instead
+    of refusing outright (#16 #68 #76: the refusal used to strand the film
+    until a power cycle). Uses the real exception class on purpose: the
+    old fake-substitute version of this test could not catch a
+    class-identity regression."""
     roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
-    roll.eject_effect = _EjectNotAvailable(
+    roll.eject_effect = coolscanpy.EjectNotAvailable(
         "no held reservation to eject: call preview() first"
     )
-    transport, _device = _opened_transport(monkeypatch, roll)
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = True
+    device.film_present_result = False
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    assert transport.eject() is True
+
+    assert roll.eject_calls == 1
+    assert roll.closed is True
+    assert transport.status().preview_established is False
+
+
+def test_eject_fallback_failure_stays_typed_and_preserves_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the Device fallback also fails, the error stays the typed
+    EJECT_FAILED of the direct device route -- and the roll session is
+    preserved exactly as the FeederParked case preserves it, because the
+    film did not come out."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.EjectFailed("vendor eject command failed")
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
 
     with pytest.raises(BridgeError) as excinfo:
         transport.eject()
 
     assert excinfo.value.code == ErrorCode.EJECT_FAILED
-    assert "no held reservation" in str(excinfo.value)
+    assert "vendor eject command failed" in str(excinfo.value)
+    assert roll.closed is False
+    assert transport.status().preview_established is True
+
+
+def test_eject_fallback_feeder_parked_maps_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked transport reported by the fallback vendor eject keeps the
+    FEEDER_PARKED taxonomy (never a silent success, never a retry)."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.FeederParked(
+        "eject accepted without confirmed clear; power cycle required"
+    )
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.FEEDER_PARKED
+    assert roll.closed is False
+
+
+def test_eject_fallback_device_busy_maps_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DeviceBusy from the fallback vendor eject is a retry-later state,
+    not an eject failure -- it must keep its own taxonomy instead of
+    collapsing into EJECT_FAILED."""
+    roll = _EjectRecordingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable("no held reservation to eject")
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = coolscanpy.DeviceBusy("io lock is held")
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.DEVICE_BUSY
+    assert roll.closed is False
+
+
+def test_vendor_eject_still_present_after_accept_is_feeder_parked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The vendor eject reports acceptance, not actuation
+    (INCIDENT-20260719-eject-from-park): a clean scanimage exit with film
+    still present is the accepted-without-progress wedge and must surface
+    as FEEDER_PARKED, never as success."""
+    transport, device = _opened_transport(monkeypatch, _FakeRoll())
+    device.eject_effect = True
+    device.film_present_result = True
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.FEEDER_PARKED
+    assert "still present" in str(excinfo.value)
+
+
+def test_vendor_eject_unconfirmable_presence_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """film_present() -> None means undetermined -- per its contract it
+    must never be read as film-absent, so an unconfirmable vendor eject
+    fails closed as EJECT_FAILED."""
+    transport, device = _opened_transport(monkeypatch, _FakeRoll())
+    device.eject_effect = True
+    device.film_present_result = None
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.EJECT_FAILED
+    assert "could not be confirmed" in str(excinfo.value)
+
+
+def test_eject_roll_close_failure_reports_film_out_not_eject_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-eject Roll.close() failure happens AFTER the film is
+    physically out: it must surface as INTERNAL with a message saying so,
+    never as an eject failure -- and `_roll` stays set so device.close can
+    still run the Roll-then-Device teardown order."""
+
+    class _CloseFailingRoll(_EjectRecordingRoll):
+        def close(self) -> None:
+            raise RuntimeError("batch worker still reporting")
+
+    roll = _CloseFailingRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = True
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.eject()
+
+    assert excinfo.value.code == ErrorCode.INTERNAL
+    assert "the film was ejected" in str(excinfo.value)
+    assert roll.closed is False
+
+
+def test_eject_after_failed_preview_ejects_via_device_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end regression for the #16/#68/#76 shape: preview fails, the
+    operator clicks Eject, and the film must come out through the Device
+    fallback instead of the guaranteed EjectNotAvailable refusal."""
+
+    class _RefusedPreviewRoll(_EjectRecordingRoll):
+        def preview(self, slots: list[int] | None = None) -> list["coolscanpy.Thumbnail"]:
+            raise coolscanpy.RefeedRequired(
+                "preview could not establish a usable roll session"
+            )
+
+    roll = _RefusedPreviewRoll(thumbnails=[_fake_thumbnail(1)])
+    roll.eject_effect = coolscanpy.EjectNotAvailable(
+        "no held reservation to eject: call preview() first"
+    )
+    transport, device = _opened_transport(monkeypatch, roll)
+    device.eject_effect = True
+    device.film_present_result = False
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+    assert excinfo.value.code == ErrorCode.REFEED_REQUIRED
+
+    assert transport.eject() is True
+    assert roll.eject_calls == 1
+    assert roll.closed is True
 
 
 # -- coolscanpy_provenance (Plan 10-09) ---------------------------------------------

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -296,7 +296,7 @@ EOF
 check_pair "protocol" "app/ScanStudio/protocol" "ports/tauri/vendor/protocol" "55577442d8b6a23ddcd3cc191ebf41a8258004047bc075511a241fa72adb0b65" <<'EOF'
 EOF
 
-check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "981cef16af0b17ded9e38bd2ff0b6321cf57bf2355a5c3e3659206b55fa4f6aa" <<'EOF'
+check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "fe42a67e872346b94d34a49dc931cf8f64f4a2801d0c15fc407e5c64923daca6" <<'EOF'
 Files app/ScanStudio/engine/Cargo.lock and ports/tauri/vendor/engine/Cargo.lock differ
 Files app/ScanStudio/engine/Cargo.toml and ports/tauri/vendor/engine/Cargo.toml differ
 Files app/ScanStudio/engine/src/evidence_package.rs and ports/tauri/vendor/engine/src/evidence_package.rs differ
@@ -307,7 +307,7 @@ Files app/ScanStudio/engine/src/render.rs and ports/tauri/vendor/engine/src/rend
 Only in ports/tauri/vendor/engine/src: wsl_io.rs
 EOF
 
-check_pair "bridge" "bridge" "ports/tauri/vendor/scanstudio-bridge" "26bdde25a8a824ac512a94eef52cd53c2a02e7bc230c846534df42a4c89bc194" <<'EOF'
+check_pair "bridge" "bridge" "ports/tauri/vendor/scanstudio-bridge" "a5ce7bf643931229a66604487fe27c00865e7196a37f1c1985b9065b79447923" <<'EOF'
 Only in ports/tauri/vendor/scanstudio-bridge: .github
 Only in ports/tauri/vendor/scanstudio-bridge/scripts: probe-linux-env.py
 Only in ports/tauri/vendor/scanstudio-bridge/scripts: verify-bridge.sh

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -296,7 +296,7 @@ EOF
 check_pair "protocol" "app/ScanStudio/protocol" "ports/tauri/vendor/protocol" "55577442d8b6a23ddcd3cc191ebf41a8258004047bc075511a241fa72adb0b65" <<'EOF'
 EOF
 
-check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "fe42a67e872346b94d34a49dc931cf8f64f4a2801d0c15fc407e5c64923daca6" <<'EOF'
+check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "ab36950447a47688b48b4676e5c42495dc06d008bd304491cb2e40e6ef38f499" <<'EOF'
 Files app/ScanStudio/engine/Cargo.lock and ports/tauri/vendor/engine/Cargo.lock differ
 Files app/ScanStudio/engine/Cargo.toml and ports/tauri/vendor/engine/Cargo.toml differ
 Files app/ScanStudio/engine/src/evidence_package.rs and ports/tauri/vendor/engine/src/evidence_package.rs differ


### PR DESCRIPTION
Contains the eject branch commits until that PR merges -- merge the eject PR first; this one then shows only its own three commits. The vendor-sync engine fingerprint in this branch is pinned against the combined tree.

Confirmed defect: the Tauri client defaulted multisamplePasses to 1 with no device-capability coercion anywhere, so a real LS-5000 scan.start from the Windows/Linux builds is refused by the engine gate ("multisamplePasses must be one of [4] for this device"). The mac app has had device coercion since beta.3; only Tauri was exposed.

- Engine: DeviceInfo gains optional supportedMultisamplePasses (omitted when absent, so simulator JSON is byte-identical), forwarded from the bridge-derived set the scan gate itself validates against. The Swift decoder for this exact key already existed and needs no change.
- Tauri: device-aware options and coercion mirroring the mac policy (wire set when present, [4] fallback for real devices, full historical set for the simulator), applied at mount, on connect, and as the last-mile net inside startScan; the recipe form and per-frame picker draw from the same list; validateRecipe intersects the device set with the protocol invariant rather than replacing it (adversarial-review finding).

cargo test green in both engine copies, vitest 419 passed, tsc clean, vendor drift check green. Two independent adversarial review passes ran against the root cause and this diff; one shipped SHIP with P2s (incorporated), the other verified the serde key end-to-end over the real engine binary's stdout and proved the TS coercion equivalent to the mac policy.