### PR TITLE
docs: sync PROTOCOL.md's DeviceInfo shape with the actual struct

### DIFF
--- a/app/ScanStudio/protocol/PROTOCOL.md
+++ b/app/ScanStudio/protocol/PROTOCOL.md
@@ -158,7 +158,8 @@ The engine's project-mutating handlers (`project.setFrameExcluded`, `project.set
 
 ```
 DeviceInfo      {deviceId: "sim-ls5000-0", model: "SUPER COOLSCAN 5000 ED",
-                 kind: "simulated", firmware: "1.03-sim", connection: "USB (simulated)"}
+                 kind: "simulated", firmware: "1.03-sim", connection: "USB (simulated)",
+                 supported: bool, supportedMultisamplePasses?: [u32]}
 ScannerStatus   {connected: bool, adapter: string|null,      // simulator: "SA-30 (simulated)" | "SA-21 (simulated)" | "MA-21 (simulated)"; real: "SA-30" | "SA-21" | "MA-21"
                  mediaLoaded: bool, carrier: "roll36"|"strip6"|"mounted"|null,
                  frameCount: u32|null, lamp: "off"|"warming"|"stable",

--- a/ports/tauri/vendor/protocol/PROTOCOL.md
+++ b/ports/tauri/vendor/protocol/PROTOCOL.md
@@ -158,7 +158,8 @@ The engine's project-mutating handlers (`project.setFrameExcluded`, `project.set
 
 ```
 DeviceInfo      {deviceId: "sim-ls5000-0", model: "SUPER COOLSCAN 5000 ED",
-                 kind: "simulated", firmware: "1.03-sim", connection: "USB (simulated)"}
+                 kind: "simulated", firmware: "1.03-sim", connection: "USB (simulated)",
+                 supported: bool, supportedMultisamplePasses?: [u32]}
 ScannerStatus   {connected: bool, adapter: string|null,      // simulator: "SA-30 (simulated)" | "SA-21 (simulated)" | "MA-21 (simulated)"; real: "SA-30" | "SA-21" | "MA-21"
                  mediaLoaded: bool, carrier: "roll36"|"strip6"|"mounted"|null,
                  frameCount: u32|null, lamp: "off"|"warming"|"stable",


### PR DESCRIPTION
PROTOCOL.md's DeviceInfo example was missing the supported and supportedMultisamplePasses fields that already exist on the real struct (supported shipped with the #14 not-supported-model work; supportedMultisamplePasses is new in the just-merged Tauri multisample fix). Both copies (primary + vendor mirror) updated identically -- byte-identical, so scripts/check_ports_vendor_sync.sh's protocol pair needs no fingerprint change.

Docs-only, zero code touched.