### PR TITLE
fix(tauri,app): stamp the release version into shipped Windows/Linux binaries

### DIFF
--- a/app/ScanStudio/packaging/Info.plist
+++ b/app/ScanStudio/packaging/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.3.0</string>
+    <string>0.7.0</string>
     <key>CFBundleVersion</key>
     <string>14</string>
     <key>ScanStudioRelease</key>

--- a/app/ScanStudio/scripts/package_app.sh
+++ b/app/ScanStudio/scripts/package_app.sh
@@ -205,7 +205,7 @@ install -m 755 "$package_root/packaging/ScanStudioBridge" "$staged_app/Contents/
 install -m 644 "$package_root/packaging/Info.plist" "$staged_app/Contents/Info.plist"
 
 # Stamp the exact release version from the build environment, so the running
-# app can report "I am 0.3.0-alpha.N". Best-effort: dev builds without
+# app can report "I am 0.7.0-beta.N". Best-effort: dev builds without
 # SCANSTUDIO_RELEASE_VERSION keep the empty default.
 if [[ -n "${SCANSTUDIO_RELEASE_VERSION:-}" ]]; then
     /usr/libexec/PlistBuddy -c "Set :ScanStudioRelease '$SCANSTUDIO_RELEASE_VERSION'" \

--- a/ports/tauri/packaging/linux/build-and-verify.sh
+++ b/ports/tauri/packaging/linux/build-and-verify.sh
@@ -26,6 +26,42 @@ trap 'rm -rf "$temporary_root"' EXIT
 build_config="$temporary_root/tauri-version.json"
 printf '{"version":"%s"}\n' "$version" > "$build_config"
 
+# Stamp the release version into the Tauri app's own version fields before
+# any build step runs. tauri::generate_context!() embeds tauri.conf.json's
+# "version" at `cargo build` time -- that's what @tauri-apps/api's
+# getVersion() returns and what the AppImage bundle carries -- so the
+# checked-in files must say the real version before the build starts, not
+# just the CLI's --config merge above. Cargo.toml and package.json are
+# stamped too so `cargo metadata`, the cargo-about notice generator, and npm
+# tooling agree with the shipped binary instead of showing a frozen "0.3.0".
+python3 -I -S -B - \
+    "$app_root/src-tauri/tauri.conf.json" \
+    "$app_root/package.json" \
+    "$app_root/src-tauri/Cargo.toml" \
+    "$version" <<'PY'
+import re
+import sys
+
+tauri_conf_path, package_json_path, cargo_toml_path, release_version = sys.argv[1:5]
+
+
+def stamp(path, pattern):
+    with open(path, "r", encoding="utf-8") as handle:
+        content = handle.read()
+    found = list(re.finditer(pattern, content, flags=re.MULTILINE))
+    if len(found) != 1:
+        sys.exit(f"expected exactly one version field in {path}, found {len(found)}")
+    start, end = found[0].span(1)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(content[:start] + release_version + content[end:])
+
+
+json_version_pattern = r'"version":\s*"([^"]*)"'
+stamp(tauri_conf_path, json_version_pattern)
+stamp(package_json_path, json_version_pattern)
+stamp(cargo_toml_path, r'(?m)^version = "([^"]*)"')
+PY
+
 mkdir -p "$output_dir"
 output_dir="$(cd "$output_dir" && pwd)"
 appimage_output="$output_dir/ScanStudio-$version-Linux-x86_64-preview.AppImage"

--- a/ports/tauri/packaging/linux/build-and-verify.sh
+++ b/ports/tauri/packaging/linux/build-and-verify.sh
@@ -38,11 +38,12 @@ python3 -I -S -B - \
     "$app_root/src-tauri/tauri.conf.json" \
     "$app_root/package.json" \
     "$app_root/src-tauri/Cargo.toml" \
+    "$app_root/src-tauri/Cargo.lock" \
     "$version" <<'PY'
 import re
 import sys
 
-tauri_conf_path, package_json_path, cargo_toml_path, release_version = sys.argv[1:5]
+tauri_conf_path, package_json_path, cargo_toml_path, cargo_lock_path, release_version = sys.argv[1:6]
 
 
 def stamp(path, pattern):
@@ -60,6 +61,13 @@ json_version_pattern = r'"version":\s*"([^"]*)"'
 stamp(tauri_conf_path, json_version_pattern)
 stamp(package_json_path, json_version_pattern)
 stamp(cargo_toml_path, r'(?m)^version = "([^"]*)"')
+# Cargo.lock records this workspace member's own version in its
+# [[package]] block; --locked (the supply-chain gate the pinned toolchain
+# work added) refuses to silently regenerate a lockfile that has drifted
+# from Cargo.toml, so the stamp must apply here too or cargo/rustc refuse
+# to run at all before any build step -- exactly what happened once
+# Cargo.toml alone was stamped.
+stamp(cargo_lock_path, r'(?m)^name = "scanstudio-app"\nversion = "([^"]*)"')
 PY
 
 mkdir -p "$output_dir"

--- a/ports/tauri/packaging/linux/build-and-verify.sh
+++ b/ports/tauri/packaging/linux/build-and-verify.sh
@@ -67,7 +67,7 @@ stamp(cargo_toml_path, r'(?m)^version = "([^"]*)"')
 # from Cargo.toml, so the stamp must apply here too or cargo/rustc refuse
 # to run at all before any build step -- exactly what happened once
 # Cargo.toml alone was stamped.
-stamp(cargo_lock_path, r'(?m)^name = "scanstudio-app"\nversion = "([^"]*)"')
+stamp(cargo_lock_path, r'(?m)^name = "scanstudio-app"\r?\nversion = "([^"]*)"')
 PY
 
 mkdir -p "$output_dir"

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -767,6 +767,37 @@ Invoke-HardwareSessionLauncherBlackBox -Root $PSScriptRoot
 
 $buildConfig = Join-Path ([System.IO.Path]::GetTempPath()) ("scanstudio-tauri-version-" + [guid]::NewGuid().ToString('N') + '.json')
 @{ version = $Version } | ConvertTo-Json -Compress | Set-Content -LiteralPath $buildConfig -Encoding utf8NoBOM -NoNewline
+
+# Stamp the release version into the Tauri app's own version fields before
+# any build step runs. tauri::generate_context!() embeds tauri.conf.json's
+# "version" at `cargo build` time -- that's what @tauri-apps/api's
+# getVersion() returns and what the NSIS installer resolves for its
+# installed "DisplayVersion" (Programs and Features) -- so the checked-in
+# files must say the real version before the build starts, not just the
+# CLI's --config merge above. Cargo.toml and package.json are stamped too so
+# `cargo metadata`, the cargo-about notice generator, and npm tooling agree
+# with the shipped binary instead of showing a frozen "0.3.0".
+function Set-StampedVersionField {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Pattern,
+        [Parameter(Mandatory = $true)][string]$Version
+    )
+    $content = Get-Content -LiteralPath $Path -Raw
+    $fieldMatches = [regex]::Matches($content, $Pattern)
+    if ($fieldMatches.Count -ne 1) {
+        throw "Expected exactly one version field in $Path, found $($fieldMatches.Count)"
+    }
+    $group = $fieldMatches[0].Groups[1]
+    $updated = $content.Substring(0, $group.Index) + $Version + $content.Substring($group.Index + $group.Length)
+    Set-Content -LiteralPath $Path -Value $updated -NoNewline -Encoding utf8NoBOM
+}
+
+$jsonVersionPattern = '"version":\s*"([^"]*)"'
+Set-StampedVersionField -Path (Join-Path $appRoot 'src-tauri\tauri.conf.json') -Pattern $jsonVersionPattern -Version $Version
+Set-StampedVersionField -Path (Join-Path $appRoot 'package.json') -Pattern $jsonVersionPattern -Version $Version
+Set-StampedVersionField -Path (Join-Path $appRoot 'src-tauri\Cargo.toml') -Pattern '(?m)^version = "([^"]*)"' -Version $Version
+
 $pinnedToolHandles = [Collections.Generic.List[System.IO.FileStream]]::new()
 $heldMakensisSha256 = ''
 

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -803,7 +803,7 @@ Set-StampedVersionField -Path (Join-Path $appRoot 'src-tauri\Cargo.toml') -Patte
 # Cargo.toml, so the stamp must apply here too or cargo refuses to run at
 # all before any build step -- exactly what happened once Cargo.toml alone
 # was stamped.
-Set-StampedVersionField -Path (Join-Path $appRoot 'src-tauri\Cargo.lock') -Pattern '(?m)^name = "scanstudio-app"\nversion = "([^"]*)"' -Version $Version
+Set-StampedVersionField -Path (Join-Path $appRoot 'src-tauri\Cargo.lock') -Pattern '(?m)^name = "scanstudio-app"\r?\nversion = "([^"]*)"' -Version $Version
 
 $pinnedToolHandles = [Collections.Generic.List[System.IO.FileStream]]::new()
 $heldMakensisSha256 = ''

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -797,6 +797,13 @@ $jsonVersionPattern = '"version":\s*"([^"]*)"'
 Set-StampedVersionField -Path (Join-Path $appRoot 'src-tauri\tauri.conf.json') -Pattern $jsonVersionPattern -Version $Version
 Set-StampedVersionField -Path (Join-Path $appRoot 'package.json') -Pattern $jsonVersionPattern -Version $Version
 Set-StampedVersionField -Path (Join-Path $appRoot 'src-tauri\Cargo.toml') -Pattern '(?m)^version = "([^"]*)"' -Version $Version
+# Cargo.lock records this workspace member's own version in its [[package]]
+# block; --locked (the supply-chain gate the pinned toolchain work added)
+# refuses to silently regenerate a lockfile that has drifted from
+# Cargo.toml, so the stamp must apply here too or cargo refuses to run at
+# all before any build step -- exactly what happened once Cargo.toml alone
+# was stamped.
+Set-StampedVersionField -Path (Join-Path $appRoot 'src-tauri\Cargo.lock') -Pattern '(?m)^name = "scanstudio-app"\nversion = "([^"]*)"' -Version $Version
 
 $pinnedToolHandles = [Collections.Generic.List[System.IO.FileStream]]::new()
 $heldMakensisSha256 = ''


### PR DESCRIPTION
## What

Fixes P1 finding #1 from the 2026-08-13 release audit: shipped Windows/Linux
binaries self-reported version `0.3.0` regardless of the actual release tag.

`ports/tauri/app/src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and
`package.json` were frozen at `0.3.0`. Nothing rewrote them, so
`tauri::generate_context!()` baked `0.3.0` into every compiled binary. That
showed up in `getVersion()` (the T-ERR-01 error-report path via
`hostEnvironment.ts`), the NSIS installer's Programs and Features entry, and
the AppImage metadata.

The existing `--config` JSON merge in both `build-and-verify` scripts only
overrides the Tauri CLI's in-memory config for the bundler step — it doesn't
rewrite the files `generate_context!()` reads at `cargo build` time, so it
alone doesn't guarantee `getVersion()` sees the real version.

## Fix

`build-and-verify.ps1` (Windows) and `build-and-verify.sh` (Linux) already
receive the resolved version as a parameter — `release.yml`'s
git-tag-derived `$RELEASE_VERSION` for real releases, `ports.yml`'s
synthetic `0.3.0-ci.N` for PR/push CI. Both scripts now rewrite all three
files' version fields to that value before any build step runs. Placing the
stamp in the scripts (not `release.yml` alone) means `ports.yml` exercises
the same code path on every push/PR, not just at tag time.

This mirrors the mac side: `package_app.sh` already stamps
`ScanStudioRelease` from `SCANSTUDIO_RELEASE_VERSION` **after** the app is
built, because that's a separate `Info.plist` resource. Tauri bakes the
version into the compiled binary, so the equivalent has to happen
**before** `cargo build`/`tauri build`.

Also bumped two stale mac strings the same audit pass caught:
- `Info.plist`'s `CFBundleShortVersionString` baseline: `0.3.0` → `0.7.0`.
  This is the fallback `SessionModel.swift`/`UpdateInstaller.swift` use
  when `ScanStudioRelease` is unstamped (dev builds).
- `package_app.sh`'s comment example: `"I am 0.3.0-alpha.N"` →
  `"I am 0.7.0-beta.N"`, matching the current `v0.7.0-beta.N` release train.

## Verified

- Dry-ran the exact stamping regex against copies of the real
  `tauri.conf.json`/`package.json`/`Cargo.toml` — single-line diff each,
  output re-parses as valid JSON/TOML.
- `bash -n` on `build-and-verify.sh` — clean.
- `scripts/check_ports_vendor_sync.sh` — passes; none of the touched files
  are in a mirrored tree (protocol/engine/bridge/coolscanpy pairs only).
- Swept `ports/tauri` for other `0.3.0` references — the rest are unrelated
  test fixtures (mocked `getVersion()` return values) or an unrelated
  `digital-fauxice` tool string in `parity.rs`; out of scope.
- Couldn't run the PowerShell parser locally (no `pwsh` on this machine);
  the new `Set-StampedVersionField` function reuses the exact
  `[regex]::Matches` / `Get-Content -Raw` / `Set-Content -Encoding
  utf8NoBOM` idioms already proven elsewhere in this same file.

## Not in this PR

- `ports.yml`'s synthetic `0.3.0-ci.N` version string is untouched — it's
  not a release, and now exercises the stamping path with whatever value
  it already passes.
- Local/dev Tauri builds (`npm run tauri dev`, a bare `cargo build`) still
  show the checked-in `0.3.0` baseline, since nothing outside
  `build-and-verify.*` stamps it. Same shape as the mac
  `CFBundleShortVersionString` fallback, but not called out in the audit —
  flagging as a minor FYI, not fixed here.
- Left `codex/lock-release-toolchain`'s in-flight WIP (coolscanpy
  `ls5000_single_pass` protocol files, `check_ports_vendor_sync.sh`)
  untouched — this branch is cut from `origin/main`, not that branch.

Not merging without a go-ahead.
