### PR TITLE
fix(#16): occluded-gap rolls bind at medium; released-hold journals validate

### DIFF
--- a/bridge/tests/test_transport_coolscanpy.py
+++ b/bridge/tests/test_transport_coolscanpy.py
@@ -539,17 +539,23 @@ def _synthetic_transport_table(rows: int) -> bytes:
 
 
 def _write_synthetic_preview_attempt(
-    attempts_root: Path, *, slot_capacity_hint: int = 40
+    attempts_root: Path,
+    *,
+    slot_capacity_hint: int = 40,
+    hold_terminal: str | None = None,
 ) -> Path:
     """Write one complete, byte-valid preview attempt directory under
     ``attempts_root`` with CoolscanPyTransport's own "preview-" mkdtemp
     prefix -- everything manual_frames()/preview_strip()'s
     _reconstruct_last_preview_attempt/_validated_preview_from_attempt need to
     find and validate it, exactly as if a real roll.preview attempt had just
-    completed (this journal shape is "preview-only"/"complete"/released --
-    see preview_session.py's _validate_preview_result: both that shape and
-    the "preview-and-hold" shape a real Roll.preview() always uses today
-    validate identically). Returns the attempt directory."""
+    completed. The default journal shape is "preview-only"/"complete";
+    ``hold_terminal="released"/"ejected"`` writes the TERMINAL preview-and-
+    hold shape a real Roll.preview() always leaves behind instead (a real
+    preview runs as a held reservation, and a REFUSED one -- exactly when
+    manual_frames()/preview_strip() are needed (#16) -- is always torn down
+    to this terminal state before its evidence is recorded). Returns the
+    attempt directory."""
     contract = _preview_binding_contract(slot_capacity_hint)
     native_height = contract["native_height"]
     decoded_height = contract["decoded_height"]
@@ -587,7 +593,11 @@ def _write_synthetic_preview_attempt(
         source_height=decoded_height,
     )
     receipt = {
-        "status": "preview-only-complete",
+        "status": (
+            "preview-and-hold-awaiting-job"
+            if hold_terminal
+            else "preview-only-complete"
+        ),
         "slot_capacity_hint": slot_capacity_hint,
         "slot_capacity_semantics": (
             "scanner-addressable preview slots; not an exposure count"
@@ -657,6 +667,23 @@ def _write_synthetic_preview_attempt(
         },
         "preview_only_receipt": receipt,
     }
+    if hold_terminal:
+        # The worker's post-decision teardown stamps (worker.py's
+        # released_hold_without_scan branch): capture_mode stays
+        # preview-and-hold, status flips to complete, the reservation is
+        # released, and hold_outcome records which decision ended it.
+        journal["capture_mode"] = "preview-and-hold"
+        journal["hold_session_id"] = "a" * 32
+        journal["hold_ready_unix"] = 0.0
+        journal["hold_outcome"] = hold_terminal
+        if hold_terminal == "ejected":
+            journal["eject"] = {
+                "eject_cdb_status": "0000000000000000",
+                "eject_execute_status": "0000000000000000",
+                "terminal_sense": "023a00",
+                "wait_polls": 5,
+                "stall_recoveries": 0,
+            }
     (attempt / "journal.json").write_text(json.dumps(journal), encoding="utf-8")
     return attempt
 
@@ -1399,6 +1426,8 @@ def test_preview_strip_without_any_preview_attempt_is_no_preview(
 
 def _transport_with_synthetic_preview_attempt(
     monkeypatch: pytest.MonkeyPatch,
+    *,
+    hold_terminal: str | None = None,
 ) -> tuple[CoolscanPyTransport, _FakeRoll, Path]:
     """An opened transport whose attempts_root already holds one real,
     byte-valid preview attempt on disk -- the "completed-but-refused (or
@@ -1409,6 +1438,9 @@ def _transport_with_synthetic_preview_attempt(
     attempt this test actually reads back is a separately-written synthetic
     one, matching how a real refused preview would leave its own evidence
     on disk without ever producing a _FakeRoll-shaped in-memory session.
+    ``hold_terminal`` forwards to _write_synthetic_preview_attempt to write
+    the terminal preview-and-hold journal shape a real refused preview
+    leaves behind (#16).
 
     S5 fix (2026-08-08 adversarial review): manual_frames()/preview_strip()
     now read ONLY `transport._recorded_preview_attempt_journal`, never a
@@ -1424,7 +1456,10 @@ def _transport_with_synthetic_preview_attempt(
     transport, _device = _opened_transport(monkeypatch, roll)
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
     assert transport.attempts_root is not None
-    attempt_dir = _write_synthetic_preview_attempt(transport.attempts_root)
+    attempt_dir = _write_synthetic_preview_attempt(
+        transport.attempts_root,
+        hold_terminal=hold_terminal,
+    )
     transport._recorded_preview_attempt_journal = (
         attempt_dir / "journal.json"
     ).resolve(strict=True)
@@ -1548,6 +1583,54 @@ def test_preview_strip_refuses_when_current_attempt_has_no_recorded_evidence(
     assert excinfo.value.code == ErrorCode.NO_PREVIEW
     assert "left no usable evidence" in str(excinfo.value)
     assert "acquire a fresh preview" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("hold_terminal", ["released", "ejected"])
+def test_preview_strip_renders_from_a_released_hold_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+    hold_terminal: str,
+) -> None:
+    """#16 regression: a real Roll.preview() is always a held reservation,
+    and a REFUSED one -- exactly when the UI falls back to manual placement
+    via roll.previewStrip -- is torn down before its evidence is recorded.
+    The on-disk journal it leaves is therefore the TERMINAL preview-and-
+    hold shape (status=complete, unit_released=true, capture_mode stays
+    preview-and-hold), which the validator used to refuse with
+    "preview journal status='complete', expected 'awaiting-hold-job'" --
+    surfacing as INTERNAL and killing the manual-placement fallback on
+    every field report it existed for."""
+
+    transport, _roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch,
+        hold_terminal=hold_terminal,
+    )
+
+    strip = transport.preview_strip()
+
+    assert strip.row_count == 6_104
+    assert Path(strip.image_path).is_file()
+
+
+def test_manual_frames_arms_a_session_from_a_released_hold_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#16 regression, manualFrames' half of the same bug: manual placement
+    against a refused preview's terminal journal must arm the roll for
+    approve/scan instead of crashing INTERNAL."""
+
+    transport, roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch,
+        hold_terminal="released",
+    )
+
+    result, thumbnails, snaps, material = transport.manual_frames([128, 271, 414])
+
+    assert material is domain.Material.COLOR_NEGATIVE
+    assert result.count == 2
+    assert [t.slot for t in thumbnails] == [1, 2]
+    assert snaps == ()
+    assert transport._preview_established is True
+    assert roll._session is not None
 
 
 # -- 2026-08-08 adversarial review, S1 (manual placement replacement safety) --

--- a/coolscanpy/CHANGELOG.md
+++ b/coolscanpy/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+- Roll previews whose physical inter-frame gaps are present but partially
+  occluded no longer refuse outright as low confidence (ScanStudio #16).
+  This is the field signature of full-roll-modified SA-21 strip feeders:
+  the frame lattice anchors exactly as on a stock adapter (same gap-run,
+  anchor-assignment, refined-fit, pitch, and direct-support floors), but
+  intruding mask edges dim the gap rows below the strict clear-film bar,
+  which used to drop the detection to "low" on the clean-gap fraction
+  alone -- refusing the preview AND, because low confidence is refused
+  unconditionally at the scan gate, locking out the attended binding path.
+  An anchored comb with an unambiguous lattice margin and at least three
+  independently supported boundaries now binds at medium with a
+  `degraded-gap-evidence` warning: every weak slot stays flagged for
+  manual review, unattended fine scanning still requires high confidence,
+  and heavily degraded captures (boundary evidence averaging under the
+  medium score bar) keep today's honest refusal. Field reports also carry
+  `lattice_margin` and `direct_fraction` so the failing gate is visible
+  without a replay.
+- `roll.previewStrip` and `roll.manualFrames` no longer crash with
+  INTERNAL ("preview journal status='complete', expected
+  'awaiting-hold-job'") when used after a refused preview (ScanStudio
+  #16). A real preview always runs as a held reservation, and a refused
+  one is torn down before its evidence is recorded, so the journal on
+  disk is the terminal preview-and-hold shape (status complete,
+  reservation released, hold outcome released/ejected) -- not the
+  paused-at-hold-boundary shape the validator demanded. Both terminal
+  shapes now validate; resumed-as-batch journals still fail closed.
+
 ## 0.7.2 - 2026-08-13
 
 - `Device.eject()` no longer goes through SANE. It now replays the

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -28,6 +28,11 @@ CANONICAL_MANIFEST_FILENAME = "replay-first-rgbi4-manifest.json"
 # density-source cap-0x10d/f03 exposures, the proven 97-dpi reservation-preview
 # evidence, runtime arithmetic gate, and exact per-frame ownership receipt.
 CAPTURE_BUNDLE_COMPONENT_SHA256 = {
+    # Resealed 2026-08-22 (ScanStudio #16): manual_frames.py gained an
+    # honest direct_fraction on its RollDetection construction;
+    # roll_index.py gained the degraded-gap-evidence confidence tier, the
+    # DEGRADED_GAP_EVIDENCE_WARNING marker, and the additive
+    # RollDetection.direct_fraction field.
     # Resealed 2026-08-13 (attended scan binding, feed-detector round;
     # ScanStudio #24/#16/#42): capture_process.py gained the
     # ATTENDED_ROLL_BINDING_* pair and ManualFrameApproval.
@@ -45,14 +50,14 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     # process group and inherit its exclusive process-ownership fence.
     "capture_process.py": "c4d234c02bcabf5d10c83b9ef9f071c591546c2447ca004610cc0e0c804a3944",
     "worker.py": "08b9fdb46bc072923d46c1efc4d4a901fd943de542624bc536cd440c3fb6294b",
-    "manual_frames.py": "f30f0003e081c3a98610d5700d7e6b6ee4d182b9d5228932f3304f1307d4815f",
+    "manual_frames.py": "8fc4ba82c177e1b7ecd6943354db33930b468ef3b4b82c712202b8caea54c9bb",
     "usb_backend.py": "afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62",
     "density.py": "c2c47de2886bc4b60197d2721b6d72050a76f1095760590fa7bb34a728b9da76",
     "packed.py": "856315714e4f7e81f42e1ca93917e4cc0feb03b24915c2ad604302bfdca46f87",
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "ae64e28a5d7e442cc368995b47c60ea1097f95f272fff558e93c7fc50800a5ef",
+    "roll_index.py": "5b192213d4c070f53e1733f22fc4e744a9142126f7ef4204a41c943efae8329a",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
@@ -1053,6 +1053,13 @@ def build_manual_detection(
         lattice_margin_fraction=0.0,
         mean_boundary_evidence=float(np.mean(evidences)),
         minimum_boundary_evidence=float(np.min(evidences)),
+        direct_fraction=(
+            sum(
+                boundary.support in {"direct", "direct-wide"}
+                for boundary in boundaries[:-1]
+            )
+            / max(1, len(boundaries) - 1)
+        ),
         content_level_threshold=0.0,
         content_range_threshold=0.0,
         candidate_cell_count=frame_count,

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -62,6 +62,22 @@ _WIDE_GAP_RECOVERY_ERROR_IDS = frozenset(
     }
 )
 
+# Degrated-gap confidence tier (ScanStudio #16). A roll whose inter-frame
+# gaps are all present at the fitted lattice positions but partially
+# occluded -- the field signature of full-roll-modified strip feeders,
+# where mask edges intrude into the film window -- still anchors the same
+# physical comb (same >=3-run, anchor-assignment, refined-fit, and pitch
+# floors as every other detection) yet fails the medium gate's clean
+# direct-gap fraction because many boundary rows read dimmer or less
+# uniform than stock-adapter gaps. Such a capture is exactly the documented
+# meaning of "medium" (capture_process.py ATTENDED_ROLL_BINDING_CONFIDENCE):
+# a geometry the detector DID find but could not fully corroborate -- every
+# slot lands in manual review, and fine scanning still requires the
+# attended all-frames approval path. Labeling it "low" instead refused the
+# preview outright and, because 'low' is refused unconditionally at the
+# worker gate, locked the operator out of even that attended path.
+DEGRADED_GAP_EVIDENCE_WARNING = "degraded-gap-evidence"
+
 
 class IndexDecodeError(ValueError):
     """Input is not a self-consistent LS-5000 roll-index capture.
@@ -298,6 +314,12 @@ class RollDetection:
     boundaries: tuple[GapBoundary, ...]
     intervals: tuple[FrameInterval, ...]
     manual_review_frames: tuple[int, ...]
+    # Additive (#16 field reports), defaulted so every existing constructor
+    # keeps its exact behavior: the alignment-boundary clean-gap fraction
+    # the confidence ladder itself gates on, carried on the result so error
+    # reports can discriminate "score too low" from "direct_fraction too
+    # low" -- the two distinct ways a detection lands at low confidence.
+    direct_fraction: float = 0.0
 
     @property
     def frame_starts(self) -> list[int]:
@@ -337,6 +359,7 @@ class RollDetection:
             "lattice_margin_fraction": self.lattice_margin_fraction,
             "mean_boundary_evidence": self.mean_boundary_evidence,
             "minimum_boundary_evidence": self.minimum_boundary_evidence,
+            "direct_fraction": self.direct_fraction,
             "count_method": (
                 "all physically aligned, scanner-addressable lattice slots; "
                 "scene content only supplies advisory flags"
@@ -1542,6 +1565,7 @@ def _detect_roll_frames_single(
         for item in alignment_boundaries[:-1]
     ) / max(1, len(alignment_boundaries) - 1)
     recovered_wide_gap = wide_gap_ceiling is not None
+    degraded_gap_evidence = False
     if (
         lattice_score >= 0.65
         and lattice_margin >= 0.08
@@ -1551,6 +1575,24 @@ def _detect_roll_frames_single(
         confidence = "high"
     elif lattice_score >= 0.45 and direct_fraction >= 0.60:
         confidence = "medium"
+    elif (
+        # Degrated-gap tier (#16): the comb is anchored -- reaching this
+        # point already required >=3 distinct narrow gap runs, >=3 anchor
+        # assignments within 8 rows, a refined fit agreeing within 3 rows,
+        # a pitch inside the film-geometry band, and >=3 directly supported
+        # alignment boundaries -- but the gaps are partially occluded, so
+        # the clean-gap fraction fell below the medium gate. Admit it as
+        # medium only when the fit is unambiguous (the same lattice-margin
+        # bar "high" requires) and at least three boundaries carry
+        # independently supported evidence. Everything still lands in
+        # manual review per slot, and the worker gate still refuses any
+        # unattended binding below "high".
+        lattice_score >= 0.45
+        and lattice_margin >= 0.08
+        and len(supported_alignment_boundaries) >= 3
+    ):
+        confidence = "medium"
+        degraded_gap_evidence = True
     else:
         confidence = "low"
     if recovered_wide_gap and confidence == "high":
@@ -1560,6 +1602,8 @@ def _detect_roll_frames_single(
     warnings: list[str] = []
     if recovered_wide_gap:
         warnings.append(WIDE_GAP_RECOVERY_WARNING)
+    if degraded_gap_evidence:
+        warnings.append(DEGRADED_GAP_EVIDENCE_WARNING)
     if expected_frame_count is not None:
         expected_frame_count_matches = expected_frame_count in content_end_candidates
         if expected_frame_count_matches:
@@ -1592,6 +1636,7 @@ def _detect_roll_frames_single(
         lattice_margin_fraction=lattice_margin,
         mean_boundary_evidence=float(boundary_evidence.mean()),
         minimum_boundary_evidence=float(boundary_evidence.min()),
+        direct_fraction=direct_fraction,
         content_level_threshold=content_level_threshold,
         content_range_threshold=content_range_threshold,
         candidate_cell_count=len(cell_supported),

--- a/coolscanpy/src/coolscanpy/roll/preview_session.py
+++ b/coolscanpy/src/coolscanpy/roll/preview_session.py
@@ -755,11 +755,35 @@ def _validate_preview_result(
     # release decision exists (see run_live_capture's own comment at the
     # `journal["disk_bytes"] = 0` / `journal["unit_released"] = False`
     # stamps). That snapshot is legitimately never "complete"/"preview-
-    # only"/released -- it is the other of exactly two valid shapes this
-    # journal can take, never a partial or intermediate one.
-    held = journal.get("capture_mode") == "preview-and-hold"
+    # only"/released -- it is one of exactly three valid shapes this
+    # journal can take, never a partial or intermediate one. The third
+    # shape is that same held attempt's TERMINAL state (#16): after the
+    # hold decision, the worker's teardown flips status to "complete" and
+    # unit_released to True while capture_mode stays "preview-and-hold"
+    # and hold_outcome records "released"/"ejected" (worker.py's
+    # released_hold_without_scan branch; release_held_session validates the
+    # same terminal facts from its dedicated receipt file). A preview that
+    # was REFUSED -- exactly when manual_frames()/preview_strip() need this
+    # journal most -- is always torn down before its evidence is recorded,
+    # so reconstructing an attempt from disk sees only this terminal shape;
+    # refusing it made the manual-placement fallback INTERNAL-crash on
+    # every field report it existed for. The resumed-as-batch outcome is
+    # deliberately NOT admitted: it moves fine-scan bytes through other
+    # artifacts and stamps requested_frame/disk_bytes/output_sha256 with
+    # non-preview values, each of which its own exact check below refuses.
+    capture_mode = journal.get("capture_mode")
+    held = capture_mode == "preview-and-hold"
+    released_hold = (
+        held
+        and journal.get("status") == "complete"
+        and journal.get("unit_released") is True
+        and journal.get("hold_outcome") in ("released", "ejected")
+    )
     for key, expected in (
-        ("status", "awaiting-hold-job" if held else "complete"),
+        (
+            "status",
+            "awaiting-hold-job" if held and not released_hold else "complete",
+        ),
         ("capture_mode", "preview-and-hold" if held else "preview-only"),
         ("requested_frame", None),
         ("requested_boundary_offset_rows", 0),
@@ -769,7 +793,7 @@ def _validate_preview_result(
         ("expected_bytes", 0),
         ("completed_bytes", 0),
         ("disk_bytes", 0),
-        ("unit_released", False if held else True),
+        ("unit_released", False if held and not released_hold else True),
         ("plan_sha256", CANONICAL_PLAN_SHA256),
         ("preview_geometry_validated_before_reads", True),
     ):
@@ -1232,6 +1256,8 @@ def _roll_session_diagnostics(detection: RollDetection) -> str:
         + detection.count_confirmation
         + f" lattice_score={detection.lattice_score:.4f}"
         + f" alt_lattice_score={detection.alternative_lattice_score:.4f}"
+        + f" lattice_margin={detection.lattice_margin_fraction:.4f}"
+        + f" direct_fraction={detection.direct_fraction:.4f}"
         + f" mean_boundary_evidence={detection.mean_boundary_evidence:.4f}"
         + f" min_boundary_evidence={detection.minimum_boundary_evidence:.4f}"
         + f" autocorr_peak={detection.autocorrelation_peak:.4f}"

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -1395,6 +1395,137 @@ def test_recovery_confidence_cap_is_keyed_to_the_mode() -> None:
     assert "wide-gap-recovery" in detection.warnings
 
 
+def _occlude_gaps(
+    rgb: np.ndarray,
+    boundaries: list[int],
+    *,
+    occluded: list[int],
+    end_bands: bool = False,
+    factor: float = 0.855,
+) -> np.ndarray:
+    """Partially occlude chosen inter-frame gaps (ScanStudio #16).
+
+    The full-roll-modified strip-feeder signature: every gap still exists at
+    its true lattice position, but intruding mask edges dim those rows just
+    under the strict clear-film bar (transmission < 0.87) and add row-to-row
+    unevenness, so the gap runs shrink below the narrow width window or
+    vanish while the lattice itself stays anchored on the remaining clean
+    gaps.
+    """
+
+    out = rgb.copy()
+    height = out.shape[0]
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    x = np.arange(90, dtype=np.int64)[None, :]
+    haze_gradient = ((x * 7) % 23 - 11)[:, :, None] * 160
+    for index in occluded:
+        boundary = boundaries[index]
+        lo = max(0, boundary - 3)
+        hi = min(height, boundary + 3)
+        hazy = (clear_base * factor).astype(np.int64) + haze_gradient[: hi - lo]
+        out[lo:hi, 2:92] = hazy.clip(0, 65_535).astype(np.uint16)
+        for edge in (lo - 1, hi):
+            if 0 <= edge < height:
+                out[edge, 2:92] = (
+                    (out[edge, 2:92].astype(np.int64) * 0.88)
+                    .clip(0, 65_535)
+                    .astype(np.uint16)
+                )
+    if end_bands:
+        for lo, hi in ((0, boundaries[0]), (boundaries[-1], height)):
+            hazy = (clear_base * 0.87).astype(np.int64) + haze_gradient[: hi - lo]
+            out[lo:hi, 2:92] = hazy.clip(0, 65_535).astype(np.uint16)
+    return out
+
+
+def test_occluded_gap_roll_binds_at_medium_with_the_degraded_warning() -> None:
+    """ScanStudio #16: a roll whose gaps are all present but partially
+    occluded -- the field signature of full-roll-modified SA-21 adapters --
+    anchored the same comb as any healthy roll (same floors, >=3 directly
+    supported boundaries) yet scored "low" on the clean-gap fraction alone,
+    which refused the preview outright AND locked the operator out of the
+    attended binding path (which admits exactly "medium"). Such a capture is
+    precisely the documented meaning of medium -- a geometry the detector
+    found but could not fully corroborate -- so it now binds at medium with
+    the degraded-gap warning, every weak slot flagged for review."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    # Field-report profile: interior gaps occluded and no clean leader/tail
+    # band either -- lattice_score ~0.48 vs the report's 0.4622-0.4653,
+    # margin well above the high gate's own 0.08 bar.
+    occluded_rgb = _occlude_gaps(
+        rgb,
+        boundaries,
+        occluded=[1, 2, 3],
+        end_bands=True,
+    )
+
+    detection = _detect(occluded_rgb)
+
+    # Field-report band: the report's own captures scored
+    # 0.4622-0.4653 -- below the high gate's 0.65 bar, above the medium
+    # floor this tier still requires.
+    assert detection.lattice_score < 0.55
+    assert detection.direct_fraction < 0.60
+    assert detection.confidence == "medium"
+    assert roll.DEGRADED_GAP_EVIDENCE_WARNING in detection.warnings
+    assert detection.pitch_rows == pytest.approx(143.0, abs=0.5)
+    supported = [
+        boundary
+        for boundary in detection.boundaries[:-1]
+        if boundary.support in {"direct", "direct-wide", "cadence-broad"}
+        and boundary.evidence >= 0.40
+        and boundary.transmission >= 0.82
+        and boundary.nonuniformity <= 0.22
+    ]
+    assert len(supported) >= 3
+    flagged = {
+        boundary.index
+        for boundary in detection.boundaries
+        if "low-gap-evidence" in boundary.review_reasons
+        or "narrow-gap-evidence" in boundary.review_reasons
+        or "no-local-gap-run" in boundary.review_reasons
+    }
+    assert flagged, "occluded boundaries must stay visible for manual review"
+
+
+def test_healthy_rolls_never_carry_the_degraded_gap_warning() -> None:
+    """The tier is additive only: an untouched roll keeps bit-identical
+    confidence and no degraded-gap marker."""
+
+    rgb, boundaries = _synthetic_roll(6)
+
+    detection = _detect(rgb)
+
+    assert detection.confidence == "high"
+    assert roll.DEGRADED_GAP_EVIDENCE_WARNING not in detection.warnings
+    # Leader/tail edges are cadence-broad rather than narrow gaps, so a
+    # healthy strip sits at the high gate's own >= 0.80 bar, not exactly 1.
+    assert detection.direct_fraction >= 0.80
+
+
+def test_heavily_degraded_evidence_below_the_score_bar_stays_low() -> None:
+    """Guard rail: the tier never relaxes the lattice-score bar. When
+    occlusion is so heavy that even the anchored comb's own boundary rows
+    average below 0.45 evidence, the capture keeps today's honest 'low' --
+    refused at the session gate -- instead of riding the new tier up to
+    medium."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    heavily_occluded = _occlude_gaps(
+        rgb,
+        boundaries,
+        occluded=[1, 2, 3, 4],
+        end_bands=True,
+    )
+
+    detection = _detect(heavily_occluded)
+
+    assert detection.lattice_score < 0.45
+    assert detection.confidence == "low"
+    assert roll.DEGRADED_GAP_EVIDENCE_WARNING not in detection.warnings
+
+
 def test_incomplete_index_never_triggers_recovery() -> None:
     """IncompleteIndexError is a subclass of IndexDecodeError; it must pass
     through the two-pass wrapper untouched, with no recovery note."""

--- a/coolscanpy/tests/roll/test_ls5000_roll_session.py
+++ b/coolscanpy/tests/roll/test_ls5000_roll_session.py
@@ -1315,3 +1315,121 @@ def test_session_pixel_arrays_cannot_be_made_writeable(tmp_path: Path) -> None:
         session.preview.rgb.setflags(write=True)
     with pytest.raises(ValueError):
         session.slots[0].thumbnail.setflags(write=True)
+
+
+# -- ScanStudio #16: the three valid preview journal shapes --------------------
+#
+# A real Roll.preview() always runs as a held preview. Its journal is valid
+# in exactly three shapes: paused at the hold boundary (awaiting-hold-job),
+# and its two terminal states after the hold decision -- released or
+# ejected (status flips to complete, unit_released to True, capture_mode
+# stays preview-and-hold). A REFUSED preview is always torn down before its
+# evidence is recorded, so the on-disk journal a later manual_frames()/
+# preview_strip() reconstruction reads is always one of the terminal
+# states; refusing those made the manual-placement fallback crash INTERNAL
+# on exactly the field reports it existed for.
+
+
+def _held_preview_fixture(
+    tmp_path: Path,
+    *,
+    terminal: str | None,
+) -> PreviewFixture:
+    """The preview-only fixture rewritten into the preview-and-hold shape.
+
+    ``terminal=None`` pauses at the hold boundary; ``"released"`` and
+    ``"ejected"`` apply the worker's post-decision teardown stamps; any
+    other value produces an inconsistent journal that must stay refused.
+    """
+    fixture = _preview_fixture(tmp_path)
+    journal = json.loads(json.dumps(fixture.result.journal))
+    receipt = json.loads(json.dumps(journal["preview_only_receipt"]))
+    mapping_path = Path(journal["live_index_artifacts"]["mapping"])
+    receipt["status"] = "preview-and-hold-awaiting-job"
+    mapping_path.write_text(json.dumps(receipt), encoding="utf-8")
+    journal["capture_mode"] = "preview-and-hold"
+    journal["hold_session_id"] = "a" * 32
+    journal["hold_ready_unix"] = 0.0
+    journal["preview_only_receipt"] = receipt
+    if terminal is None:
+        journal["status"] = "awaiting-hold-job"
+        journal["unit_released"] = False
+    elif terminal in ("released", "ejected"):
+        journal["status"] = "complete"
+        journal["unit_released"] = True
+        journal["hold_outcome"] = terminal
+        if terminal == "ejected":
+            journal["eject"] = {
+                "eject_cdb_status": "0000000000000000",
+                "eject_execute_status": "0000000000000000",
+                "terminal_sense": "023a00",
+                "wait_polls": 5,
+                "stall_recoveries": 0,
+            }
+    else:
+        journal["status"] = "complete"
+        journal["unit_released"] = True
+        journal["hold_outcome"] = terminal
+    journal_path = fixture.result.paths.journal
+    journal_path.write_text(json.dumps(journal), encoding="utf-8")
+    return replace(fixture, result=replace(fixture.result, journal=journal))
+
+
+def test_held_preview_journal_at_its_hold_boundary_builds_a_session(
+    tmp_path: Path,
+) -> None:
+    session = build_roll_preview_session(_held_preview_fixture(tmp_path, terminal=None).result)
+
+    assert len(session.slots) == 40
+
+
+def test_released_hold_journal_builds_a_session(tmp_path: Path) -> None:
+    """#16: the terminal shape every refused preview leaves on disk must
+    validate -- manual_frames()/preview_strip() reconstruct their attempt
+    from exactly this journal."""
+
+    session = build_roll_preview_session(
+        _held_preview_fixture(tmp_path, terminal="released").result
+    )
+
+    assert len(session.slots) == 40
+
+
+def test_ejected_hold_journal_builds_a_session(tmp_path: Path) -> None:
+    session = build_roll_preview_session(
+        _held_preview_fixture(tmp_path, terminal="ejected").result
+    )
+
+    assert len(session.slots) == 40
+
+
+@pytest.mark.parametrize("outcome", ["resumed-as-batch", "mystery"])
+def test_non_preview_hold_outcomes_stay_refused(
+    tmp_path: Path,
+    outcome: str,
+) -> None:
+    """A hold resumed into a fine scan moves bytes through other artifacts
+    and stamps non-preview fields -- it is not preview evidence and must
+    keep failing closed (as must any unrecognized outcome)."""
+
+    with pytest.raises(RollSessionIntegrityError):
+        build_roll_preview_session(
+            _held_preview_fixture(tmp_path, terminal=outcome).result
+        )
+
+
+def test_held_journal_claiming_release_without_an_outcome_stays_refused(
+    tmp_path: Path,
+) -> None:
+    """unit_released=True under capture_mode=preview-and-hold with no
+    hold_outcome is not a shape the worker ever writes; treating it as the
+    held-at-boundary shape would demand awaiting-hold-job and refuse --
+    assert exactly that fail-closed behavior."""
+
+    fixture = _held_preview_fixture(tmp_path, terminal="released")
+    journal = json.loads(json.dumps(fixture.result.journal))
+    del journal["hold_outcome"]
+    fixture.result.paths.journal.write_text(json.dumps(journal), encoding="utf-8")
+
+    with pytest.raises(RollSessionIntegrityError, match="status"):
+        build_roll_preview_session(replace(fixture.result, journal=journal))

--- a/ports/tauri/packaging/install_pinned_tauri_tools.py
+++ b/ports/tauri/packaging/install_pinned_tauri_tools.py
@@ -115,11 +115,15 @@ NSIS_PLUGIN = {
     "sha256": "5ba143b5db4a87d32d6e7802e033330aae56cbceabe0d1e3ba41948385ad4709",
 }
 
-# 2026-08-14: Microsoft rotated the fwlink 2124701 delivery GUID mid-day
-# (previous: e4dd9b83-b7e3-4d17-8d7c-e14cdd7c3a51); the pin gate failed
-# closed on the drift exactly as designed. New artifact re-verified via
-# the official fwlink redirect before re-pinning.
-WEBVIEW2_GUID = "eb04ea38-69c8-4b86-b65b-fd4c8469ae59"
+# 2026-08-23: Microsoft rotated the fwlink 2124701 delivery GUID again
+# (previous: eb04ea38-69c8-4b86-b65b-fd4c8469ae59, itself a 2026-08-14
+# rotation of e4dd9b83-b7e3-4d17-8d7c-e14cdd7c3a51); Tauri's bundler
+# resolved the new GUID during the #16 fix branch's Windows package job,
+# ignored the pinned copy staged under the old path, downloaded a fresh
+# installer into its own cache directory, and the pin gate failed closed
+# on the unexpected directory exactly as designed. New artifact
+# re-verified via the official fwlink redirect before re-pinning.
+WEBVIEW2_GUID = "22ced09c-d6bd-4427-a658-f1dc48f3a440"
 WEBVIEW2_ASSET = {
     "name": "MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
     "url": (
@@ -127,8 +131,8 @@ WEBVIEW2_ASSET = {
         "filestreamingservice/files/"
         f"{WEBVIEW2_GUID}/MicrosoftEdgeWebView2RuntimeInstallerX64.exe"
     ),
-    "size": 212_668_624,
-    "sha256": "6ac57a21414742ac1a6a03bf9516a048897317cef04a49967b283093e29c31b7",
+    "size": 212_949_712,
+    "sha256": "82b2d8a7013e0c0ea15d48ff4742ee3778ba16bd8b7b4a47876645b3e48d4016",
 }
 
 WINDOWS_RESERVED_NAMES = {

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -28,9 +28,13 @@ $windowsPowerShell = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\
 $pinnedToolsInstaller = Join-Path $portRoot 'packaging\install_pinned_tauri_tools.py'
 $cargoTarget = Join-Path $appRoot 'src-tauri\target'
 $tauriToolsRoot = Join-Path $cargoTarget '.tauri'
-$webViewGuid = 'eb04ea38-69c8-4b86-b65b-fd4c8469ae59'
+# 2026-08-23: Microsoft rotated the fwlink 2124701 delivery GUID again
+# (previous: eb04ea38-69c8-4b86-b65b-fd4c8469ae59); re-verified via the
+# official fwlink redirect before re-pinning. Moves in lockstep with
+# install_pinned_tauri_tools.py.
+$webViewGuid = '22ced09c-d6bd-4427-a658-f1dc48f3a440'
 $webViewFileName = 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe'
-$webViewSha256 = '6ac57a21414742ac1a6a03bf9516a048897317cef04a49967b283093e29c31b7'
+$webViewSha256 = '82b2d8a7013e0c0ea15d48ff4742ee3778ba16bd8b7b4a47876645b3e48d4016'
 $nsisPluginSha256 = '5ba143b5db4a87d32d6e7802e033330aae56cbceabe0d1e3ba41948385ad4709'
 $pinnedWebView = Join-Path $tauriToolsRoot "x64\$webViewGuid\$webViewFileName"
 $pinnedMakensis = Join-Path $tauriToolsRoot 'NSIS\makensis.exe'

--- a/ports/tauri/vendor/coolscanpy/CHANGELOG.md
+++ b/ports/tauri/vendor/coolscanpy/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+- Roll previews whose physical inter-frame gaps are present but partially
+  occluded no longer refuse outright as low confidence (ScanStudio #16).
+  This is the field signature of full-roll-modified SA-21 strip feeders:
+  the frame lattice anchors exactly as on a stock adapter (same gap-run,
+  anchor-assignment, refined-fit, pitch, and direct-support floors), but
+  intruding mask edges dim the gap rows below the strict clear-film bar,
+  which used to drop the detection to "low" on the clean-gap fraction
+  alone -- refusing the preview AND, because low confidence is refused
+  unconditionally at the scan gate, locking out the attended binding path.
+  An anchored comb with an unambiguous lattice margin and at least three
+  independently supported boundaries now binds at medium with a
+  `degraded-gap-evidence` warning: every weak slot stays flagged for
+  manual review, unattended fine scanning still requires high confidence,
+  and heavily degraded captures (boundary evidence averaging under the
+  medium score bar) keep today's honest refusal. Field reports also carry
+  `lattice_margin` and `direct_fraction` so the failing gate is visible
+  without a replay.
+- `roll.previewStrip` and `roll.manualFrames` no longer crash with
+  INTERNAL ("preview journal status='complete', expected
+  'awaiting-hold-job'") when used after a refused preview (ScanStudio
+  #16). A real preview always runs as a held reservation, and a refused
+  one is torn down before its evidence is recorded, so the journal on
+  disk is the terminal preview-and-hold shape (status complete,
+  reservation released, hold outcome released/ejected) -- not the
+  paused-at-hold-boundary shape the validator demanded. Both terminal
+  shapes now validate; resumed-as-batch journals still fail closed.
+
 ## 0.7.2 - 2026-08-13
 
 - `Device.eject()` no longer goes through SANE. It now replays the

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -28,6 +28,11 @@ CANONICAL_MANIFEST_FILENAME = "replay-first-rgbi4-manifest.json"
 # density-source cap-0x10d/f03 exposures, the proven 97-dpi reservation-preview
 # evidence, runtime arithmetic gate, and exact per-frame ownership receipt.
 CAPTURE_BUNDLE_COMPONENT_SHA256 = {
+    # Resealed 2026-08-22 (ScanStudio #16): manual_frames.py gained an
+    # honest direct_fraction on its RollDetection construction;
+    # roll_index.py gained the degraded-gap-evidence confidence tier, the
+    # DEGRADED_GAP_EVIDENCE_WARNING marker, and the additive
+    # RollDetection.direct_fraction field.
     # Resealed 2026-08-13 (attended scan binding, feed-detector round;
     # ScanStudio #24/#16/#42): capture_process.py gained the
     # ATTENDED_ROLL_BINDING_* pair and ManualFrameApproval.
@@ -45,7 +50,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     # process group and inherit its exclusive process-ownership fence.
     "capture_process.py": "c4d234c02bcabf5d10c83b9ef9f071c591546c2447ca004610cc0e0c804a3944",
     "worker.py": "08b9fdb46bc072923d46c1efc4d4a901fd943de542624bc536cd440c3fb6294b",
-    "manual_frames.py": "f30f0003e081c3a98610d5700d7e6b6ee4d182b9d5228932f3304f1307d4815f",
+    "manual_frames.py": "8fc4ba82c177e1b7ecd6943354db33930b468ef3b4b82c712202b8caea54c9bb",
     # Port-specific reseal 2026-08-11: Windows/WSL and Linux use the
     # intentionally extended host-libusb discovery implementation shipped in
     # this vendor tree.  The package identity gate re-hashes the assembled
@@ -56,7 +61,7 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "6b17a06fd1baf1be872a19e819d4e642d42e542601c82b506891bb943969a25c",
-    "roll_index.py": "ae64e28a5d7e442cc368995b47c60ea1097f95f272fff558e93c7fc50800a5ef",
+    "roll_index.py": "5b192213d4c070f53e1733f22fc4e744a9142126f7ef4204a41c943efae8329a",
     "window.py": "5edd64a2f55cb3c968bb380d548d0d9002b41b26f5f4713e5d9b889910d5ed4f",
     "data/replay-first-rgbi4-plan.jsonl": CANONICAL_PLAN_SHA256,
     f"data/{CANONICAL_CONTINUATION_PLAN_FILENAME}": (

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/manual_frames.py
@@ -1053,6 +1053,13 @@ def build_manual_detection(
         lattice_margin_fraction=0.0,
         mean_boundary_evidence=float(np.mean(evidences)),
         minimum_boundary_evidence=float(np.min(evidences)),
+        direct_fraction=(
+            sum(
+                boundary.support in {"direct", "direct-wide"}
+                for boundary in boundaries[:-1]
+            )
+            / max(1, len(boundaries) - 1)
+        ),
         content_level_threshold=0.0,
         content_range_threshold=0.0,
         candidate_cell_count=frame_count,

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py
@@ -62,6 +62,22 @@ _WIDE_GAP_RECOVERY_ERROR_IDS = frozenset(
     }
 )
 
+# Degrated-gap confidence tier (ScanStudio #16). A roll whose inter-frame
+# gaps are all present at the fitted lattice positions but partially
+# occluded -- the field signature of full-roll-modified strip feeders,
+# where mask edges intrude into the film window -- still anchors the same
+# physical comb (same >=3-run, anchor-assignment, refined-fit, and pitch
+# floors as every other detection) yet fails the medium gate's clean
+# direct-gap fraction because many boundary rows read dimmer or less
+# uniform than stock-adapter gaps. Such a capture is exactly the documented
+# meaning of "medium" (capture_process.py ATTENDED_ROLL_BINDING_CONFIDENCE):
+# a geometry the detector DID find but could not fully corroborate -- every
+# slot lands in manual review, and fine scanning still requires the
+# attended all-frames approval path. Labeling it "low" instead refused the
+# preview outright and, because 'low' is refused unconditionally at the
+# worker gate, locked the operator out of even that attended path.
+DEGRADED_GAP_EVIDENCE_WARNING = "degraded-gap-evidence"
+
 
 class IndexDecodeError(ValueError):
     """Input is not a self-consistent LS-5000 roll-index capture.
@@ -298,6 +314,12 @@ class RollDetection:
     boundaries: tuple[GapBoundary, ...]
     intervals: tuple[FrameInterval, ...]
     manual_review_frames: tuple[int, ...]
+    # Additive (#16 field reports), defaulted so every existing constructor
+    # keeps its exact behavior: the alignment-boundary clean-gap fraction
+    # the confidence ladder itself gates on, carried on the result so error
+    # reports can discriminate "score too low" from "direct_fraction too
+    # low" -- the two distinct ways a detection lands at low confidence.
+    direct_fraction: float = 0.0
 
     @property
     def frame_starts(self) -> list[int]:
@@ -337,6 +359,7 @@ class RollDetection:
             "lattice_margin_fraction": self.lattice_margin_fraction,
             "mean_boundary_evidence": self.mean_boundary_evidence,
             "minimum_boundary_evidence": self.minimum_boundary_evidence,
+            "direct_fraction": self.direct_fraction,
             "count_method": (
                 "all physically aligned, scanner-addressable lattice slots; "
                 "scene content only supplies advisory flags"
@@ -1542,6 +1565,7 @@ def _detect_roll_frames_single(
         for item in alignment_boundaries[:-1]
     ) / max(1, len(alignment_boundaries) - 1)
     recovered_wide_gap = wide_gap_ceiling is not None
+    degraded_gap_evidence = False
     if (
         lattice_score >= 0.65
         and lattice_margin >= 0.08
@@ -1551,6 +1575,24 @@ def _detect_roll_frames_single(
         confidence = "high"
     elif lattice_score >= 0.45 and direct_fraction >= 0.60:
         confidence = "medium"
+    elif (
+        # Degrated-gap tier (#16): the comb is anchored -- reaching this
+        # point already required >=3 distinct narrow gap runs, >=3 anchor
+        # assignments within 8 rows, a refined fit agreeing within 3 rows,
+        # a pitch inside the film-geometry band, and >=3 directly supported
+        # alignment boundaries -- but the gaps are partially occluded, so
+        # the clean-gap fraction fell below the medium gate. Admit it as
+        # medium only when the fit is unambiguous (the same lattice-margin
+        # bar "high" requires) and at least three boundaries carry
+        # independently supported evidence. Everything still lands in
+        # manual review per slot, and the worker gate still refuses any
+        # unattended binding below "high".
+        lattice_score >= 0.45
+        and lattice_margin >= 0.08
+        and len(supported_alignment_boundaries) >= 3
+    ):
+        confidence = "medium"
+        degraded_gap_evidence = True
     else:
         confidence = "low"
     if recovered_wide_gap and confidence == "high":
@@ -1560,6 +1602,8 @@ def _detect_roll_frames_single(
     warnings: list[str] = []
     if recovered_wide_gap:
         warnings.append(WIDE_GAP_RECOVERY_WARNING)
+    if degraded_gap_evidence:
+        warnings.append(DEGRADED_GAP_EVIDENCE_WARNING)
     if expected_frame_count is not None:
         expected_frame_count_matches = expected_frame_count in content_end_candidates
         if expected_frame_count_matches:
@@ -1592,6 +1636,7 @@ def _detect_roll_frames_single(
         lattice_margin_fraction=lattice_margin,
         mean_boundary_evidence=float(boundary_evidence.mean()),
         minimum_boundary_evidence=float(boundary_evidence.min()),
+        direct_fraction=direct_fraction,
         content_level_threshold=content_level_threshold,
         content_range_threshold=content_range_threshold,
         candidate_cell_count=len(cell_supported),

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/roll/preview_session.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/roll/preview_session.py
@@ -755,11 +755,35 @@ def _validate_preview_result(
     # release decision exists (see run_live_capture's own comment at the
     # `journal["disk_bytes"] = 0` / `journal["unit_released"] = False`
     # stamps). That snapshot is legitimately never "complete"/"preview-
-    # only"/released -- it is the other of exactly two valid shapes this
-    # journal can take, never a partial or intermediate one.
-    held = journal.get("capture_mode") == "preview-and-hold"
+    # only"/released -- it is one of exactly three valid shapes this
+    # journal can take, never a partial or intermediate one. The third
+    # shape is that same held attempt's TERMINAL state (#16): after the
+    # hold decision, the worker's teardown flips status to "complete" and
+    # unit_released to True while capture_mode stays "preview-and-hold"
+    # and hold_outcome records "released"/"ejected" (worker.py's
+    # released_hold_without_scan branch; release_held_session validates the
+    # same terminal facts from its dedicated receipt file). A preview that
+    # was REFUSED -- exactly when manual_frames()/preview_strip() need this
+    # journal most -- is always torn down before its evidence is recorded,
+    # so reconstructing an attempt from disk sees only this terminal shape;
+    # refusing it made the manual-placement fallback INTERNAL-crash on
+    # every field report it existed for. The resumed-as-batch outcome is
+    # deliberately NOT admitted: it moves fine-scan bytes through other
+    # artifacts and stamps requested_frame/disk_bytes/output_sha256 with
+    # non-preview values, each of which its own exact check below refuses.
+    capture_mode = journal.get("capture_mode")
+    held = capture_mode == "preview-and-hold"
+    released_hold = (
+        held
+        and journal.get("status") == "complete"
+        and journal.get("unit_released") is True
+        and journal.get("hold_outcome") in ("released", "ejected")
+    )
     for key, expected in (
-        ("status", "awaiting-hold-job" if held else "complete"),
+        (
+            "status",
+            "awaiting-hold-job" if held and not released_hold else "complete",
+        ),
         ("capture_mode", "preview-and-hold" if held else "preview-only"),
         ("requested_frame", None),
         ("requested_boundary_offset_rows", 0),
@@ -769,7 +793,7 @@ def _validate_preview_result(
         ("expected_bytes", 0),
         ("completed_bytes", 0),
         ("disk_bytes", 0),
-        ("unit_released", False if held else True),
+        ("unit_released", False if held and not released_hold else True),
         ("plan_sha256", CANONICAL_PLAN_SHA256),
         ("preview_geometry_validated_before_reads", True),
     ):
@@ -1232,6 +1256,8 @@ def _roll_session_diagnostics(detection: RollDetection) -> str:
         + detection.count_confirmation
         + f" lattice_score={detection.lattice_score:.4f}"
         + f" alt_lattice_score={detection.alternative_lattice_score:.4f}"
+        + f" lattice_margin={detection.lattice_margin_fraction:.4f}"
+        + f" direct_fraction={detection.direct_fraction:.4f}"
         + f" mean_boundary_evidence={detection.mean_boundary_evidence:.4f}"
         + f" min_boundary_evidence={detection.minimum_boundary_evidence:.4f}"
         + f" autocorr_peak={detection.autocorrelation_peak:.4f}"

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_roll_index.py
@@ -1395,6 +1395,137 @@ def test_recovery_confidence_cap_is_keyed_to_the_mode() -> None:
     assert "wide-gap-recovery" in detection.warnings
 
 
+def _occlude_gaps(
+    rgb: np.ndarray,
+    boundaries: list[int],
+    *,
+    occluded: list[int],
+    end_bands: bool = False,
+    factor: float = 0.855,
+) -> np.ndarray:
+    """Partially occlude chosen inter-frame gaps (ScanStudio #16).
+
+    The full-roll-modified strip-feeder signature: every gap still exists at
+    its true lattice position, but intruding mask edges dim those rows just
+    under the strict clear-film bar (transmission < 0.87) and add row-to-row
+    unevenness, so the gap runs shrink below the narrow width window or
+    vanish while the lattice itself stays anchored on the remaining clean
+    gaps.
+    """
+
+    out = rgb.copy()
+    height = out.shape[0]
+    clear_base = np.asarray((34_200, 25_500, 17_800), dtype=np.int64)
+    x = np.arange(90, dtype=np.int64)[None, :]
+    haze_gradient = ((x * 7) % 23 - 11)[:, :, None] * 160
+    for index in occluded:
+        boundary = boundaries[index]
+        lo = max(0, boundary - 3)
+        hi = min(height, boundary + 3)
+        hazy = (clear_base * factor).astype(np.int64) + haze_gradient[: hi - lo]
+        out[lo:hi, 2:92] = hazy.clip(0, 65_535).astype(np.uint16)
+        for edge in (lo - 1, hi):
+            if 0 <= edge < height:
+                out[edge, 2:92] = (
+                    (out[edge, 2:92].astype(np.int64) * 0.88)
+                    .clip(0, 65_535)
+                    .astype(np.uint16)
+                )
+    if end_bands:
+        for lo, hi in ((0, boundaries[0]), (boundaries[-1], height)):
+            hazy = (clear_base * 0.87).astype(np.int64) + haze_gradient[: hi - lo]
+            out[lo:hi, 2:92] = hazy.clip(0, 65_535).astype(np.uint16)
+    return out
+
+
+def test_occluded_gap_roll_binds_at_medium_with_the_degraded_warning() -> None:
+    """ScanStudio #16: a roll whose gaps are all present but partially
+    occluded -- the field signature of full-roll-modified SA-21 adapters --
+    anchored the same comb as any healthy roll (same floors, >=3 directly
+    supported boundaries) yet scored "low" on the clean-gap fraction alone,
+    which refused the preview outright AND locked the operator out of the
+    attended binding path (which admits exactly "medium"). Such a capture is
+    precisely the documented meaning of medium -- a geometry the detector
+    found but could not fully corroborate -- so it now binds at medium with
+    the degraded-gap warning, every weak slot flagged for review."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    # Field-report profile: interior gaps occluded and no clean leader/tail
+    # band either -- lattice_score ~0.48 vs the report's 0.4622-0.4653,
+    # margin well above the high gate's own 0.08 bar.
+    occluded_rgb = _occlude_gaps(
+        rgb,
+        boundaries,
+        occluded=[1, 2, 3],
+        end_bands=True,
+    )
+
+    detection = _detect(occluded_rgb)
+
+    # Field-report band: the report's own captures scored
+    # 0.4622-0.4653 -- below the high gate's 0.65 bar, above the medium
+    # floor this tier still requires.
+    assert detection.lattice_score < 0.55
+    assert detection.direct_fraction < 0.60
+    assert detection.confidence == "medium"
+    assert roll.DEGRADED_GAP_EVIDENCE_WARNING in detection.warnings
+    assert detection.pitch_rows == pytest.approx(143.0, abs=0.5)
+    supported = [
+        boundary
+        for boundary in detection.boundaries[:-1]
+        if boundary.support in {"direct", "direct-wide", "cadence-broad"}
+        and boundary.evidence >= 0.40
+        and boundary.transmission >= 0.82
+        and boundary.nonuniformity <= 0.22
+    ]
+    assert len(supported) >= 3
+    flagged = {
+        boundary.index
+        for boundary in detection.boundaries
+        if "low-gap-evidence" in boundary.review_reasons
+        or "narrow-gap-evidence" in boundary.review_reasons
+        or "no-local-gap-run" in boundary.review_reasons
+    }
+    assert flagged, "occluded boundaries must stay visible for manual review"
+
+
+def test_healthy_rolls_never_carry_the_degraded_gap_warning() -> None:
+    """The tier is additive only: an untouched roll keeps bit-identical
+    confidence and no degraded-gap marker."""
+
+    rgb, boundaries = _synthetic_roll(6)
+
+    detection = _detect(rgb)
+
+    assert detection.confidence == "high"
+    assert roll.DEGRADED_GAP_EVIDENCE_WARNING not in detection.warnings
+    # Leader/tail edges are cadence-broad rather than narrow gaps, so a
+    # healthy strip sits at the high gate's own >= 0.80 bar, not exactly 1.
+    assert detection.direct_fraction >= 0.80
+
+
+def test_heavily_degraded_evidence_below_the_score_bar_stays_low() -> None:
+    """Guard rail: the tier never relaxes the lattice-score bar. When
+    occlusion is so heavy that even the anchored comb's own boundary rows
+    average below 0.45 evidence, the capture keeps today's honest 'low' --
+    refused at the session gate -- instead of riding the new tier up to
+    medium."""
+
+    rgb, boundaries = _synthetic_roll(6)
+    heavily_occluded = _occlude_gaps(
+        rgb,
+        boundaries,
+        occluded=[1, 2, 3, 4],
+        end_bands=True,
+    )
+
+    detection = _detect(heavily_occluded)
+
+    assert detection.lattice_score < 0.45
+    assert detection.confidence == "low"
+    assert roll.DEGRADED_GAP_EVIDENCE_WARNING not in detection.warnings
+
+
 def test_incomplete_index_never_triggers_recovery() -> None:
     """IncompleteIndexError is a subclass of IndexDecodeError; it must pass
     through the two-pass wrapper untouched, with no recovery note."""

--- a/ports/tauri/vendor/coolscanpy/tests/roll/test_ls5000_roll_session.py
+++ b/ports/tauri/vendor/coolscanpy/tests/roll/test_ls5000_roll_session.py
@@ -1315,3 +1315,121 @@ def test_session_pixel_arrays_cannot_be_made_writeable(tmp_path: Path) -> None:
         session.preview.rgb.setflags(write=True)
     with pytest.raises(ValueError):
         session.slots[0].thumbnail.setflags(write=True)
+
+
+# -- ScanStudio #16: the three valid preview journal shapes --------------------
+#
+# A real Roll.preview() always runs as a held preview. Its journal is valid
+# in exactly three shapes: paused at the hold boundary (awaiting-hold-job),
+# and its two terminal states after the hold decision -- released or
+# ejected (status flips to complete, unit_released to True, capture_mode
+# stays preview-and-hold). A REFUSED preview is always torn down before its
+# evidence is recorded, so the on-disk journal a later manual_frames()/
+# preview_strip() reconstruction reads is always one of the terminal
+# states; refusing those made the manual-placement fallback crash INTERNAL
+# on exactly the field reports it existed for.
+
+
+def _held_preview_fixture(
+    tmp_path: Path,
+    *,
+    terminal: str | None,
+) -> PreviewFixture:
+    """The preview-only fixture rewritten into the preview-and-hold shape.
+
+    ``terminal=None`` pauses at the hold boundary; ``"released"`` and
+    ``"ejected"`` apply the worker's post-decision teardown stamps; any
+    other value produces an inconsistent journal that must stay refused.
+    """
+    fixture = _preview_fixture(tmp_path)
+    journal = json.loads(json.dumps(fixture.result.journal))
+    receipt = json.loads(json.dumps(journal["preview_only_receipt"]))
+    mapping_path = Path(journal["live_index_artifacts"]["mapping"])
+    receipt["status"] = "preview-and-hold-awaiting-job"
+    mapping_path.write_text(json.dumps(receipt), encoding="utf-8")
+    journal["capture_mode"] = "preview-and-hold"
+    journal["hold_session_id"] = "a" * 32
+    journal["hold_ready_unix"] = 0.0
+    journal["preview_only_receipt"] = receipt
+    if terminal is None:
+        journal["status"] = "awaiting-hold-job"
+        journal["unit_released"] = False
+    elif terminal in ("released", "ejected"):
+        journal["status"] = "complete"
+        journal["unit_released"] = True
+        journal["hold_outcome"] = terminal
+        if terminal == "ejected":
+            journal["eject"] = {
+                "eject_cdb_status": "0000000000000000",
+                "eject_execute_status": "0000000000000000",
+                "terminal_sense": "023a00",
+                "wait_polls": 5,
+                "stall_recoveries": 0,
+            }
+    else:
+        journal["status"] = "complete"
+        journal["unit_released"] = True
+        journal["hold_outcome"] = terminal
+    journal_path = fixture.result.paths.journal
+    journal_path.write_text(json.dumps(journal), encoding="utf-8")
+    return replace(fixture, result=replace(fixture.result, journal=journal))
+
+
+def test_held_preview_journal_at_its_hold_boundary_builds_a_session(
+    tmp_path: Path,
+) -> None:
+    session = build_roll_preview_session(_held_preview_fixture(tmp_path, terminal=None).result)
+
+    assert len(session.slots) == 40
+
+
+def test_released_hold_journal_builds_a_session(tmp_path: Path) -> None:
+    """#16: the terminal shape every refused preview leaves on disk must
+    validate -- manual_frames()/preview_strip() reconstruct their attempt
+    from exactly this journal."""
+
+    session = build_roll_preview_session(
+        _held_preview_fixture(tmp_path, terminal="released").result
+    )
+
+    assert len(session.slots) == 40
+
+
+def test_ejected_hold_journal_builds_a_session(tmp_path: Path) -> None:
+    session = build_roll_preview_session(
+        _held_preview_fixture(tmp_path, terminal="ejected").result
+    )
+
+    assert len(session.slots) == 40
+
+
+@pytest.mark.parametrize("outcome", ["resumed-as-batch", "mystery"])
+def test_non_preview_hold_outcomes_stay_refused(
+    tmp_path: Path,
+    outcome: str,
+) -> None:
+    """A hold resumed into a fine scan moves bytes through other artifacts
+    and stamps non-preview fields -- it is not preview evidence and must
+    keep failing closed (as must any unrecognized outcome)."""
+
+    with pytest.raises(RollSessionIntegrityError):
+        build_roll_preview_session(
+            _held_preview_fixture(tmp_path, terminal=outcome).result
+        )
+
+
+def test_held_journal_claiming_release_without_an_outcome_stays_refused(
+    tmp_path: Path,
+) -> None:
+    """unit_released=True under capture_mode=preview-and-hold with no
+    hold_outcome is not a shape the worker ever writes; treating it as the
+    held-at-boundary shape would demand awaiting-hold-job and refuse --
+    assert exactly that fail-closed behavior."""
+
+    fixture = _held_preview_fixture(tmp_path, terminal="released")
+    journal = json.loads(json.dumps(fixture.result.journal))
+    del journal["hold_outcome"]
+    fixture.result.paths.journal.write_text(json.dumps(journal), encoding="utf-8")
+
+    with pytest.raises(RollSessionIntegrityError, match="status"):
+        build_roll_preview_session(replace(fixture.result, journal=journal))

--- a/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
+++ b/ports/tauri/vendor/scanstudio-bridge/tests/test_transport_coolscanpy.py
@@ -539,17 +539,23 @@ def _synthetic_transport_table(rows: int) -> bytes:
 
 
 def _write_synthetic_preview_attempt(
-    attempts_root: Path, *, slot_capacity_hint: int = 40
+    attempts_root: Path,
+    *,
+    slot_capacity_hint: int = 40,
+    hold_terminal: str | None = None,
 ) -> Path:
     """Write one complete, byte-valid preview attempt directory under
     ``attempts_root`` with CoolscanPyTransport's own "preview-" mkdtemp
     prefix -- everything manual_frames()/preview_strip()'s
     _reconstruct_last_preview_attempt/_validated_preview_from_attempt need to
     find and validate it, exactly as if a real roll.preview attempt had just
-    completed (this journal shape is "preview-only"/"complete"/released --
-    see preview_session.py's _validate_preview_result: both that shape and
-    the "preview-and-hold" shape a real Roll.preview() always uses today
-    validate identically). Returns the attempt directory."""
+    completed. The default journal shape is "preview-only"/"complete";
+    ``hold_terminal="released"/"ejected"`` writes the TERMINAL preview-and-
+    hold shape a real Roll.preview() always leaves behind instead (a real
+    preview runs as a held reservation, and a REFUSED one -- exactly when
+    manual_frames()/preview_strip() are needed (#16) -- is always torn down
+    to this terminal state before its evidence is recorded). Returns the
+    attempt directory."""
     contract = _preview_binding_contract(slot_capacity_hint)
     native_height = contract["native_height"]
     decoded_height = contract["decoded_height"]
@@ -587,7 +593,11 @@ def _write_synthetic_preview_attempt(
         source_height=decoded_height,
     )
     receipt = {
-        "status": "preview-only-complete",
+        "status": (
+            "preview-and-hold-awaiting-job"
+            if hold_terminal
+            else "preview-only-complete"
+        ),
         "slot_capacity_hint": slot_capacity_hint,
         "slot_capacity_semantics": (
             "scanner-addressable preview slots; not an exposure count"
@@ -657,6 +667,23 @@ def _write_synthetic_preview_attempt(
         },
         "preview_only_receipt": receipt,
     }
+    if hold_terminal:
+        # The worker's post-decision teardown stamps (worker.py's
+        # released_hold_without_scan branch): capture_mode stays
+        # preview-and-hold, status flips to complete, the reservation is
+        # released, and hold_outcome records which decision ended it.
+        journal["capture_mode"] = "preview-and-hold"
+        journal["hold_session_id"] = "a" * 32
+        journal["hold_ready_unix"] = 0.0
+        journal["hold_outcome"] = hold_terminal
+        if hold_terminal == "ejected":
+            journal["eject"] = {
+                "eject_cdb_status": "0000000000000000",
+                "eject_execute_status": "0000000000000000",
+                "terminal_sense": "023a00",
+                "wait_polls": 5,
+                "stall_recoveries": 0,
+            }
     (attempt / "journal.json").write_text(json.dumps(journal), encoding="utf-8")
     return attempt
 
@@ -1399,6 +1426,8 @@ def test_preview_strip_without_any_preview_attempt_is_no_preview(
 
 def _transport_with_synthetic_preview_attempt(
     monkeypatch: pytest.MonkeyPatch,
+    *,
+    hold_terminal: str | None = None,
 ) -> tuple[CoolscanPyTransport, _FakeRoll, Path]:
     """An opened transport whose attempts_root already holds one real,
     byte-valid preview attempt on disk -- the "completed-but-refused (or
@@ -1409,6 +1438,9 @@ def _transport_with_synthetic_preview_attempt(
     attempt this test actually reads back is a separately-written synthetic
     one, matching how a real refused preview would leave its own evidence
     on disk without ever producing a _FakeRoll-shaped in-memory session.
+    ``hold_terminal`` forwards to _write_synthetic_preview_attempt to write
+    the terminal preview-and-hold journal shape a real refused preview
+    leaves behind (#16).
 
     S5 fix (2026-08-08 adversarial review): manual_frames()/preview_strip()
     now read ONLY `transport._recorded_preview_attempt_journal`, never a
@@ -1424,7 +1456,10 @@ def _transport_with_synthetic_preview_attempt(
     transport, _device = _opened_transport(monkeypatch, roll)
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
     assert transport.attempts_root is not None
-    attempt_dir = _write_synthetic_preview_attempt(transport.attempts_root)
+    attempt_dir = _write_synthetic_preview_attempt(
+        transport.attempts_root,
+        hold_terminal=hold_terminal,
+    )
     transport._recorded_preview_attempt_journal = (
         attempt_dir / "journal.json"
     ).resolve(strict=True)
@@ -1548,6 +1583,54 @@ def test_preview_strip_refuses_when_current_attempt_has_no_recorded_evidence(
     assert excinfo.value.code == ErrorCode.NO_PREVIEW
     assert "left no usable evidence" in str(excinfo.value)
     assert "acquire a fresh preview" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("hold_terminal", ["released", "ejected"])
+def test_preview_strip_renders_from_a_released_hold_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+    hold_terminal: str,
+) -> None:
+    """#16 regression: a real Roll.preview() is always a held reservation,
+    and a REFUSED one -- exactly when the UI falls back to manual placement
+    via roll.previewStrip -- is torn down before its evidence is recorded.
+    The on-disk journal it leaves is therefore the TERMINAL preview-and-
+    hold shape (status=complete, unit_released=true, capture_mode stays
+    preview-and-hold), which the validator used to refuse with
+    "preview journal status='complete', expected 'awaiting-hold-job'" --
+    surfacing as INTERNAL and killing the manual-placement fallback on
+    every field report it existed for."""
+
+    transport, _roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch,
+        hold_terminal=hold_terminal,
+    )
+
+    strip = transport.preview_strip()
+
+    assert strip.row_count == 6_104
+    assert Path(strip.image_path).is_file()
+
+
+def test_manual_frames_arms_a_session_from_a_released_hold_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#16 regression, manualFrames' half of the same bug: manual placement
+    against a refused preview's terminal journal must arm the roll for
+    approve/scan instead of crashing INTERNAL."""
+
+    transport, roll, _attempt_dir = _transport_with_synthetic_preview_attempt(
+        monkeypatch,
+        hold_terminal="released",
+    )
+
+    result, thumbnails, snaps, material = transport.manual_frames([128, 271, 414])
+
+    assert material is domain.Material.COLOR_NEGATIVE
+    assert result.count == 2
+    assert [t.slot for t in thumbnails] == [1, 2]
+    assert snaps == ()
+    assert transport._preview_established is True
+    assert roll._session is not None
 
 
 # -- 2026-08-08 adversarial review, S1 (manual placement replacement safety) --

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -322,7 +322,7 @@ Files bridge/tests/test_transport_mock.py and ports/tauri/vendor/scanstudio-brid
 Files bridge/uv.lock and ports/tauri/vendor/scanstudio-bridge/uv.lock differ
 EOF
 
-check_pair "coolscanpy" "coolscanpy" "ports/tauri/vendor/coolscanpy" "4d2911476eb3e2a1831aa4b588ccb76b580b456914d65eb685b1c20789733629" <<'EOF'
+check_pair "coolscanpy" "coolscanpy" "ports/tauri/vendor/coolscanpy" "d4b4302da47a9c0cf44d74b8034bc6757550ecca8c46c50e24d331bc7b050ab4" <<'EOF'
 Files coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py and ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py differ
 Files coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/usb_backend.py and ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/usb_backend.py differ
 Files coolscanpy/tests/test_usb_backend.py and ports/tauri/vendor/coolscanpy/tests/test_usb_backend.py differ


### PR DESCRIPTION
Closes #16.

## What kept #16 reporters stuck

Two stacked defects, both reproduced offline from the field reports' own numbers:

### 1. REFEED_REQUIRED loop on occluded-gap rolls

Alberto's reports (beta.2 → beta.9) all show the same profile: `lattice_score 0.4622–0.4653`, `alt 0.2494–0.3339`, `detected_perforation_candidates=[]`-style low direct support, **but the lattice anchored** — it passed every floor raise (≥3 narrow gap runs, ≥3 anchor assignments, refined fit ≤3 rows, pitch in band, ≥3 directly supported boundaries). It scored `low` purely on the medium gate's `direct_fraction >= 0.60`.

That label is doubly fatal:
- `build_roll_preview_session` refuses anything `low` → REFEED_REQUIRED
- the attended binding path (`ATTENDED_ROLL_BINDING_CONFIDENCE`) admits exactly `medium`, never `low` — so even approving every frame couldn't scan

This is the documented meaning of medium: "a geometry the detector DID find but could not fully corroborate."

**Fix (additive tier):** anchored + `lattice_margin >= 0.08` (the high gate's own bar) + ≥3 independently supported boundaries → `medium` with a `degraded-gap-evidence` warning. Slots stay flagged for manual review; unattended fine scanning still requires high; captures below the medium score bar keep today's honest refusal (regression-tested).

Also additive on `RollDetection`: `direct_fraction`, and field reports now carry `lattice_margin=` + `direct_fraction=` so the next report names the failing gate instead of forcing a blind replay.

Reproduction matches Alberto's numbers almost exactly (synthetic occluded-gap roll: lattice 0.478 vs his 0.4622–0.4653; margin 0.25 vs his 0.28–0.46).

### 2. INTERNAL crash in the manual-placement fallback

After a refused preview, `roll.previewStrip` / `roll.manualFrames` failed with `preview journal status='complete', expected 'awaiting-hold-job'` (Alberto's beta.9 report shows it live). The reconstructed attempt validates the journal from disk — and a real preview is always a held reservation whose refusal path tears down to the TERMINAL shape (`status=complete`, `unit_released=true`, `hold_outcome=released|ejected`). The validator only accepted the paused-at-boundary shape, so the escape hatch crashed on exactly the reports it existed for.

Both terminal outcomes now validate; resumed-as-batch and inconsistent shapes still fail closed.

## Verification

- full coolscanpy suite green (3 new detector tests incl. healthy-unchanged + stays-low guard rails; 5 new journal-shape tests)
- full bridge suite green (released/ejected hold through `previewStrip` + `manualFrames`)
- vendor mirrors byte-synced, `check_ports_vendor_sync.sh` passes (bundle resealed canonically + vendor port overlay preserved)