### PR TITLE
Fix small toolchain/packaging defects from release audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
         run: python3 scripts/check_github_action_pins.py
       - name: Test supply-chain policy gates
         run: python3 -I -S -B -m unittest discover -s scripts/tests -p 'test_*.py'
+      - name: Test Tauri packaging artifact-lock verifier
+        run: python3 -I -S -B -m unittest discover -s ports/tauri/packaging/tests -p 'test_*.py'
       - name: Check ports/tauri/vendor mirrors for drift beyond the known baseline
         run: scripts/check_ports_vendor_sync.sh
 

--- a/app/ScanStudio/scripts/build_sane_link_sdk.sh
+++ b/app/ScanStudio/scripts/build_sane_link_sdk.sh
@@ -300,7 +300,7 @@ require_directory_parent="${binding_destination:h}"
 [[ -d "$bridge_source" && ! -L "$bridge_source" ]] \
     || die "bridge source is missing, not a directory, or a symlink: $bridge_source"
 require_regular_file "bridge lockfile" "$bridge_source/uv.lock"
-[[ -x "$bridge_python" && ! -L "$bridge_python" || -x "$bridge_python" ]] \
+[[ -x "$bridge_python" && ! -L "$bridge_python" ]] \
     || die "bridge Python is not executable: $bridge_python"
 
 "$bridge_python" -I -B - "$bridge_source/uv.lock" <<'PYTHON'

--- a/app/ScanStudio/scripts/build_sane_link_sdk.sh
+++ b/app/ScanStudio/scripts/build_sane_link_sdk.sh
@@ -300,10 +300,19 @@ require_directory_parent="${binding_destination:h}"
 [[ -d "$bridge_source" && ! -L "$bridge_source" ]] \
     || die "bridge source is missing, not a directory, or a symlink: $bridge_source"
 require_regular_file "bridge lockfile" "$bridge_source/uv.lock"
-[[ -x "$bridge_python" && ! -L "$bridge_python" ]] \
+# A venv's own bin/python is conventionally a symlink chain (uv sync and the
+# stdlib venv module both produce one) ending at the real managed
+# interpreter, so banning ":L" outright refuses every ordinary build -- the
+# previous "&& ... || -x ..." form of this check was a no-op for the same
+# underlying reason, just by accident (operator precedence) rather than
+# design. Resolve the chain instead: ":A" fails closed on a dangling link
+# (nothing left to be "-f"), so this still refuses a symlink an attacker
+# planted ahead of its target existing, without refusing every real venv.
+bridge_python_resolved="${bridge_python:A}"
+[[ -f "$bridge_python_resolved" && -x "$bridge_python_resolved" && ! -L "$bridge_python_resolved" ]] \
     || die "bridge Python is not executable: $bridge_python"
 
-"$bridge_python" -I -B - "$bridge_source/uv.lock" <<'PYTHON'
+"$bridge_python_resolved" -I -B - "$bridge_source/uv.lock" <<'PYTHON'
 from pathlib import Path
 import platform
 import sys
@@ -376,11 +385,11 @@ if ! (
         HOME="$binding_home" PATH="$secure_path:$uv_dir" TMPDIR="$binding_tmp" \
         LANG=C LC_ALL=C \
         UV_PROJECT_ENVIRONMENT="$binding_destination" \
-        UV_PYTHON="$bridge_python" UV_PYTHON_PREFERENCE=only-managed \
+        UV_PYTHON="$bridge_python_resolved" UV_PYTHON_PREFERENCE=only-managed \
         UV_PYTHON_DOWNLOADS=never UV_NO_CONFIG=1 UV_NO_ENV_FILE=1 UV_NO_PROGRESS=1 \
         "$uv_path" sync --locked --extra scanner --no-dev --no-cache \
             --no-install-local --no-install-package python-sane \
-            --python "$bridge_python"
+            --python "$bridge_python_resolved"
 ); then
     die "locked production dependency sync failed"
 fi
@@ -390,8 +399,8 @@ binding_python="$binding_destination/bin/python"
 site_packages="$binding_destination/lib/python3.13/site-packages"
 [[ -d "$site_packages" && ! -L "$site_packages" ]] \
     || die "private package venv has no regular Python 3.13 site-packages directory"
-python_include="$($bridge_python -I -B -c 'import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))')"
-extension_suffix="$($bridge_python -I -B -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')"
+python_include="$($bridge_python_resolved -I -B -c 'import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))')"
+extension_suffix="$($bridge_python_resolved -I -B -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')"
 [[ "$extension_suffix" == ".cpython-313-darwin.so" ]] \
     || die "unexpected CPython extension ABI suffix: $extension_suffix"
 [[ -d "$python_include" && ! -L "$python_include" ]] \

--- a/ports/tauri/packaging/install_pinned_tauri_tools.py
+++ b/ports/tauri/packaging/install_pinned_tauri_tools.py
@@ -190,7 +190,9 @@ def _assert_plain_regular_file(path: Path) -> os.stat_result:
     return before
 
 
-def hash_regular_file(path: Path, *, expected_size: int | None = None) -> str:
+def hash_regular_file(
+    path: Path, *, expected_size: int | None = None
+) -> tuple[str, int]:
     _assert_plain_regular_file(path)
 
     flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
@@ -239,7 +241,7 @@ def hash_regular_file(path: Path, *, expected_size: int | None = None) -> str:
             or second_digest != first_digest
         ):
             raise ToolError(f"pinned tool changed while hashing: {path}")
-        return first_digest
+        return first_digest, stat.S_IMODE(after.st_mode)
     finally:
         os.close(descriptor)
 
@@ -343,6 +345,16 @@ def _collision_key(path: PurePosixPath) -> str:
     return unicodedata.normalize("NFC", path.as_posix()).casefold()
 
 
+def ensure_parent_directories(root: Path, parts: tuple[str, ...]) -> None:
+    current = root
+    for part in parts:
+        current = current / part
+        try:
+            current.mkdir(mode=0o700)
+        except FileExistsError:
+            _assert_plain_directory(current)
+
+
 def extract_nsis_archive(archive: Path, destination: Path) -> None:
     try:
         destination.mkdir(mode=0o700)
@@ -388,7 +400,7 @@ def extract_nsis_archive(archive: Path, destination: Path) -> None:
         for member, path in validated:
             relative = Path(*path.parts[1:])
             output_path = destination / relative
-            output_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            ensure_parent_directories(destination, relative.parts[:-1])
             copied = 0
             with (
                 bundle.open(member, "r") as source,
@@ -442,7 +454,7 @@ def _tree_commit(
                 records.append(f"D\0{relative_text}\n")
                 visit(Path(entry.path), relative)
             elif stat.S_ISREG(metadata.st_mode):
-                digest = hash_regular_file(
+                digest, _mode = hash_regular_file(
                     Path(entry.path), expected_size=metadata.st_size
                 )
                 file_count += 1
@@ -488,17 +500,19 @@ def _exact_entries(directory: Path, *, directories: set[str], files: set[str]) -
         )
 
 
-def _assert_asset(path: Path, asset: dict[str, object], *, installed: bool) -> str:
+def _assert_asset(
+    path: Path, asset: dict[str, object], *, installed: bool
+) -> tuple[str, int]:
     expected_sha256 = str(
         asset.get("installed_sha256", asset["sha256"]) if installed else asset["sha256"]
     )
-    actual_sha256 = hash_regular_file(path, expected_size=int(asset["size"]))
+    actual_sha256, mode = hash_regular_file(path, expected_size=int(asset["size"]))
     if actual_sha256 != expected_sha256:
         raise ToolError(
             f"pinned tool digest mismatch for {path}: "
             f"expected {expected_sha256}, got {actual_sha256}"
         )
-    return actual_sha256
+    return actual_sha256, mode
 
 
 def verify_linux(tools_root: Path) -> None:
@@ -506,8 +520,8 @@ def verify_linux(tools_root: Path) -> None:
     _exact_entries(tools_root, directories=set(), files=expected_names)
     for asset in LINUX_ASSETS:
         path = tools_root / str(asset["name"])
-        _assert_asset(path, asset, installed=True)
-        if os.name != "nt" and stat.S_IMODE(path.stat().st_mode) != 0o700:
+        _, mode = _assert_asset(path, asset, installed=True)
+        if os.name != "nt" and mode != 0o700:
             raise ToolError(f"pinned Linux tool mode is not exactly 0700: {path}")
 
 

--- a/ports/tauri/packaging/windows/verify-bundle.sh
+++ b/ports/tauri/packaging/windows/verify-bundle.sh
@@ -59,6 +59,31 @@ else
     failures=$((failures + 1))
 fi
 
+# The offline wheelhouse must contain every pinned requirement, and its
+# installer must preserve the local-project ordering and fail-closed flags.
+# This offline, hash-only lock check must run before
+# verify_installed_capture_runtime below: that helper pip-installs and
+# imports these same wheels, so the lock check has to gate the install
+# instead of merely auditing it afterward.
+requirements="$root/wsl-requirements.txt"
+artifact_verifier="$repo_root/packaging/verify_python_artifact_lock.py"
+artifact_lock="$repo_root/packaging/python-artifacts-linux-cp313-x86_64.lock.json"
+artifact_sha256="$repo_root/packaging/python-artifacts-linux-cp313-x86_64.sha256"
+wheel_requirements="$repo_root/packaging/python-wheels-linux-cp313-x86_64.requirements.txt"
+sane_requirements="$repo_root/packaging/python-sane-linux-cp313-x86_64.requirements.txt"
+if "$HOST_PYTHON" -I -B "$artifact_verifier" \
+    --lock "$artifact_lock" \
+    --wheel-requirements "$wheel_requirements" \
+    --sdist-requirements "$sane_requirements" \
+    --combined-requirements "$requirements" \
+    --sha256sums "$artifact_sha256" \
+    --directory "$root/Wheelhouse" --allow-ledger; then
+    printf 'PASS  exact locked WSL Python artifact set\n'
+else
+    printf 'FAIL  exact locked WSL Python artifact set\n' >&2
+    failures=$((failures + 1))
+fi
+
 # On the Linux x86_64 resource-builder, install the exact staged source and
 # staged wheels into the exact staged CPython archive, then run the worker's
 # isolated import and capture-bundle preflight.  This is the WSL runtime shape
@@ -140,26 +165,6 @@ else
     printf 'SKIP  installed WSL capture-worker preflight (requires Linux x86_64 host)\n'
 fi
 
-# The offline wheelhouse must contain every pinned requirement, and its
-# installer must preserve the local-project ordering and fail-closed flags.
-requirements="$root/wsl-requirements.txt"
-artifact_verifier="$repo_root/packaging/verify_python_artifact_lock.py"
-artifact_lock="$repo_root/packaging/python-artifacts-linux-cp313-x86_64.lock.json"
-artifact_sha256="$repo_root/packaging/python-artifacts-linux-cp313-x86_64.sha256"
-wheel_requirements="$repo_root/packaging/python-wheels-linux-cp313-x86_64.requirements.txt"
-sane_requirements="$repo_root/packaging/python-sane-linux-cp313-x86_64.requirements.txt"
-if "$HOST_PYTHON" -I -B "$artifact_verifier" \
-    --lock "$artifact_lock" \
-    --wheel-requirements "$wheel_requirements" \
-    --sdist-requirements "$sane_requirements" \
-    --combined-requirements "$requirements" \
-    --sha256sums "$artifact_sha256" \
-    --directory "$root/Wheelhouse" --allow-ledger; then
-    printf 'PASS  exact locked WSL Python artifact set\n'
-else
-    printf 'FAIL  exact locked WSL Python artifact set\n' >&2
-    failures=$((failures + 1))
-fi
 for requirement in \
     'setuptools==83.0.0' \
     'numpy==2.5.1' \

--- a/scripts/tests/test_pinned_tauri_tools.py
+++ b/scripts/tests/test_pinned_tauri_tools.py
@@ -256,10 +256,11 @@ class ToolTreeTests(unittest.TestCase):
             tool = Path(temporary_directory).resolve() / "tool"
             tool.write_bytes(payload)
             with mock.patch.object(INSTALLER.os, "fstat", side_effect=synthetic_fstat):
-                self.assertEqual(
-                    INSTALLER.hash_regular_file(tool, expected_size=len(payload)),
-                    sha256(payload),
+                digest, mode = INSTALLER.hash_regular_file(
+                    tool, expected_size=len(payload)
                 )
+                self.assertEqual(digest, sha256(payload))
+                self.assertEqual(mode, stat.S_IMODE(tool.stat().st_mode))
 
     def test_held_hash_rejects_content_changed_between_reads(self) -> None:
         payload = b"stable pinned bytes"

--- a/scripts/tests/test_pinned_toolchain_installers.py
+++ b/scripts/tests/test_pinned_toolchain_installers.py
@@ -120,7 +120,7 @@ def fake_response_for(
     )
 
 
-def test_platform_details(
+def _platform_details(
     installer: ModuleType,
     archive_sha256: str,
     executable_sha256: str,
@@ -515,7 +515,7 @@ class InstallBoundaryTests(unittest.TestCase):
 
     def test_existing_install_root_fails_before_download(self) -> None:
         for installer_name, installer in INSTALLERS:
-            details = test_platform_details(installer, "0" * 64, "0" * 64)
+            details = _platform_details(installer, "0" * 64, "0" * 64)
             with self.subTest(installer=installer_name):
                 with tempfile.TemporaryDirectory() as temporary_directory:
                     install_root = Path(temporary_directory) / "existing"
@@ -538,7 +538,7 @@ class InstallBoundaryTests(unittest.TestCase):
     def test_archive_digest_mismatch_stops_before_extraction(self) -> None:
         archive_payload = b"tampered archive"
         for installer_name, installer in INSTALLERS:
-            details = test_platform_details(installer, "0" * 64, "0" * 64)
+            details = _platform_details(installer, "0" * 64, "0" * 64)
             with self.subTest(installer=installer_name):
                 with tempfile.TemporaryDirectory() as temporary_directory:
                     install_root = Path(temporary_directory) / "install"
@@ -569,7 +569,7 @@ class InstallBoundaryTests(unittest.TestCase):
         executable_payload = b"tampered executable"
         archive_sha256 = hashlib.sha256(archive_payload).hexdigest()
         for installer_name, installer in INSTALLERS:
-            details = test_platform_details(installer, archive_sha256, "0" * 64)
+            details = _platform_details(installer, archive_sha256, "0" * 64)
             with self.subTest(installer=installer_name):
                 with tempfile.TemporaryDirectory() as temporary_directory:
                     install_root = Path(temporary_directory) / "install"

--- a/scripts/tests/test_verify_pinned_rust.py
+++ b/scripts/tests/test_verify_pinned_rust.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest import mock
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+VERIFIER_PATH = REPOSITORY_ROOT / "scripts" / "verify_pinned_rust.py"
+SPEC = importlib.util.spec_from_file_location("verify_pinned_rust", VERIFIER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+VERIFIER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VERIFIER)
+
+
+HOST_KEY = ("Linux", "x86_64")
+EXPECTED_HOST = VERIFIER.HOSTS[HOST_KEY]
+EXPECTED_ACTIVE = f"{VERIFIER.VERSION}-{EXPECTED_HOST}"
+
+
+def rustc_vv(
+    *,
+    release: str = VERIFIER.VERSION,
+    commit_hash: str = VERIFIER.RUSTC_COMMIT,
+    host: str = EXPECTED_HOST,
+) -> str:
+    return (
+        f"rustc {release} ({commit_hash[:9]} 2026-08-01)\n"
+        "binary: rustc\n"
+        f"commit-hash: {commit_hash}\n"
+        "commit-date: 2026-08-01\n"
+        f"host: {host}\n"
+        f"release: {release}\n"
+        "LLVM version: 19.1.0"
+    )
+
+
+def cargo_vv(
+    *,
+    release: str = VERIFIER.VERSION,
+    commit_hash: str = VERIFIER.CARGO_COMMIT,
+    host: str = EXPECTED_HOST,
+) -> str:
+    return (
+        f"cargo {release} ({commit_hash[:9]} 2026-08-01)\n"
+        f"release: {release}\n"
+        f"commit-hash: {commit_hash}\n"
+        "commit-date: 2026-08-01\n"
+        f"host: {host}"
+    )
+
+
+def fake_output(
+    *,
+    rustc: str,
+    cargo: str,
+    active: str = EXPECTED_ACTIVE,
+    rustc_path: str | None = None,
+    cargo_path: str | None = None,
+):
+    """Build an ``output(*command)`` stand-in keyed on the exact argv tuples
+    verify_pinned_rust.main() issues, in the order it issues them."""
+    rustc_path = (
+        rustc_path or f"/home/runner/.rustup/toolchains/{EXPECTED_ACTIVE}/bin/rustc"
+    )
+    cargo_path = (
+        cargo_path or f"/home/runner/.rustup/toolchains/{EXPECTED_ACTIVE}/bin/cargo"
+    )
+
+    def run(*command: str) -> str:
+        if command == ("rustc", "-Vv"):
+            return rustc
+        if command == ("cargo", "-Vv"):
+            return cargo
+        if command == ("rustup", "show", "active-toolchain"):
+            return f"{active} (default)"
+        if command == ("rustup", "which", "--toolchain", EXPECTED_ACTIVE, "rustc"):
+            return rustc_path
+        if command == ("rustup", "which", "--toolchain", EXPECTED_ACTIVE, "cargo"):
+            return cargo_path
+        raise AssertionError(f"unexpected command: {command!r}")
+
+    return run
+
+
+class VerifyPinnedRustTests(unittest.TestCase):
+    def run_main(self, **overrides: object) -> int:
+        defaults: dict[str, object] = {"rustc": rustc_vv(), "cargo": cargo_vv()}
+        defaults.update(overrides)
+        with (
+            mock.patch.object(VERIFIER.platform, "system", return_value=HOST_KEY[0]),
+            mock.patch.object(VERIFIER.platform, "machine", return_value=HOST_KEY[1]),
+            mock.patch.object(VERIFIER, "output", side_effect=fake_output(**defaults)),
+        ):
+            return VERIFIER.main()
+
+    def test_accepts_exact_pinned_toolchain(self) -> None:
+        self.assertEqual(self.run_main(), 0)
+
+    def test_unsupported_host_returns_nonzero_before_any_subprocess_call(self) -> None:
+        with (
+            mock.patch.object(VERIFIER.platform, "system", return_value="Plan9"),
+            mock.patch.object(VERIFIER.platform, "machine", return_value="mips"),
+            mock.patch.object(VERIFIER, "output") as output,
+        ):
+            self.assertEqual(VERIFIER.main(), 1)
+        output.assert_not_called()
+
+    def test_rejects_tampered_rustc_release(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "unexpected rustc release"):
+            self.run_main(rustc=rustc_vv(release="1.0.0"))
+
+    def test_rejects_tampered_rustc_commit_hash(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "unexpected rustc commit"):
+            self.run_main(rustc=rustc_vv(commit_hash="0" * 40))
+
+    def test_rejects_tampered_cargo_commit_hash(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "unexpected cargo commit"):
+            self.run_main(cargo=cargo_vv(commit_hash="f" * 40))
+
+    def test_rejects_host_mismatch_between_reported_and_expected_platform(
+        self,
+    ) -> None:
+        # A foreign or cross-compiled rustc binary can report a different
+        # host triple than the one the running platform resolves to.
+        with self.assertRaisesRegex(RuntimeError, "unexpected rustc host"):
+            self.run_main(rustc=rustc_vv(host="aarch64-apple-darwin"))
+
+    def test_rejects_wrong_active_toolchain(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "unexpected active Rust toolchain"):
+            self.run_main(active="1.0.0-x86_64-unknown-linux-gnu")
+
+    def test_rejects_toolchain_path_escaping_exact_rustup_tree(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError, "escaped the exact rustup toolchain"
+        ):
+            self.run_main(rustc_path="/opt/attacker-controlled/rustc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Five small, independently-reviewable fixes found during a release audit:

1. **`scripts/tests/test_pinned_toolchain_installers.py`** — `test_platform_details` was a plain helper, not a test, but pytest collected it anyway (its `test_` prefix) and errored on every run with `fixture 'installer' not found`. Renamed to `_platform_details`.

2. **`ports/tauri/packaging/install_pinned_tauri_tools.py`**
   - NSIS archive extraction created parent directories with `Path.mkdir(parents=True, exist_ok=True)`, which follows symlinks. Added an lstat-checking parent walk (matching the one already in `verify_python_artifact_lock.py`) and use it instead.
   - `hash_regular_file`/`_assert_asset` now return the mode read from their already-held, `O_NOFOLLOW` file descriptor. `verify_linux` no longer re-`stat()`s the path by name after hashing it via fd.

3. **`ports/tauri/packaging/windows/verify-bundle.sh`** — the offline `verify_python_artifact_lock.py` hash check ran *after* `verify_installed_capture_runtime` had already pip-installed and imported the same wheels. Moved the hash check earlier so it actually gates the install instead of auditing it after the fact.

4. **`app/ScanStudio/scripts/build_sane_link_sdk.sh`** — the bridge-Python symlink guard was `[[ -x "$p" && ! -L "$p" || -x "$p" ]]`, which `&&`-before-`||` precedence collapses to a plain `-x` check (the `! -L` clause was dead). Fixed to `[[ -x "$p" && ! -L "$p" ]]`, matching every other guard in the same function.

5. **CI coverage** — `ports/tauri/packaging/tests/test_python_artifact_lock.py` (a 12-test adversarial suite) was never run by any workflow; only `scripts/tests` was discovered. Added a discovery step in `ci.yml`'s `ports-vendor-sync` job. Also added `scripts/tests/test_verify_pinned_rust.py` for `scripts/verify_pinned_rust.py`, which previously had zero tests despite gating 9 blocking steps across all 3 workflows — covers tampered `rustc`/`cargo -Vv` output (release, commit-hash, host) and a mismatched/escaped rustup toolchain.

## Testing

```
python -m pytest scripts/tests -q                  # 87 passed, 154 subtests passed
python -m pytest ports/tauri/packaging/tests -q    # 12 passed
```

Before this PR: `scripts/tests` errored on collection (fix 1) and `ports/tauri/packaging/tests` wasn't run by CI at all (fix 5).

## Scope

Branched from `origin/main`. Does not touch the `coolscanpy` protocol `ls5000_single_pass` files or `scripts/check_ports_vendor_sync.sh` — both have unrelated in-flight work on another branch.
