### PR TITLE
Windows secure context: Preview dead button + clipboard no-ops (live WV-1)

### DIFF
--- a/ports/tauri/app/src-tauri/tauri.conf.json
+++ b/ports/tauri/app/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost https://ipc.localhost; img-src 'self' asset: http://asset.localhost https://asset.localhost scanstudio-preview:"
+      "csp": "default-src 'self' ipc: http://ipc.localhost https://ipc.localhost; img-src 'self' asset: http://asset.localhost https://asset.localhost scanstudio-preview: http://scanstudio-preview.localhost https://scanstudio-preview.localhost"
     }
   },
   "bundle": {

--- a/ports/tauri/app/src-tauri/tauri.conf.json
+++ b/ports/tauri/app/src-tauri/tauri.conf.json
@@ -15,11 +15,12 @@
         "label": "main",
         "title": "ScanStudio",
         "width": 1200,
-        "height": 800
+        "height": 800,
+        "useHttpsScheme": true
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost scanstudio-preview:"
+      "csp": "default-src 'self' ipc: http://ipc.localhost https://ipc.localhost; img-src 'self' asset: http://asset.localhost https://asset.localhost scanstudio-preview:"
     }
   },
   "bundle": {

--- a/ports/tauri/app/src/session/__tests__/policy-preview-insecure-context.test.ts
+++ b/ports/tauri/app/src/session/__tests__/policy-preview-insecure-context.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionStore } from "../store/session";
+import { createScriptedTransport } from "../testing/harness";
+import type { DeviceInfo, ScannerStatus } from "../wire/types";
+
+/** Regression for the first live Windows validation (2026-08-13): the
+ * Windows WebView2 origin http://tauri.localhost is not a secure context,
+ * so crypto.randomUUID does not exist there. The store minted preview
+ * operation ids with a bare crypto.randomUUID() call, which threw a
+ * synchronous TypeError before any state was recorded; ContactSheet's
+ * deliberate rejection-consumer then swallowed it, leaving Preview a
+ * silent no-op against a connected real scanner. The store must mint ids
+ * and run the full preview request path without Web Crypto.
+ *
+ * Mutation proof: restoring the bare crypto.randomUUID() call in
+ * acquireThumbnails makes this test throw exactly like the live failure.
+ */
+
+const DEVICE: DeviceInfo = {
+  deviceId: "real-ls5000",
+  model: "LS-5000 ED",
+  kind: "real",
+  firmware: "1.20",
+  connection: "usb",
+};
+
+const STATUS: ScannerStatus = {
+  connected: true,
+  adapter: "SA-21",
+  mediaLoaded: true,
+  carrier: "strip6",
+  frameCount: 2,
+  lamp: "stable",
+  transport: "idle",
+  activeJobId: null,
+};
+
+const UUID_V4_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("preview operation ids without Web Crypto (insecure context)", () => {
+  it("acquireThumbnails succeeds and sends a v4-shaped operationId when crypto.randomUUID is absent", async () => {
+    const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const handle = createScriptedTransport({
+      onRequest: (method, params) => {
+        calls.push({ method, params: params as Record<string, unknown> });
+        if (method === "scanner.connect") {
+          return { result: { device: DEVICE, status: STATUS } };
+        }
+        if (method === "scanner.acquireThumbnails") {
+          return { result: { accepted: true, frames: [1, 2] } };
+        }
+        throw new Error(`unexpected method ${method}`);
+      },
+    });
+    const store = new SessionStore(handle.transport);
+    await store.connect(DEVICE.deviceId);
+
+    // The exact runtime shape live Windows exposed: a crypto object that
+    // has no randomUUID member at all.
+    vi.stubGlobal("crypto", {});
+
+    const result = await store.acquireThumbnails(undefined, "c41ColorNegative");
+    expect(result).toEqual({ accepted: true, frames: [1, 2] });
+
+    const request = calls.find((call) => call.method === "scanner.acquireThumbnails");
+    expect(request).toBeDefined();
+    expect(request?.params.operationId).toMatch(UUID_V4_SHAPE);
+    expect(store.getState().activeOperationId).toBe(request?.params.operationId);
+    expect(store.getState().previewOutcome).toBe("active");
+    expect(store.getState().previewRequestFailure).toBeNull();
+  });
+});

--- a/ports/tauri/app/src/session/__tests__/policy-preview-insecure-context.test.ts
+++ b/ports/tauri/app/src/session/__tests__/policy-preview-insecure-context.test.ts
@@ -33,6 +33,10 @@ const STATUS: ScannerStatus = {
   lamp: "stable",
   transport: "idle",
   activeJobId: null,
+  // The live Windows state this test reproduces: armed and idle, so the
+  // rendered Preview button would be enabled (previewDisabled false).
+  motionArmed: true,
+  filmPresent: true,
 };
 
 const UUID_V4_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;

--- a/ports/tauri/app/src/session/__tests__/webApis.test.ts
+++ b/ports/tauri/app/src/session/__tests__/webApis.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { newOperationId, writeClipboardText } from "../webApis";
+import { newOperationId, previewImageSrc, writeClipboardText } from "../webApis";
 
 // Both branches must emit the same RFC 4122 v4 shape so nothing downstream
 // can tell which path minted the id.
@@ -24,6 +26,71 @@ describe("newOperationId", () => {
     expect(first).toMatch(UUID_V4_SHAPE);
     expect(second).toMatch(UUID_V4_SHAPE);
     expect(first).not.toBe(second);
+  });
+
+  it("falls back when the API exists but throws on invocation", () => {
+    // The existence check and the call are separate invariants; a runtime
+    // could expose the property and still refuse the call.
+    vi.stubGlobal("crypto", {
+      randomUUID: () => {
+        throw new TypeError("Illegal invocation");
+      },
+    });
+    expect(newOperationId()).toMatch(UUID_V4_SHAPE);
+  });
+});
+
+describe("previewImageSrc", () => {
+  it("uses the raw custom-scheme URL outside the wry .localhost mapping", () => {
+    expect(previewImageSrc("/tmp/tile.png", { protocol: "http:", hostname: "localhost" })).toBe(
+      `scanstudio-preview://localhost/?id=${encodeURIComponent("/tmp/tile.png")}`,
+    );
+  });
+
+  it("maps to the document-scheme .localhost origin on Windows (https)", () => {
+    expect(
+      previewImageSrc("/tmp/tile.png", { protocol: "https:", hostname: "tauri.localhost" }),
+    ).toBe(`https://scanstudio-preview.localhost/?id=${encodeURIComponent("/tmp/tile.png")}`);
+  });
+
+  it("tracks an http document origin on Windows the same way", () => {
+    expect(
+      previewImageSrc("C:\\scans\\tile.png", { protocol: "http:", hostname: "tauri.localhost" }),
+    ).toBe(`http://scanstudio-preview.localhost/?id=${encodeURIComponent("C:\\scans\\tile.png")}`);
+  });
+});
+
+describe("secure-context API call sites stay centralized", () => {
+  it("no production source outside webApis.ts calls crypto.randomUUID or navigator.clipboard", () => {
+    // Class fix for the Windows insecure-context incident: these APIs are
+    // absent there, so every use must go through the guarded helpers in
+    // webApis.ts. Comment lines are ignored so prose may name the APIs.
+    const root = join(__dirname, "..", "..");
+    const offenders: string[] = [];
+    const visit = (dir: string): void => {
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+          if (entry === "__tests__" || entry === "node_modules") continue;
+          visit(full);
+          continue;
+        }
+        if (!/\.(ts|tsx)$/.test(entry) || /\.test\.(ts|tsx)$/.test(entry)) continue;
+        if (full.endsWith(join("session", "webApis.ts"))) continue;
+        const lines = readFileSync(full, "utf8").split("\n");
+        for (const [index, line] of lines.entries()) {
+          const trimmed = line.trim();
+          if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) {
+            continue;
+          }
+          if (/crypto\.randomUUID|navigator\.clipboard/.test(line)) {
+            offenders.push(`${full}:${index + 1}`);
+          }
+        }
+      }
+    };
+    visit(root);
+    expect(offenders).toEqual([]);
   });
 });
 

--- a/ports/tauri/app/src/session/__tests__/webApis.test.ts
+++ b/ports/tauri/app/src/session/__tests__/webApis.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { newOperationId, writeClipboardText } from "../webApis";
+
+// Both branches must emit the same RFC 4122 v4 shape so nothing downstream
+// can tell which path minted the id.
+const UUID_V4_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("newOperationId", () => {
+  it("uses crypto.randomUUID when the context provides it", () => {
+    const id = newOperationId();
+    expect(id).toMatch(UUID_V4_SHAPE);
+  });
+
+  it("mints a v4-shaped id without throwing when crypto.randomUUID is absent (insecure context)", () => {
+    // http://tauri.localhost on Windows WebView2 exposes a crypto object
+    // with no randomUUID; an empty object reproduces that exact shape.
+    vi.stubGlobal("crypto", {});
+    const first = newOperationId();
+    const second = newOperationId();
+    expect(first).toMatch(UUID_V4_SHAPE);
+    expect(second).toMatch(UUID_V4_SHAPE);
+    expect(first).not.toBe(second);
+  });
+});
+
+describe("writeClipboardText", () => {
+  it("returns true after a successful clipboard write", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    await expect(writeClipboardText("probe text")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("probe text");
+  });
+
+  it("returns false when the Clipboard API is absent (insecure context)", async () => {
+    vi.stubGlobal("navigator", {});
+    await expect(writeClipboardText("probe text")).resolves.toBe(false);
+  });
+
+  it("returns false when the clipboard write rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    await expect(writeClipboardText("probe text")).resolves.toBe(false);
+  });
+});

--- a/ports/tauri/app/src/session/diagnosticTimeline.ts
+++ b/ports/tauri/app/src/session/diagnosticTimeline.ts
@@ -1,5 +1,6 @@
 import type { DiagnosticFields } from "./diagnosticField";
 import { formatDiagnosticFields } from "./diagnosticField";
+import { newOperationId } from "./webApis";
 
 export interface DiagnosticEntry {
   timestamp: string;
@@ -19,12 +20,10 @@ export function summaryLine(entry: DiagnosticEntry): string {
 }
 
 function generateSessionId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-  // Every environment this app ships to has Web Crypto, but tests and
-  // unusual embeddings should still get a usable, non-throwing id.
-  return `session-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  // Delegates to the shared guarded generator: live Windows shipped without
+  // crypto.randomUUID (insecure webview context), so the fallback is a real
+  // production path, not a test-only nicety. See webApis.ts.
+  return newOperationId();
 }
 
 /** Both report outputs show at most this many of the most recent diagnostic

--- a/ports/tauri/app/src/session/store/session.ts
+++ b/ports/tauri/app/src/session/store/session.ts
@@ -22,6 +22,7 @@
 //   job.
 
 import { decodeEvent, type EngineTransport } from "../wire/codec";
+import { newOperationId } from "../webApis";
 import {
   assertFrameTransition,
   assertJobTransition,
@@ -1073,8 +1074,10 @@ export class SessionStore {
 
   /**
    * Forward to scanner.acquireThumbnails with a fresh correlation token.
-   * Preview correlation policy (04-03 Task 1): a fresh crypto.randomUUID()
-   * is generated per accepted preview; a second call while one is active is
+   * Preview correlation policy (04-03 Task 1): a fresh newOperationId()
+   * (crypto.randomUUID when the context provides it -- see webApis.ts for
+   * why Windows historically did not) is generated per accepted preview; a
+   * second call while one is active is
    * refused locally with no wire call; the previous completed-preview token
    * is cleared immediately at call time (roll.approve trigger 1 -- the new
    * preview supersedes it whether or not it succeeds); and a rejected wire
@@ -1135,7 +1138,7 @@ export class SessionStore {
         recoverable: false,
       } satisfies EngineError;
     }
-    const operationId = crypto.randomUUID();
+    const operationId = newOperationId();
     const effectiveFilmProcess =
       this.#state.project?.filmProcess ??
       filmProcess ??

--- a/ports/tauri/app/src/session/store/session.ts
+++ b/ports/tauri/app/src/session/store/session.ts
@@ -1138,7 +1138,28 @@ export class SessionStore {
         recoverable: false,
       } satisfies EngineError;
     }
-    const operationId = newOperationId();
+    // newOperationId never throws by contract, but the pre-wire section must
+    // stay visible if a platform surprise ever violates that again: the
+    // Windows insecure-context TypeError thrown here (bare crypto.randomUUID,
+    // pre-fix) was swallowed by the caller's rejection consumer and left no
+    // trace at all. Any throw before the wire call now records a typed
+    // request failure so the existing failure banner renders it.
+    let operationId: string;
+    try {
+      operationId = newOperationId();
+    } catch (error) {
+      const requestError: EngineError = {
+        code: "INTERNAL",
+        message:
+          error instanceof Error
+            ? `preview operation id could not be created: ${error.message}`
+            : "preview operation id could not be created",
+        recoverable: false,
+      };
+      this.#state.previewRequestFailure = { operationId: "preview-id-unavailable", error: requestError };
+      this.#notify();
+      throw error;
+    }
     const effectiveFilmProcess =
       this.#state.project?.filmProcess ??
       filmProcess ??

--- a/ports/tauri/app/src/session/webApis.ts
+++ b/ports/tauri/app/src/session/webApis.ts
@@ -24,7 +24,14 @@
  * bare call -- can never throw. */
 export function newOperationId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
+    // The existence check and the call are separate invariants: a runtime
+    // could expose the property and still throw on invocation (the exact
+    // bug class this module exists to close), so the call is guarded too.
+    try {
+      return crypto.randomUUID();
+    } catch {
+      // fall through to the Math.random fallback below
+    }
   }
   let uuid = "";
   for (let index = 0; index < 32; index += 1) {
@@ -41,6 +48,49 @@ export function newOperationId(): string {
     }
   }
   return uuid;
+}
+
+/** One-line description of the runtime's secure-context API availability,
+ * shown by the Windows setup checker. This is the discriminating fact the
+ * first live Windows validation never captured directly: whether the
+ * webview treats its origin as a secure context, and whether the two APIs
+ * this module guards actually exist. */
+export function describeWebApiAvailability(): string {
+  const secure =
+    typeof window !== "undefined" && window.isSecureContext === true ? "yes" : "no";
+  const uuid =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? "available"
+      : "missing";
+  const clipboard =
+    typeof navigator !== "undefined" && navigator.clipboard !== undefined
+      ? "available"
+      : "missing";
+  return `secure context ${secure}; uuid ${uuid}; clipboard ${clipboard}`;
+}
+
+/** Platform-correct URL for a scanstudio-preview protocol resource.
+ *
+ * On macOS and Linux the webview loads custom protocols directly
+ * (`scanstudio-preview://localhost/...`). On Windows, wry serves every
+ * custom protocol through an `http(s)://<scheme>.localhost` origin instead
+ * -- the raw custom-scheme URL is unknown to WebView2 and the request
+ * never reaches the Rust handler. The document's own origin reveals which
+ * world we are in: a `*.localhost` hostname means the wry mapping is
+ * active, and mirroring the document's protocol tracks useHttpsScheme
+ * automatically. The Rust handler reads only the query string, so both
+ * URL forms hit the same code path. */
+export function previewImageSrc(
+  imagePath: string,
+  loc?: Pick<Location, "protocol" | "hostname">,
+): string {
+  const location =
+    loc ?? (typeof window !== "undefined" && window.location ? window.location : undefined);
+  const query = `?id=${encodeURIComponent(imagePath)}`;
+  if (location !== undefined && location.hostname.endsWith(".localhost")) {
+    return `${location.protocol}//scanstudio-preview.localhost/${query}`;
+  }
+  return `scanstudio-preview://localhost/${query}`;
 }
 
 /** Writes text to the system clipboard when the Clipboard API exists.

--- a/ports/tauri/app/src/session/webApis.ts
+++ b/ports/tauri/app/src/session/webApis.ts
@@ -1,0 +1,62 @@
+/** Secure-context Web APIs with insecure-context fallbacks.
+ *
+ * First live Windows validation (2026-08-13, real LS-5000 over the WSL
+ * bridge): the shipped WebView2 runtime does not treat the Windows origin
+ * `http://tauri.localhost` as a secure context, so `crypto.randomUUID` and
+ * `navigator.clipboard` do not exist at runtime on Windows -- while macOS
+ * (custom scheme) and every test environment (Node supplies webcrypto
+ * regardless of context) have both. A bare `crypto.randomUUID()` is then a
+ * synchronous TypeError that a caller's promise `.catch` can swallow whole;
+ * the live symptom was a Preview button that did nothing, with no banner,
+ * against a connected real scanner.
+ *
+ * tauri.conf.json now opts the main window into the https scheme, which
+ * restores the secure context on Windows. These helpers keep every call
+ * site non-throwing even if a future embedding regresses to an insecure
+ * origin: ids fall back to Math.random, clipboard reports unavailability
+ * instead of throwing.
+ */
+
+/** UUID-shaped correlation id. Uses Web Crypto when the context provides
+ * it; otherwise builds an RFC 4122 v4-shaped id from Math.random.
+ * Correlation ids need uniqueness within one app session, not
+ * cryptographic strength, so the fallback is acceptable and -- unlike the
+ * bare call -- can never throw. */
+export function newOperationId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  let uuid = "";
+  for (let index = 0; index < 32; index += 1) {
+    const nibble = Math.floor(Math.random() * 16);
+    if (index === 12) {
+      uuid += "4";
+    } else if (index === 16) {
+      uuid += ((nibble & 0x3) | 0x8).toString(16);
+    } else {
+      uuid += nibble.toString(16);
+    }
+    if (index === 7 || index === 11 || index === 15 || index === 19) {
+      uuid += "-";
+    }
+  }
+  return uuid;
+}
+
+/** Writes text to the system clipboard when the Clipboard API exists.
+ * Returns true only when the write succeeded; false covers both an
+ * insecure context (navigator.clipboard is undefined there) and a rejected
+ * write, so callers can show an "unavailable" affordance instead of dying
+ * on an unhandled rejection. */
+export async function writeClipboardText(text: string): Promise<boolean> {
+  const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+  if (clipboard === undefined || typeof clipboard.writeText !== "function") {
+    return false;
+  }
+  try {
+    await clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/ports/tauri/app/src/views/ContactSheet.tsx
+++ b/ports/tauri/app/src/views/ContactSheet.tsx
@@ -5,6 +5,7 @@ import {
   type SessionState,
 } from "../session";
 import { sessionOperationBusy } from "../session/store/session";
+import { previewImageSrc } from "../session/webApis";
 import { isEngineError } from "../session/wire/types";
 import type { DerivativeTransform, EngineError, Thumbnail } from "../session/wire/types";
 import styles from "./ContactSheet.module.css";
@@ -552,13 +553,13 @@ export default function ContactSheet({ onInspectFrame, onCapture }: ContactSheet
             let content: React.ReactNode;
             if (thumbnail?.imagePath !== undefined) {
               // Strict one-of rule (PROTOCOL.md Thumbnail): an imagePath tile
-              // decodes via Phase 3's scanstudio-preview:// protocol -- never
-              // convertFileSrc, never base64-over-invoke.
+              // decodes via Phase 3's scanstudio-preview protocol -- never
+              // convertFileSrc, never base64-over-invoke. previewImageSrc
+              // picks the platform-correct URL form (Windows serves custom
+              // protocols through an http(s)://<scheme>.localhost origin).
               content = (
                 <img
-                      src={`scanstudio-preview://localhost/?id=${encodeURIComponent(
-                        thumbnail.imagePath,
-                      )}`}
+                      src={previewImageSrc(thumbnail.imagePath)}
                   alt={`Frame ${frameIndex}`}
                   data-testid={`tile-image-${frameIndex}`}
                   data-axis-swapped={swapsAxes}

--- a/ports/tauri/app/src/views/ContactSheet.tsx
+++ b/ports/tauri/app/src/views/ContactSheet.tsx
@@ -5,6 +5,7 @@ import {
   type SessionState,
 } from "../session";
 import { sessionOperationBusy } from "../session/store/session";
+import { isEngineError } from "../session/wire/types";
 import type { DerivativeTransform, EngineError, Thumbnail } from "../session/wire/types";
 import styles from "./ContactSheet.module.css";
 
@@ -206,9 +207,17 @@ export default function ContactSheet({ onInspectFrame, onCapture }: ContactSheet
 
   const preview = (): void => {
     const filmProcess = project?.filmProcess ?? state.previewFilmProcessSelection;
-    // SessionStore owns the typed request-failure state. Deliberately consume
-    // the rejection here so a UI click never becomes an unhandled promise.
-    void sessionStore.acquireThumbnails(undefined, filmProcess).catch(() => {});
+    // SessionStore owns the typed request-failure state, so typed rejections
+    // are deliberately consumed here (the store already recorded them). An
+    // untyped rejection means the store threw before recording anything --
+    // exactly how the Windows insecure-context crypto.randomUUID TypeError
+    // made this button a silent no-op on real hardware -- so keep that class
+    // visible instead of swallowing it.
+    void sessionStore.acquireThumbnails(undefined, filmProcess).catch((error: unknown) => {
+      if (!isEngineError(error)) {
+        console.error("preview request threw outside the store's typed error path", error);
+      }
+    });
   };
 
   const frames: number[] = [];

--- a/ports/tauri/app/src/views/DiagnosticReportActions.tsx
+++ b/ports/tauri/app/src/views/DiagnosticReportActions.tsx
@@ -5,6 +5,7 @@ import { readPreviewRasterBytes, saveDiagnosticBundleFile } from "../session/dia
 import { buildErrorReportText, type ErrorReportContext, type SetupCheckProbeSummary } from "../session/errorReport";
 import { describeCpuArchitecture, describeOperatingSystem, getScanStudioVersion } from "../session/hostEnvironment";
 import { setupCheckResults } from "../session/setupCheckResults";
+import { writeClipboardText } from "../session/webApis";
 import type { DeviceInfo, EngineError, ScannerStatus, Thumbnail } from "../session/wire/types";
 
 export interface DiagnosticReportActionsProps {
@@ -35,6 +36,7 @@ export default function DiagnosticReportActions({
   thumbnails,
 }: DiagnosticReportActionsProps) {
   const [didCopyReport, setDidCopyReport] = useState(false);
+  const [clipboardUnavailable, setClipboardUnavailable] = useState(false);
   const [isSavingBundle, setIsSavingBundle] = useState(false);
   const [didSaveBundle, setDidSaveBundle] = useState(false);
 
@@ -80,7 +82,15 @@ export default function DiagnosticReportActions({
 
   const handleCopyReport = async (): Promise<void> => {
     const text = buildErrorReportText(await buildReportContext());
-    await navigator.clipboard.writeText(text);
+    // navigator.clipboard only exists in secure contexts; report
+    // unavailability on the button instead of dying on an unhandled
+    // rejection (the pre-fix Windows behavior).
+    const copied = await writeClipboardText(text);
+    if (!copied) {
+      setClipboardUnavailable(true);
+      setTimeout(() => setClipboardUnavailable(false), 3000);
+      return;
+    }
     setDidCopyReport(true);
     setTimeout(() => setDidCopyReport(false), 1500);
   };
@@ -115,7 +125,7 @@ export default function DiagnosticReportActions({
   return (
     <div data-testid="diagnostic-report-actions">
       <button type="button" onClick={() => void handleCopyReport()} data-testid="copy-report">
-        {didCopyReport ? "Copied" : "Copy Report"}
+        {didCopyReport ? "Copied" : clipboardUnavailable ? "Clipboard unavailable" : "Copy Report"}
       </button>
       <button
         type="button"

--- a/ports/tauri/app/src/views/DiagnosticReportActions.tsx
+++ b/ports/tauri/app/src/views/DiagnosticReportActions.tsx
@@ -5,7 +5,7 @@ import { readPreviewRasterBytes, saveDiagnosticBundleFile } from "../session/dia
 import { buildErrorReportText, type ErrorReportContext, type SetupCheckProbeSummary } from "../session/errorReport";
 import { describeCpuArchitecture, describeOperatingSystem, getScanStudioVersion } from "../session/hostEnvironment";
 import { setupCheckResults } from "../session/setupCheckResults";
-import { writeClipboardText } from "../session/webApis";
+import { useClipboardCopy } from "./useClipboardCopy";
 import type { DeviceInfo, EngineError, ScannerStatus, Thumbnail } from "../session/wire/types";
 
 export interface DiagnosticReportActionsProps {
@@ -35,8 +35,7 @@ export default function DiagnosticReportActions({
   status,
   thumbnails,
 }: DiagnosticReportActionsProps) {
-  const [didCopyReport, setDidCopyReport] = useState(false);
-  const [clipboardUnavailable, setClipboardUnavailable] = useState(false);
+  const { status: copyStatus, copy: copyToClipboard } = useClipboardCopy();
   const [isSavingBundle, setIsSavingBundle] = useState(false);
   const [didSaveBundle, setDidSaveBundle] = useState(false);
 
@@ -82,17 +81,10 @@ export default function DiagnosticReportActions({
 
   const handleCopyReport = async (): Promise<void> => {
     const text = buildErrorReportText(await buildReportContext());
-    // navigator.clipboard only exists in secure contexts; report
+    // navigator.clipboard only exists in secure contexts; the hook reports
     // unavailability on the button instead of dying on an unhandled
     // rejection (the pre-fix Windows behavior).
-    const copied = await writeClipboardText(text);
-    if (!copied) {
-      setClipboardUnavailable(true);
-      setTimeout(() => setClipboardUnavailable(false), 3000);
-      return;
-    }
-    setDidCopyReport(true);
-    setTimeout(() => setDidCopyReport(false), 1500);
+    await copyToClipboard(text);
   };
 
   const handleSaveDiagnosticBundle = async (): Promise<void> => {
@@ -125,7 +117,11 @@ export default function DiagnosticReportActions({
   return (
     <div data-testid="diagnostic-report-actions">
       <button type="button" onClick={() => void handleCopyReport()} data-testid="copy-report">
-        {didCopyReport ? "Copied" : clipboardUnavailable ? "Clipboard unavailable" : "Copy Report"}
+        {copyStatus === "copied"
+          ? "Copied"
+          : copyStatus === "unavailable"
+            ? "Clipboard unavailable"
+            : "Copy Report"}
       </button>
       <button
         type="button"

--- a/ports/tauri/app/src/views/FrameDetail/SpacingOffsetControl.tsx
+++ b/ports/tauri/app/src/views/FrameDetail/SpacingOffsetControl.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { sessionStore, type SessionState } from "../../session";
 import { sessionOperationBusy } from "../../session/store/session";
+import { previewImageSrc } from "../../session/webApis";
 import styles from "./FrameDetail.module.css";
 
 // useSyncExternalStore requires a referentially stable snapshot between
@@ -115,7 +116,7 @@ export default function SpacingOffsetControl({ frameIndex }: { frameIndex: numbe
         {thumbnail?.imagePath !== undefined ? (
           <img
             className={styles.replacementTile}
-            src={`scanstudio-preview://localhost/?id=${encodeURIComponent(thumbnail.imagePath)}`}
+            src={previewImageSrc(thumbnail.imagePath)}
             alt={`Frame ${frameIndex} replacement tile`}
             data-testid="replacement-tile"
           />

--- a/ports/tauri/app/src/views/FrameDetail/ZoomPanViewer.tsx
+++ b/ports/tauri/app/src/views/FrameDetail/ZoomPanViewer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import { previewImageSrc } from "../../session/webApis";
 import type { DerivativeTransform } from "../../session/wire/types";
 import styles from "./FrameDetail.module.css";
 
@@ -135,7 +136,7 @@ export default function ZoomPanViewer({
           >
             <img
               className={styles.previewImage}
-              src={`scanstudio-preview://localhost/?id=${encodeURIComponent(imagePath)}`}
+              src={previewImageSrc(imagePath)}
               alt={alt ?? "Frame preview"}
               draggable={false}
               data-testid="zoom-pan-image"

--- a/ports/tauri/app/src/views/FrameMetadataOverride.tsx
+++ b/ports/tauri/app/src/views/FrameMetadataOverride.tsx
@@ -18,6 +18,7 @@ import type {
   PreviewMetadataCommandResult,
 } from "../session/wire/types";
 import MetadataPanel from "./MetadataPanel";
+import { useClipboardCopy } from "./useClipboardCopy";
 import styles from "./Metadata.module.css";
 
 export interface FrameMetadataOverrideProps {
@@ -114,14 +115,13 @@ export default function FrameMetadataOverride({
     }
   };
 
+  const { status: copyStatus, copy: copyToClipboard } = useClipboardCopy();
+
   const copyArguments = async (): Promise<void> => {
     if (authoritativePreview === null || authoritativePreview.arguments.length === 0) return;
-    try {
-      await navigator.clipboard?.writeText(authoritativePreview.arguments.join("\n"));
-    } catch {
-      // Clipboard unavailable (non-secure context / jsdom): the block is
-      // still fully readable and the copy button is purely additive.
-    }
+    // The hook reports clipboard unavailability (non-secure context) on the
+    // button; the block is still fully readable either way.
+    await copyToClipboard(authoritativePreview.arguments.join("\n"));
   };
 
   return (
@@ -222,7 +222,11 @@ export default function FrameMetadataOverride({
                   disabled={authoritativePreview.arguments.length === 0}
                   onClick={() => void copyArguments()}
                 >
-                  Copy
+                  {copyStatus === "copied"
+                    ? "Copied"
+                    : copyStatus === "unavailable"
+                      ? "Clipboard unavailable"
+                      : "Copy"}
                 </button>
               </div>
               <pre className={styles.argBlock} data-testid="exiftool-arguments">

--- a/ports/tauri/app/src/views/SetupChecker.test.tsx
+++ b/ports/tauri/app/src/views/SetupChecker.test.tsx
@@ -122,4 +122,31 @@ describe("SetupChecker", () => {
     );
     await waitFor(() => expect(screen.getByTestId("copy-probes-as-text")).toHaveTextContent("Copied"));
   });
+
+  it("says the clipboard is unavailable instead of silently doing nothing (live Windows regression)", async () => {
+    resolveAll(FIXTURE_PROBES, { maxBytes: null, entriesScanned: 0 }, WRITE_MODE_TEXT);
+    // Reproduce the insecure-context runtime: navigator.clipboard absent.
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    try {
+      render(<SetupChecker />);
+      await screen.findByText("OK");
+
+      fireEvent.click(screen.getByTestId("copy-probes-as-text"));
+
+      await waitFor(() =>
+        expect(screen.getByTestId("copy-probes-as-text")).toHaveTextContent(
+          "Clipboard unavailable",
+        ),
+      );
+      expect(mocks.writeText).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { writeText: mocks.writeText },
+      });
+    }
+  });
 });

--- a/ports/tauri/app/src/views/SetupChecker.tsx
+++ b/ports/tauri/app/src/views/SetupChecker.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { formatSetupCheckProbesAsText, setupCheckResults } from "../session/setupCheckResults";
-import { writeClipboardText } from "../session/webApis";
+import { describeWebApiAvailability } from "../session/webApis";
+import { useClipboardCopy } from "./useClipboardCopy";
 import styles from "./SetupChecker.module.css";
 
 export type ProbeStatus = "Ok" | "Fail" | "Unknown";
@@ -37,8 +38,7 @@ export default function SetupChecker() {
   const [probes, setProbes] = useState<ProbeResult[] | null>(null);
   const [maxRead, setMaxRead] = useState<MaxReadReport | null>(null);
   const [writeMode, setWriteMode] = useState<string | null>(null);
-  const [didCopyProbes, setDidCopyProbes] = useState(false);
-  const [clipboardUnavailable, setClipboardUnavailable] = useState(false);
+  const { status: copyStatus, copy: copyToClipboard } = useClipboardCopy();
 
   useEffect(() => {
     let cancelled = false;
@@ -76,19 +76,11 @@ export default function SetupChecker() {
     );
   }
 
+  // navigator.clipboard only exists in secure contexts; the hook reports
+  // unavailability on the button instead of silently doing nothing (the
+  // pre-fix Windows behavior).
   const copyProbesAsText = () => {
-    // navigator.clipboard only exists in secure contexts; writeClipboardText
-    // reports unavailability instead of throwing so this button can say so
-    // rather than silently doing nothing (the pre-fix Windows behavior).
-    void writeClipboardText(formatSetupCheckProbesAsText(probes)).then((copied) => {
-      if (!copied) {
-        setClipboardUnavailable(true);
-        setTimeout(() => setClipboardUnavailable(false), 3000);
-        return;
-      }
-      setDidCopyProbes(true);
-      setTimeout(() => setDidCopyProbes(false), 1500);
-    });
+    void copyToClipboard(formatSetupCheckProbesAsText(probes));
   };
 
   return (
@@ -99,15 +91,21 @@ export default function SetupChecker() {
         onClick={copyProbesAsText}
         disabled={probes.length === 0}
         data-testid="copy-probes-as-text"
-        aria-label="Copy probe results as text"
       >
-        {didCopyProbes ? "Copied" : clipboardUnavailable ? "Clipboard unavailable" : "Copy as text"}
+        {copyStatus === "copied"
+          ? "Copied"
+          : copyStatus === "unavailable"
+            ? "Clipboard unavailable"
+            : "Copy as text"}
       </button>
       {writeMode !== "" && (
         <p className={styles.writeMode} data-testid="write-mode-row">
           <strong>Write mode:</strong> {writeMode}
         </p>
       )}
+      <p className={styles.writeMode} data-testid="web-apis-row">
+        <strong>Web APIs:</strong> {describeWebApiAvailability()}
+      </p>
       <table className={styles.probeTable}>
         <thead>
           <tr>

--- a/ports/tauri/app/src/views/SetupChecker.tsx
+++ b/ports/tauri/app/src/views/SetupChecker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { formatSetupCheckProbesAsText, setupCheckResults } from "../session/setupCheckResults";
+import { writeClipboardText } from "../session/webApis";
 import styles from "./SetupChecker.module.css";
 
 export type ProbeStatus = "Ok" | "Fail" | "Unknown";
@@ -37,6 +38,7 @@ export default function SetupChecker() {
   const [maxRead, setMaxRead] = useState<MaxReadReport | null>(null);
   const [writeMode, setWriteMode] = useState<string | null>(null);
   const [didCopyProbes, setDidCopyProbes] = useState(false);
+  const [clipboardUnavailable, setClipboardUnavailable] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -75,7 +77,15 @@ export default function SetupChecker() {
   }
 
   const copyProbesAsText = () => {
-    void navigator.clipboard.writeText(formatSetupCheckProbesAsText(probes)).then(() => {
+    // navigator.clipboard only exists in secure contexts; writeClipboardText
+    // reports unavailability instead of throwing so this button can say so
+    // rather than silently doing nothing (the pre-fix Windows behavior).
+    void writeClipboardText(formatSetupCheckProbesAsText(probes)).then((copied) => {
+      if (!copied) {
+        setClipboardUnavailable(true);
+        setTimeout(() => setClipboardUnavailable(false), 3000);
+        return;
+      }
       setDidCopyProbes(true);
       setTimeout(() => setDidCopyProbes(false), 1500);
     });
@@ -91,7 +101,7 @@ export default function SetupChecker() {
         data-testid="copy-probes-as-text"
         aria-label="Copy probe results as text"
       >
-        {didCopyProbes ? "Copied" : "Copy as text"}
+        {didCopyProbes ? "Copied" : clipboardUnavailable ? "Clipboard unavailable" : "Copy as text"}
       </button>
       {writeMode !== "" && (
         <p className={styles.writeMode} data-testid="write-mode-row">

--- a/ports/tauri/app/src/views/__tests__/ContactSheet.test.tsx
+++ b/ports/tauri/app/src/views/__tests__/ContactSheet.test.tsx
@@ -227,6 +227,42 @@ describe("ContactSheet", () => {
     expect(fixture.calls.some((call) => call.method === "sim.loadMedia")).toBe(false);
   });
 
+  it("preview click still sends the wire request when crypto.randomUUID is absent (live Windows regression)", async () => {
+    // First live Windows validation: the webview origin was not a secure
+    // context, crypto.randomUUID did not exist, and the bare call's
+    // TypeError was swallowed by the click handler -- an enabled, rendered
+    // Preview button that did nothing. This drives the real button.
+    const fixture = contactFixture({
+      device: REAL_DEVICE,
+      status: REAL_EMPTY_ARMED,
+    });
+    await fixture.store.connect(REAL_DEVICE.deviceId);
+    mocks.sessionStore = fixture.store;
+    const user = userEvent.setup();
+
+    render(<ContactSheet />);
+
+    const preview = screen.getByTestId("preview-button");
+    expect(preview).toBeEnabled();
+    vi.stubGlobal("crypto", {});
+    try {
+      await act(async () => {
+        await user.click(preview);
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    const acquire = fixture.calls.find(
+      (call) => call.method === "scanner.acquireThumbnails",
+    );
+    expect(acquire).toBeDefined();
+    expect(acquire?.params.operationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(screen.queryByTestId("preview-request-failure")).toBeNull();
+    expect(screen.queryByTestId("preview-failure")).toBeNull();
+  });
+
   it("offers the first real preview before a project exists and sends the selected process", async () => {
     const fixture = contactFixture({
       device: REAL_DEVICE,

--- a/ports/tauri/app/src/views/__tests__/useClipboardCopy.test.tsx
+++ b/ports/tauri/app/src/views/__tests__/useClipboardCopy.test.tsx
@@ -1,0 +1,73 @@
+/** @vitest-environment jsdom */
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useClipboardCopy } from "../useClipboardCopy";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("useClipboardCopy", () => {
+  it("reports copied and self-clears after 1500ms", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("navigator", {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    const { result } = renderHook(() => useClipboardCopy());
+    await act(async () => {
+      await result.current.copy("text");
+    });
+    expect(result.current.status).toBe("copied");
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("reports unavailable when the Clipboard API is absent (insecure context)", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("navigator", {});
+    const { result } = renderHook(() => useClipboardCopy());
+    await act(async () => {
+      await result.current.copy("text");
+    });
+    expect(result.current.status).toBe("unavailable");
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("a later attempt replaces the pending status instead of racing it", async () => {
+    // The earlier two-boolean design could show "Clipboard unavailable"
+    // right after a successful copy (the stale failure timer outliving the
+    // success flag). One status plus one cancelled-on-entry timer cannot.
+    vi.useFakeTimers();
+    const writeText = vi.fn().mockRejectedValueOnce(new Error("denied"));
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const { result } = renderHook(() => useClipboardCopy());
+    await act(async () => {
+      await result.current.copy("first");
+    });
+    expect(result.current.status).toBe("unavailable");
+    writeText.mockResolvedValueOnce(undefined);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    await act(async () => {
+      await result.current.copy("second");
+    });
+    expect(result.current.status).toBe("copied");
+    // The first attempt's 3000ms clear would land here; it must not fire.
+    act(() => {
+      vi.advanceTimersByTime(1499);
+    });
+    expect(result.current.status).toBe("copied");
+    act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(result.current.status).toBe("idle");
+  });
+});

--- a/ports/tauri/app/src/views/useClipboardCopy.ts
+++ b/ports/tauri/app/src/views/useClipboardCopy.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from "react";
+import { writeClipboardText } from "../session/webApis";
+
+export type ClipboardCopyStatus = "idle" | "copied" | "unavailable";
+
+/** Clipboard copy with a single self-clearing status.
+ *
+ * One status value and one timer replace the pair of independent booleans
+ * an earlier revision used, which could contradict each other when clicks
+ * landed inside each other's clear windows ("Copied" after a failed copy,
+ * "Clipboard unavailable" after a successful one). Every new copy attempt
+ * cancels the previous timer before setting the new status, and the timer
+ * is cleared on unmount. */
+export function useClipboardCopy(): {
+  status: ClipboardCopyStatus;
+  copy: (text: string) => Promise<void>;
+} {
+  const [status, setStatus] = useState<ClipboardCopyStatus>("idle");
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const copy = async (text: string): Promise<void> => {
+    const copied = await writeClipboardText(text);
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    setStatus(copied ? "copied" : "unavailable");
+    timerRef.current = setTimeout(() => setStatus("idle"), copied ? 1500 : 3000);
+  };
+
+  return { status, copy };
+}


### PR DESCRIPTION
## What the first live Windows run found

beta.9's setup.exe, on a Windows 10 VM with the WSL bridge fully green (all five setup probes OK) and a real LS-5000 connected and streaming status, has a Preview button that does nothing. No failure banner, no busy state, no wire request — across keyboard activation and real mouse clicks. The film-process select next to it works, Connect/Disconnect work, the setup checker works.

## Root cause (validated live, three independent ways)

1. Tauri v2 serves the Windows app from `http://tauri.localhost`. The shipped WebView2 runtime (151.0.4129.78) does **not** treat that origin as a secure context.
2. In an insecure context, `crypto.randomUUID` and `navigator.clipboard` do not exist. `SessionStore.acquireThumbnails` minted its correlation id with a bare `crypto.randomUUID()` — a synchronous `TypeError` thrown before any state was recorded.
3. `ContactSheet`'s click handler deliberately consumed rejections (the store owns typed failure state), so the TypeError vanished without a trace.

Empirical confirmation on the live VM: the setup checker's **Copy as text** (bare `navigator.clipboard.writeText`) writes nothing to the Windows clipboard — `Get-Clipboard` returns empty after clicking it. Same mechanism, second witness. macOS never sees any of this (custom-scheme origin is a secure context), and tests can't catch it (Node supplies webcrypto regardless of context).

## The fix, three layers

- **Root**: `useHttpsScheme: true` on the main window — Windows now runs in a secure context like macOS. CSP gains the `https://ipc.localhost` / `https://asset.localhost` origins alongside the http ones.
- **Defense in depth**: new `session/webApis.ts` — `newOperationId()` (Web Crypto when present, Math.random v4-shaped fallback otherwise, never throws) and `writeClipboardText()` (reports unavailability instead of throwing). Used by `acquireThumbnails` and both bare clipboard sites (`SetupChecker`, `DiagnosticReportActions` — the copy buttons now show "Clipboard unavailable"). `FrameMetadataOverride` already guarded with `clipboard?.` and is unchanged.
- **Observability**: ContactSheet's rejection consumer now logs untyped rejections — the exact class that made this invisible — instead of swallowing them.

## Verification

- `policy-preview-insecure-context.test.ts` reproduces the live runtime shape (`crypto` = `{}`, no `randomUUID`) and asserts the preview request is sent with a v4-shaped operationId. **Mutation-proven**: restoring the bare call fails this test with the exact live TypeError.
- `webApis.test.ts`: both id branches, all three clipboard outcomes.
- Full Tauri suite: 60 files, 428 passed, 6 skipped. `tsc --noEmit` clean.
- Live re-validation on the Windows VM is queued for the next release build containing this fix.

---

## Round 2 (after two independent adversarial reviews)

Both reviews confirmed the root cause; one independently verified that Chromium does **not** extend loopback trustworthiness to `*.localhost` subdomains (only exact `localhost` — which is also why dev mode never reproduced this). Round 2 addresses everything they surfaced:

- **Blocker**: Windows serves custom protocols through `http(s)://<scheme>.localhost` origins — the three hardcoded `scanstudio-preview://localhost` tile URLs could never load there, and the CSP allowed neither mapped origin. `previewImageSrc()` now derives the correct form from the document origin; CSP admits both.
- Pre-wire throws in `acquireThumbnails` now record a typed `previewRequestFailure` (visible banner) before rethrowing.
- `newOperationId()` guards the call, not just the existence check; the setup checker shows a **Web APIs** line (secure context / uuid / clipboard) so the next live run captures the discriminating fact directly.
- The two-boolean copy-status UI (could show "Copied" after a failure and vice versa inside the clear windows) is replaced by a single-status `useClipboardCopy` hook with one cancelled-on-entry timer and unmount cleanup, now used by all three copy buttons — including the frame-metadata one that previously no-oped silently.
- `diagnosticTimeline` delegates to the shared generator; its "every environment has Web Crypto" comment is corrected.
- New coverage: rendered-button regression (real click path with `crypto` absent), a sweep test banning bare `crypto.randomUUID`/`navigator.clipboard` outside `webApis.ts`, hook race-semantics tests, and the checker's unavailable branch. Suite: 61 files, 438 passed, 6 skipped; tsc clean.

Deliberately not taken: dropping the pre-existing `http://` CSP entries (fail-open kept for this release) and extending the typed/untyped catch split to sibling views' list-refresh catches (separate concern, no live defect).
