### PR TITLE
Fix Windows publication and complete the release audit

### DIFF
--- a/.github/workflows/ports.yml
+++ b/.github/workflows/ports.yml
@@ -21,6 +21,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  windows-persistence:
+    name: Windows project persistence
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
+        with:
+          toolchain: '1.97.1'
+      - name: Verify exact Rust toolchain
+        run: python -I -S -B scripts/verify_pinned_rust.py
+      - name: Exercise native NTFS persistence before installer assembly
+        shell: pwsh
+        run: |
+          cargo build --locked --manifest-path ports/tauri/vendor/engine/Cargo.toml
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python -I -S -B scripts/smoke_project_persistence.py ports/tauri/vendor/engine/target/debug/scanstudio-engine.exe
+
   windows-resources:
     name: Assemble Windows offline resources
     runs-on: ubuntu-22.04

--- a/.github/workflows/ports.yml
+++ b/.github/workflows/ports.yml
@@ -40,6 +40,9 @@ jobs:
           cargo build --locked --manifest-path ports/tauri/vendor/engine/Cargo.toml
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -I -S -B scripts/smoke_project_persistence.py ports/tauri/vendor/engine/target/debug/scanstudio-engine.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cargo test --locked --manifest-path ports/tauri/vendor/engine/Cargo.toml --lib
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   windows-resources:
     name: Assemble Windows offline resources

--- a/.github/workflows/signing-dry-run.yml
+++ b/.github/workflows/signing-dry-run.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       UV_PYTHON_PREFERENCE: only-managed
       UV_PYTHON_CPYTHON_BUILD: "20260718"
+      SCANSTUDIO_RELEASE_VERSION: 0.0.0-signing-dry-run
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -99,7 +100,8 @@ jobs:
         working-directory: app/ScanStudio
         run: |
           PYBIN="$(/usr/bin/find .build/ScanStudio.app/Contents/Resources -type f -name 'python3.13' -path '*/bin/*' | head -1)"
-          "$PYBIN" -I -c "import ctypes; ctypes.CDLL('.build/ScanStudio.app/Contents/Frameworks/coolscanpy/_native/libusb-1.0.dylib'); print('dlopen ok under hardened runtime')"
+          "$PYBIN" -I -B -c "import ctypes; from pathlib import Path; ctypes.CDLL(str(Path('.build/ScanStudio.app/Contents/Frameworks/coolscanpy/_native/libusb-1.0.dylib').resolve())); print('dlopen ok under hardened runtime')"
+          codesign --verify --deep --strict .build/ScanStudio.app
       - name: Build the DMG from the stapled app
         working-directory: app/ScanStudio
         run: ./scripts/package_dmg.sh

--- a/.github/workflows/signing-dry-run.yml
+++ b/.github/workflows/signing-dry-run.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           name: signing-dry-run-dmg
           path: app/ScanStudio/.build/ScanStudio-*-macOS-*.dmg
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 3
       - name: Delete the throwaway signing keychain and key material

--- a/DNG-PLAN.md
+++ b/DNG-PLAN.md
@@ -105,7 +105,7 @@ A SubIFD is chosen instead of a fourth main-image `ExtraSample`. TIFF's `ExtraSa
 
 ### Separate infrared TIFF
 
-For either main format, `tiffInfrared=sidecar` writes captured IR to `{main-stem}-ir.tif` in the same destination. The sidecar is classic little-endian TIFF, full-resolution, uncompressed, unsigned 16-bit, one-sample `BlackIsZero`, chunky, Orientation 1, and has the same X/Y resolution and inch unit as the main export. It carries `ImageDescription` identifying the untouched scanner plane and private ASCII tag 65001 with `scanstudio.infrared.linear.uint16.v1`. The main DNG has no `SubIFDs` tag; the main TIFF has the existing RGB-only layout.
+For either main format, `tiffInfrared=sidecar` writes captured IR to `{main-stem}-ir.tif` in the same destination. The sidecar is classic little-endian TIFF, full-resolution, uncompressed, unsigned 16-bit, one-sample `BlackIsZero`, chunky, Orientation 1, and has the same X/Y resolution and inch unit as the main export. It carries `ImageDescription` identifying the untouched scanner plane and private ASCII tag 65010 with `scanstudio.infrared.linear.uint16.v1`. The main DNG has no `SubIFDs` tag; the main TIFF has the existing RGB-only layout.
 
 ## Linear TIFF layout
 
@@ -115,7 +115,7 @@ Both TIFF modes use classic little-endian TIFF, unsigned 16-bit samples, no comp
 - **RGB + IR**: samples are interleaved R,G,B,IR; `PhotometricInterpretation=RGB`, `SamplesPerPixel=4`, `BitsPerSample=16,16,16,16`, and `ExtraSamples=0` for the one IR channel. “Unspecified” is intentional: IR is neither associated nor unassociated alpha.
 - **RGB + separate IR**: the main file is the existing RGB-only layout and the infrared plane uses the separate TIFF contract above.
 
-The four-channel TIFF also carries private tag 65001 with the same infrared marker. Software that only understands RGB may ignore or reject the fourth sample; that is why RGB-only is an explicit alternative rather than a silent fallback.
+The four-channel TIFF also carries private tag 65010 with the same infrared marker. Software that only understands RGB may ignore or reject the fourth sample; that is why RGB-only is an explicit alternative rather than a silent fallback.
 
 ## Fail-closed publication and compatibility
 

--- a/app/ScanStudio/README.md
+++ b/app/ScanStudio/README.md
@@ -1,6 +1,6 @@
 # ScanStudio
 
-ScanStudio is a macOS alpha for scanning 35 mm film with a Nikon Coolscan
+ScanStudio is a macOS app for scanning 35 mm film with a Nikon Coolscan
 LS-5000. It keeps the scan workflow in one place: identify the film that is
 loaded, preview the roll, select frames, choose the capture settings, scan,
 and stop safely when needed.
@@ -11,7 +11,8 @@ already includes the CoolscanPy bridge and its direct-USB runtime; source
 builds can instead configure a separate compatible bridge. The app never
 presents the simulator as hardware.
 
-This is an alpha. It has been tested on one Mac and one LS-5000 setup. Treat
+Apple Silicon support is Beta; Intel support is Preview. Real scanning has
+been tested on one Apple Silicon Mac and one LS-5000 setup. Treat
 each real scan as a new operation: confirm the detected carrier and the
 preview before starting capture. Real black-and-white fine scanning remains
 blocked rather than pretending that infrared dust removal is available for

--- a/app/ScanStudio/engine/src/evidence_package.rs
+++ b/app/ScanStudio/engine/src/evidence_package.rs
@@ -811,7 +811,7 @@ fn create_package_file(
 fn cleanup_staged_manifest(
     package: &crate::render::ReservedEvidencePackage,
     temporary_name: &std::ffi::OsStr,
-    staged: &std::fs::File,
+    staged: std::fs::File,
 ) -> Result<(), String> {
     package
         .retire_exact_root_file(temporary_name, staged)
@@ -820,7 +820,7 @@ fn cleanup_staged_manifest(
 
 fn rollback_committed_manifest(
     package: &crate::render::ReservedEvidencePackage,
-    manifest_file: &std::fs::File,
+    manifest_file: std::fs::File,
 ) -> Result<(), String> {
     package
         .retire_exact_root_file(std::ffi::OsStr::new("manifest.json"), manifest_file)
@@ -878,7 +878,7 @@ where
         Ok(())
     })();
     if let Err(error) = staged {
-        return match cleanup_staged_manifest(package, &temporary_name, &manifest_file) {
+        return match cleanup_staged_manifest(package, &temporary_name, manifest_file) {
             Ok(()) => Err(error),
             Err(cleanup) => Err(format!(
                 "{error}; HOLD: staged evidence manifest cleanup could not be proven: {cleanup}"
@@ -893,7 +893,7 @@ where
         std::ffi::OsStr::new("manifest.json"),
     ) {
         let primary = format!("create-only authoritative evidence manifest commit: {error}");
-        return match cleanup_staged_manifest(package, &temporary_name, &manifest_file) {
+        return match cleanup_staged_manifest(package, &temporary_name, manifest_file) {
             Ok(()) => Err(primary),
             Err(cleanup) => Err(format!(
                 "{primary}; HOLD: staged evidence manifest cleanup could not be proven: {cleanup}"
@@ -919,7 +919,7 @@ where
     })();
     match post_commit {
         Ok(()) => Ok(()),
-        Err(primary) => match rollback_committed_manifest(package, &manifest_file) {
+        Err(primary) => match rollback_committed_manifest(package, manifest_file) {
             Ok(()) => Err(format!(
                 "{primary}; authoritative manifest was rolled back and completion was not reported"
             )),
@@ -1042,7 +1042,7 @@ where
     Ok((
         FileDigest {
             path: source.display().to_string(),
-            package_path: destination.to_string_lossy().to_string(),
+            package_path: destination.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/"),
             sha256: source_hash,
         },
         PackageFileProof {
@@ -1504,7 +1504,7 @@ mod tests {
         })
         .expect_err("post-commit ambiguity must never return successful completion");
         assert!(error.contains("ordering ambiguity"));
-        assert!(error.contains("rolled back"));
+        assert!(error.contains("rolled back"), "{error}");
         assert!(!package.final_path().join("manifest.json").exists());
 
         let _ = std::fs::remove_dir_all(root);

--- a/app/ScanStudio/engine/src/exiftool.rs
+++ b/app/ScanStudio/engine/src/exiftool.rs
@@ -3198,6 +3198,11 @@ pub(crate) mod metadata_publish_sys {
     }
 
     pub fn open_regular(parent: &File, name: &OsStr) -> io::Result<File> {
+        // Readers must coexist with publication handles that deny deletion.
+        relative_file(parent, name, false, false, false, false, true)
+    }
+
+    fn open_regular_for_delete(parent: &File, name: &OsStr) -> io::Result<File> {
         relative_file(parent, name, false, false, false, true, true)
     }
 
@@ -3265,8 +3270,8 @@ pub(crate) mod metadata_publish_sys {
         to_directory: &File,
         to_name: &OsStr,
     ) -> io::Result<()> {
-        let source = open_regular(from_directory, from_name)?;
-        let target = open_regular(to_directory, to_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
+        let target = open_regular_for_delete(to_directory, to_name)?;
         let parking = from_name
             .to_str()
             .and_then(|name| name.strip_prefix(".swap-"))
@@ -3319,7 +3324,7 @@ pub(crate) mod metadata_publish_sys {
                 ))
             }
         }
-        let source = open_regular(from_directory, from_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
         rename_handle(&source, to_directory, to_name, false)
     }
 
@@ -3345,7 +3350,7 @@ pub(crate) mod metadata_publish_sys {
         to_directory: &File,
         to_name: &OsStr,
     ) -> io::Result<()> {
-        let source = open_regular(from_directory, from_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
         rename_handle(&source, to_directory, to_name, true)
     }
 
@@ -3371,7 +3376,7 @@ pub(crate) mod metadata_publish_sys {
     }
 
     pub fn unlink(parent: &File, name: &OsStr) -> io::Result<()> {
-        let file = open_regular(parent, name)?;
+        let file = open_regular_for_delete(parent, name)?;
         delete_handle(&file)
     }
 

--- a/app/ScanStudio/engine/src/exiftool.rs
+++ b/app/ScanStudio/engine/src/exiftool.rs
@@ -2592,7 +2592,7 @@ pub(crate) mod metadata_publish_sys {
     const FILE_OPEN: u32 = 0x0000_0001;
     const FILE_CREATE: u32 = 0x0000_0002;
     const FILE_NAMES_INFORMATION_CLASS: u32 = 12;
-    const FILE_RENAME_INFO_EX_CLASS: u32 = 22;
+    const FILE_RENAME_INFORMATION_CLASS: u32 = 10;
     const FILE_DISPOSITION_INFO_EX_CLASS: u32 = 21;
     const FILE_DISPOSITION_FLAG_DELETE: u32 = 0x0000_0001;
     const FILE_DISPOSITION_FLAG_POSIX_SEMANTICS: u32 = 0x0000_0002;
@@ -2612,8 +2612,8 @@ pub(crate) mod metadata_publish_sys {
     const ACL_SIZE_INFORMATION_CLASS: u32 = 2;
 
     #[repr(C)]
-    struct FileRenameInfoEx {
-        flags: u32,
+    struct FileRenameInformation {
+        replace_if_exists: u8,
         root_directory: Handle,
         file_name_length: u32,
         file_name: [u16; 1],
@@ -2781,6 +2781,13 @@ pub(crate) mod metadata_publish_sys {
 
     #[link(name = "ntdll")]
     extern "system" {
+        fn NtSetInformationFile(
+            file: Handle,
+            io_status_block: *mut IoStatusBlock,
+            information: *mut std::ffi::c_void,
+            information_size: u32,
+            information_class: u32,
+        ) -> i32;
         fn NtCreateFile(
             file: *mut Handle,
             desired_access: u32,
@@ -3205,14 +3212,14 @@ pub(crate) mod metadata_publish_sys {
         replace: bool,
     ) -> io::Result<()> {
         let name = component(destination_name)?;
-        let header_size = offset_of!(FileRenameInfoEx, file_name);
+        let header_size = offset_of!(FileRenameInformation, file_name);
         let byte_len = name.len().checked_mul(size_of::<u16>()).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Windows rename name is too long",
             )
         })?;
-        let total = header_size.checked_add(byte_len).ok_or_else(|| {
+        let total = size_of::<FileRenameInformation>().checked_add(byte_len).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Windows rename buffer overflow",
@@ -3220,9 +3227,9 @@ pub(crate) mod metadata_publish_sys {
         })?;
         let words = total.div_ceil(size_of::<usize>());
         let mut storage = vec![0_usize; words];
-        let info = storage.as_mut_ptr().cast::<FileRenameInfoEx>();
+        let info = storage.as_mut_ptr().cast::<FileRenameInformation>();
         unsafe {
-            (*info).flags = u32::from(replace);
+            (*info).replace_if_exists = u8::from(replace);
             (*info).root_directory = destination_directory.as_raw_handle();
             (*info).file_name_length = byte_len as u32;
             std::ptr::copy_nonoverlapping(
@@ -3231,17 +3238,22 @@ pub(crate) mod metadata_publish_sys {
                 byte_len,
             );
         }
-        let result = unsafe {
-            SetFileInformationByHandle(
+        // Use the native handle-relative operation, matching NtCreateFile above.
+        // The Win32 rename wrapper rejects this directory-relative request with
+        // ERROR_INVALID_PARAMETER on supported Windows hosts.
+        let mut status_block = IoStatusBlock { status_or_pointer: 0, information: 0 };
+        let status = unsafe {
+            NtSetInformationFile(
                 source.as_raw_handle(),
-                FILE_RENAME_INFO_EX_CLASS,
+                &mut status_block,
                 info.cast(),
                 total as u32,
+                FILE_RENAME_INFORMATION_CLASS,
             )
         };
-        if result == 0 {
-            let error = io::Error::last_os_error();
-            Err(io::Error::new(error.kind(), format!("SetFileInformationByHandle rename: {error}")))
+        if status < 0 {
+            let error = io::Error::from_raw_os_error(unsafe { RtlNtStatusToDosError(status) } as i32);
+            Err(io::Error::new(error.kind(), format!("NtSetInformationFile rename: {error}")))
         } else {
             Ok(())
         }

--- a/app/ScanStudio/engine/src/exiftool.rs
+++ b/app/ScanStudio/engine/src/exiftool.rs
@@ -3205,7 +3205,7 @@ pub(crate) mod metadata_publish_sys {
         relative_file(parent, name, false, false, true, false, false)
     }
 
-    fn rename_handle(
+    pub(crate) fn rename_handle(
         source: &File,
         destination_directory: &File,
         destination_name: &OsStr,
@@ -7101,7 +7101,12 @@ mod tests {
     fn windows_runner_assigns_and_resumes_a_normal_process() {
         let command =
             std::env::var("ComSpec").unwrap_or_else(|_| r"C:\Windows\System32\cmd.exe".to_string());
-        let command = bind_executable(Path::new(&command)).expect("bind Windows command");
+        // System binaries may have servicing hard links; the executable binder
+        // intentionally requires a unique file identity.
+        let root = temp_root("windows-runner");
+        let executable = root.join("cmd.exe");
+        std::fs::copy(&command, &executable).expect("copy Windows command fixture");
+        let command = bind_executable(&executable).expect("bind Windows command");
         let output = run_bounded_command(
             &command,
             &["/D".into(), "/C".into(), "exit /B 0".into()],
@@ -7110,6 +7115,8 @@ mod tests {
         )
         .expect("run a Job-contained Windows process");
         assert!(output.status.success());
+        drop(command);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[cfg(windows)]

--- a/app/ScanStudio/engine/src/exiftool.rs
+++ b/app/ScanStudio/engine/src/exiftool.rs
@@ -2043,7 +2043,8 @@ pub(crate) fn ensure_supported_metadata_filesystem(file: &File) -> std::io::Resu
         )
     };
     if result == 0 {
-        return Err(std::io::Error::last_os_error());
+        let error = std::io::Error::last_os_error();
+        return Err(std::io::Error::new(error.kind(), format!("GetVolumeInformationByHandleW: {error}")));
     }
     if !windows_metadata_filesystem_name_is_supported(&filesystem_name) {
         let name = String::from_utf16_lossy(&filesystem_name)
@@ -3158,7 +3159,8 @@ pub(crate) mod metadata_publish_sys {
         };
         if status < 0 {
             let windows_error = unsafe { RtlNtStatusToDosError(status) };
-            return Err(io::Error::from_raw_os_error(windows_error as i32));
+            let error = io::Error::from_raw_os_error(windows_error as i32);
+            return Err(io::Error::new(error.kind(), format!("NtCreateFile metadata entry: {error}")));
         }
         if handle.is_null() || handle as isize == -1 {
             return Err(io::Error::other(
@@ -3238,7 +3240,8 @@ pub(crate) mod metadata_publish_sys {
             )
         };
         if result == 0 {
-            Err(io::Error::last_os_error())
+            let error = io::Error::last_os_error();
+            Err(io::Error::new(error.kind(), format!("SetFileInformationByHandle rename: {error}")))
         } else {
             Ok(())
         }
@@ -3485,7 +3488,9 @@ pub(crate) mod metadata_publish_sys {
         // File::sync_all maps to FlushFileBuffers on Windows. Directory
         // capabilities are opened with write access so this ordering barrier
         // is enforced instead of silently assuming a rename is durable.
-        directory.sync_all()
+        directory.sync_all().map_err(|error| {
+            io::Error::new(error.kind(), format!("FlushFileBuffers directory: {error}"))
+        })
     }
 }
 

--- a/app/ScanStudio/engine/src/manifest.rs
+++ b/app/ScanStudio/engine/src/manifest.rs
@@ -1779,6 +1779,9 @@ mod tests {
             let dir = temp_project_dir();
             fs::create_dir_all(&dir).unwrap();
             fs::write(dir.join(MANIFEST_FILE_NAME), corruption).unwrap();
+            // Windows keeps its transaction-lock inode for all later opens.
+            #[cfg(windows)]
+            fs::write(dir.join(".scanstudio-manifest.lock"), b"").unwrap();
 
             let before = snapshot_regular_files(&dir);
             let err = create_project(

--- a/app/ScanStudio/engine/src/real_backend.rs
+++ b/app/ScanStudio/engine/src/real_backend.rs
@@ -1444,6 +1444,7 @@ mod private_workspace_sys {
     ) -> io::Result<std::fs::File> {
         let marker_path = root_path.join(marker_name);
         let mut file = std::fs::OpenOptions::new()
+            .write(true)
             .access_mode(GENERIC_READ | GENERIC_WRITE | DELETE_ACCESS)
             .create_new(true)
             .share_mode(FILE_SHARE_READ)
@@ -8234,6 +8235,17 @@ mod tests {
         assert!(admit_evidence_frame_slot(
             &requested, &remaining, 2, &mut error
         ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_private_workspace_creates_and_verifies_its_marker() {
+        let working = PrivateCaptureWorkingDirectory::create().expect("create Windows workspace");
+        working.verify_namespace().expect("verify held workspace authority");
+        let root = working.root.clone();
+        assert!(std::fs::metadata(root.join(PRIVATE_CAPTURE_MARKER)).unwrap().len() > 0);
+        drop(working);
+        std::fs::remove_dir_all(root).expect("remove private test workspace");
     }
 
     #[cfg(unix)]

--- a/app/ScanStudio/engine/src/render.rs
+++ b/app/ScanStudio/engine/src/render.rs
@@ -1275,7 +1275,6 @@ mod destination_sys {
     const GENERIC_READ: u32 = 0x8000_0000;
     const GENERIC_WRITE: u32 = 0x4000_0000;
     const DELETE_ACCESS: u32 = 0x0001_0000;
-    const FILE_RENAME_INFO_CLASS: u32 = 3;
     const FILE_DISPOSITION_INFO_CLASS: u32 = 4;
 
     #[link(name = "Kernel32")]
@@ -1286,14 +1285,6 @@ mod destination_sys {
             information: *mut std::ffi::c_void,
             buffer_size: u32,
         ) -> i32;
-    }
-
-    #[repr(C)]
-    struct FileRenameInfoHeader {
-        replace_if_exists: u8,
-        root_directory: *mut std::ffi::c_void,
-        file_name_length: u32,
-        file_name: [u16; 1],
     }
 
     #[repr(C)]
@@ -1625,6 +1616,7 @@ mod destination_sys {
             ));
             let path = held.display_path.join(&candidate);
             match std::fs::OpenOptions::new()
+                .write(true)
                 .access_mode(GENERIC_READ | GENERIC_WRITE | DELETE_ACCESS)
                 .share_mode(FILE_SHARE_READ)
                 .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
@@ -1701,53 +1693,12 @@ mod destination_sys {
         role: &str,
     ) -> Result<(), domain::EngineError> {
         verify_namespace(held)?;
-        let wide: Vec<u16> = final_name.encode_wide().collect();
-        let file_name_offset = std::mem::offset_of!(FileRenameInfoHeader, file_name);
-        let byte_length = wide
-            .len()
-            .checked_mul(std::mem::size_of::<u16>())
-            .ok_or_else(|| output_authority_error("final output leaf is too long"))?;
-        let total = file_name_offset
-            .checked_add(byte_length)
-            .ok_or_else(|| output_authority_error("final output rename buffer is too large"))?;
-        // `Vec<u8>` only guarantees byte alignment; casting its pointer to
-        // FILE_RENAME_INFO would be undefined behaviour on Windows. Back the
-        // variable-sized record with pointer-aligned words while still
-        // passing the exact byte length required by the API.
-        let word = std::mem::size_of::<usize>();
-        let word_count = total
-            .checked_add(word - 1)
-            .ok_or_else(|| output_authority_error("final output rename buffer is too large"))?
-            / word;
-        let mut buffer = vec![0_usize; word_count];
-        let buffer_bytes = buffer.as_mut_ptr().cast::<u8>();
-        let header = buffer_bytes.cast::<FileRenameInfoHeader>();
-        unsafe {
-            std::ptr::write(
-                header,
-                FileRenameInfoHeader {
-                    replace_if_exists: (!create_only) as u8,
-                    root_directory: held.directory.as_raw_handle().cast(),
-                    file_name_length: byte_length as u32,
-                    file_name: [0],
-                },
-            );
-            std::ptr::copy_nonoverlapping(
-                wide.as_ptr().cast::<u8>(),
-                buffer_bytes.add(file_name_offset),
-                byte_length,
-            );
-        }
-        let result = unsafe {
-            SetFileInformationByHandle(
-                temporary_file.as_raw_handle().cast(),
-                FILE_RENAME_INFO_CLASS,
-                buffer_bytes.cast(),
-                total as u32,
-            )
-        };
-        if result == 0 {
-            let error = std::io::Error::last_os_error();
+        if let Err(error) = crate::exiftool::metadata_publish_sys::rename_handle(
+            temporary_file,
+            &held.directory,
+            final_name,
+            !create_only,
+        ) {
             let code = if create_only && error.kind() == std::io::ErrorKind::AlreadyExists {
                 protocol::ErrorCode::ArchiveCollision
             } else {
@@ -2800,6 +2751,9 @@ fn validate_filesystem_output_leaf_collation(
                 ))
             })?;
         }
+        // Windows delete dispositions finish when the last held file closes.
+        // Close our exact probe handles before checking for foreign entries.
+        created.clear();
         crate::exiftool::metadata_publish_sys::sync_directory(&probe).map_err(|error| {
             output_authority_error(format!("sync emptied output-name alias probe: {error}"))
         })?;
@@ -6782,6 +6736,7 @@ fn sync_output_directory(directory: &Path) -> std::io::Result<()> {
     const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
     std::fs::OpenOptions::new()
         .read(true)
+        .write(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .open(directory)?
         .sync_all()

--- a/app/ScanStudio/engine/src/render.rs
+++ b/app/ScanStudio/engine/src/render.rs
@@ -378,7 +378,7 @@ impl ReservedEvidencePackage {
     pub(crate) fn retire_exact_root_file(
         &self,
         name: &std::ffi::OsStr,
-        expected: &std::fs::File,
+        expected: std::fs::File,
     ) -> Result<(), domain::EngineError> {
         let relative = Path::new(name);
         if relative.components().count() != 1
@@ -391,8 +391,9 @@ impl ReservedEvidencePackage {
                 "exact evidence cleanup requires one normal root-file component",
             ));
         }
-        self.verify_regular_file(relative, expected)?;
-        destination_sys::delete_exact_regular_file(expected)?;
+        self.verify_regular_file(relative, &expected)?;
+        destination_sys::delete_exact_regular_file(&expected)?;
+        drop(expected);
         crate::exiftool::metadata_publish_sys::sync_directory(self.directory_handle()).map_err(
             |error| {
                 output_authority_error(format!(
@@ -10278,17 +10279,34 @@ mod tests {
         output.preview.enabled = false;
         output.raw_export.enabled = false;
 
-        let error = acquire_job_output_authorities(
+        // NTFS upcase tables vary by volume generation. Derive the expected
+        // answer from actual ordinary Windows file creation on this volume.
+        let first = project.join("Σ_0001.tif");
+        let second = project.join("ς_0001.tif");
+        std::fs::write(&first, b"oracle").unwrap();
+        let oracle = std::fs::OpenOptions::new().write(true).create_new(true).open(&second);
+        let collision = match oracle {
+            Ok(file) => { drop(file); false }
+            Err(error) => {
+                assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+                true
+            }
+        };
+        let result = acquire_job_output_authorities(
             Some(&project),
             &[1],
             &domain::CaptureRecipe::default(),
             &output,
             &std::collections::HashMap::new(),
         )
-        .expect_err("NTFS-upcase aliases must collide before capture");
-
-        assert_eq!(error.code, protocol::ErrorCode::InvalidParams);
-        assert!(error.message.contains("filename collation"), "{error}");
+        ;
+        if collision {
+            let error = result.expect_err("filesystem aliases must collide before capture");
+            assert_eq!(error.code, protocol::ErrorCode::InvalidParams);
+            assert!(error.message.contains("filename collation"), "{error}");
+        } else {
+            result.expect("distinct filesystem names must remain usable");
+        }
         let _ = std::fs::remove_dir_all(&project);
     }
 
@@ -11886,7 +11904,16 @@ mod tests {
 
         let positive = written.positive_path.as_ref().unwrap();
         let displaced = root.join("engine-authored-positive.tif");
-        std::fs::rename(positive, &displaced).unwrap();
+        let renamed = std::fs::rename(positive, &displaced);
+        if cfg!(windows) {
+            assert!(renamed.is_err(), "held Windows output must deny replacement");
+            crate::exiftool::bind_metadata_output_publications(&root, &written.metadata_publications)
+                .expect("denied replacement retains the original binding");
+            drop(written);
+            let _ = std::fs::remove_dir_all(root);
+            return;
+        }
+        renamed.unwrap();
         std::fs::write(positive, b"attacker replacement").unwrap();
 
         let error = crate::exiftool::bind_metadata_output_publications(

--- a/app/ScanStudio/engine/src/server.rs
+++ b/app/ScanStudio/engine/src/server.rs
@@ -4831,6 +4831,7 @@ mod tests {
                 .recv_timeout(std::time::Duration::from_secs(10))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.completed" {
                 break;
             }

--- a/app/ScanStudio/engine/src/sim.rs
+++ b/app/ScanStudio/engine/src/sim.rs
@@ -1976,7 +1976,18 @@ mod tests {
         )
         .unwrap();
         let positive = written.positive_path.as_ref().unwrap();
-        std::fs::rename(positive, root.join("engine-positive.tif")).unwrap();
+        let renamed = std::fs::rename(positive, root.join("engine-positive.tif"));
+        if cfg!(windows) {
+            assert!(renamed.is_err(), "held Windows output must deny replacement");
+            build_receipt(
+                "job-binding-replacement", 1, 1000, &recipe, &processing, &output,
+                DEVICE_ID, &written, Some(&project_root),
+            ).expect("denied replacement retains valid receipt evidence");
+            drop((written, project_root));
+            let _ = std::fs::remove_dir_all(root);
+            return;
+        }
+        renamed.unwrap();
         std::fs::write(positive, b"unrelated replacement").unwrap();
 
         let error = build_receipt(
@@ -2606,6 +2617,7 @@ mod tests {
                 .recv_timeout(Duration::from_secs(30))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.completed" {
                 break;
             }
@@ -2691,6 +2703,7 @@ mod tests {
                 .recv_timeout(Duration::from_secs(30))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.frameState" && value["payload"]["frameIndex"] == 1 {
                 match value["payload"]["state"].as_str() {
                     Some("completed") => {

--- a/app/ScanStudio/scripts/test_packaged_bridge.sh
+++ b/app/ScanStudio/scripts/test_packaged_bridge.sh
@@ -166,6 +166,7 @@ output="$workdir/bridge.ndjson"
 bridge="$relocated_app/Contents/MacOS/scanstudio-bridge"
 engine="$relocated_app/Contents/MacOS/scanstudio-engine"
 runtime_python="$relocated_app/Contents/Resources/BridgeRuntime/python/bin/python3.13"
+"$runtime_python" -I -S -B "$package_root/../../scripts/smoke_project_persistence.py" "$engine"
 runtime_sysconfig="$relocated_app/Contents/Resources/BridgeRuntime/python/lib/python3.13/_sysconfigdata__darwin_darwin.py"
 coolscanpy_pyproject="$relocated_app/Contents/Resources/CorrespondingSource/coolscanpy/pyproject.toml"
 if [[ ! -f "$runtime_sysconfig" || -L "$runtime_sysconfig" ]] \

--- a/bridge/uv.lock
+++ b/bridge/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/coolscanpy/CHANGELOG.md
+++ b/coolscanpy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.7.5 - 2026-09-06
+
+- Accept the observed EBDE-prefixed LS-5000 padding counter dialect only when the entire padding block matches its exact counter train. Offline and streaming decoding retain strict corruption rejection and identical sample output.
+
 ## 0.7.4 - 2026-08-23
 
 - Linear DNG and raw-export infrared markers moved from private tag

--- a/coolscanpy/pyproject.toml
+++ b/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -53,7 +53,9 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "manual_frames.py": "8fc4ba82c177e1b7ecd6943354db33930b468ef3b4b82c712202b8caea54c9bb",
     "usb_backend.py": "afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62",
     "density.py": "c2c47de2886bc4b60197d2721b6d72050a76f1095760590fa7bb34a728b9da76",
-    "packed.py": "856315714e4f7e81f42e1ca93917e4cc0feb03b24915c2ad604302bfdca46f87",
+    # Resealed 2026-08-12 after a complete 2,980-record LS-5000 capture
+    # established the strict EBDE-prefixed padding-counter dialect.
+    "packed.py": "abff893d6ec5ff36aa33be86ef401a28ffbd6054e2279129e8fb88d7f650b435",
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "b03b3212d1ff1f8e3ad8ca7b512765ad6a115d4766e3f3eb5a86de3573076d4e",

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/packed.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/packed.py
@@ -112,11 +112,11 @@ def _counter_train_ok(
 def _padding_counter_dialect(block: np.ndarray) -> str | None:
     """Identify any complete padding counter dialect observed live.
 
-    The original captures begin with the canonical ``AA55,D893`` pair.  Four
+    The original captures begin with the canonical ``AA55,D893`` pair.  Five
     further stable LS-5000 states, each observed identically in both long
     padding blocks across every record of its captured stream, replace only
     the first three words with a repeated sentinel — ``E9EA``, ``E004``,
-    ``DC4C``, or ``F6B1``.
+    ``DC4C``, ``F6B1``, or ``EBDE``.
     The fourth word remains ``D894`` and the canonical ``AA55,D895...`` train
     resumes immediately afterward.  Accept only those exact whole-block forms.
     """
@@ -130,6 +130,7 @@ def _padding_counter_dialect(block: np.ndarray) -> str | None:
         (0xE004, "e004-prefixed"),
         (0xDC4C, "dc4c-prefixed"),
         (0xF6B1, "f6b1-prefixed"),
+        (0xEBDE, "ebde-prefixed"),
     ):
         sentinel_prefix = np.array(
             [sentinel, sentinel, sentinel, 0xD894],

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_packed.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_packed.py
@@ -33,6 +33,11 @@ def _e004_prefixed_counter_train(words: np.ndarray) -> None:
     _counter_train(words[4:], 0xD895)
 
 
+def _ebde_prefixed_counter_train(words: np.ndarray) -> None:
+    words[:4] = (0xEBDE, 0xEBDE, 0xEBDE, 0xD894)
+    _counter_train(words[4:], 0xD895)
+
+
 def _synthetic_full_records(height: int = 3) -> tuple[np.ndarray, np.ndarray]:
     records = (height + 1) // 2
     base = (np.arange(records * 2 * WIDTH * 4, dtype=np.uint32).reshape(records * 2, WIDTH, 4) % 20_000).astype(np.uint16)
@@ -211,6 +216,67 @@ def test_full_decoder_rejects_e004_padding_1_with_e9ea_padding_3(tmp_path: Path)
     path.write_bytes(full.astype(">u2").tobytes())
 
     with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_accepts_ebde_prefixed_padding_counter_dialect(tmp_path: Path) -> None:
+    base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    path = tmp_path / "ebde-prefixed.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    decoded, report = decode_full_records(path, height=3)
+
+    expected = base.copy()
+    expected[..., :3] += 2
+    np.testing.assert_array_equal(expected, decoded)
+    assert report["padding_1_3_counter_dialect"] == "ebde-prefixed"
+
+
+@pytest.mark.parametrize(
+    "corrupt_word_offset",
+    [110_840 // 2, 110_840 // 2 + 3, 110_840 // 2 + 4, 111_616 // 2 - 1],
+    ids=["sentinel", "d894", "train-head", "train-tail"],
+)
+def test_full_decoder_rejects_corrupt_ebde_prefixed_padding(
+    tmp_path: Path, corrupt_word_offset: int
+) -> None:
+    _base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    full[1, corrupt_word_offset] ^= 1
+    path = tmp_path / "corrupt-ebde-prefixed.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 1 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_rejects_ebde_padding_1_with_canonical_padding_3(
+    tmp_path: Path,
+) -> None:
+    _base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+    path = tmp_path / "mixed-ebde-canonical.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_rejects_cross_record_ebde_dialect_change(tmp_path: Path) -> None:
+    _base, full = _synthetic_full_records()
+    record = full[1]
+    _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+    _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    path = tmp_path / "cross-record-ebde-dialect-change.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 1 counter train mismatch"):
         decode_full_records(path, height=3)
 
 

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_streaming.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_streaming.py
@@ -65,6 +65,11 @@ def _f6b1_prefixed_counter_train(words: np.ndarray) -> None:
     _counter_train(words[4:], 0xD895)
 
 
+def _ebde_prefixed_counter_train(words: np.ndarray) -> None:
+    words[:4] = (0xEBDE, 0xEBDE, 0xEBDE, 0xD894)
+    _counter_train(words[4:], 0xD895)
+
+
 def _synthetic_full_records(height: int = 3) -> tuple[np.ndarray, np.ndarray]:
     records = (height + 1) // 2
     base = (
@@ -250,6 +255,69 @@ class TestStreamingFrameDecoder:
 
         np.testing.assert_array_equal(offline, decoded)
         assert offline_report["padding_1_3_counter_dialect"] == "f6b1-prefixed"
+
+    def test_ebde_prefixed_stream_matches_offline_decode_byte_for_byte(
+        self, tmp_path: Path
+    ) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+            _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        stream = full.astype(">u2").tobytes()
+        path = tmp_path / "ebde-capture.bin"
+        path.write_bytes(stream)
+        offline, offline_report = decode_full_records(path, height=3)
+
+        decoder = StreamingFrameDecoder(height=3)
+        _feed(decoder, stream, 4_096)
+        decoded, _ = decoder.finish()
+
+        np.testing.assert_array_equal(offline, decoded)
+        assert offline_report["padding_1_3_counter_dialect"] == "ebde-prefixed"
+
+    @pytest.mark.parametrize(
+        "corrupt_word_offset,match",
+        [
+            (110_840 // 2, "padding 1 counter train mismatch"),
+            (110_840 // 2 + 4, "padding 1 counter train mismatch"),
+            (207_096 // 2, "padding 3 counter train mismatch"),
+            (207_872 // 2 - 1, "padding 3 counter train mismatch"),
+        ],
+        ids=["pad1-sentinel", "pad1-train-head", "pad3-sentinel", "pad3-train-tail"],
+    )
+    def test_corrupt_ebde_prefixed_padding_fails_closed(
+        self, corrupt_word_offset: int, match: str
+    ) -> None:
+        _base, full = _synthetic_full_records(height=5)  # 3 records
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+            _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        full[1, corrupt_word_offset] ^= 1
+        decoder = StreamingFrameDecoder(height=5)
+
+        with pytest.raises(ValueError, match=match):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
+
+    def test_mixed_ebde_and_canonical_padding_dialects_fail_closed(self) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        decoder = StreamingFrameDecoder(height=3)
+
+        with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
+
+    def test_cross_record_ebde_dialect_change_fails_closed(self) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        record = full[1]
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        decoder = StreamingFrameDecoder(height=3)
+
+        with pytest.raises(
+            ValueError, match="dialect changed at record 1: canonical -> ebde-prefixed"
+        ):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
 
     @pytest.mark.parametrize(
         "corrupt_word_offset,match",

--- a/coolscanpy/uv.lock
+++ b/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/docs/HARDWARE-SUPPORT.md
+++ b/docs/HARDWARE-SUPPORT.md
@@ -4,7 +4,7 @@ This is the canonical ScanStudio hardware-support matrix. It records what the
 project has actually observed at four separate boundaries; a built package or
 an enumerated USB device is not evidence that preview or capture works.
 
-Current published release: [v0.7.0-beta.12](releases/v0.7.0-beta.12.md).
+Latest release notes: [v0.7.0-beta.13](releases/v0.7.0-beta.13.md).
 
 | Host and scanner | Package built | Device enumerated | Preview exercised | One-frame capture validated | Support / next evidence |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/releases/v0.7.0-beta.13.md
+++ b/docs/releases/v0.7.0-beta.13.md
@@ -10,6 +10,11 @@ verification around real project persistence.
   This fixes the `The parameter is incorrect` failure reproduced on NTFS
   during project creation (#100), while retaining locked directory authority
   and create-only publication. Native Windows persistence now runs in CI.
+- Windows output publication shares the native rename helper with manifests.
+  Private output files request creation access, directory flushes request
+  write access, and filename-collision probes close their deleted handles
+  before checking for unexpected entries. WSL infrared and meter sidecar
+  names retain Linux separators when validated by the Windows engine.
 - Project creation is strictly create-only. An existing manifest is refused
   with `PROJECT_ALREADY_EXISTS`, preserving projects with or without scan
   receipts instead of silently overwriting them (#99).

--- a/docs/releases/v0.7.0-beta.13.md
+++ b/docs/releases/v0.7.0-beta.13.md
@@ -6,6 +6,10 @@ verification around real project persistence.
 
 ## Everything that changed
 
+- Windows project publication uses the native handle-relative rename API.
+  This fixes the `The parameter is incorrect` failure reproduced on NTFS
+  during project creation (#100), while retaining locked directory authority
+  and create-only publication. Native Windows persistence now runs in CI.
 - Project creation is strictly create-only. An existing manifest is refused
   with `PROJECT_ALREADY_EXISTS`, preserving projects with or without scan
   receipts instead of silently overwriting them (#99).
@@ -78,9 +82,9 @@ the GPL bridge/driver corresponding source and applicable license notices.
 Physical validation on additional scanners, firmware, adapters, and operating
 systems remains outstanding. USB LS-40/LS-50 and FireWire models do not gain
 full scanning support in this release. No unattended hardware test was run
-for this audit. The Windows storage report in #100 and the post-preview film
-status report in #77 require comparison against the verified current build;
-this release does not claim to reproduce every affected field setup.
+for this audit. The post-preview film-status report in #77 still requires
+physical reproduction. The NTFS failure in #100 was reproduced and fixed;
+other storage configurations have not been exhaustively validated.
 
 Raw negative export remains unavailable on the Windows/WSL path. Real
 black-and-white fine scanning and optional host-SANE operations retain their

--- a/docs/releases/v0.7.0-beta.13.md
+++ b/docs/releases/v0.7.0-beta.13.md
@@ -1,0 +1,88 @@
+# ScanStudio v0.7.0-beta.13
+
+This prerelease brings the completed issue-audit fixes into the release line,
+adds the observed EBDE scanner-padding dialect, and strengthens package
+verification around real project persistence.
+
+## Everything that changed
+
+- Project creation is strictly create-only. An existing manifest is refused
+  with `PROJECT_ALREADY_EXISTS`, preserving projects with or without scan
+  receipts instead of silently overwriting them (#99).
+- Failed scans retain bounded transport witnesses and per-frame attempt
+  evidence. Both clients can explain the failure using that evidence;
+  diagnostic exports redact private fields and bound evidence references
+  (#76, #98, #106).
+- Meter-controller failures have typed, journaled refusal details, and
+  unknown SANE scanner identities cannot enter a supported motion path
+  (#101, #103).
+- Windows hardware-session ownership and process cleanup are hardened;
+  ordinary launches retain their separate unarmed behavior (#75).
+- Linear DNG infrared SubIFDs use the TIFF/EP LONG pointer type and a
+  standard image-description marker. TIFF infrared markers use tag 65010;
+  readers still accept legacy tag 65001. Stored image samples are unchanged
+  (#105).
+- Scanner-contract documentation, recovery guidance, and the hardware/OS
+  support matrix agree with the implemented capabilities (#29, #102).
+- Publication requires successful same-run verification of the exact tagged
+  commit and rechecks the remote tag object before publishing (#104).
+- CoolscanPy 0.7.5 accepts the exact EBDE-prefixed LS-5000 padding-counter
+  dialect in offline and streaming decoding, while rejecting malformed
+  padding. ScanStudio's driver generation matches the standalone package.
+- The relocated Mac package and both Windows package layouts exercise
+  project creation, mutation, reopening, and overwrite refusal using paths
+  containing spaces and #. Windows also runs this check before packaging.
+- Tauri build-tool downloads use hash-verified release URLs instead of
+  rate-limited unauthenticated API endpoints. The AppImage plugin is pinned
+  to a versioned release instead of a deleted continuous-build asset.
+- The DNG plan's TIFF marker references and the Mac developer README's
+  support-stage description match the implementation and support matrix.
+- The signing rehearsal's runtime probe disables Python bytecode writes,
+  uses an absolute library path, and re-verifies the signature afterward.
+  This prevents the check itself from modifying a notarized app bundle.
+- The hardware matrix labels its version link as release notes, so preparing
+  the next release does not incorrectly claim it is already published.
+
+## Validation
+
+- Apple Silicon local validation passed the Rust engine suite (529 unit
+  tests plus integration suites), 78 XCTest tests and 502 Swift Testing
+  tests, the bridge and CoolscanPy suites, 464 Tauri UI tests, the Tauri
+  production build, and Tauri Rust unit/integration tests.
+- The Developer ID-signed Mac app passed relocation, bundled-runtime,
+  launcher, project-persistence, and seeded updater verification. A manual
+  simulator session acquired six previews, saved a project, scanned one
+  frame, and persisted all three output files with matching SHA-256 receipts.
+- The tagged release workflow independently gates publication on native
+  Mac architecture builds, the macOS 14 runtime floor, updater checks, and
+  Windows/Linux package verification. A failed or skipped prerequisite
+  prevents publication.
+
+## Platform support and installation
+
+- Apple Silicon macOS: Beta, with real-film validation limited to the
+  documented LS-5000 setup. This audit's interactive scan was simulated.
+- Intel macOS: Preview; package checks do not establish real-scanner support.
+- Windows x64: Preview through WSL2 Ubuntu 24.04 and usbipd-win. Use the
+  documented Hardware Session launcher for explicit hardware operations.
+- Linux x64: Preview; requires the documented runtime packages and device
+  permissions. Real-scanner validation remains limited.
+
+macOS requires version 14 or later. Release DMGs are Developer ID signed,
+notarized, and stapled by the release workflow. Choose the DMG matching the
+Mac architecture. Windows and Linux packages remain unsigned. Bundles include
+the GPL bridge/driver corresponding source and applicable license notices.
+
+## Known limitations
+
+Physical validation on additional scanners, firmware, adapters, and operating
+systems remains outstanding. USB LS-40/LS-50 and FireWire models do not gain
+full scanning support in this release. No unattended hardware test was run
+for this audit. The Windows storage report in #100 and the post-preview film
+status report in #77 require comparison against the verified current build;
+this release does not claim to reproduce every affected field setup.
+
+Raw negative export remains unavailable on the Windows/WSL path. Real
+black-and-white fine scanning and optional host-SANE operations retain their
+documented limits. A simulator result is not evidence of physical scanner
+operation.

--- a/ports/tauri/packaging/install_pinned_tauri_tools.py
+++ b/ports/tauri/packaging/install_pinned_tauri_tools.py
@@ -116,16 +116,10 @@ NSIS_PLUGIN = {
     "sha256": "5ba143b5db4a87d32d6e7802e033330aae56cbceabe0d1e3ba41948385ad4709",
 }
 
-# 2026-08-24: Microsoft rotated the fwlink 2124701 delivery GUID again
-# (previous: 22ced09c-d6bd-4427-a658-f1dc48f3a440, itself a 2026-08-23
-# rotation of eb04ea38-69c8-4b86-b65b-fd4c8469ae59, itself a 2026-08-14
-# rotation of e4dd9b83-b7e3-4d17-8d7c-e14cdd7c3a51); Tauri's bundler
-# resolved the new GUID during the eleven-issue PR's Windows package job,
-# ignored the pinned copy staged under the old path, downloaded a fresh
-# installer into its own cache directory, and the pin gate failed closed
-# on the unexpected directory exactly as designed. New artifact
-# re-verified via the official fwlink redirect before re-pinning.
-WEBVIEW2_GUID = "89620190-81af-46a2-bb59-6228918a312e"
+# 2026-09-06: verified the official fwlink 2124701 redirect and repinned its
+# current installer. Tauri resolves that redirect to choose its cache path;
+# an unexpected rotation must still fail the exact-tree and Authenticode gates.
+WEBVIEW2_GUID = "a8f5ad97-0b01-41e5-9245-e8fc9ba9b311"
 WEBVIEW2_ASSET = {
     "name": "MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
     "url": (
@@ -133,8 +127,8 @@ WEBVIEW2_ASSET = {
         "filestreamingservice/files/"
         f"{WEBVIEW2_GUID}/MicrosoftEdgeWebView2RuntimeInstallerX64.exe"
     ),
-    "size": 213_044_432,
-    "sha256": "358a11cff88ce519301c3b60bcefe848f922688ab0a333fc0f18ddf83bb3b4f3",
+    "size": 258_614_480,
+    "sha256": "e7fa35755196ad9223596ef021a1ce6799509142eaa40ba35f634026be50b831",
 }
 
 WINDOWS_RESERVED_NAMES = {

--- a/ports/tauri/packaging/install_pinned_tauri_tools.py
+++ b/ports/tauri/packaging/install_pinned_tauri_tools.py
@@ -37,8 +37,8 @@ LINUX_ASSETS = (
     {
         "name": "AppRun-x86_64",
         "url": (
-            "https://api.github.com/repos/tauri-apps/binary-releases/"
-            "releases/assets/274691722"
+            "https://github.com/tauri-apps/binary-releases/"
+            "releases/download/apprun-old/AppRun-x86_64"
         ),
         "size": 31_552,
         "sha256": "f30140a43a0a59e46db21bdefdf749b9e9f2c6946e92afabbacf98b8ae73fb4f",
@@ -46,8 +46,8 @@ LINUX_ASSETS = (
     {
         "name": "linuxdeploy-x86_64.AppImage",
         "url": (
-            "https://api.github.com/repos/tauri-apps/binary-releases/"
-            "releases/assets/182515537"
+            "https://github.com/tauri-apps/binary-releases/"
+            "releases/download/linuxdeploy/linuxdeploy-x86_64.AppImage"
         ),
         "size": 13_264_064,
         "sha256": "e762bea85c8eb0d4b3508d46e5c1f037f717d0f9303ae3b4aafc8b04991fa1ef",
@@ -81,19 +81,20 @@ LINUX_ASSETS = (
     {
         "name": "linuxdeploy-plugin-appimage.AppImage",
         "url": (
-            "https://api.github.com/repos/linuxdeploy/"
-            "linuxdeploy-plugin-appimage/releases/assets/497460911"
+            "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/"
+            "releases/download/1-alpha-20250213-1/linuxdeploy-plugin-appimage-x86_64.AppImage"
         ),
-        "size": 16_484_856,
-        "sha256": "a45d3e227bc7f397e9cf6bfa4c9507494efa2293357b6e86690a3de2ca992e79",
+        # Use a versioned release: continuous assets are deleted on replacement.
+        "size": 15_889_136,
+        "sha256": "992d502a248e14ab185448ddf6f6e7d25558cb84d4623c354c3af350c25fccb3",
     },
 )
 
 NSIS_ARCHIVE = {
     "name": "nsis-3.11.zip",
     "url": (
-        "https://api.github.com/repos/tauri-apps/binary-releases/"
-        "releases/assets/317051073"
+        "https://github.com/tauri-apps/binary-releases/"
+        "releases/download/nsis-3.11/nsis-3.11.zip"
     ),
     "size": 2_361_546,
     "sha256": "c7d27f780ddb6cffb4730138cd1591e841f4b7edb155856901cdf5f214394fa1",
@@ -108,8 +109,8 @@ NSIS_BASE_TREE_SHA256 = (
 NSIS_PLUGIN = {
     "name": "nsis_tauri_utils.dll",
     "url": (
-        "https://api.github.com/repos/tauri-apps/nsis-tauri-utils/"
-        "releases/assets/345882097"
+        "https://github.com/tauri-apps/nsis-tauri-utils/"
+        "releases/download/nsis_tauri_utils-v0.5.3/nsis_tauri_utils.dll"
     ),
     "size": 34_304,
     "sha256": "5ba143b5db4a87d32d6e7802e033330aae56cbceabe0d1e3ba41948385ad4709",

--- a/ports/tauri/packaging/linux/build-and-verify.sh
+++ b/ports/tauri/packaging/linux/build-and-verify.sh
@@ -129,6 +129,7 @@ PY
         exit 1
     fi
     npm run sync-engine
+    cargo test --locked --manifest-path ../vendor/engine/Cargo.toml --lib
     npm test
     npx tsc --noEmit
     npm run build

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -815,6 +815,7 @@ try {
     }
     npm run sync-engine
     Invoke-EngineSmoke -Tree (Join-Path $appRoot 'src-tauri\binaries')
+    cargo test --locked --manifest-path ..\vendor\engine\Cargo.toml --lib
     npm test
     npx tsc --noEmit
     npm run build

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -28,13 +28,12 @@ $windowsPowerShell = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\
 $pinnedToolsInstaller = Join-Path $portRoot 'packaging\install_pinned_tauri_tools.py'
 $cargoTarget = Join-Path $appRoot 'src-tauri\target'
 $tauriToolsRoot = Join-Path $cargoTarget '.tauri'
-# 2026-08-24: Microsoft rotated the fwlink 2124701 delivery GUID again
-# (previous: 22ced09c-d6bd-4427-a658-f1dc48f3a440); re-verified via the
-# official fwlink redirect before re-pinning. Moves in lockstep with
-# install_pinned_tauri_tools.py.
-$webViewGuid = '89620190-81af-46a2-bb59-6228918a312e'
+# 2026-09-06: verified the current official fwlink 2124701 redirect.
+# Moves in lockstep with install_pinned_tauri_tools.py; verify Microsoft
+# Authenticode before the bundler or installer consumes these pinned bytes.
+$webViewGuid = 'a8f5ad97-0b01-41e5-9245-e8fc9ba9b311'
 $webViewFileName = 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe'
-$webViewSha256 = '358a11cff88ce519301c3b60bcefe848f922688ab0a333fc0f18ddf83bb3b4f3'
+$webViewSha256 = 'e7fa35755196ad9223596ef021a1ce6799509142eaa40ba35f634026be50b831'
 $nsisPluginSha256 = '5ba143b5db4a87d32d6e7802e033330aae56cbceabe0d1e3ba41948385ad4709'
 $pinnedWebView = Join-Path $tauriToolsRoot "x64\$webViewGuid\$webViewFileName"
 $pinnedMakensis = Join-Path $tauriToolsRoot 'NSIS\makensis.exe'

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -714,6 +714,11 @@ function Invoke-EngineSmoke {
         throw "Expected exactly one engine sidecar under $Tree, found $($engines.Count): $engines"
     }
 
+    # Exercise filesystem operations in both the installed and portable builds
+    # (#100); a hello/list handshake never touches project persistence.
+    & python -I -S -B (Join-Path $portRoot '..\..\scripts\smoke_project_persistence.py') $engines[0].FullName
+    if ($LASTEXITCODE -ne 0) { throw 'Packaged engine project persistence failed' }
+
     $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
     $startInfo.FileName = $engines[0].FullName
     $startInfo.UseShellExecute = $false

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -814,6 +814,7 @@ try {
         throw "Unexpected Tauri CLI version: $tauriCliVersion"
     }
     npm run sync-engine
+    Invoke-EngineSmoke -Tree (Join-Path $appRoot 'src-tauri\binaries')
     npm test
     npx tsc --noEmit
     npm run build

--- a/ports/tauri/vendor/coolscanpy/CHANGELOG.md
+++ b/ports/tauri/vendor/coolscanpy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.7.5 - 2026-09-06
+
+- Accept the observed EBDE-prefixed LS-5000 padding counter dialect only when the entire padding block matches its exact counter train. Offline and streaming decoding retain strict corruption rejection and identical sample output.
+
 ## 0.7.4 - 2026-08-23
 
 - Linear DNG and raw-export infrared markers moved from private tag

--- a/ports/tauri/vendor/coolscanpy/pyproject.toml
+++ b/ports/tauri/vendor/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -57,7 +57,9 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     # source snapshot, so this cannot silently drift again.
     "usb_backend.py": "77499a606dc48049521d2fd0359a0405cb55525242843d61165b642c78841208",
     "density.py": "c2c47de2886bc4b60197d2721b6d72050a76f1095760590fa7bb34a728b9da76",
-    "packed.py": "856315714e4f7e81f42e1ca93917e4cc0feb03b24915c2ad604302bfdca46f87",
+    # Resealed 2026-08-12 after a complete 2,980-record LS-5000 capture
+    # established the strict EBDE-prefixed padding-counter dialect.
+    "packed.py": "abff893d6ec5ff36aa33be86ef401a28ffbd6054e2279129e8fb88d7f650b435",
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "b03b3212d1ff1f8e3ad8ca7b512765ad6a115d4766e3f3eb5a86de3573076d4e",

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/packed.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/packed.py
@@ -112,11 +112,11 @@ def _counter_train_ok(
 def _padding_counter_dialect(block: np.ndarray) -> str | None:
     """Identify any complete padding counter dialect observed live.
 
-    The original captures begin with the canonical ``AA55,D893`` pair.  Four
+    The original captures begin with the canonical ``AA55,D893`` pair.  Five
     further stable LS-5000 states, each observed identically in both long
     padding blocks across every record of its captured stream, replace only
     the first three words with a repeated sentinel — ``E9EA``, ``E004``,
-    ``DC4C``, or ``F6B1``.
+    ``DC4C``, ``F6B1``, or ``EBDE``.
     The fourth word remains ``D894`` and the canonical ``AA55,D895...`` train
     resumes immediately afterward.  Accept only those exact whole-block forms.
     """
@@ -130,6 +130,7 @@ def _padding_counter_dialect(block: np.ndarray) -> str | None:
         (0xE004, "e004-prefixed"),
         (0xDC4C, "dc4c-prefixed"),
         (0xF6B1, "f6b1-prefixed"),
+        (0xEBDE, "ebde-prefixed"),
     ):
         sentinel_prefix = np.array(
             [sentinel, sentinel, sentinel, 0xD894],

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_packed.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_packed.py
@@ -33,6 +33,11 @@ def _e004_prefixed_counter_train(words: np.ndarray) -> None:
     _counter_train(words[4:], 0xD895)
 
 
+def _ebde_prefixed_counter_train(words: np.ndarray) -> None:
+    words[:4] = (0xEBDE, 0xEBDE, 0xEBDE, 0xD894)
+    _counter_train(words[4:], 0xD895)
+
+
 def _synthetic_full_records(height: int = 3) -> tuple[np.ndarray, np.ndarray]:
     records = (height + 1) // 2
     base = (np.arange(records * 2 * WIDTH * 4, dtype=np.uint32).reshape(records * 2, WIDTH, 4) % 20_000).astype(np.uint16)
@@ -211,6 +216,67 @@ def test_full_decoder_rejects_e004_padding_1_with_e9ea_padding_3(tmp_path: Path)
     path.write_bytes(full.astype(">u2").tobytes())
 
     with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_accepts_ebde_prefixed_padding_counter_dialect(tmp_path: Path) -> None:
+    base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    path = tmp_path / "ebde-prefixed.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    decoded, report = decode_full_records(path, height=3)
+
+    expected = base.copy()
+    expected[..., :3] += 2
+    np.testing.assert_array_equal(expected, decoded)
+    assert report["padding_1_3_counter_dialect"] == "ebde-prefixed"
+
+
+@pytest.mark.parametrize(
+    "corrupt_word_offset",
+    [110_840 // 2, 110_840 // 2 + 3, 110_840 // 2 + 4, 111_616 // 2 - 1],
+    ids=["sentinel", "d894", "train-head", "train-tail"],
+)
+def test_full_decoder_rejects_corrupt_ebde_prefixed_padding(
+    tmp_path: Path, corrupt_word_offset: int
+) -> None:
+    _base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    full[1, corrupt_word_offset] ^= 1
+    path = tmp_path / "corrupt-ebde-prefixed.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 1 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_rejects_ebde_padding_1_with_canonical_padding_3(
+    tmp_path: Path,
+) -> None:
+    _base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+    path = tmp_path / "mixed-ebde-canonical.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_rejects_cross_record_ebde_dialect_change(tmp_path: Path) -> None:
+    _base, full = _synthetic_full_records()
+    record = full[1]
+    _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+    _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    path = tmp_path / "cross-record-ebde-dialect-change.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 1 counter train mismatch"):
         decode_full_records(path, height=3)
 
 

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_streaming.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_streaming.py
@@ -65,6 +65,11 @@ def _f6b1_prefixed_counter_train(words: np.ndarray) -> None:
     _counter_train(words[4:], 0xD895)
 
 
+def _ebde_prefixed_counter_train(words: np.ndarray) -> None:
+    words[:4] = (0xEBDE, 0xEBDE, 0xEBDE, 0xD894)
+    _counter_train(words[4:], 0xD895)
+
+
 def _synthetic_full_records(height: int = 3) -> tuple[np.ndarray, np.ndarray]:
     records = (height + 1) // 2
     base = (
@@ -250,6 +255,69 @@ class TestStreamingFrameDecoder:
 
         np.testing.assert_array_equal(offline, decoded)
         assert offline_report["padding_1_3_counter_dialect"] == "f6b1-prefixed"
+
+    def test_ebde_prefixed_stream_matches_offline_decode_byte_for_byte(
+        self, tmp_path: Path
+    ) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+            _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        stream = full.astype(">u2").tobytes()
+        path = tmp_path / "ebde-capture.bin"
+        path.write_bytes(stream)
+        offline, offline_report = decode_full_records(path, height=3)
+
+        decoder = StreamingFrameDecoder(height=3)
+        _feed(decoder, stream, 4_096)
+        decoded, _ = decoder.finish()
+
+        np.testing.assert_array_equal(offline, decoded)
+        assert offline_report["padding_1_3_counter_dialect"] == "ebde-prefixed"
+
+    @pytest.mark.parametrize(
+        "corrupt_word_offset,match",
+        [
+            (110_840 // 2, "padding 1 counter train mismatch"),
+            (110_840 // 2 + 4, "padding 1 counter train mismatch"),
+            (207_096 // 2, "padding 3 counter train mismatch"),
+            (207_872 // 2 - 1, "padding 3 counter train mismatch"),
+        ],
+        ids=["pad1-sentinel", "pad1-train-head", "pad3-sentinel", "pad3-train-tail"],
+    )
+    def test_corrupt_ebde_prefixed_padding_fails_closed(
+        self, corrupt_word_offset: int, match: str
+    ) -> None:
+        _base, full = _synthetic_full_records(height=5)  # 3 records
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+            _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        full[1, corrupt_word_offset] ^= 1
+        decoder = StreamingFrameDecoder(height=5)
+
+        with pytest.raises(ValueError, match=match):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
+
+    def test_mixed_ebde_and_canonical_padding_dialects_fail_closed(self) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        decoder = StreamingFrameDecoder(height=3)
+
+        with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
+
+    def test_cross_record_ebde_dialect_change_fails_closed(self) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        record = full[1]
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        decoder = StreamingFrameDecoder(height=3)
+
+        with pytest.raises(
+            ValueError, match="dialect changed at record 1: canonical -> ebde-prefixed"
+        ):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
 
     @pytest.mark.parametrize(
         "corrupt_word_offset,match",

--- a/ports/tauri/vendor/coolscanpy/uv.lock
+++ b/ports/tauri/vendor/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/engine/src/evidence_package.rs
+++ b/ports/tauri/vendor/engine/src/evidence_package.rs
@@ -1056,7 +1056,7 @@ fn create_package_file(
 fn cleanup_staged_manifest(
     package: &crate::render::ReservedEvidencePackage,
     temporary_name: &std::ffi::OsStr,
-    staged: &std::fs::File,
+    staged: std::fs::File,
 ) -> Result<(), String> {
     package
         .retire_exact_root_file(temporary_name, staged)
@@ -1065,7 +1065,7 @@ fn cleanup_staged_manifest(
 
 fn rollback_committed_manifest(
     package: &crate::render::ReservedEvidencePackage,
-    manifest_file: &std::fs::File,
+    manifest_file: std::fs::File,
 ) -> Result<(), String> {
     package
         .retire_exact_root_file(std::ffi::OsStr::new("manifest.json"), manifest_file)
@@ -1123,7 +1123,7 @@ where
         Ok(())
     })();
     if let Err(error) = staged {
-        return match cleanup_staged_manifest(package, &temporary_name, &manifest_file) {
+        return match cleanup_staged_manifest(package, &temporary_name, manifest_file) {
             Ok(()) => Err(error),
             Err(cleanup) => Err(format!(
                 "{error}; HOLD: staged evidence manifest cleanup could not be proven: {cleanup}"
@@ -1138,7 +1138,7 @@ where
         std::ffi::OsStr::new("manifest.json"),
     ) {
         let primary = format!("create-only authoritative evidence manifest commit: {error}");
-        return match cleanup_staged_manifest(package, &temporary_name, &manifest_file) {
+        return match cleanup_staged_manifest(package, &temporary_name, manifest_file) {
             Ok(()) => Err(primary),
             Err(cleanup) => Err(format!(
                 "{primary}; HOLD: staged evidence manifest cleanup could not be proven: {cleanup}"
@@ -1164,7 +1164,7 @@ where
     })();
     match post_commit {
         Ok(()) => Ok(()),
-        Err(primary) => match rollback_committed_manifest(package, &manifest_file) {
+        Err(primary) => match rollback_committed_manifest(package, manifest_file) {
             Ok(()) => Err(format!(
                 "{primary}; authoritative manifest was rolled back and completion was not reported"
             )),
@@ -1287,7 +1287,7 @@ where
     Ok((
         FileDigest {
             path: source.display().to_string(),
-            package_path: destination.to_string_lossy().to_string(),
+            package_path: destination.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/"),
             sha256: source_hash,
         },
         PackageFileProof {
@@ -1837,7 +1837,7 @@ mod tests {
         })
         .expect_err("post-commit ambiguity must never return successful completion");
         assert!(error.contains("ordering ambiguity"));
-        assert!(error.contains("rolled back"));
+        assert!(error.contains("rolled back"), "{error}");
         assert!(!package.final_path().join("manifest.json").exists());
 
         let _ = std::fs::remove_dir_all(root);

--- a/ports/tauri/vendor/engine/src/exiftool.rs
+++ b/ports/tauri/vendor/engine/src/exiftool.rs
@@ -3198,6 +3198,11 @@ pub(crate) mod metadata_publish_sys {
     }
 
     pub fn open_regular(parent: &File, name: &OsStr) -> io::Result<File> {
+        // Readers must coexist with publication handles that deny deletion.
+        relative_file(parent, name, false, false, false, false, true)
+    }
+
+    fn open_regular_for_delete(parent: &File, name: &OsStr) -> io::Result<File> {
         relative_file(parent, name, false, false, false, true, true)
     }
 
@@ -3265,8 +3270,8 @@ pub(crate) mod metadata_publish_sys {
         to_directory: &File,
         to_name: &OsStr,
     ) -> io::Result<()> {
-        let source = open_regular(from_directory, from_name)?;
-        let target = open_regular(to_directory, to_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
+        let target = open_regular_for_delete(to_directory, to_name)?;
         let parking = from_name
             .to_str()
             .and_then(|name| name.strip_prefix(".swap-"))
@@ -3319,7 +3324,7 @@ pub(crate) mod metadata_publish_sys {
                 ))
             }
         }
-        let source = open_regular(from_directory, from_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
         rename_handle(&source, to_directory, to_name, false)
     }
 
@@ -3345,7 +3350,7 @@ pub(crate) mod metadata_publish_sys {
         to_directory: &File,
         to_name: &OsStr,
     ) -> io::Result<()> {
-        let source = open_regular(from_directory, from_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
         rename_handle(&source, to_directory, to_name, true)
     }
 
@@ -3371,7 +3376,7 @@ pub(crate) mod metadata_publish_sys {
     }
 
     pub fn unlink(parent: &File, name: &OsStr) -> io::Result<()> {
-        let file = open_regular(parent, name)?;
+        let file = open_regular_for_delete(parent, name)?;
         delete_handle(&file)
     }
 

--- a/ports/tauri/vendor/engine/src/exiftool.rs
+++ b/ports/tauri/vendor/engine/src/exiftool.rs
@@ -2592,7 +2592,7 @@ pub(crate) mod metadata_publish_sys {
     const FILE_OPEN: u32 = 0x0000_0001;
     const FILE_CREATE: u32 = 0x0000_0002;
     const FILE_NAMES_INFORMATION_CLASS: u32 = 12;
-    const FILE_RENAME_INFO_EX_CLASS: u32 = 22;
+    const FILE_RENAME_INFORMATION_CLASS: u32 = 10;
     const FILE_DISPOSITION_INFO_EX_CLASS: u32 = 21;
     const FILE_DISPOSITION_FLAG_DELETE: u32 = 0x0000_0001;
     const FILE_DISPOSITION_FLAG_POSIX_SEMANTICS: u32 = 0x0000_0002;
@@ -2612,8 +2612,8 @@ pub(crate) mod metadata_publish_sys {
     const ACL_SIZE_INFORMATION_CLASS: u32 = 2;
 
     #[repr(C)]
-    struct FileRenameInfoEx {
-        flags: u32,
+    struct FileRenameInformation {
+        replace_if_exists: u8,
         root_directory: Handle,
         file_name_length: u32,
         file_name: [u16; 1],
@@ -2781,6 +2781,13 @@ pub(crate) mod metadata_publish_sys {
 
     #[link(name = "ntdll")]
     extern "system" {
+        fn NtSetInformationFile(
+            file: Handle,
+            io_status_block: *mut IoStatusBlock,
+            information: *mut std::ffi::c_void,
+            information_size: u32,
+            information_class: u32,
+        ) -> i32;
         fn NtCreateFile(
             file: *mut Handle,
             desired_access: u32,
@@ -3205,14 +3212,14 @@ pub(crate) mod metadata_publish_sys {
         replace: bool,
     ) -> io::Result<()> {
         let name = component(destination_name)?;
-        let header_size = offset_of!(FileRenameInfoEx, file_name);
+        let header_size = offset_of!(FileRenameInformation, file_name);
         let byte_len = name.len().checked_mul(size_of::<u16>()).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Windows rename name is too long",
             )
         })?;
-        let total = header_size.checked_add(byte_len).ok_or_else(|| {
+        let total = size_of::<FileRenameInformation>().checked_add(byte_len).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Windows rename buffer overflow",
@@ -3220,9 +3227,9 @@ pub(crate) mod metadata_publish_sys {
         })?;
         let words = total.div_ceil(size_of::<usize>());
         let mut storage = vec![0_usize; words];
-        let info = storage.as_mut_ptr().cast::<FileRenameInfoEx>();
+        let info = storage.as_mut_ptr().cast::<FileRenameInformation>();
         unsafe {
-            (*info).flags = u32::from(replace);
+            (*info).replace_if_exists = u8::from(replace);
             (*info).root_directory = destination_directory.as_raw_handle();
             (*info).file_name_length = byte_len as u32;
             std::ptr::copy_nonoverlapping(
@@ -3231,17 +3238,22 @@ pub(crate) mod metadata_publish_sys {
                 byte_len,
             );
         }
-        let result = unsafe {
-            SetFileInformationByHandle(
+        // Use the native handle-relative operation, matching NtCreateFile above.
+        // The Win32 rename wrapper rejects this directory-relative request with
+        // ERROR_INVALID_PARAMETER on supported Windows hosts.
+        let mut status_block = IoStatusBlock { status_or_pointer: 0, information: 0 };
+        let status = unsafe {
+            NtSetInformationFile(
                 source.as_raw_handle(),
-                FILE_RENAME_INFO_EX_CLASS,
+                &mut status_block,
                 info.cast(),
                 total as u32,
+                FILE_RENAME_INFORMATION_CLASS,
             )
         };
-        if result == 0 {
-            let error = io::Error::last_os_error();
-            Err(io::Error::new(error.kind(), format!("SetFileInformationByHandle rename: {error}")))
+        if status < 0 {
+            let error = io::Error::from_raw_os_error(unsafe { RtlNtStatusToDosError(status) } as i32);
+            Err(io::Error::new(error.kind(), format!("NtSetInformationFile rename: {error}")))
         } else {
             Ok(())
         }

--- a/ports/tauri/vendor/engine/src/exiftool.rs
+++ b/ports/tauri/vendor/engine/src/exiftool.rs
@@ -3205,7 +3205,7 @@ pub(crate) mod metadata_publish_sys {
         relative_file(parent, name, false, false, true, false, false)
     }
 
-    fn rename_handle(
+    pub(crate) fn rename_handle(
         source: &File,
         destination_directory: &File,
         destination_name: &OsStr,
@@ -7101,7 +7101,12 @@ mod tests {
     fn windows_runner_assigns_and_resumes_a_normal_process() {
         let command =
             std::env::var("ComSpec").unwrap_or_else(|_| r"C:\Windows\System32\cmd.exe".to_string());
-        let command = bind_executable(Path::new(&command)).expect("bind Windows command");
+        // System binaries may have servicing hard links; the executable binder
+        // intentionally requires a unique file identity.
+        let root = temp_root("windows-runner");
+        let executable = root.join("cmd.exe");
+        std::fs::copy(&command, &executable).expect("copy Windows command fixture");
+        let command = bind_executable(&executable).expect("bind Windows command");
         let output = run_bounded_command(
             &command,
             &["/D".into(), "/C".into(), "exit /B 0".into()],
@@ -7110,6 +7115,8 @@ mod tests {
         )
         .expect("run a Job-contained Windows process");
         assert!(output.status.success());
+        drop(command);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[cfg(windows)]

--- a/ports/tauri/vendor/engine/src/exiftool.rs
+++ b/ports/tauri/vendor/engine/src/exiftool.rs
@@ -2043,7 +2043,8 @@ pub(crate) fn ensure_supported_metadata_filesystem(file: &File) -> std::io::Resu
         )
     };
     if result == 0 {
-        return Err(std::io::Error::last_os_error());
+        let error = std::io::Error::last_os_error();
+        return Err(std::io::Error::new(error.kind(), format!("GetVolumeInformationByHandleW: {error}")));
     }
     if !windows_metadata_filesystem_name_is_supported(&filesystem_name) {
         let name = String::from_utf16_lossy(&filesystem_name)
@@ -3158,7 +3159,8 @@ pub(crate) mod metadata_publish_sys {
         };
         if status < 0 {
             let windows_error = unsafe { RtlNtStatusToDosError(status) };
-            return Err(io::Error::from_raw_os_error(windows_error as i32));
+            let error = io::Error::from_raw_os_error(windows_error as i32);
+            return Err(io::Error::new(error.kind(), format!("NtCreateFile metadata entry: {error}")));
         }
         if handle.is_null() || handle as isize == -1 {
             return Err(io::Error::other(
@@ -3238,7 +3240,8 @@ pub(crate) mod metadata_publish_sys {
             )
         };
         if result == 0 {
-            Err(io::Error::last_os_error())
+            let error = io::Error::last_os_error();
+            Err(io::Error::new(error.kind(), format!("SetFileInformationByHandle rename: {error}")))
         } else {
             Ok(())
         }
@@ -3485,7 +3488,9 @@ pub(crate) mod metadata_publish_sys {
         // File::sync_all maps to FlushFileBuffers on Windows. Directory
         // capabilities are opened with write access so this ordering barrier
         // is enforced instead of silently assuming a rename is durable.
-        directory.sync_all()
+        directory.sync_all().map_err(|error| {
+            io::Error::new(error.kind(), format!("FlushFileBuffers directory: {error}"))
+        })
     }
 }
 

--- a/ports/tauri/vendor/engine/src/manifest.rs
+++ b/ports/tauri/vendor/engine/src/manifest.rs
@@ -1787,6 +1787,9 @@ mod tests {
             let dir = temp_project_dir();
             fs::create_dir_all(&dir).unwrap();
             fs::write(dir.join(MANIFEST_FILE_NAME), corruption).unwrap();
+            // Windows keeps its transaction-lock inode for all later opens.
+            #[cfg(windows)]
+            fs::write(dir.join(".scanstudio-manifest.lock"), b"").unwrap();
 
             let before = snapshot_regular_files(&dir);
             let err = create_project(

--- a/ports/tauri/vendor/engine/src/real_backend.rs
+++ b/ports/tauri/vendor/engine/src/real_backend.rs
@@ -1452,6 +1452,7 @@ mod private_workspace_sys {
     ) -> io::Result<std::fs::File> {
         let marker_path = root_path.join(marker_name);
         let mut file = std::fs::OpenOptions::new()
+            .write(true)
             .access_mode(GENERIC_READ | GENERIC_WRITE | DELETE_ACCESS)
             .create_new(true)
             .share_mode(FILE_SHARE_READ)
@@ -8785,6 +8786,17 @@ mod tests {
         drop(working);
         std::fs::remove_dir_all(workspace_root).unwrap();
         std::fs::remove_dir_all(test_root).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_private_workspace_creates_and_verifies_its_marker() {
+        let working = PrivateCaptureWorkingDirectory::create().expect("create Windows workspace");
+        working.verify_namespace().expect("verify held workspace authority");
+        let root = working.root.clone();
+        assert!(std::fs::metadata(root.join(PRIVATE_CAPTURE_MARKER)).unwrap().len() > 0);
+        drop(working);
+        std::fs::remove_dir_all(root).expect("remove private test workspace");
     }
 
     #[cfg(unix)]

--- a/ports/tauri/vendor/engine/src/render.rs
+++ b/ports/tauri/vendor/engine/src/render.rs
@@ -378,7 +378,7 @@ impl ReservedEvidencePackage {
     pub(crate) fn retire_exact_root_file(
         &self,
         name: &std::ffi::OsStr,
-        expected: &std::fs::File,
+        expected: std::fs::File,
     ) -> Result<(), domain::EngineError> {
         let relative = Path::new(name);
         if relative.components().count() != 1
@@ -391,8 +391,9 @@ impl ReservedEvidencePackage {
                 "exact evidence cleanup requires one normal root-file component",
             ));
         }
-        self.verify_regular_file(relative, expected)?;
-        destination_sys::delete_exact_regular_file(expected)?;
+        self.verify_regular_file(relative, &expected)?;
+        destination_sys::delete_exact_regular_file(&expected)?;
+        drop(expected);
         crate::exiftool::metadata_publish_sys::sync_directory(self.directory_handle()).map_err(
             |error| {
                 output_authority_error(format!(
@@ -10302,17 +10303,34 @@ mod tests {
         output.preview.enabled = false;
         output.raw_export.enabled = false;
 
-        let error = acquire_job_output_authorities(
+        // NTFS upcase tables vary by volume generation. Derive the expected
+        // answer from actual ordinary Windows file creation on this volume.
+        let first = project.join("Σ_0001.tif");
+        let second = project.join("ς_0001.tif");
+        std::fs::write(&first, b"oracle").unwrap();
+        let oracle = std::fs::OpenOptions::new().write(true).create_new(true).open(&second);
+        let collision = match oracle {
+            Ok(file) => { drop(file); false }
+            Err(error) => {
+                assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+                true
+            }
+        };
+        let result = acquire_job_output_authorities(
             Some(&project),
             &[1],
             &domain::CaptureRecipe::default(),
             &output,
             &std::collections::HashMap::new(),
         )
-        .expect_err("NTFS-upcase aliases must collide before capture");
-
-        assert_eq!(error.code, protocol::ErrorCode::InvalidParams);
-        assert!(error.message.contains("filename collation"), "{error}");
+        ;
+        if collision {
+            let error = result.expect_err("filesystem aliases must collide before capture");
+            assert_eq!(error.code, protocol::ErrorCode::InvalidParams);
+            assert!(error.message.contains("filename collation"), "{error}");
+        } else {
+            result.expect("distinct filesystem names must remain usable");
+        }
         let _ = std::fs::remove_dir_all(&project);
     }
 
@@ -11985,7 +12003,16 @@ mod tests {
 
         let positive = written.positive_path.as_ref().unwrap();
         let displaced = root.join("engine-authored-positive.tif");
-        std::fs::rename(positive, &displaced).unwrap();
+        let renamed = std::fs::rename(positive, &displaced);
+        if cfg!(windows) {
+            assert!(renamed.is_err(), "held Windows output must deny replacement");
+            crate::exiftool::bind_metadata_output_publications(&root, &written.metadata_publications)
+                .expect("denied replacement retains the original binding");
+            drop(written);
+            let _ = std::fs::remove_dir_all(root);
+            return;
+        }
+        renamed.unwrap();
         std::fs::write(positive, b"attacker replacement").unwrap();
 
         let error = crate::exiftool::bind_metadata_output_publications(

--- a/ports/tauri/vendor/engine/src/render.rs
+++ b/ports/tauri/vendor/engine/src/render.rs
@@ -1275,7 +1275,6 @@ mod destination_sys {
     const GENERIC_READ: u32 = 0x8000_0000;
     const GENERIC_WRITE: u32 = 0x4000_0000;
     const DELETE_ACCESS: u32 = 0x0001_0000;
-    const FILE_RENAME_INFO_CLASS: u32 = 3;
     const FILE_DISPOSITION_INFO_CLASS: u32 = 4;
 
     #[link(name = "Kernel32")]
@@ -1286,14 +1285,6 @@ mod destination_sys {
             information: *mut std::ffi::c_void,
             buffer_size: u32,
         ) -> i32;
-    }
-
-    #[repr(C)]
-    struct FileRenameInfoHeader {
-        replace_if_exists: u8,
-        root_directory: *mut std::ffi::c_void,
-        file_name_length: u32,
-        file_name: [u16; 1],
     }
 
     #[repr(C)]
@@ -1625,6 +1616,7 @@ mod destination_sys {
             ));
             let path = held.display_path.join(&candidate);
             match std::fs::OpenOptions::new()
+                .write(true)
                 .access_mode(GENERIC_READ | GENERIC_WRITE | DELETE_ACCESS)
                 .share_mode(FILE_SHARE_READ)
                 .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
@@ -1701,53 +1693,12 @@ mod destination_sys {
         role: &str,
     ) -> Result<(), domain::EngineError> {
         verify_namespace(held)?;
-        let wide: Vec<u16> = final_name.encode_wide().collect();
-        let file_name_offset = std::mem::offset_of!(FileRenameInfoHeader, file_name);
-        let byte_length = wide
-            .len()
-            .checked_mul(std::mem::size_of::<u16>())
-            .ok_or_else(|| output_authority_error("final output leaf is too long"))?;
-        let total = file_name_offset
-            .checked_add(byte_length)
-            .ok_or_else(|| output_authority_error("final output rename buffer is too large"))?;
-        // `Vec<u8>` only guarantees byte alignment; casting its pointer to
-        // FILE_RENAME_INFO would be undefined behaviour on Windows. Back the
-        // variable-sized record with pointer-aligned words while still
-        // passing the exact byte length required by the API.
-        let word = std::mem::size_of::<usize>();
-        let word_count = total
-            .checked_add(word - 1)
-            .ok_or_else(|| output_authority_error("final output rename buffer is too large"))?
-            / word;
-        let mut buffer = vec![0_usize; word_count];
-        let buffer_bytes = buffer.as_mut_ptr().cast::<u8>();
-        let header = buffer_bytes.cast::<FileRenameInfoHeader>();
-        unsafe {
-            std::ptr::write(
-                header,
-                FileRenameInfoHeader {
-                    replace_if_exists: (!create_only) as u8,
-                    root_directory: held.directory.as_raw_handle().cast(),
-                    file_name_length: byte_length as u32,
-                    file_name: [0],
-                },
-            );
-            std::ptr::copy_nonoverlapping(
-                wide.as_ptr().cast::<u8>(),
-                buffer_bytes.add(file_name_offset),
-                byte_length,
-            );
-        }
-        let result = unsafe {
-            SetFileInformationByHandle(
-                temporary_file.as_raw_handle().cast(),
-                FILE_RENAME_INFO_CLASS,
-                buffer_bytes.cast(),
-                total as u32,
-            )
-        };
-        if result == 0 {
-            let error = std::io::Error::last_os_error();
+        if let Err(error) = crate::exiftool::metadata_publish_sys::rename_handle(
+            temporary_file,
+            &held.directory,
+            final_name,
+            !create_only,
+        ) {
             let code = if create_only && error.kind() == std::io::ErrorKind::AlreadyExists {
                 protocol::ErrorCode::ArchiveCollision
             } else {
@@ -2800,6 +2751,9 @@ fn validate_filesystem_output_leaf_collation(
                 ))
             })?;
         }
+        // Windows delete dispositions finish when the last held file closes.
+        // Close our exact probe handles before checking for foreign entries.
+        created.clear();
         crate::exiftool::metadata_publish_sys::sync_directory(&probe).map_err(|error| {
             output_authority_error(format!("sync emptied output-name alias probe: {error}"))
         })?;
@@ -6783,6 +6737,7 @@ fn sync_output_directory(directory: &Path) -> std::io::Result<()> {
     const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
     std::fs::OpenOptions::new()
         .read(true)
+        .write(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .open(directory)?
         .sync_all()

--- a/ports/tauri/vendor/engine/src/server.rs
+++ b/ports/tauri/vendor/engine/src/server.rs
@@ -4831,6 +4831,7 @@ mod tests {
                 .recv_timeout(std::time::Duration::from_secs(10))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.completed" {
                 break;
             }

--- a/ports/tauri/vendor/engine/src/sim.rs
+++ b/ports/tauri/vendor/engine/src/sim.rs
@@ -1976,7 +1976,18 @@ mod tests {
         )
         .unwrap();
         let positive = written.positive_path.as_ref().unwrap();
-        std::fs::rename(positive, root.join("engine-positive.tif")).unwrap();
+        let renamed = std::fs::rename(positive, root.join("engine-positive.tif"));
+        if cfg!(windows) {
+            assert!(renamed.is_err(), "held Windows output must deny replacement");
+            build_receipt(
+                "job-binding-replacement", 1, 1000, &recipe, &processing, &output,
+                DEVICE_ID, &written, Some(&project_root),
+            ).expect("denied replacement retains valid receipt evidence");
+            drop((written, project_root));
+            let _ = std::fs::remove_dir_all(root);
+            return;
+        }
+        renamed.unwrap();
         std::fs::write(positive, b"unrelated replacement").unwrap();
 
         let error = build_receipt(
@@ -2606,6 +2617,7 @@ mod tests {
                 .recv_timeout(Duration::from_secs(30))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.completed" {
                 break;
             }
@@ -2691,6 +2703,7 @@ mod tests {
                 .recv_timeout(Duration::from_secs(30))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.frameState" && value["payload"]["frameIndex"] == 1 {
                 match value["payload"]["state"].as_str() {
                     Some("completed") => {

--- a/ports/tauri/vendor/engine/src/wsl_io.rs
+++ b/ports/tauri/vendor/engine/src/wsl_io.rs
@@ -242,10 +242,8 @@ fn sidecar_path(rgb: &str, label: &str) -> Result<String, String> {
     let parent = path
         .parent()
         .ok_or_else(|| format!("capture path has no parent: {rgb:?}"))?;
-    Ok(parent
-        .join(format!("{stem}_{label}.tif"))
-        .to_string_lossy()
-        .to_string())
+    // These names belong to Linux even when this engine runs on Windows.
+    Ok(format!("{}/{stem}_{label}.tif", parent.display()))
 }
 
 pub fn validate_staged_receipt_paths(

--- a/ports/tauri/vendor/scanstudio-bridge/uv.lock
+++ b/ports/tauri/vendor/scanstudio-bridge/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/scripts/check_coolscanpy_pypi_sync.sh
+++ b/scripts/check_coolscanpy_pypi_sync.sh
@@ -6,7 +6,7 @@
 # debugging confusion the instrumented-refusal work exists to prevent
 # (owner policy, 2026-08-08: "keep them in sync so there's no delta").
 #
-# Mechanics: download the exact authenticated coolscanpy 0.7.4 sdist and compare its
+# Mechanics: download the exact authenticated coolscanpy 0.7.5 sdist and compare its
 # src/coolscanpy tree byte-for-byte against this repo's vendored
 # coolscanpy/src/coolscanpy. Version strings are NOT trusted as the primary
 # signal (an unbumped version with changed code is precisely the failure
@@ -30,19 +30,19 @@ VENDORED_DIR="coolscanpy/src/coolscanpy"
 # Re-pin: shasum -a 256 <both files>, update the entry in the same change
 # that alters the file.
 KNOWN_VENDORED_DIVERGENCE=(
-  # required scanner_identity + capture-timing feature; re-pinned for 0.7.4
+  # required scanner_identity + capture-timing feature; re-pinned for 0.7.5
   # (meter-controller refusal + transport-failure witness landed upstream)
   "protocol/ls5000_single_pass/worker.py|773d9915cf68fd5f6d0937a3f26cdee488f257a584ff8bfe4950b33b96678777|22ba191b7f9d313d80aeec195db648bc686f631849145b620851d0961dcbc5cf"
-  # LeadingFrameClippedError + confident-clear-film gate; re-pinned for 0.7.4
+  # LeadingFrameClippedError + confident-clear-film gate; re-pinned for 0.7.5
   # (failure witness replay landed upstream)
   "protocol/ls5000_single_pass/roll_index.py|c99c54a434d0d53e94e51ed503f0289709b5f20365e16606f365264a617c8b17|38013a1e942c3d1d1798ca0e718fb7ccdc3bc605277ca729e9891fa53bcde311"
   # its export surface for the class above
   "protocol/ls5000_single_pass/__init__.py|ce8aa97b707f5ef83f96128b378722191f7280bd41c1f3acbb04c75e3ea7523e|1f0f324034a95e2c8ca772ce52a78a800b0bf215d3ae4ec77422b08b1376856c"
-  # pins differ because the two files above differ; re-pinned for 0.7.4
-  "protocol/ls5000_single_pass/bundle.py|7167c9cd7cbc50d1d641b3847fc1f71e6d37a06d6d8c4d90f2199443d1d5e812|a3a3e7bd307806c6c1b022dac59295525a3d8644e8059069864180fedb40167f"
+  # pins differ because the two files above differ; re-pinned for 0.7.5
+  "protocol/ls5000_single_pass/bundle.py|538dced76ea84c12d9c73c566da6a79955a717ca4a6a7d6b1857aeca02dbc9f6|b6e983319feaa37fbe67263fccc317c7844d81280986a34d15fed0d43b397175"
   # packaged-app libusb resolution (app bundles its own signed binary)
   "protocol/ls5000_single_pass/usb_backend.py|afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62|666a476ce706a4a854aac50116575e7143f5a1a7c1b1085125347696d89348d1"
-  # capture-timing receipt fields (started_at/duration); re-pinned for 0.7.4
+  # capture-timing receipt fields (started_at/duration); re-pinned for 0.7.5
   "_roll.py|29903307ce3c0e6f76785b437857450de1d35783fc01c2df9705f03f94fa3df3|61850c5da59b625dd1ce5dc854fe5be01a5a4f687c81fad0f589c9b1c865d094"
   "capture/single_pass_workflow.py|a5a01b15ff50df9a6f78d1c2c4f39d10548e7651cf3365e8698d479b633b5914|c8d93dce3c7de3b585c2d051b7d09054802a130797c590c97b36b78889def15c"
   "types.py|1343c93c03ade64f0927602fe8e8e25353bada6b1b8a919ce9084c5cbcb321de|f853b8dde9c4a6c3b7ce96195d320c7ba9c88839019bed9ce55fe444ea08e54a"
@@ -51,12 +51,12 @@ KNOWN_VENDORED_DIVERGENCE=(
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
-echo "fetching authenticated coolscanpy 0.7.4 source from PyPI..."
+echo "fetching authenticated coolscanpy 0.7.5 source from PyPI..."
 published_root="$(python3 -I -S -B scripts/fetch_pinned_coolscanpy_sdist.py \
   --destination "$workdir/published")"
 published_src="$published_root/src/coolscanpy"
 test -d "$published_src"
-pypi_version="0.7.4"
+pypi_version="0.7.5"
 
 printf '%s\n' "${KNOWN_VENDORED_DIVERGENCE[@]}" > "$workdir/exemptions"
 if PUBLISHED_SRC="$published_src" VENDORED_DIR="$VENDORED_DIR" \

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -296,7 +296,7 @@ EOF
 check_pair "protocol" "app/ScanStudio/protocol" "ports/tauri/vendor/protocol" "55577442d8b6a23ddcd3cc191ebf41a8258004047bc075511a241fa72adb0b65" <<'EOF'
 EOF
 
-check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "228c9c43e13a1e817cfb7e7c84f501d14b9e6af89d659ce2a1c828ec2474ca56" <<'EOF'
+check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "8bc07be47b3396d32f518b1fd7e89746492cefdbad086a0b931ee76efbecffab" <<'EOF'
 Files app/ScanStudio/engine/Cargo.lock and ports/tauri/vendor/engine/Cargo.lock differ
 Files app/ScanStudio/engine/Cargo.toml and ports/tauri/vendor/engine/Cargo.toml differ
 Files app/ScanStudio/engine/src/evidence_package.rs and ports/tauri/vendor/engine/src/evidence_package.rs differ

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -307,7 +307,7 @@ Files app/ScanStudio/engine/src/render.rs and ports/tauri/vendor/engine/src/rend
 Only in ports/tauri/vendor/engine/src: wsl_io.rs
 EOF
 
-check_pair "bridge" "bridge" "ports/tauri/vendor/scanstudio-bridge" "bc7676818b08648d47753255783e3b06105feed0aa4cf41d50174c98f7ab37aa" <<'EOF'
+check_pair "bridge" "bridge" "ports/tauri/vendor/scanstudio-bridge" "c6522e45b972ae719ab8f8e1b2fc8526e0842ebbe137395b0d543425f87cb3df" <<'EOF'
 Only in ports/tauri/vendor/scanstudio-bridge: .github
 Only in ports/tauri/vendor/scanstudio-bridge/scripts: probe-linux-env.py
 Only in ports/tauri/vendor/scanstudio-bridge/scripts: verify-bridge.sh

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -321,7 +321,7 @@ Only in ports/tauri/vendor/scanstudio-bridge/tests: test_stdout_byte_discipline.
 Files bridge/uv.lock and ports/tauri/vendor/scanstudio-bridge/uv.lock differ
 EOF
 
-check_pair "coolscanpy" "coolscanpy" "ports/tauri/vendor/coolscanpy" "63d4ce49d4e1977cb5a38b1fb99992d2f844de15dd39cb85fe2ec04c34920140" <<'EOF'
+check_pair "coolscanpy" "coolscanpy" "ports/tauri/vendor/coolscanpy" "cfd8b1e25cef049742e683a31a658e7ee37017e930200e51d94c246bca46dc31" <<'EOF'
 Files coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py and ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py differ
 Files coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/usb_backend.py and ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/usb_backend.py differ
 Files coolscanpy/tests/test_usb_backend.py and ports/tauri/vendor/coolscanpy/tests/test_usb_backend.py differ

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -296,7 +296,7 @@ EOF
 check_pair "protocol" "app/ScanStudio/protocol" "ports/tauri/vendor/protocol" "55577442d8b6a23ddcd3cc191ebf41a8258004047bc075511a241fa72adb0b65" <<'EOF'
 EOF
 
-check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "8bc07be47b3396d32f518b1fd7e89746492cefdbad086a0b931ee76efbecffab" <<'EOF'
+check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "2291ca17e46fe03540e79678d08551c21fb487a3418f9732acca417d00b18c30" <<'EOF'
 Files app/ScanStudio/engine/Cargo.lock and ports/tauri/vendor/engine/Cargo.lock differ
 Files app/ScanStudio/engine/Cargo.toml and ports/tauri/vendor/engine/Cargo.toml differ
 Files app/ScanStudio/engine/src/evidence_package.rs and ports/tauri/vendor/engine/src/evidence_package.rs differ

--- a/scripts/fetch_pinned_coolscanpy_sdist.py
+++ b/scripts/fetch_pinned_coolscanpy_sdist.py
@@ -16,20 +16,20 @@ import unicodedata
 import urllib.request
 
 
-VERSION = "0.7.4"
+VERSION = "0.7.5"
 FILENAME = f"coolscanpy-{VERSION}.tar.gz"
 URL = (
-    "https://files.pythonhosted.org/packages/f9/98/"
-    "4e60eb52655d5579cf7b25631509c287f7c3b8c75a69abfeb1fac0e71d01/"
+    "https://files.pythonhosted.org/packages/08/c9/"
+    "7a27d8fd2149d33b9f3514c2b6c54611c48c30a12b07b816ca7aeca9911b/"
     f"{FILENAME}"
 )
-SIZE = 556_523
-SHA256 = "e60b7b4a5464c9ace6b2f3002e7a2c7c8d0d6cd917e4d74bad98bb36ae573bab"
+SIZE = 556_532
+SHA256 = "7adee250d325b6f4b9872a9e7fef1199349558f87d673a3b48a46890c9d141f6"
 ROOT = f"coolscanpy-{VERSION}"
 ENTRY_COUNT = 104
 FILE_COUNT = 89
 DIRECTORY_COUNT = 15
-EXPANDED_FILE_BYTES = 2_447_475
+EXPANDED_FILE_BYTES = 2_447_520
 
 
 class FetchError(RuntimeError):

--- a/scripts/smoke_project_persistence.py
+++ b/scripts/smoke_project_persistence.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Exercise real project persistence through a packaged engine, without hardware."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def main(engine):
+    with tempfile.TemporaryDirectory(prefix="ScanStudio # project ") as root:
+        directory = str(Path(root) / "Saved roll # 1")
+        create = {"name": "Package check", "carrier": "strip6", "frameCount": 2,
+                  "filmProcess": "c41ColorNegative", "directory": directory}
+        commands = [
+            ("engine.hello", {"clientName": "persistence-smoke", "protocolVersion": 1}),
+            ("project.create", create),
+            ("project.setFrameExcluded", {"frameIndex": 1, "excluded": True}),
+            ("project.open", {"directory": directory}),
+            ("project.create", create),
+            ("project.open", {"directory": directory}),
+            ("engine.shutdown", {}),
+        ]
+        environment = {key: value for key, value in os.environ.items()
+                       if not key.startswith("SCANSTUDIO_")}
+        result = subprocess.run(
+            [engine], input="".join(json.dumps({"id": index, "method": method,
+                                               "params": params}) + "\n"
+                                    for index, (method, params) in enumerate(commands, 1)),
+            text=True, capture_output=True, timeout=30, env=environment, check=True,
+        )
+        responses = {}
+        for line in result.stdout.splitlines():
+            message = json.loads(line)
+            if "id" in message:
+                assert message["id"] not in responses, message
+                responses[message["id"]] = message
+        assert set(responses) == set(range(1, 8)), result.stdout
+        for index, response in responses.items():
+            if index == 5:
+                assert response.get("error", {}).get("code") == "PROJECT_ALREADY_EXISTS", response
+            else:
+                assert "result" in response and not response.get("error"), response
+        original_id = responses[2]["result"]["project"]["id"]
+        for index in (4, 6):
+            project = responses[index]["result"]["project"]
+            assert project["id"] == original_id, project
+            assert project["frames"][0]["excluded"] is True, project
+        manifest = json.loads((Path(directory) / "manifest.json").read_text())
+        assert manifest == responses[6]["result"]["project"], manifest
+        assert not list(Path(directory).glob(".manifest.json.*")), directory
+    print("Project create, mutate, reopen, and overwrite refusal passed (spaces and # in path)")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/scripts/tests/test_verify_hardware_support_docs.py
+++ b/scripts/tests/test_verify_hardware_support_docs.py
@@ -26,7 +26,7 @@ class HardwareSupportDocsTests(unittest.TestCase):
         (root / "docs" / "releases" / "v0.7.0-beta.11.md").write_text("old\n")
         (root / "docs" / "releases" / "v0.7.0-beta.12.md").write_text("new\n")
         (root / "docs" / "HARDWARE-SUPPORT.md").write_text(
-            "Current published release: [v0.7.0-beta.12]\n"
+            "Latest release notes: [v0.7.0-beta.12]\n"
             "Package built | Device enumerated | Preview exercised | One-frame capture validated\n"
             "closed evidence #24\nclosed evidence #26\nissues/101\nissues/104\n"
         )

--- a/scripts/verify_hardware_support_docs.py
+++ b/scripts/verify_hardware_support_docs.py
@@ -49,7 +49,7 @@ def verify_hardware_support_docs(root: Path = REPOSITORY_ROOT) -> None:
         raise HardwareSupportDocsError(f"cannot read {CANONICAL_MATRIX}: {error}") from error
 
     latest = _latest_release_note(root)
-    if f"Current published release: [{latest}]" not in matrix:
+    if f"Latest release notes: [{latest}]" not in matrix:
         raise HardwareSupportDocsError(
             f"{CANONICAL_MATRIX} does not name the newest documented release {latest}"
         )


### PR DESCRIPTION
Project creation on Windows NTFS failed with `The parameter is incorrect (os error 87)`. The packaged-engine regression reproduced the failure and isolated it to the Win32 rename wrapper. Use the native handle-relative rename operation, preserving directory authority, exclusive creation and durable saves. Windows CI now exercises creation, mutation, reopening and overwrite refusal before packaging. The expanded native suite also exposed and fixed output creation access, delayed delete cleanup, directory flushing, Linux sidecar separators, portable evidence paths, and receipt readers requesting unnecessary delete access. Native engine tests now gate Windows and Linux release packaging. The same persistence check runs against relocated Mac and installed/portable Windows packages.

The release audit also fixes deleted/rate-limited Tauri tool downloads, makes the signing probe preserve the sealed bundle, and includes hidden `.build` DMGs in the signing artifact upload. CoolscanPy 0.7.5 is published to PyPI with the observed EBDE padding fix and offline/streaming regressions; ScanStudio's corresponding-source pins and vendor mirrors match it. Beta.13 release notes include the merged issue-audit changes and retain physical-hardware limitations.

Validation: the NTFS persistence regression fails on the prior implementation and passes with the native rename fix. All 486 native Windows engine tests pass. All 545 vendored engine tests pass on macOS, along with the canonical Rust/Swift, Python, Tauri UI/Rust and production builds. A Developer ID-signed Mac app passed relocation, runtime, persistence and updater verification, plus a simulated preview/save/scan session with matching output receipts. The signing rehearsal succeeded end to end, including artifact upload. The downloaded app and DMG both pass local codesign, stapler and Gatekeeper verification; the mounted engine passes project persistence. Complete final Verify and Cross-platform port workflows passed (34015653832 and 34015653694): both Mac architectures, macOS 14 floor, updater install/rollback, Windows installed/portable packages and Linux extracted packages. The current Microsoft WebView2 installer is hash-pinned and its Authenticode signature verified before consumption. Vendored Python suites also pass: bridge 399 tests and CoolscanPy 1,848 tests (5 skipped, 1 expected failure).

Fixes #100. Physical post-preview film status in #77 and the hardware-validation issues remain outside the evidence available from this host.
