### PR TITLE
docs(runbooks): genericize private-infra references

### DIFF
--- a/ports/tauri/runbooks/LINUX-LIVE-VALIDATION.md
+++ b/ports/tauri/runbooks/LINUX-LIVE-VALIDATION.md
@@ -31,11 +31,11 @@ Both preconditions apply before any live step below.
 
 ## [a] VM and USB Passthrough Setup
 
-- Reuse the same Unraid VM + USB-controller-passthrough pattern already used
-  for the owner's existing scanner-attached VM(s) on the same host: pass the
-  LS-5000's USB controller/device through to the Ubuntu VM via Unraid's VM
-  Manager USB/PCI passthrough settings.
-- Exact menu labels vary by Unraid version, so mirror your existing
+- Reuse the same hypervisor VM + USB-controller-passthrough pattern already
+  used for the owner's existing scanner-attached VM(s) on the same host: pass
+  the LS-5000's USB controller/device through to the Ubuntu VM via the
+  hypervisor's VM management USB/PCI passthrough settings.
+- Exact menu labels vary by hypervisor version, so mirror your existing
   passthrough setup rather than following a fixed click path invented here.
 - Once passthrough is active, the Ubuntu VM must see the device at VID:PID
   `04b0:4002`; that visibility is confirmed by the probe in section [b], not

--- a/ports/tauri/runbooks/WINDOWS-LIVE-VALIDATION.md
+++ b/ports/tauri/runbooks/WINDOWS-LIVE-VALIDATION.md
@@ -19,11 +19,11 @@ repeat that setup — it assumes WSL2 with the pinned Ubuntu-24.04 distro, the
 bridge bundle installed inside WSL, usbipd-win installed and bound, and the
 WebView2 runtime present.
 
-This runs on the owner's existing Filmscan Windows VM (or a clone of it).
-Attaching the LS-5000 to WSL2 via `usbipd attach` takes the device away from
-any Nikon Scan/USBPcap workflow running on that same VM for as long as it stays
-attached; this is reversible at any time via `usbipd detach --busid <busid>`.
-No driver is swapped or replaced by the WSL lane.
+This runs on a Windows VM with the Nikon Scan toolchain already installed (or
+a clone of one). Attaching the LS-5000 to WSL2 via `usbipd attach` takes the
+device away from any Nikon Scan/USBPcap workflow running on that same VM for
+as long as it stays attached; this is reversible at any time via `usbipd
+detach --busid <busid>`. No driver is swapped or replaced by the WSL lane.
 
 ### Checker pre-flight
 


### PR DESCRIPTION
From the 2026-08-13 release audit (P1 finding #2): a public runbook named the owner's private dev VM by internal codename plus its role, and a second runbook named the owner's hypervisor product by name three times.

## Changes

- `ports/tauri/runbooks/WINDOWS-LIVE-VALIDATION.md:22` — "the owner's existing Filmscan Windows VM" → "a Windows VM with the Nikon Scan toolchain already installed"
- `ports/tauri/runbooks/LINUX-LIVE-VALIDATION.md:34,36,38` — three "Unraid" mentions → "hypervisor" / "VM management ... settings"

No instructional or behavioral content changed — same steps, same preconditions, same warnings. Confirmed via full-tree grep that these were the only occurrences of either string (excluding `FilmScanSweep`, an unrelated Swift animation-view name in `app/ScanStudio/Sources/ScanStudio/RollLoadingWorkspaceView.swift`, left as-is).

Scope note: these strings are already in prior pushed history; this PR is forward-looking tree cleanup only, not a history rewrite.

Do not merge without sign-off.