### PR TITLE
Attended scan binding: let an operator approve a medium-confidence roll and scan

### DIFF
--- a/app/ScanStudio/Sources/ScanStudio/ContentView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ContentView.swift
@@ -413,6 +413,20 @@ private struct WorkspaceErrorBanner: View {
         presentation.canPlaceFramesManually && sessionModel.refeedRequired
     }
 
+    /// Attended binding (feed-detector round; issues #24/#16/#42). Offered
+    /// only when the policy classified this refusal as the rescuable
+    /// (medium) confidence gate AND there are frames selected to approve --
+    /// the action approves every selected frame and re-scans, so with an
+    /// empty selection it would have nothing to authorize.
+    private var showsApproveEveryFrameAction: Bool {
+        presentation.canApproveEveryFrameAndScan
+            && !sessionModel.selectedFrames.isEmpty
+    }
+
+    private var isApprovingEveryFrame: Bool {
+        sessionModel.approvingFrameIndex != nil
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 10) {
@@ -463,7 +477,10 @@ private struct WorkspaceErrorBanner: View {
                 // composes NOT_CONNECTED over the old message), and the
                 // button renders without a sentence for undiagnosed
                 // refeeds.
-                if showsManualPlacementAction || presentation.probableCause != nil {
+                if showsManualPlacementAction
+                    || showsApproveEveryFrameAction
+                    || presentation.probableCause != nil
+                {
                     VStack(alignment: .leading, spacing: 8) {
                         if let probableCause = presentation.probableCause {
                             Text(probableCause)
@@ -497,13 +514,49 @@ private struct WorkspaceErrorBanner: View {
                             .disabled(isLoadingManualPlacement)
                             .help("Draw your own frame boundaries on the captured film strip")
                         }
+
+                        // Attended binding (feed-detector round; issues
+                        // #24/#16/#42). The operator is standing at the
+                        // scanner looking at correct thumbnails the
+                        // detector could not fully corroborate. This
+                        // approves every selected frame against the exact
+                        // preview they reviewed and re-issues the scan.
+                        if showsApproveEveryFrameAction {
+                            Button {
+                                Task {
+                                    await sessionModel.approveEveryFrameAndScan()
+                                }
+                            } label: {
+                                if isApprovingEveryFrame {
+                                    HStack(spacing: 6) {
+                                        ProgressView().controlSize(.small)
+                                        Text("Approving Frames…")
+                                    }
+                                } else {
+                                    Label(
+                                        "Approve every frame and scan",
+                                        systemImage: "checkmark.seal"
+                                    )
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                            .tint(.scanStudioAmber)
+                            .font(.system(size: 11, weight: .medium))
+                            .disabled(isApprovingEveryFrame)
+                            .help(
+                                "Confirm the previewed framing yourself and scan the "
+                                + "selected frames with you supervising"
+                            )
+                        }
                     }
                     .padding(10)
                     .background(Color.scanStudioRaised, in: RoundedRectangle(cornerRadius: 6))
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel(
                         presentation.probableCause.map { "Probable cause: \($0)" }
-                            ?? "Manual frame placement is available"
+                            ?? (showsApproveEveryFrameAction
+                                ? "Approving every frame yourself is available"
+                                : "Manual frame placement is available")
                     )
                 }
 

--- a/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
@@ -88,6 +88,14 @@ public struct ErrorPresentation: Equatable, Sendable {
     /// manually" offered). Drives the workspace error card's button on its
     /// own; the diagnosis sentence next to it stays gated on `probableCause`.
     public let canPlaceFramesManually: Bool
+    /// True when this refusal is the scan-time roll-confidence gate and the
+    /// operator can clear it by accepting every frame themselves (attended
+    /// binding; feed-detector round, issues #24/#16/#42). The workspace
+    /// error card turns this into an "Approve every frame and scan" button,
+    /// which approves each requested frame against the current preview and
+    /// re-issues the scan. False for every other refusal, including the
+    /// `low`-confidence one attendance cannot rescue.
+    public let canApproveEveryFrameAndScan: Bool
 
     public init(
         title: String,
@@ -95,7 +103,8 @@ public struct ErrorPresentation: Equatable, Sendable {
         technicalDetails: String,
         issueURL: URL,
         probableCause: String? = nil,
-        canPlaceFramesManually: Bool = false
+        canPlaceFramesManually: Bool = false,
+        canApproveEveryFrameAndScan: Bool = false
     ) {
         self.title = title
         self.guidance = guidance
@@ -103,6 +112,7 @@ public struct ErrorPresentation: Equatable, Sendable {
         self.issueURL = issueURL
         self.probableCause = probableCause
         self.canPlaceFramesManually = canPlaceFramesManually
+        self.canApproveEveryFrameAndScan = canApproveEveryFrameAndScan
     }
 }
 
@@ -242,8 +252,32 @@ public enum ErrorPresentationPolicy {
             probableCause: copy.code == "REFEED_REQUIRED"
                 ? ProbableCauseExtractor.extract(from: lastErrorMessage)
                 : nil,
-            canPlaceFramesManually: copy.code == "REFEED_REQUIRED"
+            canPlaceFramesManually: copy.code == "REFEED_REQUIRED",
+            // Attended binding (feed-detector round; issues #24/#16/#42).
+            // Offered only for the confidence gate this policy itself
+            // classified, and only when the roll is rescuable: the driver
+            // binds an operator-approved roll at 'medium' but never at
+            // 'low', so offering the button on a 'low' refusal would
+            // promise a recovery that is guaranteed to refuse again.
+            canApproveEveryFrameAndScan: isAttendedRescuableConfidenceRefusal(
+                in: lastErrorMessage
+            )
         )
+    }
+
+    /// The scan-time roll-confidence refusal, restricted to the confidence
+    /// an operator's own approval can actually bind.
+    static func isAttendedRescuableConfidenceRefusal(in message: String) -> Bool {
+        guard
+            message.range(
+                of: "unattended frame binding requires",
+                options: .caseInsensitive
+            ) != nil
+        else { return false }
+        return message.range(
+            of: "confidence is 'medium'",
+            options: .caseInsensitive
+        ) != nil
     }
 
     private static func leadingFrameClippedCopy(in message: String) -> Copy? {
@@ -310,13 +344,30 @@ public enum ErrorPresentationPolicy {
         ) != nil else {
             return nil
         }
+        // Attended binding (feed-detector round; issues #24/#16/#42) split
+        // this one refusal into two honestly different situations. At
+        // 'medium' the detector DID find the frame lattice but could not
+        // corroborate it well enough to cut film unsupervised, so an
+        // operator who checks the frames themselves can authorize the scan.
+        // At 'low' it never anchored a lattice at all, and no amount of
+        // approving thumbnails changes that -- refeeding is the only real
+        // advice, so that copy must not promise a button.
+        if isAttendedRescuableConfidenceRefusal(in: message) {
+            return Copy(
+                code: "ROLL_MISMATCH",
+                title: "This roll needs you to confirm the frames",
+                guidance: "ScanStudio found the frame edges on this roll but is not "
+                    + "confident enough to cut film unsupervised. Check that the preview "
+                    + "thumbnails are framed correctly, then approve every frame and scan "
+                    + "-- or refeed the strip and preview again to try for a cleaner read."
+            )
+        }
         return Copy(
             code: "ROLL_MISMATCH",
             title: "This roll previewed with low confidence",
             guidance: "This roll previewed below the confidence the unattended scanner "
                 + "binding requires. Refeeding the strip or previewing it again may raise "
-                + "that confidence. A future release is expected to widen what the "
-                + "detector accepts here."
+                + "that confidence."
         )
     }
 

--- a/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
@@ -1694,6 +1694,114 @@ public final class SessionModel {
         _ = await approveManualReviewAndStart(authorization)
     }
 
+    /// Attended binding (feed-detector round; issues #24/#16/#42). Recovery
+    /// for the one refusal a human standing at the scanner can legitimately
+    /// clear: the roll previewed correctly, the operator can see the frames
+    /// are right, but the detector's lattice confidence is below what
+    /// unattended scanning requires.
+    ///
+    /// This approves EVERY frame the operator is about to scan -- not only
+    /// the ones the detector flagged -- against the exact completed preview
+    /// they reviewed, then re-issues the scan. Anything less than every
+    /// frame is refused by the driver, so approving a subset here would only
+    /// produce the same refusal again more slowly.
+    ///
+    /// Fails closed the same way every other approval path does: no preview
+    /// binding, an approval error, or a readiness change all stop before
+    /// `scan.start`.
+    @discardableResult
+    public func approveEveryFrameAndScan() async -> Bool {
+        guard pendingManualReviewApproval == nil else { return false }
+        guard pendingScanStart == nil else {
+            lastErrorMessage = "A scan is already starting."
+            return false
+        }
+        let frames = selectedFrames
+        guard !frames.isEmpty else {
+            lastErrorMessage = "Select the frames to scan first."
+            return false
+        }
+        guard let previewOperationId = latestCompletedPreviewOperationId else {
+            lastErrorMessage =
+                "These frames are not bound to a completed preview. "
+                + "Acquire a fresh preview before scanning."
+            return false
+        }
+        let readiness = scanReadiness(for: frames)
+        guard readiness.isReady else {
+            lastErrorMessage = readiness.reason
+            return false
+        }
+
+        lastErrorMessage = nil
+        let marker = PendingManualReviewApproval(
+            id: UUID(),
+            requestId: UUID(),
+            previewOperationId: previewOperationId,
+            connectionEpoch: connectionEpoch
+        )
+        pendingManualReviewApproval = marker
+        defer {
+            if pendingManualReviewApproval?.id == marker.id {
+                pendingManualReviewApproval = nil
+                approvingFrameIndex = nil
+            }
+        }
+
+        for frameIndex in frames {
+            approvingFrameIndex = frameIndex
+            do {
+                let params = RollApproveParams(
+                    frameIndex: frameIndex,
+                    operationId: marker.previewOperationId,
+                    attended: true
+                )
+                let _: EmptyResult = try await engineClient.request(
+                    "roll.approve",
+                    params: params
+                )
+            } catch {
+                guard manualReviewApprovalIsCurrent(marker) else { return false }
+                recordOperationFailure(error, operation: "roll.approve")
+                lastErrorMessage = Self.describe(error)
+                return false
+            }
+            guard manualReviewApprovalIsCurrent(marker) else { return false }
+        }
+
+        for frameIndex in frames {
+            manualReviewDecisions[frameIndex] = .useFrameAnyway
+        }
+        recordDiagnostic(
+            event: "scan.attendedBinding.approved",
+            fields: [
+                "frames": frames.map(String.init).joined(separator: ","),
+                "requestedFrameCount": String(frames.count),
+            ]
+        )
+
+        let readinessAfterApproval = scanReadiness(for: frames)
+        guard readinessAfterApproval.isReady else {
+            lastErrorMessage = readinessAfterApproval.reason
+            return false
+        }
+
+        do {
+            guard let result = try await dispatchScanStart(frames: frames) else {
+                return false
+            }
+            clearPendingManualReviewScan()
+            beginJob(id: result.jobId, frames: frames)
+            return true
+        } catch {
+            guard manualReviewApprovalIsCurrent(marker) else { return false }
+            recordOperationFailure(error, operation: "scan.start")
+            lastErrorMessage = Self.describe(error)
+            noteRefeedRequired(from: error)
+            return false
+        }
+    }
+
     /// Executes one already-authorized manual-review path. The authorization
     /// may come from the scan-time sheet or from contact-sheet decisions that
     /// resolved every flagged frame before Scan was pressed.

--- a/app/ScanStudio/Sources/ScanStudioKit/WireProtocol.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/WireProtocol.swift
@@ -448,10 +448,34 @@ public struct RollSetSpacingOffsetResult: Decodable, Sendable {
 public struct RollApproveParams: Codable, Sendable {
     public let frameIndex: Int
     public let operationId: String
+    /// Attended binding (feed-detector round; issues #24/#16/#42). `nil`
+    /// -- the default and every pre-existing caller -- is omitted from the
+    /// encoded params entirely, so this request stays byte-identical to
+    /// before the field existed. `true` accepts one frame of a roll whose
+    /// lattice confidence is too low to bind unattended; the driver
+    /// refuses it on any other roll shape.
+    public let attended: Bool?
 
-    public init(frameIndex: Int, operationId: String) {
+    public init(frameIndex: Int, operationId: String, attended: Bool? = nil) {
         self.frameIndex = frameIndex
         self.operationId = operationId
+        self.attended = attended
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case frameIndex
+        case operationId
+        case attended
+    }
+
+    // Written out rather than synthesized so the omission of `attended`
+    // when nil is a property of this type, not of whatever the compiler
+    // happens to synthesize for Optionals.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(frameIndex, forKey: .frameIndex)
+        try container.encode(operationId, forKey: .operationId)
+        try container.encodeIfPresent(attended, forKey: .attended)
     }
 }
 

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
@@ -583,13 +583,65 @@ struct ErrorPresentationPolicyTests {
         #expect(presentation.title == "This roll previewed with low confidence")
         #expect(
             presentation.guidance
-                == "This roll previewed below the confidence the unattended scanner binding requires. Refeeding the strip or previewing it again may raise that confidence. A future release is expected to widen what the detector accepts here."
+                == "This roll previewed below the confidence the unattended scanner binding requires. Refeeding the strip or previewing it again may raise that confidence."
         )
         #expect(presentation.technicalDetails == rawMessage)
         // Deliberately its own code, distinct from REFEED_REQUIRED: this is
         // a scan-time capture refusal, not a preview failure, and no
         // manual-placement raster is guaranteed to exist for it.
         #expect(!presentation.canPlaceFramesManually)
+        // Attended binding (feed-detector round; issues #24/#16/#42): 'low'
+        // is the confidence an operator's approval CANNOT rescue -- the
+        // detector never anchored a lattice -- so this copy must not offer
+        // a button that is guaranteed to refuse again.
+        #expect(!presentation.canApproveEveryFrameAndScan)
+    }
+
+    // MARK: - Attended binding (feed-detector round; issues #24/#16/#42)
+
+    @Test("a medium-confidence refusal offers approving every frame, and says so")
+    func mediumConfidenceRefusalOffersAttendedBinding() {
+        let rawMessage = "ROLL_MISMATCH: roll boundary lattice confidence is 'medium'; "
+            + "unattended frame binding requires 'high'"
+
+        let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+
+        #expect(presentation.canApproveEveryFrameAndScan)
+        #expect(presentation.title == "This roll needs you to confirm the frames")
+        #expect(presentation.guidance.contains("approve every frame and scan"))
+        #expect(presentation.technicalDetails == rawMessage)
+        #expect(!presentation.canPlaceFramesManually)
+    }
+
+    @Test("the attended offer survives the engine's own wrapping of the bridge code")
+    func mediumConfidenceRefusalMatchesWrappedForm() {
+        let rawMessage = "INTERNAL: bridge scan.error (ROLL_MISMATCH): roll boundary lattice "
+            + "confidence is 'medium'; unattended frame binding requires 'high'"
+
+        let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+
+        #expect(presentation.canApproveEveryFrameAndScan)
+        #expect(presentation.title == "This roll needs you to confirm the frames")
+    }
+
+    @Test("no other refusal offers approving every frame")
+    func attendedOfferIsNotLeakedToOtherRefusals() {
+        let rawMessages = [
+            "REFEED_REQUIRED: transport read was not one uniform traversal",
+            "ROLL_MISMATCH: the film in the scanner does not match this roll",
+            "INTERNAL: bridge scan.error (METER_UNUSABLE): meter pass 2 controller refused",
+            // The phrase without a confidence this path can bind.
+            "ROLL_MISMATCH: roll boundary lattice confidence is 'low'; "
+                + "unattended frame binding requires 'high'",
+        ]
+
+        for rawMessage in rawMessages {
+            let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+            #expect(
+                !presentation.canApproveEveryFrameAndScan,
+                "expected false for: \(rawMessage)"
+            )
+        }
     }
 
     @Test("the unattended-binding phrase is recognized regardless of how the engine wraps the code")

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ProjectWireProtocolTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ProjectWireProtocolTests.swift
@@ -48,6 +48,28 @@ struct ProjectWireProtocolTests {
 
         #expect(object["frameIndex"] as? Int == 7)
         #expect(object["operationId"] as? String == "preview-operation-7")
+        // Attended binding (feed-detector round; issues #24/#16/#42) is
+        // additive: an ordinary approval must stay byte-identical on the
+        // wire, so the key is absent rather than present-and-false.
+        #expect(object["attended"] == nil)
+    }
+
+    @Test("an attended approval says so explicitly on the wire")
+    func rollApproveParamsEncodeAttendedOptIn() throws {
+        let data = try JSONEncoder().encode(
+            RollApproveParams(
+                frameIndex: 3,
+                operationId: "preview-operation-3",
+                attended: true
+            )
+        )
+        let object = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+
+        #expect(object["frameIndex"] as? Int == 3)
+        #expect(object["operationId"] as? String == "preview-operation-3")
+        #expect(object["attended"] as? Bool == true)
     }
 
     @Test("legacy ProcessingRecipe without software dust removal decodes as safely off")

--- a/app/ScanStudio/engine/src/bridge_protocol.rs
+++ b/app/ScanStudio/engine/src/bridge_protocol.rs
@@ -602,6 +602,12 @@ pub struct BridgeRollApproveParams {
     /// roll's current fingerprint (BRIDGE.md `roll.approve`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fingerprint: Option<String>,
+    /// Attended binding (feed-detector round; ScanStudio #24/#16/#42).
+    /// Omitted from the wire entirely when false (`skip_serializing_if`),
+    /// so a bridge or bridge test double that predates this field sees
+    /// byte-identical params to before it existed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub attended: bool,
 }
 
 // ---------------------------------------------------------------------

--- a/app/ScanStudio/engine/src/protocol.rs
+++ b/app/ScanStudio/engine/src/protocol.rs
@@ -301,6 +301,21 @@ pub struct RollApproveParams {
     /// review warning the user is acknowledging. Unlike preview's optional
     /// token, approval has no safe legacy fallback.
     pub operation_id: String,
+    /// Attended binding (feed-detector round; ScanStudio #24/#16/#42).
+    /// `false` (the default, and every pre-existing client) is unchanged
+    /// behavior: only a frame the completed preview flagged
+    /// `needsApproval` may be approved. `true` means the operator is
+    /// accepting a frame of a roll whose lattice confidence is too low to
+    /// bind unattended, so the frame need not be individually flagged --
+    /// but every frame of the batch must then be approved this way, and
+    /// the driver still refuses any roll shape other than an automatically
+    /// detected medium-confidence one.
+    ///
+    /// Omitted from the wire entirely when false (`skip_serializing_if`),
+    /// so a client that predates this field, and every request that does
+    /// not opt in, produces byte-identical params to before it existed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub attended: bool,
 }
 
 /// `roll.approve` intentionally returns no payload. Approval is a
@@ -880,6 +895,7 @@ mod tests {
         let params = RollApproveParams {
             frame_index: 7,
             operation_id: "completed-preview-7".to_string(),
+            attended: false,
         };
         assert_eq!(
             serde_json::to_value(&params).unwrap(),

--- a/app/ScanStudio/engine/src/real_backend.rs
+++ b/app/ScanStudio/engine/src/real_backend.rs
@@ -3299,7 +3299,12 @@ impl RealLs5000 {
     /// scanner-addressable `slot`. This is intentionally a single
     /// session-scoped request: it never starts a preview, moves film, starts
     /// capture, or follows up with `device.status`.
-    pub fn roll_approve(&self, frame_index: u32, operation_id: &str) -> Result<(), EngineError> {
+    pub fn roll_approve(
+        &self,
+        frame_index: u32,
+        operation_id: &str,
+        attended: bool,
+    ) -> Result<(), EngineError> {
         if operation_id.trim().is_empty() {
             return Err(EngineError::new(
                 ErrorCode::InvalidParams,
@@ -3329,10 +3334,29 @@ impl RealLs5000 {
         // one the completed preview never returned at all, or one that was
         // never flagged for review in the first place. `binding` is `Some`
         // here (proven by the check immediately above).
+        //
+        // Attended binding (feed-detector round; ScanStudio #24/#16/#42)
+        // relaxes the SECOND half of that check only. The frame must still
+        // be one this exact completed preview actually returned -- an index
+        // the preview never produced is refused either way, which is the
+        // part of S3 that matters. What attended acceptance drops is the
+        // requirement that the DETECTOR flagged it: on a roll whose lattice
+        // confidence is too low to bind unattended, the frames an operator
+        // has to vouch for are precisely the ones nothing flagged. The
+        // driver remains the authority on whether this roll is eligible at
+        // all (it refuses `attended` on any roll that is not an
+        // automatically detected medium-confidence one), so relaxing it
+        // here cannot create a binding the driver would not make.
         let thumbnail = binding
             .as_ref()
             .and_then(|binding| binding.thumbnails.get(&frame_index));
-        if !thumbnail.is_some_and(|thumbnail| thumbnail.needs_approval) {
+        let Some(thumbnail) = thumbnail else {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                "frameIndex is not a frame the completed preview returned",
+            ));
+        };
+        if !attended && !thumbnail.needs_approval {
             return Err(EngineError::new(
                 ErrorCode::InvalidParams,
                 "frameIndex is not a frame the completed preview flagged for manual review",
@@ -3347,6 +3371,7 @@ impl RealLs5000 {
             fingerprint: binding
                 .as_ref()
                 .and_then(|binding| binding.fingerprint.clone()),
+            attended,
         };
         let value = serde_json::to_value(params).expect("BridgeRollApproveParams serializes");
         self.call_session_scoped(session_epoch, bridge_generation, "roll.approve", value)?;

--- a/app/ScanStudio/engine/src/server.rs
+++ b/app/ScanStudio/engine/src/server.rs
@@ -398,7 +398,12 @@ impl Backends {
     /// real bridge session. `roll.approve` is deliberately not folded into
     /// `scan.start`: the operator must make a distinct, reviewable decision
     /// before a frame that was flagged by preview can move.
-    fn roll_approve(&self, frame_index: u32, operation_id: &str) -> Result<(), EngineError> {
+    fn roll_approve(
+        &self,
+        frame_index: u32,
+        operation_id: &str,
+        attended: bool,
+    ) -> Result<(), EngineError> {
         if frame_index == 0 {
             return Err(EngineError::new(
                 ErrorCode::InvalidParams,
@@ -416,14 +421,14 @@ impl Backends {
                 .real
                 .as_ref()
                 .unwrap()
-                .roll_approve(frame_index, operation_id),
+                .roll_approve(frame_index, operation_id, attended),
             // S7a (adversarial review, 2026-08-08): the simulator now has
             // exactly one manual-review gate -- a frame its own last
             // successful `manual_frames()` call returned, under that exact
             // operationId (see `SimulatedLs5000::roll_approve`'s own doc
             // comment). Every other case is refused with the same
             // "no manual-review gate" message as before this change.
-            Some(ActiveDevice::Sim) => self.sim.roll_approve(frame_index, operation_id),
+            Some(ActiveDevice::Sim) => self.sim.roll_approve(frame_index, operation_id, attended),
             None => Err(EngineError::new(
                 ErrorCode::NotConnected,
                 "scanner is not connected",
@@ -1053,7 +1058,7 @@ fn handle_request(
         }
         "roll.approve" => {
             let params: protocol::RollApproveParams = parse_params(&request.params)?;
-            backends.roll_approve(params.frame_index, &params.operation_id)?;
+            backends.roll_approve(params.frame_index, &params.operation_id, params.attended)?;
             to_json(&protocol::RollApproveResult {})
         }
         "roll.setSpacingOffset" => {

--- a/app/ScanStudio/engine/src/sim.rs
+++ b/app/ScanStudio/engine/src/sim.rs
@@ -596,7 +596,23 @@ impl SimulatedLs5000 {
     /// produced it" principle). Not part of `ScannerBackend`: dispatched
     /// directly from `Backends::roll_approve`, exactly like every other
     /// roll.* method that is real-only or sim-only.
-    pub fn roll_approve(&self, frame_index: u32, operation_id: &str) -> Result<(), EngineError> {
+    pub fn roll_approve(
+        &self,
+        frame_index: u32,
+        operation_id: &str,
+        attended: bool,
+    ) -> Result<(), EngineError> {
+        // The simulator has no lattice-confidence detector, so it has no
+        // medium-confidence roll for an attended acceptance to rescue. It
+        // refuses `attended` outright rather than pretending to support it,
+        // the same posture it already takes on the manual-review gate.
+        if attended {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                "attended roll binding is not available on the simulator; it has no \
+                 lattice-confidence detector",
+            ));
+        }
         let state = self.state.lock().unwrap();
         let approvable = state.manual_approval_binding.as_ref().is_some_and(|binding| {
             binding.operation_id == operation_id && binding.frame_indices.contains(&frame_index)
@@ -2917,9 +2933,9 @@ mod tests {
         sim.load_media(MediaCarrier::Roll36).expect("load media");
 
         let result = sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
-        sim.roll_approve(1, &result.operation_id)
+        sim.roll_approve(1, &result.operation_id, false)
             .expect("a frame this placement returned must be approvable");
-        sim.roll_approve(2, &result.operation_id)
+        sim.roll_approve(2, &result.operation_id, false)
             .expect("every returned frame is individually approvable");
     }
 
@@ -2933,7 +2949,7 @@ mod tests {
         // No manual_frames() call was ever made this session -- the
         // simulator's pre-existing "no manual-review gate" refusal must be
         // completely unchanged.
-        let err = sim.roll_approve(1, "some-operation-id").unwrap_err();
+        let err = sim.roll_approve(1, "some-operation-id", false).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidParams);
         assert!(err.message.contains("no other manual-review gate"));
     }
@@ -2946,7 +2962,7 @@ mod tests {
         sim.load_media(MediaCarrier::Roll36).expect("load media");
 
         let result = sim.manual_frames(vec![0, 135, 270]).expect("2-frame placement");
-        let err = sim.roll_approve(99, &result.operation_id).unwrap_err();
+        let err = sim.roll_approve(99, &result.operation_id, false).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidParams);
     }
 
@@ -2958,7 +2974,7 @@ mod tests {
         sim.load_media(MediaCarrier::Roll36).expect("load media");
 
         sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
-        let err = sim.roll_approve(1, "not-the-real-operation-id").unwrap_err();
+        let err = sim.roll_approve(1, "not-the-real-operation-id", false).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidParams);
     }
 
@@ -2975,7 +2991,7 @@ mod tests {
         // materially different registration" principle, applied here to
         // the simulator's session-scoped approval binding).
         sim.load_media(MediaCarrier::Strip6).expect("reload media");
-        let err = sim.roll_approve(1, &result.operation_id).unwrap_err();
+        let err = sim.roll_approve(1, &result.operation_id, false).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidParams);
     }
 
@@ -2991,7 +3007,7 @@ mod tests {
         sim.connect(DEVICE_ID, &ConnectOptions::default())
             .expect("reconnect");
         sim.load_media(MediaCarrier::Roll36).expect("reload media");
-        let err = sim.roll_approve(1, &result.operation_id).unwrap_err();
+        let err = sim.roll_approve(1, &result.operation_id, false).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidParams);
     }
 }

--- a/app/ScanStudio/engine/tests/real_backend_mapping.rs
+++ b/app/ScanStudio/engine/tests/real_backend_mapping.rs
@@ -779,7 +779,7 @@ fn restart_during_preview_keeps_old_reader_attached_until_it_detaches() {
     }
 
     let stale_approval = backend
-        .roll_approve(1, "predecessor-preview")
+        .roll_approve(1, "predecessor-preview", false)
         .expect_err("a predecessor approval must be stale after reconnect");
     assert_eq!(stale_approval.code, ErrorCode::InvalidParams);
 
@@ -794,7 +794,7 @@ fn restart_during_preview_keeps_old_reader_attached_until_it_detaches() {
     .expect("the replacement preview should be accepted only after the old reader detached");
 
     let premature_approval = backend
-        .roll_approve(1, "replacement-preview")
+        .roll_approve(1, "replacement-preview", false)
         .expect_err("the replacement is not approvable before its own completion");
     assert_eq!(premature_approval.code, ErrorCode::InvalidParams);
     assert!(
@@ -854,11 +854,11 @@ fn restart_during_preview_keeps_old_reader_attached_until_it_detaches() {
     );
 
     let stale_after_replacement = backend
-        .roll_approve(1, "predecessor-preview")
+        .roll_approve(1, "predecessor-preview", false)
         .expect_err("the predecessor remains stale after replacement completion");
     assert_eq!(stale_after_replacement.code, ErrorCode::InvalidParams);
     let mismatched_replacement = backend
-        .roll_approve(1, "wrong-replacement-preview")
+        .roll_approve(1, "wrong-replacement-preview", false)
         .expect_err("a mismatched replacement operation must be rejected locally");
     assert_eq!(mismatched_replacement.code, ErrorCode::InvalidParams);
     assert!(
@@ -870,7 +870,7 @@ fn restart_during_preview_keeps_old_reader_attached_until_it_detaches() {
     );
 
     backend
-        .roll_approve(1, "replacement-preview")
+        .roll_approve(1, "replacement-preview", false)
         .expect("the replacement becomes approvable only after its own completion");
     let bridge_calls = std::fs::read_to_string(&call_log_path)
         .expect("read final mock bridge call log")

--- a/app/ScanStudio/protocol/BRIDGE.md
+++ b/app/ScanStudio/protocol/BRIDGE.md
@@ -53,7 +53,7 @@ Errors that can occur on any request — `UNKNOWN_METHOD` (unrecognized method n
 | `device.status` | `{}` | `DeviceStatus` | `NOT_CONNECTED` |
 | `device.close` | `{}` | `{}` | `NOT_CONNECTED`, `HARDWARE_LANE_BUSY` |
 | `roll.preview` | `{material: "colorNegative"\|"blackAndWhiteNegative", slots?: [number]}` | `{accepted: true}` | `NOT_CONNECTED`, `HW_MOTION_NOT_ARMED`, `HARDWARE_LANE_BUSY`; via `roll.previewError`: `FEEDER_PARKED`, `ADAPTER_UNSUPPORTED`, `REFEED_REQUIRED`, `DEVICE_BUSY`, `ROLL_MISMATCH` |
-| `roll.approve` | `{slot: number}` | `{}` | `NOT_CONNECTED`, `NO_PREVIEW` |
+| `roll.approve` | `{slot: number, fingerprint?: string, attended?: boolean}` | `{}` | `NOT_CONNECTED`, `NO_PREVIEW`, `INVALID_PARAMS`, `FINGERPRINT_REFUSED` |
 | `roll.setSpacingOffset` | `{slot: number, offsetRows: number}` | `{thumbnail: Thumbnail}` | `NOT_CONNECTED`, `NO_PREVIEW`, `INVALID_PARAMS` |
 | `roll.manualFrames` | `{rows: [number]}` | `{count: number, fingerprint: string, thumbnails: [Thumbnail], snaps: [BoundarySnap]}` | `NOT_CONNECTED`, `NO_PREVIEW`, `HARDWARE_LANE_BUSY`, `INVALID_PARAMS`, `METER_UNUSABLE` |
 | `roll.previewStrip` | `{}` | `PreviewStrip` | `NOT_CONNECTED`, `NO_PREVIEW`, `HARDWARE_LANE_BUSY`, `METER_UNUSABLE` |
@@ -82,6 +82,20 @@ Returns `HARDWARE_LANE_BUSY` while a job holds the lane — the safety rule hold
 ### `roll.approve`
 
 Records manual-review approval for one slot. Not motion-capable — no transport movement, no latch check. Required before scanning any slot whose last `roll.thumbnail` event had `needsApproval: true`; omitting it surfaces as `MANUAL_REVIEW_REQUIRED` when that slot's turn in `scan.start` comes up.
+
+`fingerprint`, when present, is the Roll fingerprint the approval was minted against; a value that no longer matches the roll's current fingerprint is refused with `FINGERPRINT_REFUSED` before any approval is recorded.
+
+#### `attended` (additive, 2026-08-13 — feed-detector round)
+
+`attended: true` records an operator-**attended** acceptance instead of a per-slot manual review, and is what lets a roll be scanned when its boundary-lattice confidence is below what unattended frame binding requires (issues #24, #16, #42 — "previews fine but will not scan").
+
+- It may approve a slot the detector never flagged. That is the point: on a roll the detector could not fully corroborate, the frames an operator has to vouch for are precisely the ones nothing flagged.
+- It is **all-or-nothing per batch.** The driver binds such a roll only when *every* slot in the subsequent `scan.start` carries an attended approval. A partially attended batch refuses exactly as an unapproved one does.
+- Eligibility is the driver's decision, not the bridge's. CoolscanPy accepts `attended` only for an automatically detected roll at `medium` lattice confidence; a `high` roll needs no rescue, a `low` roll has no anchored lattice to vouch for, and a manual placement binds through its own path. Every other case is refused with `INVALID_PARAMS` carrying the driver's own message.
+- Omitted (or `false`) is unchanged pre-existing behavior in every respect.
+- The mock transport refuses `attended` with `INVALID_PARAMS`: it has no lattice-confidence detector, so it has no roll for an attended acceptance to rescue.
+
+Each acceptance is recorded in the capture journal under `live_frame_selection.attended_roll_binding`, so an evidence audit can tell which mode bound a frame.
 
 ### `roll.setSpacingOffset`
 

--- a/app/ScanStudio/protocol/PROTOCOL.md
+++ b/app/ScanStudio/protocol/PROTOCOL.md
@@ -56,7 +56,7 @@ Errors: `NOT_CONNECTED`, `NO_MEDIA`, `SCANNER_BUSY`, `INVALID_PARAMS` (active-pr
 
 ### `roll.approve`
 
-`{frameIndex: u32, operationId: string}` → `{}`. Explicitly records the
+`{frameIndex: u32, operationId: string, attended?: bool}` → `{}`. Explicitly records the
 operator's approval for a single frame that the active **real-device** preview
 marked as requiring manual review. `operationId` is required, nonempty, and
 must exactly equal the token from the most recent successfully completed real
@@ -71,10 +71,27 @@ preview, scan, eject, check the motion latch, or refresh device status. It is
 scoped to the currently open bridge device session and is never retried after
 that session is lost.
 
+`attended` (additive, 2026-08-13 — feed-detector round; issues #24, #16, #42)
+defaults to `false` and is omitted from the wire entirely when false, so an
+ordinary approval is byte-identical to before this field existed. `true`
+records an operator-**attended** acceptance: the operator is authorizing a
+frame of a roll whose boundary-lattice confidence is below what unattended
+scanning requires, having checked the previewed framing themselves.
+
+An attended approval relaxes exactly one local check — the frame no longer has
+to be one the completed preview flagged `needsApproval`. It must still be a
+frame that exact completed preview actually returned; an index the preview
+never produced is refused with `INVALID_PARAMS` either way. Whether the roll is
+eligible at all remains the driver's decision (see BRIDGE.md `roll.approve`),
+and attended binding is all-or-nothing: the client must send an attended
+`roll.approve` for **every** frame of the subsequent `scan.start`, then send
+that original complete frame list in one request.
+
 The simulator has no manual-review gate and refuses this method with
-`INVALID_PARAMS`. Errors: `NOT_CONNECTED`, `INVALID_PARAMS`, `INTERNAL` (for
-a bridge refusal after a valid locally-bound approval; the bridge's specific
-diagnostic remains in the message).
+`INVALID_PARAMS`; it likewise has no lattice-confidence detector and refuses
+`attended: true` outright. Errors: `NOT_CONNECTED`, `INVALID_PARAMS`,
+`INTERNAL` (for a bridge refusal after a valid locally-bound approval; the
+bridge's specific diagnostic remains in the message).
 
 ### `roll.setSpacingOffset`
 
@@ -258,7 +275,7 @@ ApplyMetadataResult {success: bool, exitCode: i32, stdout: string, stderr: strin
 
 `PartialDate` never invents precision it wasn't given — `monthOnly`/`yearOnly` carry no day/month value at all rather than a placeholder like `01`; `unknown` carries no date value whatsoever. `MetadataSet.process` is independent of `ScanProject.filmProcess` and is never auto-synced with it.
 
-`Thumbnail`'s `brightness`/`tint` and `imagePath` are mutually exclusive: exactly one of the `{brightness, tint}` pair or `imagePath` is populated per instance, never both, never neither. The simulator populates `brightness`/`tint` and omits the real transport fields. A real backend populates `imagePath` (BRIDGE.md's bridge-written, Nikon-render-oriented preview tile), `boundaryRows`, `spacingOffset`, `needsApproval`, and `warnings`, while omitting `brightness`/`tint` rather than fabricating them. `spacingOffset` is the bridge-confirmed value active in this exact preview session; a project manifest value alone is not equivalent. Before sending `scan.start`, clients must inspect every requested frame's current completed-preview thumbnail. If any has `needsApproval: true`, the client must obtain explicit operator confirmation, send `roll.approve` for every such frame with that preview's exact `operationId`, and only then send the original complete frame list in one `scan.start`. Starting an unapproved subset and retrying the omitted frame as a second job is not equivalent: it loses the one-traversal transport assumption.
+`Thumbnail`'s `brightness`/`tint` and `imagePath` are mutually exclusive: exactly one of the `{brightness, tint}` pair or `imagePath` is populated per instance, never both, never neither. The simulator populates `brightness`/`tint` and omits the real transport fields. A real backend populates `imagePath` (BRIDGE.md's bridge-written, Nikon-render-oriented preview tile), `boundaryRows`, `spacingOffset`, `needsApproval`, and `warnings`, while omitting `brightness`/`tint` rather than fabricating them. `spacingOffset` is the bridge-confirmed value active in this exact preview session; a project manifest value alone is not equivalent. Before sending `scan.start`, clients must inspect every requested frame's current completed-preview thumbnail. If any has `needsApproval: true`, the client must obtain explicit operator confirmation, send `roll.approve` for every such frame with that preview's exact `operationId`, and only then send the original complete frame list in one `scan.start`. Starting an unapproved subset and retrying the omitted frame as a second job is not equivalent: it loses the one-traversal transport assumption. Separately, when `scan.start` is refused because the roll's boundary-lattice confidence is below what unattended binding requires, a client may offer the operator an attended retry: send `roll.approve` with `attended: true` for *every* frame of the batch under that same `operationId`, then resend the original complete frame list. This is only offered for the `medium` confidence the driver can bind; a `low`-confidence refusal is not rescuable this way and needs a refeed.
 
 `ScannerStatus.filmPresent` mirrors BRIDGE.md's `DeviceStatus.filmPresent` for a real backend — a live, no-motion film-presence read. `true` means the scanner reports film gripped, `false` is the verified MEDIUM NOT PRESENT response, and `null` means no trustworthy verdict was available; `null` is never absence. A verified `false` also invalidates any preview-derived `mediaLoaded`/`frameCount` claim, so the emitted status carries `mediaLoaded: false` and `frameCount: null`; this cannot discard project receipts or the unfinished resume set. Presence is not motion readiness because an end-stop-parked strip can still report `true`. The simulator always omits this field (it has no bridge to source it from).
 

--- a/bridge/src/scanstudio_bridge/service.py
+++ b/bridge/src/scanstudio_bridge/service.py
@@ -65,7 +65,7 @@ _METHOD_PARAM_SCHEMAS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
     "device.status": ((), ()),
     "device.close": ((), ()),
     "roll.preview": (("material",), ("slots",)),
-    "roll.approve": (("slot",), ("fingerprint",)),
+    "roll.approve": (("slot",), ("fingerprint", "attended")),
     "roll.setSpacingOffset": (("slot", "offsetRows"), ()),
     "roll.manualFrames": (("rows",), ()),
     "roll.previewStrip": ((), ()),
@@ -206,6 +206,12 @@ def _require_string(
             ErrorCode.INVALID_PARAMS,
             f"{name} length must be between {minimum_length} and {maximum_length}",
         )
+    return value
+
+
+def _require_bool(value: object, name: str) -> bool:
+    if type(value) is not bool:
+        raise BridgeError(ErrorCode.INVALID_PARAMS, f"{name} must be true or false")
     return value
 
 
@@ -455,9 +461,19 @@ class BridgeService:
                 fingerprint = _require_string(
                     fingerprint, "fingerprint", maximum_length=256
                 )
+            # Attended binding (feed-detector round; ScanStudio #24/#16/#42):
+            # optional on the wire and omitted by every pre-existing caller,
+            # so the default is byte-identical to today's behavior. When
+            # true, the operator is accepting one frame of an automatically
+            # detected medium-confidence roll so the roll can be scanned
+            # with them watching -- coolscanpy refuses it on any other roll
+            # shape (INVALID_PARAMS).
+            attended = params.get("attended")
+            attended = False if attended is None else _require_bool(attended, "attended")
             self._transport.approve(
                 _require_plain_int(params["slot"], "slot", minimum=1, maximum=40),
                 fingerprint=fingerprint,
+                attended=attended,
             )
             return {}
         if method == "roll.setSpacingOffset":

--- a/bridge/src/scanstudio_bridge/transport/__init__.py
+++ b/bridge/src/scanstudio_bridge/transport/__init__.py
@@ -68,7 +68,13 @@ class Transport(Protocol):
         on_thumbnail: Callable[[domain.Thumbnail], None],
     ) -> domain.PreviewResult: ...
 
-    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
+    def approve(
+        self,
+        slot: int,
+        *,
+        fingerprint: str | None = None,
+        attended: bool = False,
+    ) -> None:
         """Approve `slot`. `fingerprint`, when given, is the Roll
         fingerprint (BRIDGE.md's `roll.approve`) the approval being
         submitted was minted against -- additive (2026-08-08 adversarial
@@ -76,7 +82,15 @@ class Transport(Protocol):
         given value that no longer matches the roll's CURRENT fingerprint
         must be refused with `FINGERPRINT_REFUSED` before any underlying
         approval call, never silently approved against whatever session
-        happens to be current now."""
+        happens to be current now.
+
+        `attended` (feed-detector round; ScanStudio #24/#16/#42) marks this
+        as an operator-ATTENDED acceptance rather than a per-slot manual
+        review: it may approve a slot the detector never flagged, and it is
+        what lets a medium-confidence roll be scanned at all. It is only
+        valid on a roll whose detection is automatic and medium-confidence;
+        anywhere else it must be refused with `INVALID_PARAMS`. `False` (the
+        default, and every pre-existing caller) is unchanged behavior."""
         ...
 
     def set_spacing_offset(

--- a/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -919,7 +919,13 @@ class CoolscanPyTransport:
         self._preview_established = True
         return domain.PreviewResult(count=len(thumbnails), fingerprint=self._roll.fingerprint.sha256)
 
-    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
+    def approve(
+        self,
+        slot: int,
+        *,
+        fingerprint: str | None = None,
+        attended: bool = False,
+    ) -> None:
         if self._device is None:
             raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
         if not self._preview_established:
@@ -948,8 +954,16 @@ class CoolscanPyTransport:
                 "that no longer matches the roll's current state; acquire a "
                 "fresh preview or placement and approve again",
             )
+        # Attended binding (feed-detector round; ScanStudio #24/#16/#42).
+        # coolscanpy owns the authority here: Roll.approve(attended=True)
+        # refuses with ValueError unless this roll is an automatically
+        # detected medium-confidence session, which is the only shape the
+        # scan-time gate will bind below "high". The bridge does not
+        # second-guess that -- it forwards the operator's intent and maps
+        # the refusal, exactly as it already does for "slot does not
+        # require manual review".
         try:
-            self._roll.approve(slot)
+            self._roll.approve(slot, attended=attended)
         except ValueError as exc:
             raise BridgeError(ErrorCode.INVALID_PARAMS, str(exc)) from exc
 

--- a/bridge/src/scanstudio_bridge/transport/mock.py
+++ b/bridge/src/scanstudio_bridge/transport/mock.py
@@ -296,7 +296,13 @@ class MockTransport:
         self._fingerprint = fingerprint
         return domain.PreviewResult(count=self._slot_count, fingerprint=fingerprint)
 
-    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
+    def approve(
+        self,
+        slot: int,
+        *,
+        fingerprint: str | None = None,
+        attended: bool = False,
+    ) -> None:
         self._require_connected()
         # Additive (2026-08-08 adversarial review, S1) -- see
         # transport.Transport.approve's own docstring. `None` (the default,
@@ -309,7 +315,19 @@ class MockTransport:
                 "that no longer matches the roll's current state; acquire a "
                 "fresh preview or placement and approve again",
             )
-        if slot < 1 or slot > self._slot_count or slot not in self._needs_approval_slots:
+        if slot < 1 or slot > self._slot_count:
+            raise BridgeError(ErrorCode.INVALID_PARAMS, f"slot {slot} does not need approval")
+        # The simulator has no roll-confidence detector, so it has no
+        # medium-confidence roll for an attended acceptance to rescue. It
+        # refuses `attended` rather than pretending to support it -- the
+        # same posture PROTOCOL.md already documents for the simulator's
+        # missing manual-review gate.
+        if attended:
+            raise BridgeError(
+                ErrorCode.INVALID_PARAMS,
+                "attended roll binding is not available on the mock transport",
+            )
+        if slot not in self._needs_approval_slots:
             raise BridgeError(ErrorCode.INVALID_PARAMS, f"slot {slot} does not need approval")
         self._approved_slots.add(slot)
 

--- a/bridge/tests/test_transport_coolscanpy.py
+++ b/bridge/tests/test_transport_coolscanpy.py
@@ -74,6 +74,7 @@ class _FakeRoll:
         self._scan_results = {slot: list(outcomes) for slot, outcomes in (scan_results or {}).items()}
         self.scan_many_calls: list[tuple[int, ...]] = []
         self.approve_calls: list[int] = []
+        self.attended_approve_calls: list[tuple[int, bool]] = []
         self.spacing_offset_calls: list[tuple[int, int]] = []
         self.safe_stop_calls = 0
         self.closed = False
@@ -128,8 +129,13 @@ class _FakeRoll:
     def slot_count(self) -> int:
         return len(self._thumbnails)
 
-    def approve(self, slot: int) -> None:
+    def approve(self, slot: int, *, attended: bool = False) -> None:
+        # Mirrors coolscanpy.Roll.approve's own signature (feed-detector
+        # round; attended binding). Recorded as a (slot, attended) pair so a
+        # test can prove the operator's intent reached the driver, while the
+        # pre-existing `approve_calls` slot list stays exactly as it was.
         self.approve_calls.append(slot)
+        self.attended_approve_calls.append((slot, attended))
 
     def set_spacing_offset(
         self, slot: int, offset_rows: int
@@ -1627,6 +1633,54 @@ def test_approve_with_no_fingerprint_keeps_pre_existing_behavior(
     transport.approve(1)
 
     assert roll.approve_calls == [1]
+    assert roll.attended_approve_calls == [(1, False)]
+
+
+# ---------------------------------------------------------------------------
+# Attended binding (feed-detector round; ScanStudio #24/#16/#42)
+# ---------------------------------------------------------------------------
+
+
+def test_attended_approval_reaches_the_driver_as_an_explicit_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The operator's intent must arrive at coolscanpy as `attended=True`.
+    The bridge never decides eligibility itself -- Roll.approve is the
+    authority on which roll shapes may bind below 'high'."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)], fingerprint_sha256="c" * 64)
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    transport.approve(1, attended=True)
+
+    assert roll.attended_approve_calls == [(1, True)]
+
+
+def test_attended_approval_refused_by_the_driver_maps_to_invalid_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """coolscanpy refuses `attended` on any roll that is not an
+    automatically detected medium-confidence one. That refusal must surface
+    as a typed INVALID_PARAMS, not an unhandled fault."""
+
+    class _RefusingRoll(_FakeRoll):
+        def approve(self, slot: int, *, attended: bool = False) -> None:
+            if attended:
+                raise ValueError(
+                    "attended roll binding requires an automatically detected "
+                    "medium-confidence roll; this session is 'high'"
+                )
+            super().approve(slot, attended=attended)
+
+    roll = _RefusingRoll(thumbnails=[_fake_thumbnail(1)], fingerprint_sha256="c" * 64)
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.approve(1, attended=True)
+
+    assert excinfo.value.code is ErrorCode.INVALID_PARAMS
+    assert "attended roll binding requires" in str(excinfo.value)
 
 
 def test_manual_frames_refuses_when_current_attempt_has_no_recorded_evidence(

--- a/coolscanpy/src/coolscanpy/_roll.py
+++ b/coolscanpy/src/coolscanpy/_roll.py
@@ -944,11 +944,22 @@ class Roll:
 
     # -- manual review / approval --------------------------------------
 
-    def approve(self, slot: int) -> ManualFrameApproval:
+    def approve(self, slot: int, *, attended: bool = False) -> ManualFrameApproval:
         """Approve ``slot`` and return its immutable, content-bound receipt.
 
         The returned receipt is the exact object retained for the subsequent
         batch. Raises ``ValueError`` if the slot doesn't need approval.
+
+        ``attended`` (feed-detector round, ScanStudio #24/#16/#42) marks this
+        as an ATTENDED acceptance rather than a per-slot manual review. Use
+        it only when :attr:`attended_binding_available` is true, and only for
+        EVERY slot about to be scanned: the scan-time gate binds a
+        medium-confidence roll exclusively when every requested frame carries
+        one of these. Approving some frames attended and others not, or
+        approving only the flagged ones, refuses at bind time exactly as an
+        unapproved roll does. ``ValueError`` if this session cannot mint an
+        attended receipt at all (see
+        :attr:`RollPreviewSession.attended_binding_available`).
         """
 
         with self._state_condition:
@@ -956,9 +967,29 @@ class Roll:
             session = self._require_session_locked()
             self._check_slot(session, slot)
             offset = session.slots[slot - 1].boundary_offset_rows
-            approval = session.approve_manual_origin(slot, offset)
+            approval = session.approve_manual_origin(
+                slot,
+                offset,
+                attended_roll_binding=attended,
+            )
             self._approvals[slot] = approval
             return approval
+
+    @property
+    def attended_binding_available(self) -> bool:
+        """Whether this roll can be rescued by approving every frame.
+
+        True only for an automatically detected roll the detector placed at
+        medium confidence -- the "previews fine but will not scan" case. The
+        application layer reads this to decide whether to offer an
+        approve-every-frame affordance; ``False`` means either nothing needs
+        rescuing ('high') or nothing can rescue it ('low', where the detector
+        never anchored a lattice to vouch for).
+        """
+
+        with self._state_condition:
+            session = self._require_session_locked()
+            return session.attended_binding_available
 
     def needs_approval(self, slot: int) -> bool:
         with self._state_condition:
@@ -1082,9 +1113,9 @@ class Roll:
         with self._state_condition:
             approvals = dict(self._approvals)
             for slot in ordered_slots:
+                approval = approvals.get(slot)
+                offset = session.slots[slot - 1].boundary_offset_rows
                 if session.slots[slot - 1].manual_review:
-                    approval = approvals.get(slot)
-                    offset = session.slots[slot - 1].boundary_offset_rows
                     if approval is None or not session.validate_manual_approval(
                         approval,
                         slot_id=slot,
@@ -1095,6 +1126,46 @@ class Roll:
                             f"call approve({slot}) before scanning it",
                             slot=slot,
                         )
+                elif approval is not None and not session.validate_manual_approval(
+                    approval,
+                    slot_id=slot,
+                    boundary_offset_rows=offset,
+                ):
+                    # An approval retained for a slot that does NOT require
+                    # manual review is an attended receipt (or a stale one
+                    # left by an offset nudge that did not clear it). Either
+                    # way it is about to be put on the wire, so it gets the
+                    # same "does this session still mint exactly this" check
+                    # a flagged slot's receipt has always had, rather than
+                    # travelling unvalidated to the worker.
+                    raise ManualReviewRequired(
+                        f"slot {slot} approval no longer matches this reviewed "
+                        f"preview; re-approve slot {slot} before scanning it",
+                        slot=slot,
+                    )
+            # Attended binding (feed-detector round): a medium-confidence
+            # automatic roll can only bind with EVERY requested frame
+            # approved. Refuse the partial case here, before any film moves,
+            # with an error that names what to do -- the pinned worker's
+            # gate would refuse it anyway, but only after a reservation, a
+            # traversal, and a ROLL_MISMATCH the field cannot act on.
+            if session.attended_binding_available:
+                unapproved = [
+                    slot
+                    for slot in ordered_slots
+                    if approvals.get(slot) is None
+                    or not approvals[slot].is_attended_roll_binding
+                ]
+                if unapproved:
+                    raise ManualReviewRequired(
+                        "roll boundary lattice confidence is "
+                        f"{session.detection.confidence!r}; scanning it requires "
+                        "an operator to approve every requested frame -- "
+                        f"{len(unapproved)} of {len(ordered_slots)} still "
+                        f"unapproved (first: slot {unapproved[0]}); call "
+                        "approve(slot, attended=True) on each",
+                        slot=unapproved[0],
+                    )
 
             if session.recipe.capture_route is not CaptureRoute.SINGLE_PASS_RGBI4:
                 raise NotImplementedError(_BLACK_AND_WHITE_NOT_WIRED)

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -36,8 +36,14 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     # additive manual_boundary_rows field plus its batch-job.json plumbing.
     # Resealed 2026-08-11: capture descendants remain in the bridge-owned
     # process group and inherit its exclusive process-ownership fence.
-    "capture_process.py": "a7a4eb4d09c6c6daf399e4a868375a291cf80f220f45a1c13bc36ebff37e1cc9",
-    "worker.py": "d826249919c94b67f76b6a36400374a090ef2c9b2c05138f51913e9576e67650",
+    # Resealed 2026-08-13 (attended scan binding, feed-detector round;
+    # ScanStudio #24/#16/#42): capture_process.py gained the
+    # ATTENDED_ROLL_BINDING_* pair and ManualFrameApproval.
+    # is_attended_roll_binding; worker.py gained the attended branch of the
+    # roll-confidence gate plus its journal marker. No wire resource, plan,
+    # or continuation template changed, so their pins are untouched.
+    "capture_process.py": "c4d234c02bcabf5d10c83b9ef9f071c591546c2447ca004610cc0e0c804a3944",
+    "worker.py": "08b9fdb46bc072923d46c1efc4d4a901fd943de542624bc536cd440c3fb6294b",
     "manual_frames.py": "f30f0003e081c3a98610d5700d7e6b6ee4d182b9d5228932f3304f1307d4815f",
     "usb_backend.py": "afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62",
     "density.py": "c2c47de2886bc4b60197d2721b6d72050a76f1095760590fa7bb34a728b9da76",

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
@@ -93,6 +93,38 @@ REVIEWED_ROLL_FINGERPRINT_VERSION = 2
 # is), so there is no backward-compatibility case to preserve here the way
 # F7 preserved one for session JSON.
 MANUAL_FRAME_APPROVAL_VERSION = 2
+
+# Attended scan binding (FEEDING-DETECTOR-ROUND, ScanStudio #24/#16/#42).
+# The one review reason that marks a ManualFrameApproval as an OPERATOR-
+# ATTENDED acceptance of an automatically detected roll, rather than the
+# per-slot "this specific frame was flagged and a human looked at it"
+# receipt every other reason denotes.
+#
+# It lives here, beside ManualFrameApproval itself, for the same reason
+# digest_manual_boundary_rows does: the receipt's producer
+# (roll.preview_session.RollPreviewSession.approve_manual_origin) and its
+# consumer (the pinned capture worker's confidence gate) must never
+# independently drift on the exact string, and the string is inside
+# binding_payload()/binding_sha256 -- so a receipt cannot gain or lose this
+# marker after signing without invalidating its own digest.
+#
+# What it does NOT do: it grants no confidence, no threshold change, and no
+# exemption from any other check. It is only the evidence the worker gate
+# reads to tell "a human explicitly accepted every requested frame of this
+# medium-confidence automatic roll" apart from "an unattended caller passed
+# an approval flag" -- which still refuses, unchanged.
+ATTENDED_ROLL_BINDING_REASON = "attended-roll-binding"
+
+# The only detector confidence the attended path may bind. 'low' is not a
+# "slightly worse medium": it is the detector saying it could not anchor the
+# lattice at all, so a human approving thumbnails proves nothing about where
+# the frames physically are. Attended binding is an operator vouching for a
+# geometry the detector DID find but could not fully corroborate -- there is
+# no such geometry to vouch for at 'low'. Kept here, beside the reason
+# string, so the receipt producer and the pinned worker gate read one
+# definition rather than two.
+ATTENDED_ROLL_BINDING_CONFIDENCE = "medium"
+
 MAX_VISUAL_MEDIAN_HAMMING = 24
 MAX_VISUAL_P90_HAMMING = 48
 MAX_SELECTED_VISUAL_HAMMING = 48
@@ -634,6 +666,20 @@ class ManualFrameApproval:
     review_reasons: tuple[str, ...]
     manual_boundary_rows_sha256: str
     schema_version: int = MANUAL_FRAME_APPROVAL_VERSION
+
+    @property
+    def is_attended_roll_binding(self) -> bool:
+        """Whether this receipt is an operator-attended roll acceptance.
+
+        Single source of truth for reading ATTENDED_ROLL_BINDING_REASON off a
+        receipt, so the producer, the facade's own re-validation, and the
+        pinned worker gate all ask the same question the same way. The reason
+        is part of ``binding_payload()`` and therefore of ``binding_sha256``:
+        it cannot be added to or removed from a signed receipt without
+        breaking the digest ``from_payload`` re-checks.
+        """
+
+        return ATTENDED_ROLL_BINDING_REASON in self.review_reasons
 
     @staticmethod
     def digest_manual_boundary_rows(rows: Sequence[int] | None) -> str:

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
@@ -49,6 +49,7 @@ from .density import (
     density_source_geometry_for_startup_records,
 )
 from .capture_process import (
+    ATTENDED_ROLL_BINDING_CONFIDENCE,
     ManualFrameApproval,
     ReviewedRollFingerprint,
     RollFingerprintComparison,
@@ -402,6 +403,7 @@ class LiveFrameSelection:
     reviewed_leading_residual_rows: float | None = None
     origin_rebased: bool = False
     origin_rebase_info: OriginRebaseInfo | None = None
+    attended_roll_binding_accepted: bool = False
 
     def diagnostics(self) -> dict[str, Any]:
         return {
@@ -410,6 +412,21 @@ class LiveFrameSelection:
             "usable_rows": self.usable_rows,
             "preview_sha256": self.preview_sha256,
             "table_sha256": self.table_sha256,
+            # Which mode bound this frame. None (the overwhelmingly common
+            # case) means it bound on detector confidence alone -- the
+            # journal shape every existing evidence audit already reads is
+            # unchanged for those. A dict means the roll was below "high"
+            # and an operator's per-frame approvals are what carried it, so
+            # an audit can find every attended frame without re-running the
+            # detector.
+            "attended_roll_binding": (
+                None
+                if not self.attended_roll_binding_accepted
+                else {
+                    "origin": ATTENDED_ROLL_BINDING_ACCEPTED_ORIGIN,
+                    "detection_confidence": self.detection.confidence,
+                }
+            ),
             "leading_anchor_divergence_accepted": (
                 None
                 if not self.leading_anchor_divergence_accepted
@@ -1326,6 +1343,12 @@ def _derive_index_geometry(plan: list[dict]) -> IndexGeometry:
 
 LEADING_ANCHOR_DIVERGENCE_ACCEPTED_ORIGIN = "leading-anchor-divergence-accepted"
 ORIGIN_REBASED_OUTSIDE_AFFINE_ACCEPTED_ORIGIN = "origin-rebased-outside-affine"
+# Journal marker for an acceptance that bound through the attended path
+# rather than on detector confidence alone. Every acceptance this gate makes
+# is journaled with its own origin string so an evidence audit can tell,
+# from the artifact alone and without re-running the detector, WHICH mode
+# bound a given frame.
+ATTENDED_ROLL_BINDING_ACCEPTED_ORIGIN = "attended-roll-binding-accepted"
 
 
 @dataclass(frozen=True)
@@ -1385,13 +1408,16 @@ def _derive_live_frame_selection(
     reviewed_as_automatic: bool = False,
     reviewed_leading_residual_rows: float | None = None,
     manual_boundary_rows: tuple[int, ...] | None = None,
+    attended_roll_binding: bool = False,
 ) -> LiveFrameSelection:
     """Resolve one frame origin from same-traversal live data.
 
     Automatic (default, ``manual_boundary_rows`` omitted): resolves via
     ``detect_roll_frames``/``derive_transport_mapping`` exactly as this
-    function has always worked. See the gate comment below for the one new
-    path manual placement adds to this function's confidence gate.
+    function has always worked. See the gate comment below for the two
+    paths that may bind an automatic or manually placed detection below
+    "high": manual placement, and (``attended_roll_binding``) an operator
+    who explicitly approved every frame of a medium-confidence roll.
 
     Manual (Rung 4, FEEDING-UX-LADDER-OVERNIGHT-20260807.md):
     ``manual_boundary_rows`` is never trusted as a serialized detection
@@ -1480,12 +1506,73 @@ def _derive_live_frame_selection(
     # every one of these frames independently. This gate only decides
     # whether the ROLL-level confidence check may be attempted at all; it
     # grants no exemption from any other check in this function.
+    #
+    # ------------------------------------------------------------------
+    # ATTENDED BINDING (feed-detector round; ScanStudio #24/#16/#42 --
+    # "previews fine but will not scan"). The SECOND, and only other, path
+    # this gate has ever granted below "high".
+    #
+    # The field shape: a roll the detector places at "medium" -- it found a
+    # lattice, corroborated it well enough to render every thumbnail the
+    # operator then visually checked, but not well enough to bind film
+    # geometry with nobody watching. Preview accepts it; scanning refuses
+    # it; the operator is standing right there looking at correct frames.
+    #
+    # What unlocks it is not a lower threshold -- no accept window, no
+    # lattice/evidence/direct-fraction bound in roll_index.py moves by this
+    # change, and "medium" is still exactly as hard to earn as it was. What
+    # unlocks it is EVIDENCE OF ATTENDANCE: a ManualFrameApproval receipt
+    # for EVERY frame this batch requested, each one carrying
+    # ATTENDED_ROLL_BINDING_REASON, which RollPreviewSession.
+    # approve_manual_origin only ever mints when an operator explicitly
+    # approves that slot against this session's own reviewed thumbnail.
+    # ``attended_roll_binding`` is that derived all-frames-approved verdict
+    # (see _derive_live_batch_selections, which is the only production
+    # caller that can ever pass it true).
+    #
+    # Why a caller cannot forge it, in the same terms as the manual gate
+    # above:
+    #   * The reason string lives inside ManualFrameApproval.
+    #     binding_payload(), hence inside binding_sha256, which
+    #     from_payload re-derives and compares -- a receipt cannot be
+    #     hand-edited to gain the marker.
+    #   * load_validated_batch_job already refuses any receipt whose
+    #     reviewed_fingerprint_sha256 is not THIS job's reviewed
+    #     fingerprint, and whose manual_boundary_rows_sha256 is not this
+    #     job's placement digest. So every receipt admitted here was signed
+    #     against the CURRENT preview operation's own evidence, not a
+    #     previous roll's, and not a different placement of this one.
+    #   * The whole-roll and per-slot visual fingerprint comparisons below
+    #     independently prove the bytes about to be bound are still the
+    #     bytes that were reviewed.
+    #   * ``all()`` over the batch's frames means a partially approved
+    #     batch is not attended. One unapproved requested frame refuses the
+    #     whole batch, because "the operator checked the ones that were
+    #     flagged" is not the claim this path binds on -- "the operator
+    #     accepted every frame about to be scanned" is.
+    #
+    # Deliberately NOT widened:
+    #   * 'low' still refuses with or without any number of approvals
+    #     (ATTENDED_ROLL_BINDING_CONFIDENCE; see its comment).
+    #   * UNATTENDED 'medium' still refuses byte-for-byte as before -- the
+    #     wide-gap-recovery/automatic caller that passes
+    #     manual_review_approved=True and nothing else takes the identical
+    #     raise with the identical message.
+    #   * Binding here grants no exemption from anything else in this
+    #     function or in apply_batch_boundary_offsets. It decides only
+    #     whether the ROLL-level confidence check may be passed at all.
     manual_placement = (
         manual_boundary_rows is not None
         and MANUAL_PLACEMENT_WARNING in detection.warnings
     )
+    attended_roll_binding_accepted = (
+        attended_roll_binding
+        and not manual_placement
+        and detection.confidence == ATTENDED_ROLL_BINDING_CONFIDENCE
+    )
     if detection.confidence != "high" and not (
-        manual_placement and manual_review_approved
+        (manual_placement and manual_review_approved)
+        or attended_roll_binding_accepted
     ):
         raise ProtocolError(
             f"roll boundary lattice confidence is {detection.confidence!r}; "
@@ -1622,6 +1709,7 @@ def _derive_live_frame_selection(
             if leading_anchor_divergence_accepted
             else None
         ),
+        attended_roll_binding_accepted=attended_roll_binding_accepted,
         origin_rebased=origin_rebase_info is not None,
         origin_rebase_info=origin_rebase_info,
         reviewed_fingerprint_sha256=(
@@ -1656,6 +1744,13 @@ def _derive_live_batch_selections(
     ``automatic=False, manual_review=True``, so every frame in a manual
     batch already has to appear in ``approved_manual_slots`` or that
     pre-existing, unmodified check refuses it).
+
+    Attended binding (feed-detector round, ScanStudio #24/#16/#42): this
+    function is also where the attended verdict is DERIVED -- see the
+    ``attended_roll_binding`` assignment below and the gate comment in
+    ``_derive_live_frame_selection``. It is deliberately not a parameter:
+    attendance is proven only by the per-frame receipts this batch already
+    carries, so there is nothing for a caller to assert.
     """
 
     if not frames:
@@ -1673,6 +1768,19 @@ def _derive_live_batch_selections(
     reviewed_automatic_slots = frozenset(
         spec.slot for spec in frames if spec.manual_review_approval is None
     )
+    # Attended binding (feed-detector round): the all-frames-approved verdict
+    # _derive_live_frame_selection's gate consumes. Derived here, from the
+    # receipts load_validated_batch_job already authenticated against THIS
+    # job's reviewed fingerprint and placement digest -- never taken as a
+    # bare boolean off the job JSON, so there is no wire field a caller could
+    # set to claim attendance it does not have. ``all()`` over every
+    # requested frame is the whole claim: one unapproved frame in the batch
+    # and this is False, and the gate refuses exactly as it does today.
+    attended_roll_binding = all(
+        spec.manual_review_approval is not None
+        and spec.manual_review_approval.is_attended_roll_binding
+        for spec in frames
+    )
     # A zero-offset selection performs the expensive same-traversal decode and
     # gives us the unmodified detector mapping.  All requested offsets are then
     # applied together to that mapping before SEND(0x8f) can execute.
@@ -1687,6 +1795,7 @@ def _derive_live_batch_selections(
         manual_review_approved=frames[0].manual_review_approval is not None,
         reviewed_as_automatic=frames[0].slot in reviewed_automatic_slots,
         manual_boundary_rows=manual_boundary_rows,
+        attended_roll_binding=attended_roll_binding,
     )
     if context.fresh_fingerprint is None:
         raise ProtocolError("fresh batch roll fingerprint was not retained")
@@ -1729,6 +1838,15 @@ def _derive_live_batch_selections(
     manual_placement = (
         manual_boundary_rows is not None
         and MANUAL_PLACEMENT_WARNING in context.detection.warnings
+    )
+    # The same verdict _derive_live_frame_selection's gate reached for this
+    # batch's one context call, recomputed for the per-frame journal
+    # annotation below. `attended_roll_binding` first: an unattended batch
+    # short-circuits before touching `detection`.
+    attended_roll_binding_accepted = (
+        attended_roll_binding
+        and not manual_placement
+        and context.detection.confidence == ATTENDED_ROLL_BINDING_CONFIDENCE
     )
     # S6 hardening (FEEDING-UX-LADDER-OVERNIGHT-20260807.md F1 rework):
     # load_validated_batch_job already checked each approval's own
@@ -1856,6 +1974,17 @@ def _derive_live_batch_selections(
                 and spec.slot in reviewed_automatic_slots
                 and _is_narrowly_divergent_leading_anchor(base)
             ),
+            # Placement-wide, exactly like manual_boundary_rows: the single
+            # context call above is what actually passed (or failed) the
+            # roll-level confidence gate for this whole batch, so every
+            # frame in it is journaled with the same verdict. Recomputed
+            # here rather than read back off `context`, for the same reason
+            # leading_anchor_divergence_accepted just above is: this is the
+            # journal annotation, and the authoritative decision already
+            # happened inside the gate. Conjunction order matters -- the
+            # cheap, always-available flag first, so a batch that is not
+            # attended never dereferences `detection` at all.
+            attended_roll_binding_accepted=attended_roll_binding_accepted,
             origin_rebased=origin_rebase_info is not None,
             origin_rebase_info=origin_rebase_info,
             reviewed_fingerprint_sha256=context.reviewed_fingerprint_sha256,

--- a/coolscanpy/src/coolscanpy/roll/preview_session.py
+++ b/coolscanpy/src/coolscanpy/roll/preview_session.py
@@ -20,6 +20,8 @@ import numpy as np
 
 from coolscanpy.exceptions import MeterUnusableError
 from coolscanpy.protocol.ls5000_single_pass.capture_process import (
+    ATTENDED_ROLL_BINDING_CONFIDENCE,
+    ATTENDED_ROLL_BINDING_REASON,
     AttemptPaths,
     CaptureAttemptResult,
     CaptureMode,
@@ -355,15 +357,65 @@ class RollPreviewSession:
             return None
         return tuple(boundary.output_row for boundary in self.detection.boundaries)
 
+    @property
+    def attended_binding_available(self) -> bool:
+        """Whether this session may be scanned through the attended path.
+
+        True exactly when the scan-time roll gate would refuse this session
+        unattended but an operator CAN rescue it by approving every frame:
+        an automatically detected roll the detector placed at
+        ATTENDED_ROLL_BINDING_CONFIDENCE. False for a 'high' session (which
+        needs no rescue), for 'low' (which no amount of approval rescues --
+        the detector never found a lattice to vouch for), and for a manual
+        placement (which already has its own binding path).
+
+        The application layer reads this to decide whether to offer the
+        "approve every frame and scan" affordance at all; it is advisory
+        UI state, and the authoritative refusal is still the pinned
+        worker's own gate.
+        """
+
+        return (
+            self.detection.confidence == ATTENDED_ROLL_BINDING_CONFIDENCE
+            and self.manual_boundary_rows is None
+        )
+
     def approve_manual_origin(
         self,
         slot_id: int,
         boundary_offset_rows: int = 0,
+        *,
+        attended_roll_binding: bool = False,
     ) -> ManualFrameApproval:
-        """Create an immutable receipt for one visually reviewed slot."""
+        """Create an immutable receipt for one visually reviewed slot.
+
+        ``attended_roll_binding`` (feed-detector round, ScanStudio
+        #24/#16/#42) is the opt-in that turns this into an ATTENDED
+        acceptance: the operator is not confirming a slot the detector
+        flagged, they are vouching for one frame of a medium-confidence
+        automatic roll so the whole roll can be scanned with them watching.
+        It is refused unless :attr:`attended_binding_available` -- a 'high'
+        session has nothing to rescue, a 'low' one has no geometry worth
+        vouching for, and a manual placement binds through its own path --
+        and, when granted, records ATTENDED_ROLL_BINDING_REASON inside the
+        receipt's signed payload. The pinned capture worker reads exactly
+        that marker, on every requested frame, before it will bind a roll
+        below "high".
+
+        Default (False) behavior is unchanged in every respect: the slot
+        must itself carry manual_review, and the receipt never gains the
+        attended marker.
+        """
 
         slot = self._slot(slot_id)
-        if not slot.manual_review:
+        if attended_roll_binding and not self.attended_binding_available:
+            raise ValueError(
+                "attended roll binding requires an automatically detected "
+                f"{ATTENDED_ROLL_BINDING_CONFIDENCE}-confidence roll; this "
+                f"session is {self.detection.confidence!r}"
+                + ("" if self.manual_boundary_rows is None else " and manually placed")
+            )
+        if not slot.manual_review and not attended_roll_binding:
             raise ValueError(f"slot {slot_id} does not require manual review")
         thumbnail = reload_thumbnail(
             self.preview,
@@ -378,6 +430,13 @@ class RollPreviewSession:
         reasons = tuple(
             dict.fromkeys((*slot.warnings, *slot.base_origin.review_reasons))
         )
+        if attended_roll_binding:
+            # Appended, never substituted: an attended acceptance of a slot
+            # that ALSO carries its own review reasons keeps every one of
+            # them, so the worker's per-slot fresh-origin cross-check
+            # (review_reasons must be a superset of the freshly resolved
+            # origin's) still has the real reasons to compare against.
+            reasons = tuple(dict.fromkeys((*reasons, ATTENDED_ROLL_BINDING_REASON)))
         if not reasons:
             reasons = ("transport-origin-manual-review",)
         return ManualFrameApproval(
@@ -403,14 +462,28 @@ class RollPreviewSession:
         slot_id: int,
         boundary_offset_rows: int,
     ) -> bool:
-        """Return whether an approval exactly matches this reviewed thumbnail."""
+        """Return whether an approval exactly matches this reviewed thumbnail.
+
+        The attended flag is read off the receipt rather than taken as a
+        parameter, so this stays a pure "would this exact session mint this
+        exact receipt again" comparison for both kinds. A receipt claiming
+        the attended marker against a session that cannot mint one (any
+        confidence but ATTENDED_ROLL_BINDING_CONFIDENCE, or a manual
+        placement) makes approve_manual_origin raise, which is a failed
+        validation, not an accepted one -- hence the ValueError catch.
+        """
 
         if not isinstance(approval, ManualFrameApproval):
             return False
-        return approval == self.approve_manual_origin(
-            slot_id,
-            boundary_offset_rows,
-        )
+        try:
+            expected = self.approve_manual_origin(
+                slot_id,
+                boundary_offset_rows,
+                attended_roll_binding=approval.is_attended_roll_binding,
+            )
+        except ValueError:
+            return False
+        return approval == expected
 
     def with_material(self, material: ScanMaterial) -> RollPreviewSession:
         """Return this preview with the material's explicit capture recipe."""

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
@@ -17,6 +17,7 @@ import pytest
 from coolscanpy.protocol.ls5000_single_pass import worker as worker_module
 from coolscanpy.protocol.ls5000_single_pass import manual_frames
 from coolscanpy.protocol.ls5000_single_pass.capture_process import (
+    ATTENDED_ROLL_BINDING_REASON,
     AttemptPaths,
     CaptureAttemptResult,
     CaptureMode,
@@ -3405,6 +3406,285 @@ def test_non_manual_medium_detection_still_refuses_even_with_approval_flags(
             manual_review_approved=True,
             # manual_boundary_rows intentionally omitted: the automatic path.
         )
+
+
+# ---------------------------------------------------------------------------
+# Attended binding (feed-detector round; ScanStudio #24/#16/#42). These tests
+# attack the SECOND path _derive_live_frame_selection's gate grants below
+# "high": an operator who explicitly approved every requested frame of an
+# automatically detected medium-confidence roll. The manual-placement tests
+# above, and test_non_manual_medium_detection_still_refuses_even_with_
+# approval_flags in particular, are the untouched regression proving the old
+# behavior is byte-for-byte intact.
+# ---------------------------------------------------------------------------
+
+
+def _attended_gate_mapping() -> TransportMapping:
+    """An ORDINARY automatic origin: nothing here is flagged for review."""
+
+    origin = NativeFrameOrigin(
+        frame=1,
+        boundary_index=0,
+        boundary_output_row=10,
+        lookup_row=10,
+        code=6 * (10 % 18),
+        selector=10 // 18,
+        native_origin=420,
+        method="affine-transport-fit",
+        automatic=True,
+        manual_review=False,
+        review_reasons=(),
+        affine_residual_rows=0.0,
+    )
+    return TransportMapping(
+        record_count=500,
+        native_intercept=0.0,
+        native_units_per_preview_row=42.0,
+        anchor_mae_rows=0.0,
+        anchor_max_error_rows=0.0,
+        origins=(origin,),
+    )
+
+
+def _wire_attended_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    confidence: str,
+) -> None:
+    """Wire the AUTOMATIC detector path at a chosen roll confidence."""
+
+    rgb = np.zeros((500, 96, 3), dtype=np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+    # A geometry rich enough for LiveFrameSelection.diagnostics(), so these
+    # tests can assert the JOURNAL the gate produces, not just its verdict.
+    monkeypatch.setattr(
+        worker_module,
+        "_derive_index_geometry",
+        lambda _plan: SimpleNamespace(
+            height=500,
+            pitch=41,
+            native_height=250_278,
+            requested_resolution=97,
+            native_resolution=4000,
+            native_width=4000,
+            width=96,
+            expected_stream_bytes=500 * 96 * 6,
+        ),
+    )
+    detection = _manual_gate_detection(confidence=confidence, user_picked=False)
+    detection.diagnostics = lambda: {"confidence": confidence}
+    mapping = _attended_gate_mapping()
+    monkeypatch.setattr(worker_module, "detect_roll_frames", lambda *_a, **_k: detection)
+    monkeypatch.setattr(
+        worker_module, "scanner_addressable_interval_count", lambda *_a, **_k: 1
+    )
+    monkeypatch.setattr(
+        worker_module, "derive_transport_mapping", lambda *_a, **_k: mapping
+    )
+
+
+def test_attended_medium_detection_binds_and_marks_the_journal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The field case: automatic roll, medium confidence, operator approved
+    every frame. It binds, and the journal says WHICH mode bound it."""
+
+    _wire_attended_gate(monkeypatch, confidence="medium")
+
+    selection = worker_module._derive_live_frame_selection(
+        [],
+        b"fresh-preview",
+        b"fresh-table",
+        frame=1,
+        attended_roll_binding=True,
+    )
+
+    assert selection.detection.confidence == "medium"
+    assert selection.selected.native_origin == 420
+    assert selection.attended_roll_binding_accepted is True
+    marker = selection.diagnostics()["attended_roll_binding"]
+    assert marker == {
+        "origin": worker_module.ATTENDED_ROLL_BINDING_ACCEPTED_ORIGIN,
+        "detection_confidence": "medium",
+    }
+
+
+def test_high_confidence_binding_is_never_marked_attended(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 'high' roll binds on confidence alone and must not be journaled as
+    an attended acceptance, even if every frame happens to be approved --
+    otherwise an evidence audit could not tell the two apart."""
+
+    _wire_attended_gate(monkeypatch, confidence="high")
+
+    selection = worker_module._derive_live_frame_selection(
+        [],
+        b"fresh-preview",
+        b"fresh-table",
+        frame=1,
+        attended_roll_binding=True,
+    )
+
+    assert selection.attended_roll_binding_accepted is False
+    assert selection.diagnostics()["attended_roll_binding"] is None
+
+
+def test_attended_low_confidence_detection_always_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """'low' is not rescuable by attendance. The detector never anchored a
+    lattice, so there is no geometry for an operator to vouch for."""
+
+    _wire_attended_gate(monkeypatch, confidence="low")
+
+    with pytest.raises(
+        ProtocolError, match="unattended frame binding requires 'high'"
+    ):
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            attended_roll_binding=True,
+        )
+
+
+def test_unattended_medium_detection_refuses_with_the_identical_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The refusal a field user sees today must be byte-for-byte unchanged
+    when nobody is attending -- same text, same quoting, same confidence."""
+
+    _wire_attended_gate(monkeypatch, confidence="medium")
+
+    with pytest.raises(ProtocolError) as excinfo:
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            attended_roll_binding=False,
+        )
+
+    assert str(excinfo.value) == (
+        "roll boundary lattice confidence is 'medium'; "
+        "unattended frame binding requires 'high'"
+    )
+
+
+def _attended_receipt(slot: int, *, attended: bool) -> ManualFrameApproval:
+    reasons: tuple[str, ...] = ("transport-origin-manual-review",)
+    if attended:
+        reasons = (*reasons, ATTENDED_ROLL_BINDING_REASON)
+    return ManualFrameApproval(
+        reviewed_fingerprint_sha256="a" * 64,
+        slot=slot,
+        boundary_offset_rows=0,
+        thumbnail_sha256="b" * 64,
+        reviewed_lookup_row=10,
+        reviewed_native_origin=420,
+        review_reasons=reasons,
+        manual_boundary_rows_sha256=(
+            ManualFrameApproval.digest_manual_boundary_rows(None)
+        ),
+    )
+
+
+def _capture_attended_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    frames: tuple[worker_module.BatchFrameSpec, ...],
+) -> bool:
+    """Run _derive_live_batch_selections far enough to observe the attended
+    verdict it derives, without needing a full live traversal."""
+
+    captured: dict[str, object] = {}
+
+    def fake_selection(*_args: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        raise ProtocolError("stop-after-derivation")
+
+    monkeypatch.setattr(
+        worker_module, "_derive_live_frame_selection", fake_selection
+    )
+    reviewed = _reviewed_fingerprint_with_count(6)
+    with pytest.raises(ProtocolError, match="stop-after-derivation"):
+        worker_module._derive_live_batch_selections(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frames,
+            reviewed_fingerprint=reviewed,
+        )
+    verdict = captured["attended_roll_binding"]
+    assert isinstance(verdict, bool)
+    return verdict
+
+
+def _attended_batch(
+    tmp_path: Path, root_name: str, marks: dict[int, bool | None]
+) -> tuple[worker_module.BatchFrameSpec, ...]:
+    frame_root = tmp_path / root_name
+    return tuple(
+        worker_module.BatchFrameSpec(
+            slot=slot,
+            boundary_offset_rows=0,
+            manual_review_approval=(
+                None if attended is None else _attended_receipt(slot, attended=attended)
+            ),
+            output=frame_root / f"frame-{slot:03d}" / "capture.bin",
+            journal=frame_root / f"frame-{slot:03d}" / "journal.json",
+            ack=frame_root / f"frame-{slot:03d}" / "parent-ack.json",
+        )
+        for slot, attended in sorted(marks.items())
+    )
+
+
+def test_batch_derives_attended_only_when_every_frame_is_attended_approved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Attendance is all-or-nothing across the requested batch."""
+
+    assert (
+        _capture_attended_flag(
+            monkeypatch, _attended_batch(tmp_path, "all", {1: True, 2: True, 3: True})
+        )
+        is True
+    )
+
+
+def test_batch_partial_attended_approval_is_not_attended(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One requested frame the operator did not approve refuses the batch --
+    'they checked the flagged ones' is not the claim this path binds on."""
+
+    assert (
+        _capture_attended_flag(
+            monkeypatch,
+            _attended_batch(tmp_path, "partial", {1: True, 2: None, 3: True}),
+        )
+        is False
+    )
+
+
+def test_batch_ordinary_manual_review_receipts_are_not_attended(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A batch where every frame carries an ORDINARY manual-review receipt
+    is still not attended: the pre-existing per-slot approval flow cannot
+    silently become a roll-level confidence bypass."""
+
+    assert (
+        _capture_attended_flag(
+            monkeypatch,
+            _attended_batch(tmp_path, "ordinary", {1: False, 2: False}),
+        )
+        is False
+    )
 
 
 def test_manual_selection_still_refuses_on_fingerprint_mismatch(

--- a/coolscanpy/tests/roll/test_ls5000_roll_session.py
+++ b/coolscanpy/tests/roll/test_ls5000_roll_session.py
@@ -14,6 +14,7 @@ import pytest
 from coolscanpy.protocol.ls5000_single_pass import roll_index
 from coolscanpy.roll import preview_session as preview_session_module
 from coolscanpy.protocol.ls5000_single_pass.capture_process import (
+    ATTENDED_ROLL_BINDING_REASON,
     AttemptPaths,
     CaptureAttemptResult,
     CaptureMode,
@@ -29,6 +30,7 @@ from coolscanpy.roll.preview_session import (
     PARTIAL_FRAME_MIN_COVERAGE,
     ArtifactIdentity,
     CaptureRoute,
+    RollPreviewSession,
     RollSessionIntegrityError,
     ValidatedRollPreview,
     _crop_coverage,
@@ -1152,6 +1154,132 @@ def test_manual_origin_approval_is_bound_to_exact_reviewed_thumbnail_and_roll(
 
     with pytest.raises(ValueError, match="does not require manual review"):
         session.approve_manual_origin(2, 0)
+
+
+# ---------------------------------------------------------------------------
+# Attended binding (feed-detector round; ScanStudio #24/#16/#42) -- the
+# receipt-minting side of the worker's attended gate.
+# ---------------------------------------------------------------------------
+
+
+def _medium_confidence_session(tmp_path: Path) -> RollPreviewSession:
+    """The field shape: an automatically detected roll at medium confidence."""
+
+    session = build_roll_preview_session(
+        _preview_fixture(tmp_path, content_frames=36).result,
+        expected_frame_count=36,
+    )
+    return replace(
+        session,
+        detection=replace(session.detection, confidence="medium"),
+    )
+
+
+def test_medium_confidence_automatic_roll_offers_attended_binding(
+    tmp_path: Path,
+) -> None:
+    session = _medium_confidence_session(tmp_path)
+
+    assert session.detection.confidence == "medium"
+    assert session.manual_boundary_rows is None
+    assert session.attended_binding_available is True
+
+
+def test_attended_approval_marks_an_otherwise_unflagged_slot(
+    tmp_path: Path,
+) -> None:
+    """Slot 2 needs no manual review, so today it cannot be approved at all.
+    Attended acceptance is what lets an operator vouch for it."""
+
+    session = _medium_confidence_session(tmp_path)
+    assert session.slots[1].manual_review is False
+
+    with pytest.raises(ValueError, match="does not require manual review"):
+        session.approve_manual_origin(2, 0)
+
+    approval = session.approve_manual_origin(2, 0, attended_roll_binding=True)
+
+    assert approval.is_attended_roll_binding is True
+    assert ATTENDED_ROLL_BINDING_REASON in approval.review_reasons
+    assert approval.slot == 2
+    assert (
+        approval.reviewed_fingerprint_sha256
+        == session.reviewed_fingerprint().binding_sha256
+    )
+    assert session.validate_manual_approval(
+        approval, slot_id=2, boundary_offset_rows=0
+    )
+
+
+def test_attended_approval_keeps_a_flagged_slots_own_review_reasons(
+    tmp_path: Path,
+) -> None:
+    """Appending the marker must not erase why the slot was flagged -- the
+    worker cross-checks a receipt's reasons against the fresh origin's."""
+
+    session = _medium_confidence_session(tmp_path)
+    assert session.slots[36].manual_review is True
+
+    ordinary = session.approve_manual_origin(37, 0)
+    attended = session.approve_manual_origin(37, 0, attended_roll_binding=True)
+
+    assert set(ordinary.review_reasons) < set(attended.review_reasons)
+    assert attended.review_reasons[-1] == ATTENDED_ROLL_BINDING_REASON
+    assert ordinary.is_attended_roll_binding is False
+
+
+def test_high_confidence_session_refuses_to_mint_attended_receipts(
+    tmp_path: Path,
+) -> None:
+    """Nothing to rescue: a 'high' roll binds unattended already."""
+
+    session = build_roll_preview_session(
+        _preview_fixture(tmp_path, content_frames=36).result,
+        expected_frame_count=36,
+    )
+    session = replace(
+        session, detection=replace(session.detection, confidence="high")
+    )
+
+    assert session.attended_binding_available is False
+    with pytest.raises(ValueError, match="attended roll binding requires"):
+        session.approve_manual_origin(2, 0, attended_roll_binding=True)
+
+
+def test_low_confidence_session_refuses_to_mint_attended_receipts(
+    tmp_path: Path,
+) -> None:
+    """Nothing to vouch for: the detector never anchored a lattice."""
+
+    session = build_roll_preview_session(
+        _preview_fixture(tmp_path, content_frames=36).result,
+        expected_frame_count=36,
+    )
+    session = replace(
+        session, detection=replace(session.detection, confidence="low")
+    )
+
+    assert session.attended_binding_available is False
+    with pytest.raises(ValueError, match="attended roll binding requires"):
+        session.approve_manual_origin(37, 0, attended_roll_binding=True)
+
+
+def test_attended_receipt_fails_validation_against_a_high_confidence_session(
+    tmp_path: Path,
+) -> None:
+    """A receipt carrying the attended marker cannot be replayed against a
+    session that could never have minted one."""
+
+    medium = _medium_confidence_session(tmp_path)
+    approval = medium.approve_manual_origin(2, 0, attended_roll_binding=True)
+    high = replace(
+        medium, detection=replace(medium.detection, confidence="high")
+    )
+
+    assert (
+        high.validate_manual_approval(approval, slot_id=2, boundary_offset_rows=0)
+        is False
+    )
 
 
 def test_boundary_only_review_with_automatic_origin_can_be_approved(

--- a/coolscanpy/tests/test_facade.py
+++ b/coolscanpy/tests/test_facade.py
@@ -2840,6 +2840,61 @@ class TestRollPreview:
             roll.close()
             dev.close()
 
+    def test_medium_confidence_roll_refuses_until_every_frame_is_attended(
+        self, fake_service_factory, tmp_path: Path
+    ) -> None:
+        """Attended binding, facade level (ScanStudio #24/#16/#42): the
+        'previews fine but will not scan' roll refuses BEFORE any film moves,
+        with an error naming what the operator has to do -- and stops
+        refusing once every requested frame carries an attended approval."""
+
+        from dataclasses import replace as _replace
+
+        dev = _open_device(fake_service_factory)
+        roll, _worker = _make_roll(tmp_path, dev, batch_spawner=_success_spawner([]))
+        try:
+            roll.preview()
+            # Force the field shape: an automatically detected roll the
+            # detector placed at medium confidence.
+            roll._session = _replace(
+                roll._session,
+                detection=_replace(roll._session.detection, confidence="medium"),
+            )
+            assert roll.attended_binding_available is True
+
+            requested = [1, 2]
+            # A slot the detector itself flagged keeps its own, more precise
+            # pre-existing refusal -- attendance does not replace it.
+            for slot in requested:
+                if roll.needs_approval(slot):
+                    with pytest.raises(coolscanpy.ManualReviewRequired) as excinfo:
+                        next(iter(roll.scan_many(requested)))
+                    assert "requires visual review" in str(excinfo.value)
+                    roll.approve(slot)
+
+            # Every flagged slot is now approved, yet the roll still refuses:
+            # attendance is a claim about EVERY requested frame.
+            with pytest.raises(coolscanpy.ManualReviewRequired) as excinfo:
+                next(iter(roll.scan_many(requested)))
+            assert "approve every requested frame" in str(excinfo.value)
+            assert excinfo.value.slot in requested
+
+            # Approving only part of the batch is still not attendance.
+            roll.approve(requested[0], attended=True)
+            with pytest.raises(coolscanpy.ManualReviewRequired) as excinfo:
+                next(iter(roll.scan_many(requested)))
+            assert excinfo.value.slot == requested[1]
+
+            roll.approve(requested[1], attended=True)
+            approvals = roll._approvals
+            assert set(requested) <= set(approvals)
+            assert all(
+                approvals[slot].is_attended_roll_binding for slot in requested
+            )
+        finally:
+            roll.close()
+            dev.close()
+
     def test_approve_returns_the_exact_content_bound_receipt_retained_for_batch(
         self, fake_service_factory, tmp_path: Path
     ) -> None:

--- a/ports/tauri/app/PARITY-NOTES.md
+++ b/ports/tauri/app/PARITY-NOTES.md
@@ -34,3 +34,14 @@ organization (CSS modules instead of a `Theme` struct) — are named intentional
 choices, not omissions. Reachability of the newly-wired Phase 7 components is
 guard-railed by `src/__tests__/App.test.tsx` (shell navigation) and the
 fixture-driven component tests.
+
+## Known parity gaps opened after this ledger was written
+
+This ledger was written at Phase 07-03 and maps the 14 SwiftUI files that
+existed then. Two later SwiftUI features have no Tauri equivalent. They are
+recorded here rather than silently carried as "parity".
+
+| SwiftUI feature | Added | Tauri status | notes |
+|---|---|---|---|
+| Manual frame placement (`ManualFramePlacementView.swift`, `ManualFramePlacementSheet`, `ManualFramePlacementValidation.swift`) | 2026-08-07 (feeding UX ladder, Rung 4) | **GAP — not ported** | The Tauri app implements neither `roll.previewStrip` nor `roll.manualFrames`; there is no strip editor and no boundary-drawing UI. A Tauri operator whose roll refuses with `REFEED_REQUIRED` can only refeed and retry. Porting this is a whole subsystem (raster strip viewer, draggable boundary model, row validation), not an affordance, and is deliberately out of scope for the feed-detector round. |
+| Attended scan binding — "Approve every frame and scan" (`ErrorPresentation.canApproveEveryFrameAndScan`, `SessionModel.approveEveryFrameAndScan`, workspace error-card button) | 2026-08-13 (feed-detector round; issues #24/#16/#42) | **partial — wire and store parity, no error-card button** | `SessionStore.approveFrame(frameIndex, { attended })` and `SessionStore.approveEveryFrameAttended(frames)` exist and are tested, so the capability is reachable from the Tauri store. What is not ported is the SwiftUI *presentation* layer that turns a confidence refusal into a one-click recovery: the Tauri app has no `ErrorPresentationPolicy` equivalent classifying refusal text into copy plus affordances (`src/session/store/session.ts` handles only the `FILM_FEED_INTERRUPTED` legacy-compat classification). Adding the button means porting that policy layer first. |

--- a/ports/tauri/app/src/session/__tests__/policy-approval-binding.test.ts
+++ b/ports/tauri/app/src/session/__tests__/policy-approval-binding.test.ts
@@ -100,6 +100,71 @@ describe("SessionStore approval binding (scripted transport)", () => {
     expect(store.getState().approvedFrames[opId]).toContain(1);
   });
 
+  // Attended binding (feed-detector round; ScanStudio #24/#16/#42).
+
+  it("an ordinary approval never puts attended on the wire", async () => {
+    const { store, handle, calls } = scriptedStore();
+
+    await store.acquireThumbnails();
+    const opId = calls[0].params.operationId as string;
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 1, operationId: opId },
+    });
+
+    await store.approveFrame(1);
+    const approve = calls.find((call) => call.method === "roll.approve");
+    expect(approve?.params).toEqual({ frameIndex: 1, operationId: opId });
+    expect(approve?.params).not.toHaveProperty("attended");
+  });
+
+  it("an attended approval opts in explicitly on the wire", async () => {
+    const { store, handle, calls } = scriptedStore();
+
+    await store.acquireThumbnails();
+    const opId = calls[0].params.operationId as string;
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 1, operationId: opId },
+    });
+
+    await store.approveFrame(1, { attended: true });
+    expect(calls).toContainEqual({
+      method: "roll.approve",
+      params: { frameIndex: 1, operationId: opId, attended: true },
+    });
+    expect(store.getState().approvedFrames[opId]).toContain(1);
+  });
+
+  it("approveEveryFrameAttended approves the whole batch and refuses an empty one", async () => {
+    const { store, handle, calls } = scriptedStore();
+
+    await store.acquireThumbnails();
+    const opId = calls[0].params.operationId as string;
+    handle.emitEvent({
+      event: "scanner.thumbnailsComplete",
+      payload: { count: 1, operationId: opId },
+    });
+
+    await store.approveEveryFrameAttended([1, 2, 3]);
+    const approvals = calls.filter((call) => call.method === "roll.approve");
+    expect(approvals).toHaveLength(3);
+    for (const approval of approvals) {
+      expect(approval.params.attended).toBe(true);
+      expect(approval.params.operationId).toBe(opId);
+    }
+    expect(store.getState().approvedFrames[opId]).toEqual([1, 2, 3]);
+
+    let caught: unknown;
+    try {
+      await store.approveEveryFrameAttended([]);
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as EngineError).code).toBe("INVALID_PARAMS");
+    expect(calls.filter((call) => call.method === "roll.approve")).toHaveLength(3);
+  });
+
   it("starting a new preview clears a prior completed token immediately", async () => {
     const { store, handle, calls } = scriptedStore();
 

--- a/ports/tauri/app/src/session/store/session.ts
+++ b/ports/tauri/app/src/session/store/session.ts
@@ -1223,7 +1223,7 @@ export class SessionStore {
    * operationId, so a superseded token's approvals become unreachable
    * without an explicit clear).
    */
-  async approveFrame(frameIndex: number): Promise<void> {
+  async approveFrame(frameIndex: number, options?: { attended?: boolean }): Promise<void> {
     const operationId = this.#state.latestCompletedPreviewOperationId;
     if (operationId === null) {
       throw {
@@ -1232,13 +1232,42 @@ export class SessionStore {
         recoverable: false,
       } satisfies EngineError;
     }
-    await this.transport.sendRequest("roll.approve", { frameIndex, operationId });
+    // Attended binding (feed-detector round; ScanStudio #24/#16/#42).
+    // `attended` is omitted from the params entirely unless the caller opted
+    // in, so an ordinary approval stays byte-identical on the wire. It is
+    // the driver, not this store, that decides whether a roll may bind
+    // below "high"; an ineligible roll comes back INVALID_PARAMS.
+    const params: Record<string, unknown> = { frameIndex, operationId };
+    if (options?.attended === true) params.attended = true;
+    await this.transport.sendRequest("roll.approve", params);
     const approved = this.#state.approvedFrames[operationId] ?? [];
     if (!approved.includes(frameIndex)) {
       approved.push(frameIndex);
     }
     this.#state.approvedFrames = { ...this.#state.approvedFrames, [operationId]: approved };
     this.#notify();
+  }
+
+  /**
+   * Attended binding (feed-detector round; ScanStudio #24/#16/#42). Approves
+   * EVERY requested frame against the current completed preview as an
+   * operator-attended acceptance, so a roll whose lattice confidence is
+   * below what unattended scanning requires can still be scanned with a
+   * human watching. Anything less than every requested frame is refused by
+   * the driver, so this deliberately has no partial-subset form -- the same
+   * whole-batch shape the needsApproval gate above already enforces.
+   */
+  async approveEveryFrameAttended(frames: readonly number[]): Promise<void> {
+    if (frames.length === 0) {
+      throw {
+        code: "INVALID_PARAMS",
+        message: "attended approval requires at least one frame",
+        recoverable: false,
+      } satisfies EngineError;
+    }
+    for (const frameIndex of frames) {
+      await this.approveFrame(frameIndex, { attended: true });
+    }
   }
 
   /**

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/_roll.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/_roll.py
@@ -944,11 +944,22 @@ class Roll:
 
     # -- manual review / approval --------------------------------------
 
-    def approve(self, slot: int) -> ManualFrameApproval:
+    def approve(self, slot: int, *, attended: bool = False) -> ManualFrameApproval:
         """Approve ``slot`` and return its immutable, content-bound receipt.
 
         The returned receipt is the exact object retained for the subsequent
         batch. Raises ``ValueError`` if the slot doesn't need approval.
+
+        ``attended`` (feed-detector round, ScanStudio #24/#16/#42) marks this
+        as an ATTENDED acceptance rather than a per-slot manual review. Use
+        it only when :attr:`attended_binding_available` is true, and only for
+        EVERY slot about to be scanned: the scan-time gate binds a
+        medium-confidence roll exclusively when every requested frame carries
+        one of these. Approving some frames attended and others not, or
+        approving only the flagged ones, refuses at bind time exactly as an
+        unapproved roll does. ``ValueError`` if this session cannot mint an
+        attended receipt at all (see
+        :attr:`RollPreviewSession.attended_binding_available`).
         """
 
         with self._state_condition:
@@ -956,9 +967,29 @@ class Roll:
             session = self._require_session_locked()
             self._check_slot(session, slot)
             offset = session.slots[slot - 1].boundary_offset_rows
-            approval = session.approve_manual_origin(slot, offset)
+            approval = session.approve_manual_origin(
+                slot,
+                offset,
+                attended_roll_binding=attended,
+            )
             self._approvals[slot] = approval
             return approval
+
+    @property
+    def attended_binding_available(self) -> bool:
+        """Whether this roll can be rescued by approving every frame.
+
+        True only for an automatically detected roll the detector placed at
+        medium confidence -- the "previews fine but will not scan" case. The
+        application layer reads this to decide whether to offer an
+        approve-every-frame affordance; ``False`` means either nothing needs
+        rescuing ('high') or nothing can rescue it ('low', where the detector
+        never anchored a lattice to vouch for).
+        """
+
+        with self._state_condition:
+            session = self._require_session_locked()
+            return session.attended_binding_available
 
     def needs_approval(self, slot: int) -> bool:
         with self._state_condition:
@@ -1082,9 +1113,9 @@ class Roll:
         with self._state_condition:
             approvals = dict(self._approvals)
             for slot in ordered_slots:
+                approval = approvals.get(slot)
+                offset = session.slots[slot - 1].boundary_offset_rows
                 if session.slots[slot - 1].manual_review:
-                    approval = approvals.get(slot)
-                    offset = session.slots[slot - 1].boundary_offset_rows
                     if approval is None or not session.validate_manual_approval(
                         approval,
                         slot_id=slot,
@@ -1095,6 +1126,46 @@ class Roll:
                             f"call approve({slot}) before scanning it",
                             slot=slot,
                         )
+                elif approval is not None and not session.validate_manual_approval(
+                    approval,
+                    slot_id=slot,
+                    boundary_offset_rows=offset,
+                ):
+                    # An approval retained for a slot that does NOT require
+                    # manual review is an attended receipt (or a stale one
+                    # left by an offset nudge that did not clear it). Either
+                    # way it is about to be put on the wire, so it gets the
+                    # same "does this session still mint exactly this" check
+                    # a flagged slot's receipt has always had, rather than
+                    # travelling unvalidated to the worker.
+                    raise ManualReviewRequired(
+                        f"slot {slot} approval no longer matches this reviewed "
+                        f"preview; re-approve slot {slot} before scanning it",
+                        slot=slot,
+                    )
+            # Attended binding (feed-detector round): a medium-confidence
+            # automatic roll can only bind with EVERY requested frame
+            # approved. Refuse the partial case here, before any film moves,
+            # with an error that names what to do -- the pinned worker's
+            # gate would refuse it anyway, but only after a reservation, a
+            # traversal, and a ROLL_MISMATCH the field cannot act on.
+            if session.attended_binding_available:
+                unapproved = [
+                    slot
+                    for slot in ordered_slots
+                    if approvals.get(slot) is None
+                    or not approvals[slot].is_attended_roll_binding
+                ]
+                if unapproved:
+                    raise ManualReviewRequired(
+                        "roll boundary lattice confidence is "
+                        f"{session.detection.confidence!r}; scanning it requires "
+                        "an operator to approve every requested frame -- "
+                        f"{len(unapproved)} of {len(ordered_slots)} still "
+                        f"unapproved (first: slot {unapproved[0]}); call "
+                        "approve(slot, attended=True) on each",
+                        slot=unapproved[0],
+                    )
 
             if session.recipe.capture_route is not CaptureRoute.SINGLE_PASS_RGBI4:
                 raise NotImplementedError(_BLACK_AND_WHITE_NOT_WIRED)

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -33,8 +33,14 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     # additive manual_boundary_rows field plus its batch-job.json plumbing.
     # Resealed 2026-08-11: capture descendants remain in the bridge-owned
     # process group and inherit its exclusive process-ownership fence.
-    "capture_process.py": "a7a4eb4d09c6c6daf399e4a868375a291cf80f220f45a1c13bc36ebff37e1cc9",
-    "worker.py": "d826249919c94b67f76b6a36400374a090ef2c9b2c05138f51913e9576e67650",
+    # Resealed 2026-08-13 (attended scan binding, feed-detector round;
+    # ScanStudio #24/#16/#42): capture_process.py gained the
+    # ATTENDED_ROLL_BINDING_* pair and ManualFrameApproval.
+    # is_attended_roll_binding; worker.py gained the attended branch of the
+    # roll-confidence gate plus its journal marker. No wire resource, plan,
+    # or continuation template changed, so their pins are untouched.
+    "capture_process.py": "c4d234c02bcabf5d10c83b9ef9f071c591546c2447ca004610cc0e0c804a3944",
+    "worker.py": "08b9fdb46bc072923d46c1efc4d4a901fd943de542624bc536cd440c3fb6294b",
     "manual_frames.py": "f30f0003e081c3a98610d5700d7e6b6ee4d182b9d5228932f3304f1307d4815f",
     # Port-specific reseal 2026-08-11: Windows/WSL and Linux use the
     # intentionally extended host-libusb discovery implementation shipped in

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py
@@ -93,6 +93,38 @@ REVIEWED_ROLL_FINGERPRINT_VERSION = 2
 # is), so there is no backward-compatibility case to preserve here the way
 # F7 preserved one for session JSON.
 MANUAL_FRAME_APPROVAL_VERSION = 2
+
+# Attended scan binding (FEEDING-DETECTOR-ROUND, ScanStudio #24/#16/#42).
+# The one review reason that marks a ManualFrameApproval as an OPERATOR-
+# ATTENDED acceptance of an automatically detected roll, rather than the
+# per-slot "this specific frame was flagged and a human looked at it"
+# receipt every other reason denotes.
+#
+# It lives here, beside ManualFrameApproval itself, for the same reason
+# digest_manual_boundary_rows does: the receipt's producer
+# (roll.preview_session.RollPreviewSession.approve_manual_origin) and its
+# consumer (the pinned capture worker's confidence gate) must never
+# independently drift on the exact string, and the string is inside
+# binding_payload()/binding_sha256 -- so a receipt cannot gain or lose this
+# marker after signing without invalidating its own digest.
+#
+# What it does NOT do: it grants no confidence, no threshold change, and no
+# exemption from any other check. It is only the evidence the worker gate
+# reads to tell "a human explicitly accepted every requested frame of this
+# medium-confidence automatic roll" apart from "an unattended caller passed
+# an approval flag" -- which still refuses, unchanged.
+ATTENDED_ROLL_BINDING_REASON = "attended-roll-binding"
+
+# The only detector confidence the attended path may bind. 'low' is not a
+# "slightly worse medium": it is the detector saying it could not anchor the
+# lattice at all, so a human approving thumbnails proves nothing about where
+# the frames physically are. Attended binding is an operator vouching for a
+# geometry the detector DID find but could not fully corroborate -- there is
+# no such geometry to vouch for at 'low'. Kept here, beside the reason
+# string, so the receipt producer and the pinned worker gate read one
+# definition rather than two.
+ATTENDED_ROLL_BINDING_CONFIDENCE = "medium"
+
 MAX_VISUAL_MEDIAN_HAMMING = 24
 MAX_VISUAL_P90_HAMMING = 48
 MAX_SELECTED_VISUAL_HAMMING = 48
@@ -634,6 +666,20 @@ class ManualFrameApproval:
     review_reasons: tuple[str, ...]
     manual_boundary_rows_sha256: str
     schema_version: int = MANUAL_FRAME_APPROVAL_VERSION
+
+    @property
+    def is_attended_roll_binding(self) -> bool:
+        """Whether this receipt is an operator-attended roll acceptance.
+
+        Single source of truth for reading ATTENDED_ROLL_BINDING_REASON off a
+        receipt, so the producer, the facade's own re-validation, and the
+        pinned worker gate all ask the same question the same way. The reason
+        is part of ``binding_payload()`` and therefore of ``binding_sha256``:
+        it cannot be added to or removed from a signed receipt without
+        breaking the digest ``from_payload`` re-checks.
+        """
+
+        return ATTENDED_ROLL_BINDING_REASON in self.review_reasons
 
     @staticmethod
     def digest_manual_boundary_rows(rows: Sequence[int] | None) -> str:

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/worker.py
@@ -49,6 +49,7 @@ from .density import (
     density_source_geometry_for_startup_records,
 )
 from .capture_process import (
+    ATTENDED_ROLL_BINDING_CONFIDENCE,
     ManualFrameApproval,
     ReviewedRollFingerprint,
     RollFingerprintComparison,
@@ -402,6 +403,7 @@ class LiveFrameSelection:
     reviewed_leading_residual_rows: float | None = None
     origin_rebased: bool = False
     origin_rebase_info: OriginRebaseInfo | None = None
+    attended_roll_binding_accepted: bool = False
 
     def diagnostics(self) -> dict[str, Any]:
         return {
@@ -410,6 +412,21 @@ class LiveFrameSelection:
             "usable_rows": self.usable_rows,
             "preview_sha256": self.preview_sha256,
             "table_sha256": self.table_sha256,
+            # Which mode bound this frame. None (the overwhelmingly common
+            # case) means it bound on detector confidence alone -- the
+            # journal shape every existing evidence audit already reads is
+            # unchanged for those. A dict means the roll was below "high"
+            # and an operator's per-frame approvals are what carried it, so
+            # an audit can find every attended frame without re-running the
+            # detector.
+            "attended_roll_binding": (
+                None
+                if not self.attended_roll_binding_accepted
+                else {
+                    "origin": ATTENDED_ROLL_BINDING_ACCEPTED_ORIGIN,
+                    "detection_confidence": self.detection.confidence,
+                }
+            ),
             "leading_anchor_divergence_accepted": (
                 None
                 if not self.leading_anchor_divergence_accepted
@@ -1326,6 +1343,12 @@ def _derive_index_geometry(plan: list[dict]) -> IndexGeometry:
 
 LEADING_ANCHOR_DIVERGENCE_ACCEPTED_ORIGIN = "leading-anchor-divergence-accepted"
 ORIGIN_REBASED_OUTSIDE_AFFINE_ACCEPTED_ORIGIN = "origin-rebased-outside-affine"
+# Journal marker for an acceptance that bound through the attended path
+# rather than on detector confidence alone. Every acceptance this gate makes
+# is journaled with its own origin string so an evidence audit can tell,
+# from the artifact alone and without re-running the detector, WHICH mode
+# bound a given frame.
+ATTENDED_ROLL_BINDING_ACCEPTED_ORIGIN = "attended-roll-binding-accepted"
 
 
 @dataclass(frozen=True)
@@ -1385,13 +1408,16 @@ def _derive_live_frame_selection(
     reviewed_as_automatic: bool = False,
     reviewed_leading_residual_rows: float | None = None,
     manual_boundary_rows: tuple[int, ...] | None = None,
+    attended_roll_binding: bool = False,
 ) -> LiveFrameSelection:
     """Resolve one frame origin from same-traversal live data.
 
     Automatic (default, ``manual_boundary_rows`` omitted): resolves via
     ``detect_roll_frames``/``derive_transport_mapping`` exactly as this
-    function has always worked. See the gate comment below for the one new
-    path manual placement adds to this function's confidence gate.
+    function has always worked. See the gate comment below for the two
+    paths that may bind an automatic or manually placed detection below
+    "high": manual placement, and (``attended_roll_binding``) an operator
+    who explicitly approved every frame of a medium-confidence roll.
 
     Manual (Rung 4, FEEDING-UX-LADDER-OVERNIGHT-20260807.md):
     ``manual_boundary_rows`` is never trusted as a serialized detection
@@ -1480,12 +1506,73 @@ def _derive_live_frame_selection(
     # every one of these frames independently. This gate only decides
     # whether the ROLL-level confidence check may be attempted at all; it
     # grants no exemption from any other check in this function.
+    #
+    # ------------------------------------------------------------------
+    # ATTENDED BINDING (feed-detector round; ScanStudio #24/#16/#42 --
+    # "previews fine but will not scan"). The SECOND, and only other, path
+    # this gate has ever granted below "high".
+    #
+    # The field shape: a roll the detector places at "medium" -- it found a
+    # lattice, corroborated it well enough to render every thumbnail the
+    # operator then visually checked, but not well enough to bind film
+    # geometry with nobody watching. Preview accepts it; scanning refuses
+    # it; the operator is standing right there looking at correct frames.
+    #
+    # What unlocks it is not a lower threshold -- no accept window, no
+    # lattice/evidence/direct-fraction bound in roll_index.py moves by this
+    # change, and "medium" is still exactly as hard to earn as it was. What
+    # unlocks it is EVIDENCE OF ATTENDANCE: a ManualFrameApproval receipt
+    # for EVERY frame this batch requested, each one carrying
+    # ATTENDED_ROLL_BINDING_REASON, which RollPreviewSession.
+    # approve_manual_origin only ever mints when an operator explicitly
+    # approves that slot against this session's own reviewed thumbnail.
+    # ``attended_roll_binding`` is that derived all-frames-approved verdict
+    # (see _derive_live_batch_selections, which is the only production
+    # caller that can ever pass it true).
+    #
+    # Why a caller cannot forge it, in the same terms as the manual gate
+    # above:
+    #   * The reason string lives inside ManualFrameApproval.
+    #     binding_payload(), hence inside binding_sha256, which
+    #     from_payload re-derives and compares -- a receipt cannot be
+    #     hand-edited to gain the marker.
+    #   * load_validated_batch_job already refuses any receipt whose
+    #     reviewed_fingerprint_sha256 is not THIS job's reviewed
+    #     fingerprint, and whose manual_boundary_rows_sha256 is not this
+    #     job's placement digest. So every receipt admitted here was signed
+    #     against the CURRENT preview operation's own evidence, not a
+    #     previous roll's, and not a different placement of this one.
+    #   * The whole-roll and per-slot visual fingerprint comparisons below
+    #     independently prove the bytes about to be bound are still the
+    #     bytes that were reviewed.
+    #   * ``all()`` over the batch's frames means a partially approved
+    #     batch is not attended. One unapproved requested frame refuses the
+    #     whole batch, because "the operator checked the ones that were
+    #     flagged" is not the claim this path binds on -- "the operator
+    #     accepted every frame about to be scanned" is.
+    #
+    # Deliberately NOT widened:
+    #   * 'low' still refuses with or without any number of approvals
+    #     (ATTENDED_ROLL_BINDING_CONFIDENCE; see its comment).
+    #   * UNATTENDED 'medium' still refuses byte-for-byte as before -- the
+    #     wide-gap-recovery/automatic caller that passes
+    #     manual_review_approved=True and nothing else takes the identical
+    #     raise with the identical message.
+    #   * Binding here grants no exemption from anything else in this
+    #     function or in apply_batch_boundary_offsets. It decides only
+    #     whether the ROLL-level confidence check may be passed at all.
     manual_placement = (
         manual_boundary_rows is not None
         and MANUAL_PLACEMENT_WARNING in detection.warnings
     )
+    attended_roll_binding_accepted = (
+        attended_roll_binding
+        and not manual_placement
+        and detection.confidence == ATTENDED_ROLL_BINDING_CONFIDENCE
+    )
     if detection.confidence != "high" and not (
-        manual_placement and manual_review_approved
+        (manual_placement and manual_review_approved)
+        or attended_roll_binding_accepted
     ):
         raise ProtocolError(
             f"roll boundary lattice confidence is {detection.confidence!r}; "
@@ -1622,6 +1709,7 @@ def _derive_live_frame_selection(
             if leading_anchor_divergence_accepted
             else None
         ),
+        attended_roll_binding_accepted=attended_roll_binding_accepted,
         origin_rebased=origin_rebase_info is not None,
         origin_rebase_info=origin_rebase_info,
         reviewed_fingerprint_sha256=(
@@ -1656,6 +1744,13 @@ def _derive_live_batch_selections(
     ``automatic=False, manual_review=True``, so every frame in a manual
     batch already has to appear in ``approved_manual_slots`` or that
     pre-existing, unmodified check refuses it).
+
+    Attended binding (feed-detector round, ScanStudio #24/#16/#42): this
+    function is also where the attended verdict is DERIVED -- see the
+    ``attended_roll_binding`` assignment below and the gate comment in
+    ``_derive_live_frame_selection``. It is deliberately not a parameter:
+    attendance is proven only by the per-frame receipts this batch already
+    carries, so there is nothing for a caller to assert.
     """
 
     if not frames:
@@ -1673,6 +1768,19 @@ def _derive_live_batch_selections(
     reviewed_automatic_slots = frozenset(
         spec.slot for spec in frames if spec.manual_review_approval is None
     )
+    # Attended binding (feed-detector round): the all-frames-approved verdict
+    # _derive_live_frame_selection's gate consumes. Derived here, from the
+    # receipts load_validated_batch_job already authenticated against THIS
+    # job's reviewed fingerprint and placement digest -- never taken as a
+    # bare boolean off the job JSON, so there is no wire field a caller could
+    # set to claim attendance it does not have. ``all()`` over every
+    # requested frame is the whole claim: one unapproved frame in the batch
+    # and this is False, and the gate refuses exactly as it does today.
+    attended_roll_binding = all(
+        spec.manual_review_approval is not None
+        and spec.manual_review_approval.is_attended_roll_binding
+        for spec in frames
+    )
     # A zero-offset selection performs the expensive same-traversal decode and
     # gives us the unmodified detector mapping.  All requested offsets are then
     # applied together to that mapping before SEND(0x8f) can execute.
@@ -1687,6 +1795,7 @@ def _derive_live_batch_selections(
         manual_review_approved=frames[0].manual_review_approval is not None,
         reviewed_as_automatic=frames[0].slot in reviewed_automatic_slots,
         manual_boundary_rows=manual_boundary_rows,
+        attended_roll_binding=attended_roll_binding,
     )
     if context.fresh_fingerprint is None:
         raise ProtocolError("fresh batch roll fingerprint was not retained")
@@ -1729,6 +1838,15 @@ def _derive_live_batch_selections(
     manual_placement = (
         manual_boundary_rows is not None
         and MANUAL_PLACEMENT_WARNING in context.detection.warnings
+    )
+    # The same verdict _derive_live_frame_selection's gate reached for this
+    # batch's one context call, recomputed for the per-frame journal
+    # annotation below. `attended_roll_binding` first: an unattended batch
+    # short-circuits before touching `detection`.
+    attended_roll_binding_accepted = (
+        attended_roll_binding
+        and not manual_placement
+        and context.detection.confidence == ATTENDED_ROLL_BINDING_CONFIDENCE
     )
     # S6 hardening (FEEDING-UX-LADDER-OVERNIGHT-20260807.md F1 rework):
     # load_validated_batch_job already checked each approval's own
@@ -1856,6 +1974,17 @@ def _derive_live_batch_selections(
                 and spec.slot in reviewed_automatic_slots
                 and _is_narrowly_divergent_leading_anchor(base)
             ),
+            # Placement-wide, exactly like manual_boundary_rows: the single
+            # context call above is what actually passed (or failed) the
+            # roll-level confidence gate for this whole batch, so every
+            # frame in it is journaled with the same verdict. Recomputed
+            # here rather than read back off `context`, for the same reason
+            # leading_anchor_divergence_accepted just above is: this is the
+            # journal annotation, and the authoritative decision already
+            # happened inside the gate. Conjunction order matters -- the
+            # cheap, always-available flag first, so a batch that is not
+            # attended never dereferences `detection` at all.
+            attended_roll_binding_accepted=attended_roll_binding_accepted,
             origin_rebased=origin_rebase_info is not None,
             origin_rebase_info=origin_rebase_info,
             reviewed_fingerprint_sha256=context.reviewed_fingerprint_sha256,

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/roll/preview_session.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/roll/preview_session.py
@@ -20,6 +20,8 @@ import numpy as np
 
 from coolscanpy.exceptions import MeterUnusableError
 from coolscanpy.protocol.ls5000_single_pass.capture_process import (
+    ATTENDED_ROLL_BINDING_CONFIDENCE,
+    ATTENDED_ROLL_BINDING_REASON,
     AttemptPaths,
     CaptureAttemptResult,
     CaptureMode,
@@ -355,15 +357,65 @@ class RollPreviewSession:
             return None
         return tuple(boundary.output_row for boundary in self.detection.boundaries)
 
+    @property
+    def attended_binding_available(self) -> bool:
+        """Whether this session may be scanned through the attended path.
+
+        True exactly when the scan-time roll gate would refuse this session
+        unattended but an operator CAN rescue it by approving every frame:
+        an automatically detected roll the detector placed at
+        ATTENDED_ROLL_BINDING_CONFIDENCE. False for a 'high' session (which
+        needs no rescue), for 'low' (which no amount of approval rescues --
+        the detector never found a lattice to vouch for), and for a manual
+        placement (which already has its own binding path).
+
+        The application layer reads this to decide whether to offer the
+        "approve every frame and scan" affordance at all; it is advisory
+        UI state, and the authoritative refusal is still the pinned
+        worker's own gate.
+        """
+
+        return (
+            self.detection.confidence == ATTENDED_ROLL_BINDING_CONFIDENCE
+            and self.manual_boundary_rows is None
+        )
+
     def approve_manual_origin(
         self,
         slot_id: int,
         boundary_offset_rows: int = 0,
+        *,
+        attended_roll_binding: bool = False,
     ) -> ManualFrameApproval:
-        """Create an immutable receipt for one visually reviewed slot."""
+        """Create an immutable receipt for one visually reviewed slot.
+
+        ``attended_roll_binding`` (feed-detector round, ScanStudio
+        #24/#16/#42) is the opt-in that turns this into an ATTENDED
+        acceptance: the operator is not confirming a slot the detector
+        flagged, they are vouching for one frame of a medium-confidence
+        automatic roll so the whole roll can be scanned with them watching.
+        It is refused unless :attr:`attended_binding_available` -- a 'high'
+        session has nothing to rescue, a 'low' one has no geometry worth
+        vouching for, and a manual placement binds through its own path --
+        and, when granted, records ATTENDED_ROLL_BINDING_REASON inside the
+        receipt's signed payload. The pinned capture worker reads exactly
+        that marker, on every requested frame, before it will bind a roll
+        below "high".
+
+        Default (False) behavior is unchanged in every respect: the slot
+        must itself carry manual_review, and the receipt never gains the
+        attended marker.
+        """
 
         slot = self._slot(slot_id)
-        if not slot.manual_review:
+        if attended_roll_binding and not self.attended_binding_available:
+            raise ValueError(
+                "attended roll binding requires an automatically detected "
+                f"{ATTENDED_ROLL_BINDING_CONFIDENCE}-confidence roll; this "
+                f"session is {self.detection.confidence!r}"
+                + ("" if self.manual_boundary_rows is None else " and manually placed")
+            )
+        if not slot.manual_review and not attended_roll_binding:
             raise ValueError(f"slot {slot_id} does not require manual review")
         thumbnail = reload_thumbnail(
             self.preview,
@@ -378,6 +430,13 @@ class RollPreviewSession:
         reasons = tuple(
             dict.fromkeys((*slot.warnings, *slot.base_origin.review_reasons))
         )
+        if attended_roll_binding:
+            # Appended, never substituted: an attended acceptance of a slot
+            # that ALSO carries its own review reasons keeps every one of
+            # them, so the worker's per-slot fresh-origin cross-check
+            # (review_reasons must be a superset of the freshly resolved
+            # origin's) still has the real reasons to compare against.
+            reasons = tuple(dict.fromkeys((*reasons, ATTENDED_ROLL_BINDING_REASON)))
         if not reasons:
             reasons = ("transport-origin-manual-review",)
         return ManualFrameApproval(
@@ -403,14 +462,28 @@ class RollPreviewSession:
         slot_id: int,
         boundary_offset_rows: int,
     ) -> bool:
-        """Return whether an approval exactly matches this reviewed thumbnail."""
+        """Return whether an approval exactly matches this reviewed thumbnail.
+
+        The attended flag is read off the receipt rather than taken as a
+        parameter, so this stays a pure "would this exact session mint this
+        exact receipt again" comparison for both kinds. A receipt claiming
+        the attended marker against a session that cannot mint one (any
+        confidence but ATTENDED_ROLL_BINDING_CONFIDENCE, or a manual
+        placement) makes approve_manual_origin raise, which is a failed
+        validation, not an accepted one -- hence the ValueError catch.
+        """
 
         if not isinstance(approval, ManualFrameApproval):
             return False
-        return approval == self.approve_manual_origin(
-            slot_id,
-            boundary_offset_rows,
-        )
+        try:
+            expected = self.approve_manual_origin(
+                slot_id,
+                boundary_offset_rows,
+                attended_roll_binding=approval.is_attended_roll_binding,
+            )
+        except ValueError:
+            return False
+        return approval == expected
 
     def with_material(self, material: ScanMaterial) -> RollPreviewSession:
         """Return this preview with the material's explicit capture recipe."""

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_worker.py
@@ -17,6 +17,7 @@ import pytest
 from coolscanpy.protocol.ls5000_single_pass import worker as worker_module
 from coolscanpy.protocol.ls5000_single_pass import manual_frames
 from coolscanpy.protocol.ls5000_single_pass.capture_process import (
+    ATTENDED_ROLL_BINDING_REASON,
     AttemptPaths,
     CaptureAttemptResult,
     CaptureMode,
@@ -3405,6 +3406,285 @@ def test_non_manual_medium_detection_still_refuses_even_with_approval_flags(
             manual_review_approved=True,
             # manual_boundary_rows intentionally omitted: the automatic path.
         )
+
+
+# ---------------------------------------------------------------------------
+# Attended binding (feed-detector round; ScanStudio #24/#16/#42). These tests
+# attack the SECOND path _derive_live_frame_selection's gate grants below
+# "high": an operator who explicitly approved every requested frame of an
+# automatically detected medium-confidence roll. The manual-placement tests
+# above, and test_non_manual_medium_detection_still_refuses_even_with_
+# approval_flags in particular, are the untouched regression proving the old
+# behavior is byte-for-byte intact.
+# ---------------------------------------------------------------------------
+
+
+def _attended_gate_mapping() -> TransportMapping:
+    """An ORDINARY automatic origin: nothing here is flagged for review."""
+
+    origin = NativeFrameOrigin(
+        frame=1,
+        boundary_index=0,
+        boundary_output_row=10,
+        lookup_row=10,
+        code=6 * (10 % 18),
+        selector=10 // 18,
+        native_origin=420,
+        method="affine-transport-fit",
+        automatic=True,
+        manual_review=False,
+        review_reasons=(),
+        affine_residual_rows=0.0,
+    )
+    return TransportMapping(
+        record_count=500,
+        native_intercept=0.0,
+        native_units_per_preview_row=42.0,
+        anchor_mae_rows=0.0,
+        anchor_max_error_rows=0.0,
+        origins=(origin,),
+    )
+
+
+def _wire_attended_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    confidence: str,
+) -> None:
+    """Wire the AUTOMATIC detector path at a chosen roll confidence."""
+
+    rgb = np.zeros((500, 96, 3), dtype=np.uint16)
+    _wire_manual_gate_common(monkeypatch, rgb)
+    # A geometry rich enough for LiveFrameSelection.diagnostics(), so these
+    # tests can assert the JOURNAL the gate produces, not just its verdict.
+    monkeypatch.setattr(
+        worker_module,
+        "_derive_index_geometry",
+        lambda _plan: SimpleNamespace(
+            height=500,
+            pitch=41,
+            native_height=250_278,
+            requested_resolution=97,
+            native_resolution=4000,
+            native_width=4000,
+            width=96,
+            expected_stream_bytes=500 * 96 * 6,
+        ),
+    )
+    detection = _manual_gate_detection(confidence=confidence, user_picked=False)
+    detection.diagnostics = lambda: {"confidence": confidence}
+    mapping = _attended_gate_mapping()
+    monkeypatch.setattr(worker_module, "detect_roll_frames", lambda *_a, **_k: detection)
+    monkeypatch.setattr(
+        worker_module, "scanner_addressable_interval_count", lambda *_a, **_k: 1
+    )
+    monkeypatch.setattr(
+        worker_module, "derive_transport_mapping", lambda *_a, **_k: mapping
+    )
+
+
+def test_attended_medium_detection_binds_and_marks_the_journal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The field case: automatic roll, medium confidence, operator approved
+    every frame. It binds, and the journal says WHICH mode bound it."""
+
+    _wire_attended_gate(monkeypatch, confidence="medium")
+
+    selection = worker_module._derive_live_frame_selection(
+        [],
+        b"fresh-preview",
+        b"fresh-table",
+        frame=1,
+        attended_roll_binding=True,
+    )
+
+    assert selection.detection.confidence == "medium"
+    assert selection.selected.native_origin == 420
+    assert selection.attended_roll_binding_accepted is True
+    marker = selection.diagnostics()["attended_roll_binding"]
+    assert marker == {
+        "origin": worker_module.ATTENDED_ROLL_BINDING_ACCEPTED_ORIGIN,
+        "detection_confidence": "medium",
+    }
+
+
+def test_high_confidence_binding_is_never_marked_attended(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 'high' roll binds on confidence alone and must not be journaled as
+    an attended acceptance, even if every frame happens to be approved --
+    otherwise an evidence audit could not tell the two apart."""
+
+    _wire_attended_gate(monkeypatch, confidence="high")
+
+    selection = worker_module._derive_live_frame_selection(
+        [],
+        b"fresh-preview",
+        b"fresh-table",
+        frame=1,
+        attended_roll_binding=True,
+    )
+
+    assert selection.attended_roll_binding_accepted is False
+    assert selection.diagnostics()["attended_roll_binding"] is None
+
+
+def test_attended_low_confidence_detection_always_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """'low' is not rescuable by attendance. The detector never anchored a
+    lattice, so there is no geometry for an operator to vouch for."""
+
+    _wire_attended_gate(monkeypatch, confidence="low")
+
+    with pytest.raises(
+        ProtocolError, match="unattended frame binding requires 'high'"
+    ):
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            attended_roll_binding=True,
+        )
+
+
+def test_unattended_medium_detection_refuses_with_the_identical_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The refusal a field user sees today must be byte-for-byte unchanged
+    when nobody is attending -- same text, same quoting, same confidence."""
+
+    _wire_attended_gate(monkeypatch, confidence="medium")
+
+    with pytest.raises(ProtocolError) as excinfo:
+        worker_module._derive_live_frame_selection(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frame=1,
+            attended_roll_binding=False,
+        )
+
+    assert str(excinfo.value) == (
+        "roll boundary lattice confidence is 'medium'; "
+        "unattended frame binding requires 'high'"
+    )
+
+
+def _attended_receipt(slot: int, *, attended: bool) -> ManualFrameApproval:
+    reasons: tuple[str, ...] = ("transport-origin-manual-review",)
+    if attended:
+        reasons = (*reasons, ATTENDED_ROLL_BINDING_REASON)
+    return ManualFrameApproval(
+        reviewed_fingerprint_sha256="a" * 64,
+        slot=slot,
+        boundary_offset_rows=0,
+        thumbnail_sha256="b" * 64,
+        reviewed_lookup_row=10,
+        reviewed_native_origin=420,
+        review_reasons=reasons,
+        manual_boundary_rows_sha256=(
+            ManualFrameApproval.digest_manual_boundary_rows(None)
+        ),
+    )
+
+
+def _capture_attended_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    frames: tuple[worker_module.BatchFrameSpec, ...],
+) -> bool:
+    """Run _derive_live_batch_selections far enough to observe the attended
+    verdict it derives, without needing a full live traversal."""
+
+    captured: dict[str, object] = {}
+
+    def fake_selection(*_args: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        raise ProtocolError("stop-after-derivation")
+
+    monkeypatch.setattr(
+        worker_module, "_derive_live_frame_selection", fake_selection
+    )
+    reviewed = _reviewed_fingerprint_with_count(6)
+    with pytest.raises(ProtocolError, match="stop-after-derivation"):
+        worker_module._derive_live_batch_selections(
+            [],
+            b"fresh-preview",
+            b"fresh-table",
+            frames,
+            reviewed_fingerprint=reviewed,
+        )
+    verdict = captured["attended_roll_binding"]
+    assert isinstance(verdict, bool)
+    return verdict
+
+
+def _attended_batch(
+    tmp_path: Path, root_name: str, marks: dict[int, bool | None]
+) -> tuple[worker_module.BatchFrameSpec, ...]:
+    frame_root = tmp_path / root_name
+    return tuple(
+        worker_module.BatchFrameSpec(
+            slot=slot,
+            boundary_offset_rows=0,
+            manual_review_approval=(
+                None if attended is None else _attended_receipt(slot, attended=attended)
+            ),
+            output=frame_root / f"frame-{slot:03d}" / "capture.bin",
+            journal=frame_root / f"frame-{slot:03d}" / "journal.json",
+            ack=frame_root / f"frame-{slot:03d}" / "parent-ack.json",
+        )
+        for slot, attended in sorted(marks.items())
+    )
+
+
+def test_batch_derives_attended_only_when_every_frame_is_attended_approved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Attendance is all-or-nothing across the requested batch."""
+
+    assert (
+        _capture_attended_flag(
+            monkeypatch, _attended_batch(tmp_path, "all", {1: True, 2: True, 3: True})
+        )
+        is True
+    )
+
+
+def test_batch_partial_attended_approval_is_not_attended(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One requested frame the operator did not approve refuses the batch --
+    'they checked the flagged ones' is not the claim this path binds on."""
+
+    assert (
+        _capture_attended_flag(
+            monkeypatch,
+            _attended_batch(tmp_path, "partial", {1: True, 2: None, 3: True}),
+        )
+        is False
+    )
+
+
+def test_batch_ordinary_manual_review_receipts_are_not_attended(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A batch where every frame carries an ORDINARY manual-review receipt
+    is still not attended: the pre-existing per-slot approval flow cannot
+    silently become a roll-level confidence bypass."""
+
+    assert (
+        _capture_attended_flag(
+            monkeypatch,
+            _attended_batch(tmp_path, "ordinary", {1: False, 2: False}),
+        )
+        is False
+    )
 
 
 def test_manual_selection_still_refuses_on_fingerprint_mismatch(

--- a/ports/tauri/vendor/coolscanpy/tests/roll/test_ls5000_roll_session.py
+++ b/ports/tauri/vendor/coolscanpy/tests/roll/test_ls5000_roll_session.py
@@ -14,6 +14,7 @@ import pytest
 from coolscanpy.protocol.ls5000_single_pass import roll_index
 from coolscanpy.roll import preview_session as preview_session_module
 from coolscanpy.protocol.ls5000_single_pass.capture_process import (
+    ATTENDED_ROLL_BINDING_REASON,
     AttemptPaths,
     CaptureAttemptResult,
     CaptureMode,
@@ -29,6 +30,7 @@ from coolscanpy.roll.preview_session import (
     PARTIAL_FRAME_MIN_COVERAGE,
     ArtifactIdentity,
     CaptureRoute,
+    RollPreviewSession,
     RollSessionIntegrityError,
     ValidatedRollPreview,
     _crop_coverage,
@@ -1152,6 +1154,132 @@ def test_manual_origin_approval_is_bound_to_exact_reviewed_thumbnail_and_roll(
 
     with pytest.raises(ValueError, match="does not require manual review"):
         session.approve_manual_origin(2, 0)
+
+
+# ---------------------------------------------------------------------------
+# Attended binding (feed-detector round; ScanStudio #24/#16/#42) -- the
+# receipt-minting side of the worker's attended gate.
+# ---------------------------------------------------------------------------
+
+
+def _medium_confidence_session(tmp_path: Path) -> RollPreviewSession:
+    """The field shape: an automatically detected roll at medium confidence."""
+
+    session = build_roll_preview_session(
+        _preview_fixture(tmp_path, content_frames=36).result,
+        expected_frame_count=36,
+    )
+    return replace(
+        session,
+        detection=replace(session.detection, confidence="medium"),
+    )
+
+
+def test_medium_confidence_automatic_roll_offers_attended_binding(
+    tmp_path: Path,
+) -> None:
+    session = _medium_confidence_session(tmp_path)
+
+    assert session.detection.confidence == "medium"
+    assert session.manual_boundary_rows is None
+    assert session.attended_binding_available is True
+
+
+def test_attended_approval_marks_an_otherwise_unflagged_slot(
+    tmp_path: Path,
+) -> None:
+    """Slot 2 needs no manual review, so today it cannot be approved at all.
+    Attended acceptance is what lets an operator vouch for it."""
+
+    session = _medium_confidence_session(tmp_path)
+    assert session.slots[1].manual_review is False
+
+    with pytest.raises(ValueError, match="does not require manual review"):
+        session.approve_manual_origin(2, 0)
+
+    approval = session.approve_manual_origin(2, 0, attended_roll_binding=True)
+
+    assert approval.is_attended_roll_binding is True
+    assert ATTENDED_ROLL_BINDING_REASON in approval.review_reasons
+    assert approval.slot == 2
+    assert (
+        approval.reviewed_fingerprint_sha256
+        == session.reviewed_fingerprint().binding_sha256
+    )
+    assert session.validate_manual_approval(
+        approval, slot_id=2, boundary_offset_rows=0
+    )
+
+
+def test_attended_approval_keeps_a_flagged_slots_own_review_reasons(
+    tmp_path: Path,
+) -> None:
+    """Appending the marker must not erase why the slot was flagged -- the
+    worker cross-checks a receipt's reasons against the fresh origin's."""
+
+    session = _medium_confidence_session(tmp_path)
+    assert session.slots[36].manual_review is True
+
+    ordinary = session.approve_manual_origin(37, 0)
+    attended = session.approve_manual_origin(37, 0, attended_roll_binding=True)
+
+    assert set(ordinary.review_reasons) < set(attended.review_reasons)
+    assert attended.review_reasons[-1] == ATTENDED_ROLL_BINDING_REASON
+    assert ordinary.is_attended_roll_binding is False
+
+
+def test_high_confidence_session_refuses_to_mint_attended_receipts(
+    tmp_path: Path,
+) -> None:
+    """Nothing to rescue: a 'high' roll binds unattended already."""
+
+    session = build_roll_preview_session(
+        _preview_fixture(tmp_path, content_frames=36).result,
+        expected_frame_count=36,
+    )
+    session = replace(
+        session, detection=replace(session.detection, confidence="high")
+    )
+
+    assert session.attended_binding_available is False
+    with pytest.raises(ValueError, match="attended roll binding requires"):
+        session.approve_manual_origin(2, 0, attended_roll_binding=True)
+
+
+def test_low_confidence_session_refuses_to_mint_attended_receipts(
+    tmp_path: Path,
+) -> None:
+    """Nothing to vouch for: the detector never anchored a lattice."""
+
+    session = build_roll_preview_session(
+        _preview_fixture(tmp_path, content_frames=36).result,
+        expected_frame_count=36,
+    )
+    session = replace(
+        session, detection=replace(session.detection, confidence="low")
+    )
+
+    assert session.attended_binding_available is False
+    with pytest.raises(ValueError, match="attended roll binding requires"):
+        session.approve_manual_origin(37, 0, attended_roll_binding=True)
+
+
+def test_attended_receipt_fails_validation_against_a_high_confidence_session(
+    tmp_path: Path,
+) -> None:
+    """A receipt carrying the attended marker cannot be replayed against a
+    session that could never have minted one."""
+
+    medium = _medium_confidence_session(tmp_path)
+    approval = medium.approve_manual_origin(2, 0, attended_roll_binding=True)
+    high = replace(
+        medium, detection=replace(medium.detection, confidence="high")
+    )
+
+    assert (
+        high.validate_manual_approval(approval, slot_id=2, boundary_offset_rows=0)
+        is False
+    )
 
 
 def test_boundary_only_review_with_automatic_origin_can_be_approved(

--- a/ports/tauri/vendor/coolscanpy/tests/test_facade.py
+++ b/ports/tauri/vendor/coolscanpy/tests/test_facade.py
@@ -2840,6 +2840,61 @@ class TestRollPreview:
             roll.close()
             dev.close()
 
+    def test_medium_confidence_roll_refuses_until_every_frame_is_attended(
+        self, fake_service_factory, tmp_path: Path
+    ) -> None:
+        """Attended binding, facade level (ScanStudio #24/#16/#42): the
+        'previews fine but will not scan' roll refuses BEFORE any film moves,
+        with an error naming what the operator has to do -- and stops
+        refusing once every requested frame carries an attended approval."""
+
+        from dataclasses import replace as _replace
+
+        dev = _open_device(fake_service_factory)
+        roll, _worker = _make_roll(tmp_path, dev, batch_spawner=_success_spawner([]))
+        try:
+            roll.preview()
+            # Force the field shape: an automatically detected roll the
+            # detector placed at medium confidence.
+            roll._session = _replace(
+                roll._session,
+                detection=_replace(roll._session.detection, confidence="medium"),
+            )
+            assert roll.attended_binding_available is True
+
+            requested = [1, 2]
+            # A slot the detector itself flagged keeps its own, more precise
+            # pre-existing refusal -- attendance does not replace it.
+            for slot in requested:
+                if roll.needs_approval(slot):
+                    with pytest.raises(coolscanpy.ManualReviewRequired) as excinfo:
+                        next(iter(roll.scan_many(requested)))
+                    assert "requires visual review" in str(excinfo.value)
+                    roll.approve(slot)
+
+            # Every flagged slot is now approved, yet the roll still refuses:
+            # attendance is a claim about EVERY requested frame.
+            with pytest.raises(coolscanpy.ManualReviewRequired) as excinfo:
+                next(iter(roll.scan_many(requested)))
+            assert "approve every requested frame" in str(excinfo.value)
+            assert excinfo.value.slot in requested
+
+            # Approving only part of the batch is still not attendance.
+            roll.approve(requested[0], attended=True)
+            with pytest.raises(coolscanpy.ManualReviewRequired) as excinfo:
+                next(iter(roll.scan_many(requested)))
+            assert excinfo.value.slot == requested[1]
+
+            roll.approve(requested[1], attended=True)
+            approvals = roll._approvals
+            assert set(requested) <= set(approvals)
+            assert all(
+                approvals[slot].is_attended_roll_binding for slot in requested
+            )
+        finally:
+            roll.close()
+            dev.close()
+
     def test_approve_returns_the_exact_content_bound_receipt_retained_for_batch(
         self, fake_service_factory, tmp_path: Path
     ) -> None:

--- a/ports/tauri/vendor/engine/src/bridge_protocol.rs
+++ b/ports/tauri/vendor/engine/src/bridge_protocol.rs
@@ -602,6 +602,12 @@ pub struct BridgeRollApproveParams {
     /// roll's current fingerprint (BRIDGE.md `roll.approve`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fingerprint: Option<String>,
+    /// Attended binding (feed-detector round; ScanStudio #24/#16/#42).
+    /// Omitted from the wire entirely when false (`skip_serializing_if`),
+    /// so a bridge or bridge test double that predates this field sees
+    /// byte-identical params to before it existed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub attended: bool,
 }
 
 // ---------------------------------------------------------------------

--- a/ports/tauri/vendor/engine/src/protocol.rs
+++ b/ports/tauri/vendor/engine/src/protocol.rs
@@ -301,6 +301,21 @@ pub struct RollApproveParams {
     /// review warning the user is acknowledging. Unlike preview's optional
     /// token, approval has no safe legacy fallback.
     pub operation_id: String,
+    /// Attended binding (feed-detector round; ScanStudio #24/#16/#42).
+    /// `false` (the default, and every pre-existing client) is unchanged
+    /// behavior: only a frame the completed preview flagged
+    /// `needsApproval` may be approved. `true` means the operator is
+    /// accepting a frame of a roll whose lattice confidence is too low to
+    /// bind unattended, so the frame need not be individually flagged --
+    /// but every frame of the batch must then be approved this way, and
+    /// the driver still refuses any roll shape other than an automatically
+    /// detected medium-confidence one.
+    ///
+    /// Omitted from the wire entirely when false (`skip_serializing_if`),
+    /// so a client that predates this field, and every request that does
+    /// not opt in, produces byte-identical params to before it existed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub attended: bool,
 }
 
 /// `roll.approve` intentionally returns no payload. Approval is a
@@ -880,6 +895,7 @@ mod tests {
         let params = RollApproveParams {
             frame_index: 7,
             operation_id: "completed-preview-7".to_string(),
+            attended: false,
         };
         assert_eq!(
             serde_json::to_value(&params).unwrap(),

--- a/ports/tauri/vendor/engine/src/real_backend.rs
+++ b/ports/tauri/vendor/engine/src/real_backend.rs
@@ -3379,7 +3379,12 @@ impl RealLs5000 {
     /// scanner-addressable `slot`. This is intentionally a single
     /// session-scoped request: it never starts a preview, moves film, starts
     /// capture, or follows up with `device.status`.
-    pub fn roll_approve(&self, frame_index: u32, operation_id: &str) -> Result<(), EngineError> {
+    pub fn roll_approve(
+        &self,
+        frame_index: u32,
+        operation_id: &str,
+        attended: bool,
+    ) -> Result<(), EngineError> {
         if operation_id.trim().is_empty() {
             return Err(EngineError::new(
                 ErrorCode::InvalidParams,
@@ -3409,10 +3414,29 @@ impl RealLs5000 {
         // one the completed preview never returned at all, or one that was
         // never flagged for review in the first place. `binding` is `Some`
         // here (proven by the check immediately above).
+        //
+        // Attended binding (feed-detector round; ScanStudio #24/#16/#42)
+        // relaxes the SECOND half of that check only. The frame must still
+        // be one this exact completed preview actually returned -- an index
+        // the preview never produced is refused either way, which is the
+        // part of S3 that matters. What attended acceptance drops is the
+        // requirement that the DETECTOR flagged it: on a roll whose lattice
+        // confidence is too low to bind unattended, the frames an operator
+        // has to vouch for are precisely the ones nothing flagged. The
+        // driver remains the authority on whether this roll is eligible at
+        // all (it refuses `attended` on any roll that is not an
+        // automatically detected medium-confidence one), so relaxing it
+        // here cannot create a binding the driver would not make.
         let thumbnail = binding
             .as_ref()
             .and_then(|binding| binding.thumbnails.get(&frame_index));
-        if !thumbnail.is_some_and(|thumbnail| thumbnail.needs_approval) {
+        let Some(thumbnail) = thumbnail else {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                "frameIndex is not a frame the completed preview returned",
+            ));
+        };
+        if !attended && !thumbnail.needs_approval {
             return Err(EngineError::new(
                 ErrorCode::InvalidParams,
                 "frameIndex is not a frame the completed preview flagged for manual review",
@@ -3427,6 +3451,7 @@ impl RealLs5000 {
             fingerprint: binding
                 .as_ref()
                 .and_then(|binding| binding.fingerprint.clone()),
+            attended,
         };
         let value = serde_json::to_value(params).expect("BridgeRollApproveParams serializes");
         self.call_session_scoped(session_epoch, bridge_generation, "roll.approve", value)?;

--- a/ports/tauri/vendor/engine/src/server.rs
+++ b/ports/tauri/vendor/engine/src/server.rs
@@ -398,7 +398,12 @@ impl Backends {
     /// real bridge session. `roll.approve` is deliberately not folded into
     /// `scan.start`: the operator must make a distinct, reviewable decision
     /// before a frame that was flagged by preview can move.
-    fn roll_approve(&self, frame_index: u32, operation_id: &str) -> Result<(), EngineError> {
+    fn roll_approve(
+        &self,
+        frame_index: u32,
+        operation_id: &str,
+        attended: bool,
+    ) -> Result<(), EngineError> {
         if frame_index == 0 {
             return Err(EngineError::new(
                 ErrorCode::InvalidParams,
@@ -416,14 +421,14 @@ impl Backends {
                 .real
                 .as_ref()
                 .unwrap()
-                .roll_approve(frame_index, operation_id),
+                .roll_approve(frame_index, operation_id, attended),
             // S7a (adversarial review, 2026-08-08): the simulator now has
             // exactly one manual-review gate -- a frame its own last
             // successful `manual_frames()` call returned, under that exact
             // operationId (see `SimulatedLs5000::roll_approve`'s own doc
             // comment). Every other case is refused with the same
             // "no manual-review gate" message as before this change.
-            Some(ActiveDevice::Sim) => self.sim.roll_approve(frame_index, operation_id),
+            Some(ActiveDevice::Sim) => self.sim.roll_approve(frame_index, operation_id, attended),
             None => Err(EngineError::new(
                 ErrorCode::NotConnected,
                 "scanner is not connected",
@@ -1053,7 +1058,7 @@ fn handle_request(
         }
         "roll.approve" => {
             let params: protocol::RollApproveParams = parse_params(&request.params)?;
-            backends.roll_approve(params.frame_index, &params.operation_id)?;
+            backends.roll_approve(params.frame_index, &params.operation_id, params.attended)?;
             to_json(&protocol::RollApproveResult {})
         }
         "roll.setSpacingOffset" => {

--- a/ports/tauri/vendor/engine/src/sim.rs
+++ b/ports/tauri/vendor/engine/src/sim.rs
@@ -596,7 +596,23 @@ impl SimulatedLs5000 {
     /// produced it" principle). Not part of `ScannerBackend`: dispatched
     /// directly from `Backends::roll_approve`, exactly like every other
     /// roll.* method that is real-only or sim-only.
-    pub fn roll_approve(&self, frame_index: u32, operation_id: &str) -> Result<(), EngineError> {
+    pub fn roll_approve(
+        &self,
+        frame_index: u32,
+        operation_id: &str,
+        attended: bool,
+    ) -> Result<(), EngineError> {
+        // The simulator has no lattice-confidence detector, so it has no
+        // medium-confidence roll for an attended acceptance to rescue. It
+        // refuses `attended` outright rather than pretending to support it,
+        // the same posture it already takes on the manual-review gate.
+        if attended {
+            return Err(EngineError::new(
+                ErrorCode::InvalidParams,
+                "attended roll binding is not available on the simulator; it has no \
+                 lattice-confidence detector",
+            ));
+        }
         let state = self.state.lock().unwrap();
         let approvable = state.manual_approval_binding.as_ref().is_some_and(|binding| {
             binding.operation_id == operation_id && binding.frame_indices.contains(&frame_index)
@@ -2917,9 +2933,9 @@ mod tests {
         sim.load_media(MediaCarrier::Roll36).expect("load media");
 
         let result = sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
-        sim.roll_approve(1, &result.operation_id)
+        sim.roll_approve(1, &result.operation_id, false)
             .expect("a frame this placement returned must be approvable");
-        sim.roll_approve(2, &result.operation_id)
+        sim.roll_approve(2, &result.operation_id, false)
             .expect("every returned frame is individually approvable");
     }
 
@@ -2933,7 +2949,7 @@ mod tests {
         // No manual_frames() call was ever made this session -- the
         // simulator's pre-existing "no manual-review gate" refusal must be
         // completely unchanged.
-        let err = sim.roll_approve(1, "some-operation-id").unwrap_err();
+        let err = sim.roll_approve(1, "some-operation-id", false).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidParams);
         assert!(err.message.contains("no other manual-review gate"));
     }
@@ -2946,7 +2962,7 @@ mod tests {
         sim.load_media(MediaCarrier::Roll36).expect("load media");
 
         let result = sim.manual_frames(vec![0, 135, 270]).expect("2-frame placement");
-        let err = sim.roll_approve(99, &result.operation_id).unwrap_err();
+        let err = sim.roll_approve(99, &result.operation_id, false).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidParams);
     }
 
@@ -2958,7 +2974,7 @@ mod tests {
         sim.load_media(MediaCarrier::Roll36).expect("load media");
 
         sim.manual_frames(vec![0, 135, 270]).expect("valid placement");
-        let err = sim.roll_approve(1, "not-the-real-operation-id").unwrap_err();
+        let err = sim.roll_approve(1, "not-the-real-operation-id", false).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidParams);
     }
 
@@ -2975,7 +2991,7 @@ mod tests {
         // materially different registration" principle, applied here to
         // the simulator's session-scoped approval binding).
         sim.load_media(MediaCarrier::Strip6).expect("reload media");
-        let err = sim.roll_approve(1, &result.operation_id).unwrap_err();
+        let err = sim.roll_approve(1, &result.operation_id, false).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidParams);
     }
 
@@ -2991,7 +3007,7 @@ mod tests {
         sim.connect(DEVICE_ID, &ConnectOptions::default())
             .expect("reconnect");
         sim.load_media(MediaCarrier::Roll36).expect("reload media");
-        let err = sim.roll_approve(1, &result.operation_id).unwrap_err();
+        let err = sim.roll_approve(1, &result.operation_id, false).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidParams);
     }
 }

--- a/ports/tauri/vendor/engine/tests/real_backend_mapping.rs
+++ b/ports/tauri/vendor/engine/tests/real_backend_mapping.rs
@@ -779,7 +779,7 @@ fn restart_during_preview_keeps_old_reader_attached_until_it_detaches() {
     }
 
     let stale_approval = backend
-        .roll_approve(1, "predecessor-preview")
+        .roll_approve(1, "predecessor-preview", false)
         .expect_err("a predecessor approval must be stale after reconnect");
     assert_eq!(stale_approval.code, ErrorCode::InvalidParams);
 
@@ -794,7 +794,7 @@ fn restart_during_preview_keeps_old_reader_attached_until_it_detaches() {
     .expect("the replacement preview should be accepted only after the old reader detached");
 
     let premature_approval = backend
-        .roll_approve(1, "replacement-preview")
+        .roll_approve(1, "replacement-preview", false)
         .expect_err("the replacement is not approvable before its own completion");
     assert_eq!(premature_approval.code, ErrorCode::InvalidParams);
     assert!(
@@ -854,11 +854,11 @@ fn restart_during_preview_keeps_old_reader_attached_until_it_detaches() {
     );
 
     let stale_after_replacement = backend
-        .roll_approve(1, "predecessor-preview")
+        .roll_approve(1, "predecessor-preview", false)
         .expect_err("the predecessor remains stale after replacement completion");
     assert_eq!(stale_after_replacement.code, ErrorCode::InvalidParams);
     let mismatched_replacement = backend
-        .roll_approve(1, "wrong-replacement-preview")
+        .roll_approve(1, "wrong-replacement-preview", false)
         .expect_err("a mismatched replacement operation must be rejected locally");
     assert_eq!(mismatched_replacement.code, ErrorCode::InvalidParams);
     assert!(
@@ -870,7 +870,7 @@ fn restart_during_preview_keeps_old_reader_attached_until_it_detaches() {
     );
 
     backend
-        .roll_approve(1, "replacement-preview")
+        .roll_approve(1, "replacement-preview", false)
         .expect("the replacement becomes approvable only after its own completion");
     let bridge_calls = std::fs::read_to_string(&call_log_path)
         .expect("read final mock bridge call log")

--- a/ports/tauri/vendor/protocol/BRIDGE.md
+++ b/ports/tauri/vendor/protocol/BRIDGE.md
@@ -53,7 +53,7 @@ Errors that can occur on any request — `UNKNOWN_METHOD` (unrecognized method n
 | `device.status` | `{}` | `DeviceStatus` | `NOT_CONNECTED` |
 | `device.close` | `{}` | `{}` | `NOT_CONNECTED`, `HARDWARE_LANE_BUSY` |
 | `roll.preview` | `{material: "colorNegative"\|"blackAndWhiteNegative", slots?: [number]}` | `{accepted: true}` | `NOT_CONNECTED`, `HW_MOTION_NOT_ARMED`, `HARDWARE_LANE_BUSY`; via `roll.previewError`: `FEEDER_PARKED`, `ADAPTER_UNSUPPORTED`, `REFEED_REQUIRED`, `DEVICE_BUSY`, `ROLL_MISMATCH` |
-| `roll.approve` | `{slot: number}` | `{}` | `NOT_CONNECTED`, `NO_PREVIEW` |
+| `roll.approve` | `{slot: number, fingerprint?: string, attended?: boolean}` | `{}` | `NOT_CONNECTED`, `NO_PREVIEW`, `INVALID_PARAMS`, `FINGERPRINT_REFUSED` |
 | `roll.setSpacingOffset` | `{slot: number, offsetRows: number}` | `{thumbnail: Thumbnail}` | `NOT_CONNECTED`, `NO_PREVIEW`, `INVALID_PARAMS` |
 | `roll.manualFrames` | `{rows: [number]}` | `{count: number, fingerprint: string, thumbnails: [Thumbnail], snaps: [BoundarySnap]}` | `NOT_CONNECTED`, `NO_PREVIEW`, `HARDWARE_LANE_BUSY`, `INVALID_PARAMS`, `METER_UNUSABLE` |
 | `roll.previewStrip` | `{}` | `PreviewStrip` | `NOT_CONNECTED`, `NO_PREVIEW`, `HARDWARE_LANE_BUSY`, `METER_UNUSABLE` |
@@ -82,6 +82,20 @@ Returns `HARDWARE_LANE_BUSY` while a job holds the lane — the safety rule hold
 ### `roll.approve`
 
 Records manual-review approval for one slot. Not motion-capable — no transport movement, no latch check. Required before scanning any slot whose last `roll.thumbnail` event had `needsApproval: true`; omitting it surfaces as `MANUAL_REVIEW_REQUIRED` when that slot's turn in `scan.start` comes up.
+
+`fingerprint`, when present, is the Roll fingerprint the approval was minted against; a value that no longer matches the roll's current fingerprint is refused with `FINGERPRINT_REFUSED` before any approval is recorded.
+
+#### `attended` (additive, 2026-08-13 — feed-detector round)
+
+`attended: true` records an operator-**attended** acceptance instead of a per-slot manual review, and is what lets a roll be scanned when its boundary-lattice confidence is below what unattended frame binding requires (issues #24, #16, #42 — "previews fine but will not scan").
+
+- It may approve a slot the detector never flagged. That is the point: on a roll the detector could not fully corroborate, the frames an operator has to vouch for are precisely the ones nothing flagged.
+- It is **all-or-nothing per batch.** The driver binds such a roll only when *every* slot in the subsequent `scan.start` carries an attended approval. A partially attended batch refuses exactly as an unapproved one does.
+- Eligibility is the driver's decision, not the bridge's. CoolscanPy accepts `attended` only for an automatically detected roll at `medium` lattice confidence; a `high` roll needs no rescue, a `low` roll has no anchored lattice to vouch for, and a manual placement binds through its own path. Every other case is refused with `INVALID_PARAMS` carrying the driver's own message.
+- Omitted (or `false`) is unchanged pre-existing behavior in every respect.
+- The mock transport refuses `attended` with `INVALID_PARAMS`: it has no lattice-confidence detector, so it has no roll for an attended acceptance to rescue.
+
+Each acceptance is recorded in the capture journal under `live_frame_selection.attended_roll_binding`, so an evidence audit can tell which mode bound a frame.
 
 ### `roll.setSpacingOffset`
 

--- a/ports/tauri/vendor/protocol/PROTOCOL.md
+++ b/ports/tauri/vendor/protocol/PROTOCOL.md
@@ -56,7 +56,7 @@ Errors: `NOT_CONNECTED`, `NO_MEDIA`, `SCANNER_BUSY`, `INVALID_PARAMS` (active-pr
 
 ### `roll.approve`
 
-`{frameIndex: u32, operationId: string}` → `{}`. Explicitly records the
+`{frameIndex: u32, operationId: string, attended?: bool}` → `{}`. Explicitly records the
 operator's approval for a single frame that the active **real-device** preview
 marked as requiring manual review. `operationId` is required, nonempty, and
 must exactly equal the token from the most recent successfully completed real
@@ -71,10 +71,27 @@ preview, scan, eject, check the motion latch, or refresh device status. It is
 scoped to the currently open bridge device session and is never retried after
 that session is lost.
 
+`attended` (additive, 2026-08-13 — feed-detector round; issues #24, #16, #42)
+defaults to `false` and is omitted from the wire entirely when false, so an
+ordinary approval is byte-identical to before this field existed. `true`
+records an operator-**attended** acceptance: the operator is authorizing a
+frame of a roll whose boundary-lattice confidence is below what unattended
+scanning requires, having checked the previewed framing themselves.
+
+An attended approval relaxes exactly one local check — the frame no longer has
+to be one the completed preview flagged `needsApproval`. It must still be a
+frame that exact completed preview actually returned; an index the preview
+never produced is refused with `INVALID_PARAMS` either way. Whether the roll is
+eligible at all remains the driver's decision (see BRIDGE.md `roll.approve`),
+and attended binding is all-or-nothing: the client must send an attended
+`roll.approve` for **every** frame of the subsequent `scan.start`, then send
+that original complete frame list in one request.
+
 The simulator has no manual-review gate and refuses this method with
-`INVALID_PARAMS`. Errors: `NOT_CONNECTED`, `INVALID_PARAMS`, `INTERNAL` (for
-a bridge refusal after a valid locally-bound approval; the bridge's specific
-diagnostic remains in the message).
+`INVALID_PARAMS`; it likewise has no lattice-confidence detector and refuses
+`attended: true` outright. Errors: `NOT_CONNECTED`, `INVALID_PARAMS`,
+`INTERNAL` (for a bridge refusal after a valid locally-bound approval; the
+bridge's specific diagnostic remains in the message).
 
 ### `roll.setSpacingOffset`
 
@@ -258,7 +275,7 @@ ApplyMetadataResult {success: bool, exitCode: i32, stdout: string, stderr: strin
 
 `PartialDate` never invents precision it wasn't given — `monthOnly`/`yearOnly` carry no day/month value at all rather than a placeholder like `01`; `unknown` carries no date value whatsoever. `MetadataSet.process` is independent of `ScanProject.filmProcess` and is never auto-synced with it.
 
-`Thumbnail`'s `brightness`/`tint` and `imagePath` are mutually exclusive: exactly one of the `{brightness, tint}` pair or `imagePath` is populated per instance, never both, never neither. The simulator populates `brightness`/`tint` and omits the real transport fields. A real backend populates `imagePath` (BRIDGE.md's bridge-written, Nikon-render-oriented preview tile), `boundaryRows`, `spacingOffset`, `needsApproval`, and `warnings`, while omitting `brightness`/`tint` rather than fabricating them. `spacingOffset` is the bridge-confirmed value active in this exact preview session; a project manifest value alone is not equivalent. Before sending `scan.start`, clients must inspect every requested frame's current completed-preview thumbnail. If any has `needsApproval: true`, the client must obtain explicit operator confirmation, send `roll.approve` for every such frame with that preview's exact `operationId`, and only then send the original complete frame list in one `scan.start`. Starting an unapproved subset and retrying the omitted frame as a second job is not equivalent: it loses the one-traversal transport assumption.
+`Thumbnail`'s `brightness`/`tint` and `imagePath` are mutually exclusive: exactly one of the `{brightness, tint}` pair or `imagePath` is populated per instance, never both, never neither. The simulator populates `brightness`/`tint` and omits the real transport fields. A real backend populates `imagePath` (BRIDGE.md's bridge-written, Nikon-render-oriented preview tile), `boundaryRows`, `spacingOffset`, `needsApproval`, and `warnings`, while omitting `brightness`/`tint` rather than fabricating them. `spacingOffset` is the bridge-confirmed value active in this exact preview session; a project manifest value alone is not equivalent. Before sending `scan.start`, clients must inspect every requested frame's current completed-preview thumbnail. If any has `needsApproval: true`, the client must obtain explicit operator confirmation, send `roll.approve` for every such frame with that preview's exact `operationId`, and only then send the original complete frame list in one `scan.start`. Starting an unapproved subset and retrying the omitted frame as a second job is not equivalent: it loses the one-traversal transport assumption. Separately, when `scan.start` is refused because the roll's boundary-lattice confidence is below what unattended binding requires, a client may offer the operator an attended retry: send `roll.approve` with `attended: true` for *every* frame of the batch under that same `operationId`, then resend the original complete frame list. This is only offered for the `medium` confidence the driver can bind; a `low`-confidence refusal is not rescuable this way and needs a refeed.
 
 `ScannerStatus.filmPresent` mirrors BRIDGE.md's `DeviceStatus.filmPresent` for a real backend — a live, no-motion film-presence read. `true` means the scanner reports film gripped, `false` is the verified MEDIUM NOT PRESENT response, and `null` means no trustworthy verdict was available; `null` is never absence. A verified `false` also invalidates any preview-derived `mediaLoaded`/`frameCount` claim, so the emitted status carries `mediaLoaded: false` and `frameCount: null`; this cannot discard project receipts or the unfinished resume set. Presence is not motion readiness because an end-stop-parked strip can still report `true`. The simulator always omits this field (it has no bridge to source it from).
 

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/service.py
@@ -74,7 +74,7 @@ _METHOD_PARAM_SCHEMAS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
     "device.status": ((), ()),
     "device.close": ((), ()),
     "roll.preview": (("material",), ("slots",)),
-    "roll.approve": (("slot",), ("fingerprint",)),
+    "roll.approve": (("slot",), ("fingerprint", "attended")),
     "roll.setSpacingOffset": (("slot", "offsetRows"), ()),
     "roll.manualFrames": (("rows",), ()),
     "roll.previewStrip": ((), ()),
@@ -215,6 +215,12 @@ def _require_string(
             ErrorCode.INVALID_PARAMS,
             f"{name} length must be between {minimum_length} and {maximum_length}",
         )
+    return value
+
+
+def _require_bool(value: object, name: str) -> bool:
+    if type(value) is not bool:
+        raise BridgeError(ErrorCode.INVALID_PARAMS, f"{name} must be true or false")
     return value
 
 
@@ -464,9 +470,19 @@ class BridgeService:
                 fingerprint = _require_string(
                     fingerprint, "fingerprint", maximum_length=256
                 )
+            # Attended binding (feed-detector round; ScanStudio #24/#16/#42):
+            # optional on the wire and omitted by every pre-existing caller,
+            # so the default is byte-identical to today's behavior. When
+            # true, the operator is accepting one frame of an automatically
+            # detected medium-confidence roll so the roll can be scanned
+            # with them watching -- coolscanpy refuses it on any other roll
+            # shape (INVALID_PARAMS).
+            attended = params.get("attended")
+            attended = False if attended is None else _require_bool(attended, "attended")
             self._transport.approve(
                 _require_plain_int(params["slot"], "slot", minimum=1, maximum=40),
                 fingerprint=fingerprint,
+                attended=attended,
             )
             return {}
         if method == "roll.setSpacingOffset":

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/__init__.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/__init__.py
@@ -68,7 +68,13 @@ class Transport(Protocol):
         on_thumbnail: Callable[[domain.Thumbnail], None],
     ) -> domain.PreviewResult: ...
 
-    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
+    def approve(
+        self,
+        slot: int,
+        *,
+        fingerprint: str | None = None,
+        attended: bool = False,
+    ) -> None:
         """Approve `slot`. `fingerprint`, when given, is the Roll
         fingerprint (BRIDGE.md's `roll.approve`) the approval being
         submitted was minted against -- additive (2026-08-08 adversarial
@@ -76,7 +82,15 @@ class Transport(Protocol):
         given value that no longer matches the roll's CURRENT fingerprint
         must be refused with `FINGERPRINT_REFUSED` before any underlying
         approval call, never silently approved against whatever session
-        happens to be current now."""
+        happens to be current now.
+
+        `attended` (feed-detector round; ScanStudio #24/#16/#42) marks this
+        as an operator-ATTENDED acceptance rather than a per-slot manual
+        review: it may approve a slot the detector never flagged, and it is
+        what lets a medium-confidence roll be scanned at all. It is only
+        valid on a roll whose detection is automatic and medium-confidence;
+        anywhere else it must be refused with `INVALID_PARAMS`. `False` (the
+        default, and every pre-existing caller) is unchanged behavior."""
         ...
 
     def set_spacing_offset(

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -919,7 +919,13 @@ class CoolscanPyTransport:
         self._preview_established = True
         return domain.PreviewResult(count=len(thumbnails), fingerprint=self._roll.fingerprint.sha256)
 
-    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
+    def approve(
+        self,
+        slot: int,
+        *,
+        fingerprint: str | None = None,
+        attended: bool = False,
+    ) -> None:
         if self._device is None:
             raise BridgeError(ErrorCode.NOT_CONNECTED, "no device is open")
         if not self._preview_established:
@@ -948,8 +954,16 @@ class CoolscanPyTransport:
                 "that no longer matches the roll's current state; acquire a "
                 "fresh preview or placement and approve again",
             )
+        # Attended binding (feed-detector round; ScanStudio #24/#16/#42).
+        # coolscanpy owns the authority here: Roll.approve(attended=True)
+        # refuses with ValueError unless this roll is an automatically
+        # detected medium-confidence session, which is the only shape the
+        # scan-time gate will bind below "high". The bridge does not
+        # second-guess that -- it forwards the operator's intent and maps
+        # the refusal, exactly as it already does for "slot does not
+        # require manual review".
         try:
-            self._roll.approve(slot)
+            self._roll.approve(slot, attended=attended)
         except ValueError as exc:
             raise BridgeError(ErrorCode.INVALID_PARAMS, str(exc)) from exc
 

--- a/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/mock.py
+++ b/ports/tauri/vendor/scanstudio-bridge/src/scanstudio_bridge/transport/mock.py
@@ -296,7 +296,13 @@ class MockTransport:
         self._fingerprint = fingerprint
         return domain.PreviewResult(count=self._slot_count, fingerprint=fingerprint)
 
-    def approve(self, slot: int, *, fingerprint: str | None = None) -> None:
+    def approve(
+        self,
+        slot: int,
+        *,
+        fingerprint: str | None = None,
+        attended: bool = False,
+    ) -> None:
         self._require_connected()
         # Additive (2026-08-08 adversarial review, S1) -- see
         # transport.Transport.approve's own docstring. `None` (the default,
@@ -309,7 +315,19 @@ class MockTransport:
                 "that no longer matches the roll's current state; acquire a "
                 "fresh preview or placement and approve again",
             )
-        if slot < 1 or slot > self._slot_count or slot not in self._needs_approval_slots:
+        if slot < 1 or slot > self._slot_count:
+            raise BridgeError(ErrorCode.INVALID_PARAMS, f"slot {slot} does not need approval")
+        # The simulator has no roll-confidence detector, so it has no
+        # medium-confidence roll for an attended acceptance to rescue. It
+        # refuses `attended` rather than pretending to support it -- the
+        # same posture PROTOCOL.md already documents for the simulator's
+        # missing manual-review gate.
+        if attended:
+            raise BridgeError(
+                ErrorCode.INVALID_PARAMS,
+                "attended roll binding is not available on the mock transport",
+            )
+        if slot not in self._needs_approval_slots:
             raise BridgeError(ErrorCode.INVALID_PARAMS, f"slot {slot} does not need approval")
         self._approved_slots.add(slot)
 

--- a/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
+++ b/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
@@ -74,6 +74,7 @@ class _FakeRoll:
         self._scan_results = {slot: list(outcomes) for slot, outcomes in (scan_results or {}).items()}
         self.scan_many_calls: list[tuple[int, ...]] = []
         self.approve_calls: list[int] = []
+        self.attended_approve_calls: list[tuple[int, bool]] = []
         self.spacing_offset_calls: list[tuple[int, int]] = []
         self.safe_stop_calls = 0
         self.closed = False
@@ -128,8 +129,13 @@ class _FakeRoll:
     def slot_count(self) -> int:
         return len(self._thumbnails)
 
-    def approve(self, slot: int) -> None:
+    def approve(self, slot: int, *, attended: bool = False) -> None:
+        # Mirrors coolscanpy.Roll.approve's own signature (feed-detector
+        # round; attended binding). Recorded as a (slot, attended) pair so a
+        # test can prove the operator's intent reached the driver, while the
+        # pre-existing `approve_calls` slot list stays exactly as it was.
         self.approve_calls.append(slot)
+        self.attended_approve_calls.append((slot, attended))
 
     def set_spacing_offset(
         self, slot: int, offset_rows: int
@@ -1627,6 +1633,54 @@ def test_approve_with_no_fingerprint_keeps_pre_existing_behavior(
     transport.approve(1)
 
     assert roll.approve_calls == [1]
+    assert roll.attended_approve_calls == [(1, False)]
+
+
+# ---------------------------------------------------------------------------
+# Attended binding (feed-detector round; ScanStudio #24/#16/#42)
+# ---------------------------------------------------------------------------
+
+
+def test_attended_approval_reaches_the_driver_as_an_explicit_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The operator's intent must arrive at coolscanpy as `attended=True`.
+    The bridge never decides eligibility itself -- Roll.approve is the
+    authority on which roll shapes may bind below 'high'."""
+    roll = _FakeRoll(thumbnails=[_fake_thumbnail(1)], fingerprint_sha256="c" * 64)
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    transport.approve(1, attended=True)
+
+    assert roll.attended_approve_calls == [(1, True)]
+
+
+def test_attended_approval_refused_by_the_driver_maps_to_invalid_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """coolscanpy refuses `attended` on any roll that is not an
+    automatically detected medium-confidence one. That refusal must surface
+    as a typed INVALID_PARAMS, not an unhandled fault."""
+
+    class _RefusingRoll(_FakeRoll):
+        def approve(self, slot: int, *, attended: bool = False) -> None:
+            if attended:
+                raise ValueError(
+                    "attended roll binding requires an automatically detected "
+                    "medium-confidence roll; this session is 'high'"
+                )
+            super().approve(slot, attended=attended)
+
+    roll = _RefusingRoll(thumbnails=[_fake_thumbnail(1)], fingerprint_sha256="c" * 64)
+    transport, _device = _opened_transport(monkeypatch, roll)
+    transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
+
+    with pytest.raises(BridgeError) as excinfo:
+        transport.approve(1, attended=True)
+
+    assert excinfo.value.code is ErrorCode.INVALID_PARAMS
+    assert "attended roll binding requires" in str(excinfo.value)
 
 
 def test_manual_frames_refuses_when_current_attempt_has_no_recorded_evidence(

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -296,7 +296,7 @@ EOF
 check_pair "protocol" "app/ScanStudio/protocol" "ports/tauri/vendor/protocol" "55577442d8b6a23ddcd3cc191ebf41a8258004047bc075511a241fa72adb0b65" <<'EOF'
 EOF
 
-check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "ab36950447a47688b48b4676e5c42495dc06d008bd304491cb2e40e6ef38f499" <<'EOF'
+check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "39b1df9b6ad8749887332e55ba8085822a4eca8d516580837e083efad2b1ae91" <<'EOF'
 Files app/ScanStudio/engine/Cargo.lock and ports/tauri/vendor/engine/Cargo.lock differ
 Files app/ScanStudio/engine/Cargo.toml and ports/tauri/vendor/engine/Cargo.toml differ
 Files app/ScanStudio/engine/src/evidence_package.rs and ports/tauri/vendor/engine/src/evidence_package.rs differ
@@ -307,7 +307,7 @@ Files app/ScanStudio/engine/src/render.rs and ports/tauri/vendor/engine/src/rend
 Only in ports/tauri/vendor/engine/src: wsl_io.rs
 EOF
 
-check_pair "bridge" "bridge" "ports/tauri/vendor/scanstudio-bridge" "a5ce7bf643931229a66604487fe27c00865e7196a37f1c1985b9065b79447923" <<'EOF'
+check_pair "bridge" "bridge" "ports/tauri/vendor/scanstudio-bridge" "c3d18d08b433e903c4ea30a422a8b3f239008224ff5a0b34cb2b98d6211d16dc" <<'EOF'
 Only in ports/tauri/vendor/scanstudio-bridge: .github
 Only in ports/tauri/vendor/scanstudio-bridge/scripts: probe-linux-env.py
 Only in ports/tauri/vendor/scanstudio-bridge/scripts: verify-bridge.sh
@@ -322,7 +322,7 @@ Files bridge/tests/test_transport_mock.py and ports/tauri/vendor/scanstudio-brid
 Files bridge/uv.lock and ports/tauri/vendor/scanstudio-bridge/uv.lock differ
 EOF
 
-check_pair "coolscanpy" "coolscanpy" "ports/tauri/vendor/coolscanpy" "557dec45c93435bd6270bf3419ebf7c740ad31f8a28b1c78ae4bbc65153e0101" <<'EOF'
+check_pair "coolscanpy" "coolscanpy" "ports/tauri/vendor/coolscanpy" "65812839fa0d05285064804e367716d5b157123615ff78378059f6a6185644ba" <<'EOF'
 Files coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py and ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py differ
 Files coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/usb_backend.py and ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/usb_backend.py differ
 Files coolscanpy/tests/test_usb_backend.py and ports/tauri/vendor/coolscanpy/tests/test_usb_backend.py differ


### PR DESCRIPTION
Closes the loop on the field reports in #24, #16 and #42 — "it previews fine but it won't scan".

## The problem

Preview accepts a roll at `medium` boundary-lattice confidence and renders every thumbnail. The scan-time gate in coolscanpy requires `high`, so scanning refuses:

```
bridge scan.error (ROLL_MISMATCH): roll boundary lattice confidence is 'medium'; unattended frame binding requires 'high'
```

The operator is standing at the scanner looking at correctly framed thumbnails they cannot scan, and there was no way out. `roll.approve` only ever accepted a frame the detector itself flagged — and on one of these rolls, the frames that need a human are exactly the ones nothing flagged.

## The change

An **attended** path. When the scan is refused for confidence, the workspace error card offers **"Approve every frame and scan"**: it approves each selected frame against the exact preview the operator reviewed, marked attended, then re-issues the original complete frame list in one `scan.start`.

**No detector threshold moved.** No accept window, no lattice / evidence / direct-fraction bound changed, and `medium` is exactly as hard to earn as before. What changed is that evidence of a human accepting every frame is now admissible at the binding gate.

## Who decides what

| Layer | Responsibility |
|---|---|
| **coolscanpy** | Owns eligibility. `Roll.approve(slot, attended=True)` mints a receipt only for an automatically detected `medium`-confidence roll. The capture worker binds `medium` only when **every** requested frame carries one — derived from receipts already authenticated against this preview's reviewed fingerprint, never from a boolean on the wire. |
| **bridge** | Forwards intent, maps refusals. `roll.approve` gains an optional `attended`, omitted from the wire unless true. |
| **engine** | Relaxes exactly one half of its S3 gate: an attended approval need not be a frame the preview *flagged*, but must still be one the preview *returned*. |
| **mac app** | Splits one refusal into two honestly different situations (below). |

### Why `low` is not rescuable

`medium` means the detector found the frame lattice but could not corroborate it well enough to cut film unsupervised — there is a real geometry for an operator to vouch for. `low` means it never anchored a lattice at all, so approving thumbnails proves nothing about where the frames physically are.

So the copy splits: `medium` says the frames can be confirmed and offers the button; `low` keeps refeed-only copy and offers nothing, because a button there is guaranteed to refuse again. The old copy's promise that *"a future release is expected to widen what the detector accepts here"* is removed — this is that release, and it widened the **path**, not the threshold.

## Unchanged, and regression-pinned

- Unattended `medium` refuses with the **byte-identical** message.
- `low` always refuses, with or without any number of approvals.
- An ordinary approval is byte-identical on the wire — no `attended` key at all.
- Simulator and mock transport refuse `attended` rather than pretending to have a detector.
- The adversarial-review regressions around this gate, including `test_non_manual_medium_detection_still_refuses_even_with_approval_flags`, are untouched and green.

Every acceptance is journaled under `live_frame_selection.attended_roll_binding`, so an evidence audit can tell which mode bound a frame without re-running the detector.

## Vendored trees and mirrors

The vendored coolscanpy trees carry the same driver change, applied as a patch (they have diverged from the driver repo by their own receipt-timing overlay), and both were re-pinned per the capture-bundle procedure. The `ports/tauri` mirrors were re-synced: every non-allowlisted file is byte-identical again, the two allowlisted overlay files (`real_backend.rs`, `service.py`) carry the identical logical edit on both sides, and the three reviewed-divergence fingerprints were recomputed **only after** diffing every changed path.

## Tauri parity — partial by design

The store-level capability is ported and tested (`approveFrame(frameIndex, { attended })`, `approveEveryFrameAttended(frames)`). The error-card **button** is not, because Tauri has no `ErrorPresentationPolicy` equivalent to classify refusal text into copy plus affordances — adding it means porting that policy layer first. The pre-existing manual-placement gap (no `roll.previewStrip` / `roll.manualFrames` at all) is now recorded in `PARITY-NOTES.md` too, rather than left implied as parity.

## Suites

Re-run after merging `origin/main` (PRs #88, #89):

| Suite | Result |
|---|---|
| `swift test` | 484 tests in 50 suites passed |
| `cargo test` (canonical engine) | 643 passed, 0 failed |
| `cargo test` (Tauri vendor engine) | 658 passed, 0 failed |
| `pytest` (canonical bridge) | 365 passed |
| `pytest` (Tauri vendor bridge) | 383 passed |
| `vitest run` (Tauri) | 422 passed, 6 skipped, 58 files |
| `pytest` (vendored coolscanpy) | 1750 passed, 4 skipped, 1 xfailed |
| `scripts/check_ports_vendor_sync.sh` | passes on all four pairs |

## Merged with main (#88, #89)

Both LV eject fixes landed after this branch was cut. Every code file auto-merged and both changesets are preserved — verified, not assumed: `real_backend.rs` carries #89's `EJECT_CALL_DEADLINE`/`SessionCallOptions` alongside the attended `roll_approve` (#89 kept `call_session_scoped` as a four-arg wrapper, so the call site is still correct), and `coolscanpy_transport.py` carries #88's vendor-eject settle-retry alongside the attended approve path.

The single conflict was the engine pair's reviewed-divergence digest, which both branches had moved. It was **not** resolved by picking a side: code files were resolved first, the digest was set to a placeholder, and `check_ports_vendor_sync.sh` was run to compute the true value for the merged tree — then the divergence was reviewed as the script demands before accepting it (allowlist reported no unexpected drift; both changesets appear with identical text on both sides; the only remaining difference is the pre-existing native-Windows/WSL overlay).

## Driver wire-compat

The bundled driver is resolved checkout-relative (`[tool.uv.sources] coolscanpy = { path = "../coolscanpy" }`), and this PR patches both vendored trees — so there is **no window** where the app-side attended wiring runs against a driver lacking it, regardless of the `0.7.1` version string. There is no driver-version gate anywhere; `coolscanpy.__version__` is reported as informational metadata only.

The assumption that an attended approval against a driver ignoring the flag would "degrade to today's typed refusal" turned out to be **false**, and is now fixed rather than relied on. A coolscanpy without the parameter raises `TypeError`, which the transport's `except ValueError` does not catch — it would have reached the client as a bare `INTERNAL`, exactly the undiagnosable shape #16/#68/#76 were made of. The keyword is now passed only when the operator opted in (so ordinary approvals keep working against an older driver, which matters because `dependencies` alone would let a plain `pip install` pull an older coolscanpy from PyPI), and an attended one against such a build is refused with a typed `INVALID_PARAMS` naming the missing capability. The `TypeError` arm is matched narrowly on the parameter name so a genuine driver fault still propagates as the defect it is.

## Still needed before release

- **Live hardware validation** of the operator flow end to end on a roll that actually detects at `medium`.
- The matching **coolscanpy release** — the driver-side change lands in the driver repo's own release, which also carries the 0.7.2 spec-eject work. This branch's vendored copies are the snapshot to reconcile against it.

