### PR TITLE
Fix desktop navigation, preview lifecycle, and misleading scan UX

### DIFF
--- a/.github/workflows/ports.yml
+++ b/.github/workflows/ports.yml
@@ -21,6 +21,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  windows-persistence:
+    name: Windows project persistence
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
+        with:
+          toolchain: '1.97.1'
+      - name: Verify exact Rust toolchain
+        run: python -I -S -B scripts/verify_pinned_rust.py
+      - name: Exercise native NTFS persistence before installer assembly
+        shell: pwsh
+        run: |
+          cargo build --locked --manifest-path ports/tauri/vendor/engine/Cargo.toml
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python -I -S -B scripts/smoke_project_persistence.py ports/tauri/vendor/engine/target/debug/scanstudio-engine.exe
+
   windows-resources:
     name: Assemble Windows offline resources
     runs-on: ubuntu-22.04

--- a/.github/workflows/ports.yml
+++ b/.github/workflows/ports.yml
@@ -40,6 +40,9 @@ jobs:
           cargo build --locked --manifest-path ports/tauri/vendor/engine/Cargo.toml
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -I -S -B scripts/smoke_project_persistence.py ports/tauri/vendor/engine/target/debug/scanstudio-engine.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cargo test --locked --manifest-path ports/tauri/vendor/engine/Cargo.toml --lib
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   windows-resources:
     name: Assemble Windows offline resources

--- a/.github/workflows/signing-dry-run.yml
+++ b/.github/workflows/signing-dry-run.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       UV_PYTHON_PREFERENCE: only-managed
       UV_PYTHON_CPYTHON_BUILD: "20260718"
+      SCANSTUDIO_RELEASE_VERSION: 0.0.0-signing-dry-run
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -99,7 +100,8 @@ jobs:
         working-directory: app/ScanStudio
         run: |
           PYBIN="$(/usr/bin/find .build/ScanStudio.app/Contents/Resources -type f -name 'python3.13' -path '*/bin/*' | head -1)"
-          "$PYBIN" -I -c "import ctypes; ctypes.CDLL('.build/ScanStudio.app/Contents/Frameworks/coolscanpy/_native/libusb-1.0.dylib'); print('dlopen ok under hardened runtime')"
+          "$PYBIN" -I -B -c "import ctypes; from pathlib import Path; ctypes.CDLL(str(Path('.build/ScanStudio.app/Contents/Frameworks/coolscanpy/_native/libusb-1.0.dylib').resolve())); print('dlopen ok under hardened runtime')"
+          codesign --verify --deep --strict .build/ScanStudio.app
       - name: Build the DMG from the stapled app
         working-directory: app/ScanStudio
         run: ./scripts/package_dmg.sh

--- a/.github/workflows/signing-dry-run.yml
+++ b/.github/workflows/signing-dry-run.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           name: signing-dry-run-dmg
           path: app/ScanStudio/.build/ScanStudio-*-macOS-*.dmg
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 3
       - name: Delete the throwaway signing keychain and key material

--- a/DNG-PLAN.md
+++ b/DNG-PLAN.md
@@ -105,7 +105,7 @@ A SubIFD is chosen instead of a fourth main-image `ExtraSample`. TIFF's `ExtraSa
 
 ### Separate infrared TIFF
 
-For either main format, `tiffInfrared=sidecar` writes captured IR to `{main-stem}-ir.tif` in the same destination. The sidecar is classic little-endian TIFF, full-resolution, uncompressed, unsigned 16-bit, one-sample `BlackIsZero`, chunky, Orientation 1, and has the same X/Y resolution and inch unit as the main export. It carries `ImageDescription` identifying the untouched scanner plane and private ASCII tag 65001 with `scanstudio.infrared.linear.uint16.v1`. The main DNG has no `SubIFDs` tag; the main TIFF has the existing RGB-only layout.
+For either main format, `tiffInfrared=sidecar` writes captured IR to `{main-stem}-ir.tif` in the same destination. The sidecar is classic little-endian TIFF, full-resolution, uncompressed, unsigned 16-bit, one-sample `BlackIsZero`, chunky, Orientation 1, and has the same X/Y resolution and inch unit as the main export. It carries `ImageDescription` identifying the untouched scanner plane and private ASCII tag 65010 with `scanstudio.infrared.linear.uint16.v1`. The main DNG has no `SubIFDs` tag; the main TIFF has the existing RGB-only layout.
 
 ## Linear TIFF layout
 
@@ -115,7 +115,7 @@ Both TIFF modes use classic little-endian TIFF, unsigned 16-bit samples, no comp
 - **RGB + IR**: samples are interleaved R,G,B,IR; `PhotometricInterpretation=RGB`, `SamplesPerPixel=4`, `BitsPerSample=16,16,16,16`, and `ExtraSamples=0` for the one IR channel. “Unspecified” is intentional: IR is neither associated nor unassociated alpha.
 - **RGB + separate IR**: the main file is the existing RGB-only layout and the infrared plane uses the separate TIFF contract above.
 
-The four-channel TIFF also carries private tag 65001 with the same infrared marker. Software that only understands RGB may ignore or reject the fourth sample; that is why RGB-only is an explicit alternative rather than a silent fallback.
+The four-channel TIFF also carries private tag 65010 with the same infrared marker. Software that only understands RGB may ignore or reject the fourth sample; that is why RGB-only is an explicit alternative rather than a silent fallback.
 
 ## Fail-closed publication and compatibility
 

--- a/app/ScanStudio/README.md
+++ b/app/ScanStudio/README.md
@@ -1,6 +1,6 @@
 # ScanStudio
 
-ScanStudio is a macOS alpha for scanning 35 mm film with a Nikon Coolscan
+ScanStudio is a macOS app for scanning 35 mm film with a Nikon Coolscan
 LS-5000. It keeps the scan workflow in one place: identify the film that is
 loaded, preview the roll, select frames, choose the capture settings, scan,
 and stop safely when needed.
@@ -11,7 +11,8 @@ already includes the CoolscanPy bridge and its direct-USB runtime; source
 builds can instead configure a separate compatible bridge. The app never
 presents the simulator as hardware.
 
-This is an alpha. It has been tested on one Mac and one LS-5000 setup. Treat
+Apple Silicon support is Beta; Intel support is Preview. Real scanning has
+been tested on one Apple Silicon Mac and one LS-5000 setup. Treat
 each real scan as a new operation: confirm the detected carrier and the
 preview before starting capture. Real black-and-white fine scanning remains
 blocked rather than pretending that infrared dust removal is available for

--- a/app/ScanStudio/Sources/ScanStudio/ContentView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ContentView.swift
@@ -5,21 +5,69 @@ import UniformTypeIdentifiers
 
 struct ContentView: View {
     @Environment(SessionModel.self) private var sessionModel
+    @State private var isShowingSidebar = false
+    @State private var isShowingProjectLauncher = false
 
     private var hasCompletePreviewRegistration: Bool {
         sessionModel.hasCompletePreviewRegistration
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        GeometryReader { geometry in
+            workspace(size: geometry.size)
+        }
+        .background(Color.scanStudioWorkspace)
+        .foregroundStyle(Color.scanStudioPrimaryText)
+        .preferredColorScheme(.dark)
+        .frame(minWidth: 980, minHeight: 640)
+        .sheet(isPresented: $isShowingProjectLauncher) {
+            ProjectLauncherView(session: sessionModel)
+        }
+        .sheet(item: manualReviewRequestBinding) { request in
+            ManualReviewScanSheet(request: request)
+        }
+        .sheet(item: manualPlacementStripBinding) { strip in
+            ManualFramePlacementSheet(strip: strip)
+        }
+        .focusedSceneValue(
+            \.scanStudioFrameIndex,
+            sessionModel.frameTransformTargetIndex
+        )
+    }
+
+    private func workspace(size: CGSize) -> some View {
+        // Keep the 680-point workspace and 292-point inspector readable.
+        // The project sidebar moves to a popover when all three cannot fit.
+        let showsSidebar = size.width >= 248 + 680 + 292 + 2
+        return VStack(spacing: 0) {
             DeviceBarView()
             Rectangle().fill(Color.scanStudioDivider).frame(height: 1)
 
-            HStack(spacing: 0) {
-                SessionSidebarView()
-                    .frame(width: 248)
+            if !showsSidebar {
+                HStack {
+                    Button {
+                        isShowingSidebar = true
+                    } label: {
+                        Label("Project & Scanner", systemImage: "sidebar.left")
+                    }
+                    .popover(isPresented: $isShowingSidebar) {
+                        SessionSidebarView(onManageProjects: showProjectLauncher)
+                            .frame(width: 248, height: min(560, size.height))
+                    }
+                    Spacer()
+                }
+                .padding(.horizontal, 18)
+                .padding(.vertical, 6)
+                .background(Color.scanStudioSidebar)
+            }
 
-                ScanStudioDivider()
+            HStack(spacing: 0) {
+                if showsSidebar {
+                    SessionSidebarView(onManageProjects: showProjectLauncher)
+                        .frame(width: 248)
+
+                    ScanStudioDivider()
+                }
 
                 VStack(spacing: 0) {
                     if let presentation = sessionModel.errorPresentation {
@@ -123,23 +171,21 @@ struct ContentView: View {
 
             if ScanPanelVisibilityPolicy.isVisible(hasOpenProject: sessionModel.project != nil) {
                 Rectangle().fill(Color.scanStudioDivider).frame(height: 1)
-                ScanPanelView()
+                ScrollView(.horizontal) {
+                    ScanPanelView()
+                        .frame(minWidth: size.width)
+                        .fixedSize(horizontal: true, vertical: false)
+                }
+                .frame(height: 86)
+                .background(Color.scanStudioSidebar)
             }
         }
-        .background(Color.scanStudioWorkspace)
-        .foregroundStyle(Color.scanStudioPrimaryText)
-        .preferredColorScheme(.dark)
-        .frame(minWidth: 1_220, minHeight: 760)
-        .sheet(item: manualReviewRequestBinding) { request in
-            ManualReviewScanSheet(request: request)
-        }
-        .sheet(item: manualPlacementStripBinding) { strip in
-            ManualFramePlacementSheet(strip: strip)
-        }
-        .focusedSceneValue(
-            \.scanStudioFrameIndex,
-            sessionModel.frameTransformTargetIndex
-        )
+    }
+
+    private func showProjectLauncher() {
+        // Present from the window, never from the compact sidebar popover.
+        isShowingSidebar = false
+        isShowingProjectLauncher = true
     }
 
     private var manualReviewRequestBinding: Binding<ManualReviewScanRequest?> {

--- a/app/ScanStudio/Sources/ScanStudio/DefectMapView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/DefectMapView.swift
@@ -2,18 +2,13 @@ import AppKit
 import ScanStudioKit
 import SwiftUI
 
-/// The three switchable modes `FrameDetailWorkspaceView`'s large preview
-/// offers (DEF-01). Exactly one is ever shown at a time — no 50/50
-/// comparison. `Final` and `Before Repair` render the identical image (see
-/// `FrameDetailWorkspaceView`'s own scope note); `Defect Map` is the only
-/// mode that visibly differs, via `DefectOverlayCanvas`.
+/// The scanner preview, with an optional defect overlay.
 enum FrameViewingMode: String, CaseIterable {
-    case finalPositive, beforeRepair, defectMap
+    case scannerPreview, defectMap
 
     var label: String {
         switch self {
-        case .finalPositive: "Final"
-        case .beforeRepair: "Before Repair"
+        case .scannerPreview: "Scanner Preview"
         case .defectMap: "Defect Map"
         }
     }

--- a/app/ScanStudio/Sources/ScanStudio/FrameDetailWorkspaceView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/FrameDetailWorkspaceView.swift
@@ -267,74 +267,72 @@ struct FrameDetailWorkspaceView: View {
         let mirrored = sessionModel.frameMirror(frameIndex)
         let verticallyMirrored = sessionModel.frameVerticalMirror(frameIndex)
 
-        return VStack(alignment: .leading, spacing: 6) {
-            viewingModeSwitcher
-            orientationControls
-
-            // `ZStack`, not `Group`: `Group`'s multiple children are NOT
-            // overlaid — inside this VStack, a second simultaneous Group
-            // child would become a separate row rather than a layer on top
-            // of the image. This ZStack keeps every modifier below chained
-            // after it exactly as before, so the defect markers inherit the
-            // SAME scaleEffect/offset the image gets and never drift off
-            // the image on pinch-zoom/pan.
-            ZStack {
-                // Preview of the persisted derivative rotation
-                // (`SessionModel.rotateFrame`).
-                // The image and the defect markers rotate together by the same
-                // angle about the same center: marker coordinates are defined
-                // in the UNROTATED frame (DefectOverlayCanvas, DefectMapView.swift),
-                // so the overlay gets the identical rotationEffect below to stay
-                // registered to the now-rotated pixels.
-                Group {
-                    if let realImage {
-                        Image(nsImage: realImage)
-                            .resizable()
-                            .scaledToFill()
-                    } else {
-                        SimulatedFrameImage(frameIndex: frameIndex, isAvailable: isAvailable)
-                    }
-                }
-                .scaleEffect(
-                    x: mirrored ? -1 : 1,
-                    y: verticallyMirrored ? -1 : 1
-                )
-                .rotationEffect(.degrees(Double(orientationDegrees)))
-                if viewingMode == .defectMap {
-                    defectMapOverlayContent(
-                        orientationDegrees: orientationDegrees,
-                        mirrored: mirrored,
-                        verticallyMirrored: verticallyMirrored
-                    )
+        // `ZStack`, not `Group`: `Group`'s multiple children are NOT
+        // overlaid — inside this VStack, a second simultaneous Group
+        // child would become a separate row rather than a layer on top
+        // of the image. This ZStack keeps every modifier below chained
+        // after it exactly as before, so the defect markers inherit the
+        // SAME scaleEffect/offset the image gets and never drift off
+        // the image on pinch-zoom/pan.
+        let previewImage = ZStack {
+            // Preview of the persisted derivative rotation
+            // (`SessionModel.rotateFrame`).
+            // The image and the defect markers rotate together by the same
+            // angle about the same center: marker coordinates are defined
+            // in the UNROTATED frame (DefectOverlayCanvas, DefectMapView.swift),
+            // so the overlay gets the identical rotationEffect below to stay
+            // registered to the now-rotated pixels.
+            Group {
+                if let realImage {
+                    Image(nsImage: realImage)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    SimulatedFrameImage(frameIndex: frameIndex, isAvailable: isAvailable)
                 }
             }
-            .scaleEffect(zoomState.scale)
-            .offset(zoomState.panOffset)
-            // Swap to portrait (2:3) at 90/270 so the rotated frame fits instead
-            // of being clipped to the landscape box (rotationEffect does not
-            // resize layout bounds).
-            .aspectRatio(
-                FrameOrientation.displayAspectRatio(orientationDegrees),
-                contentMode: .fit
+            .scaleEffect(
+                x: mirrored ? -1 : 1,
+                y: verticallyMirrored ? -1 : 1
             )
-            .frame(maxWidth: .infinity, minHeight: 360, maxHeight: 480)
-            .background {
-                GeometryReader { geometry in
-                    Color.clear
-                        .onAppear { zoomState.updateViewportSize(geometry.size) }
-                        .onChange(of: geometry.size) { _, size in
-                            zoomState.updateViewportSize(size)
-                        }
-                }
+            .rotationEffect(.degrees(Double(orientationDegrees)))
+            if viewingMode == .defectMap {
+                defectMapOverlayContent(
+                    orientationDegrees: orientationDegrees,
+                    mirrored: mirrored,
+                    verticallyMirrored: verticallyMirrored
+                )
             }
-            .background(.black)
-            .clipShape(RoundedRectangle(cornerRadius: 5))
-            .overlay(RoundedRectangle(cornerRadius: 5).stroke(Color.white.opacity(0.12)))
-            // Keep the preview's changing description scoped to the image
-            // before adding interactive overlays. Applying this label after
-            // `zoomControls` causes SwiftUI to replace each button's own
-            // accessible name with the preview description.
-            .accessibilityLabel(previewAccessibilityLabel(usesRealImage: realImage != nil))
+        }
+        .scaleEffect(zoomState.scale)
+        .offset(zoomState.panOffset)
+        // Swap to portrait (2:3) at 90/270 so the rotated frame fits instead
+        // of being clipped to the landscape box (rotationEffect does not
+        // resize layout bounds).
+        .aspectRatio(
+            FrameOrientation.displayAspectRatio(orientationDegrees),
+            contentMode: .fit
+        )
+        .frame(maxWidth: .infinity, minHeight: 360, maxHeight: 480)
+        .background {
+            GeometryReader { geometry in
+                Color.clear
+                    .onAppear { zoomState.updateViewportSize(geometry.size) }
+                    .onChange(of: geometry.size) { _, size in
+                        zoomState.updateViewportSize(size)
+                    }
+            }
+        }
+        .background(.black)
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+        .overlay(RoundedRectangle(cornerRadius: 5).stroke(Color.white.opacity(0.12)))
+        // Keep the preview's changing description scoped to the image
+        // before adding interactive overlays. Applying this label after
+        // `zoomControls` causes SwiftUI to replace each button's own
+        // accessible name with the preview description.
+        .accessibilityLabel(previewAccessibilityLabel(usesRealImage: realImage != nil))
+
+        let accessiblePreview = previewImage
             .accessibilityHint("Zoom in, then use the arrow keys while the preview is focused to pan.")
             .focusable()
             .focused($isPreviewFocused)
@@ -358,6 +356,8 @@ struct FrameDetailWorkspaceView: View {
                     .stroke(isPreviewFocused ? Color.scanStudioCyan : .clear, lineWidth: 2)
                     .allowsHitTesting(false)
             }
+
+        let decoratedPreview = accessiblePreview
             .overlay(alignment: .topTrailing) { zoomControls }
             .overlay(alignment: .bottomLeading) {
                 if viewingMode == .defectMap {
@@ -408,6 +408,11 @@ struct FrameDetailWorkspaceView: View {
             }
             .contentShape(Rectangle())
             .gesture(SimultaneousGesture(magnifyGesture, panGesture))
+
+        return VStack(alignment: .leading, spacing: 6) {
+            viewingModeSwitcher
+            orientationControls
+            decoratedPreview
 
             if FrameAlignmentAvailabilityPolicy.isVisible(
                 deviceKind: sessionModel.device?.kind

--- a/app/ScanStudio/Sources/ScanStudio/FrameDetailWorkspaceView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/FrameDetailWorkspaceView.swift
@@ -20,13 +20,14 @@ struct FrameDetailWorkspaceView: View {
     @Environment(SessionModel.self) private var sessionModel
 
     @State private var zoomState = FrameDetailZoomState()
+    @FocusState private var isPreviewFocused: Bool
 
     /// Deliberately NOT reset inside `.task(id: frameIndex)` — unlike
     /// `zoomScale`/`panOffset` (a per-image viewport that must reset), a
     /// reviewer switching frames via the filmstrip while inspecting defects
     /// across a whole roll should stay in Defect Map mode; resetting it
     /// every frame would make batch defect review unusable.
-    @State private var viewingMode: FrameViewingMode = .finalPositive
+    @State private var viewingMode: FrameViewingMode = .scannerPreview
     @State private var overlayOpacity: Double = 0.7
 
     /// Filter-chip state (DEF-02) — also NOT reset per frame, same
@@ -168,8 +169,14 @@ struct FrameDetailWorkspaceView: View {
                         defectMapControlsSection
                     }
                     filmstripSection
-                    overridesSection
-                    exifToolPanel
+                    if sessionModel.project != nil {
+                        overridesSection
+                        exifToolPanel
+                    } else {
+                        Text("Save the roll to analyze defects or edit per-frame output settings and metadata.")
+                            .font(.system(size: 12))
+                            .foregroundStyle(Color.scanStudioSecondaryText)
+                    }
                 }
                 .padding(20)
             }
@@ -188,7 +195,7 @@ struct FrameDetailWorkspaceView: View {
             selectedDefectID = nil
             metadataPreviewFrameIndex = nil
             metadataApplyResult = nil
-            if sessionModel.frameDefects[frameIndex] == nil {
+            if sessionModel.project != nil, sessionModel.frameDefects[frameIndex] == nil {
                 await sessionModel.analyzeFrameDefects(frameIndex)
             }
         }
@@ -311,6 +318,15 @@ struct FrameDetailWorkspaceView: View {
                 contentMode: .fit
             )
             .frame(maxWidth: .infinity, minHeight: 360, maxHeight: 480)
+            .background {
+                GeometryReader { geometry in
+                    Color.clear
+                        .onAppear { zoomState.updateViewportSize(geometry.size) }
+                        .onChange(of: geometry.size) { _, size in
+                            zoomState.updateViewportSize(size)
+                        }
+                }
+            }
             .background(.black)
             .clipShape(RoundedRectangle(cornerRadius: 5))
             .overlay(RoundedRectangle(cornerRadius: 5).stroke(Color.white.opacity(0.12)))
@@ -319,6 +335,29 @@ struct FrameDetailWorkspaceView: View {
             // `zoomControls` causes SwiftUI to replace each button's own
             // accessible name with the preview description.
             .accessibilityLabel(previewAccessibilityLabel(usesRealImage: realImage != nil))
+            .accessibilityHint("Zoom in, then use the arrow keys while the preview is focused to pan.")
+            .focusable()
+            .focused($isPreviewFocused)
+            .onTapGesture { isPreviewFocused = true }
+            .onMoveCommand { direction in
+                guard isPreviewFocused, !zoomState.isFitted else { return }
+                switch direction {
+                case .left: zoomState.pan(by: CGSize(width: 40, height: 0))
+                case .right: zoomState.pan(by: CGSize(width: -40, height: 0))
+                case .up: zoomState.pan(by: CGSize(width: 0, height: 40))
+                case .down: zoomState.pan(by: CGSize(width: 0, height: -40))
+                @unknown default: break
+                }
+            }
+            .accessibilityAction(named: "Pan Left") { zoomState.pan(by: CGSize(width: 40, height: 0)) }
+            .accessibilityAction(named: "Pan Right") { zoomState.pan(by: CGSize(width: -40, height: 0)) }
+            .accessibilityAction(named: "Pan Up") { zoomState.pan(by: CGSize(width: 0, height: 40)) }
+            .accessibilityAction(named: "Pan Down") { zoomState.pan(by: CGSize(width: 0, height: -40)) }
+            .overlay {
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(isPreviewFocused ? Color.scanStudioCyan : .clear, lineWidth: 2)
+                    .allowsHitTesting(false)
+            }
             .overlay(alignment: .topTrailing) { zoomControls }
             .overlay(alignment: .bottomLeading) {
                 if viewingMode == .defectMap {
@@ -389,11 +428,7 @@ struct FrameDetailWorkspaceView: View {
         }
     }
 
-    /// Final/Before Repair/Defect Map (DEF-01) — exactly one mode is ever
-    /// shown, no 50/50 comparison. Segmented style matches the mode-picker
-    /// precedent this app already establishes (`BatchInspectorView`'s
-    /// Digital ICE mode picker, this file's own `processingEditorRows`
-    /// Digital ICE mode picker).
+    /// Both modes use the scanner preview; Defect Map adds the analysis overlay.
     private var viewingModeSwitcher: some View {
         Picker("Viewing mode", selection: $viewingMode) {
             ForEach(FrameViewingMode.allCases, id: \.self) { mode in
@@ -403,6 +438,8 @@ struct FrameDetailWorkspaceView: View {
         .pickerStyle(.segmented)
         .labelsHidden()
         .controlSize(.small)
+        .disabled(sessionModel.project == nil)
+        .help(sessionModel.project == nil ? "Save the roll to analyze and view defects." : "Choose the scanner preview or defect overlay.")
     }
 
     private var orientationControls: some View {
@@ -542,16 +579,8 @@ struct FrameDetailWorkspaceView: View {
         }
     }
 
-    /// `beforeRepair` gets its own honest caption (see this plan's
-    /// `scope_decision`: no pixel pipeline in this codebase currently
-    /// produces a genuinely different before/after-ICE buffer for any
-    /// frame); `finalPositive`/`defectMap` keep the existing real/simulated
-    /// caption unchanged.
     private func previewCaption(usesRealImage: Bool) -> String {
-        if viewingMode == .beforeRepair {
-            return "Before-repair view: Digital ICE correction is not yet applied to any rendered output in this build — shown identically to Final."
-        }
-        return usesRealImage
+        usesRealImage
             ? "Real scanner preview tile · zoom and pan"
             : "Simulated preview crop, the same source imagery shown throughout Scan Studio · zoom and pan"
     }

--- a/app/ScanStudio/Sources/ScanStudio/ProjectLauncherView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ProjectLauncherView.swift
@@ -35,6 +35,7 @@ struct ProjectLauncherView: View {
     @State private var createAttemptError: LauncherAttemptError?
     @State private var openRecentAttemptError: LauncherAttemptError?
     @State private var isSubmitting = false
+    @State private var isLoadingRecentProjects = true
 
     init(
         session: SessionModel,
@@ -62,15 +63,33 @@ struct ProjectLauncherView: View {
                 .labelsHidden()
                 .padding([.horizontal, .top])
                 .accessibilityLabel("Project launcher tab")
+                .disabled(isSubmitting)
 
                 Group {
                     if selectedTab == .newProject {
-                        newProjectForm
+                        if registeredPreviewFrameCount == nil {
+                            ContentUnavailableView(
+                                "Preview a roll first",
+                                systemImage: "photo.stack",
+                                description: Text("Return to the film workspace, connect your scanner, and acquire previews. Then save the roll as a new project.")
+                            )
+                        } else {
+                            newProjectForm
+                        }
                     } else {
                         openRecentSection
                     }
                 }
             }
+            Divider()
+                .padding(.top, 12)
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel) { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                    .disabled(isSubmitting)
+            }
+            .padding(.top, 12)
         }
         .frame(width: 420, height: 460)
         .padding(20)
@@ -172,6 +191,7 @@ struct ProjectLauncherView: View {
                           let previewProcess = session.previewFilmProcess,
                           registeredPreviewFrameCount != nil
                     else { return }
+                    guard !isSubmitting else { return }
                     createAttemptError = nil
                     isSubmitting = true
                     let completed: Bool
@@ -227,6 +247,7 @@ struct ProjectLauncherView: View {
             .keyboardShortcut(.defaultAction)
         }
         .padding(.top, 12)
+        .disabled(isSubmitting)
     }
 
     private var registeredPreviewFrameCount: Int? {
@@ -279,8 +300,8 @@ struct ProjectLauncherView: View {
     }
 
     private var disabledReason: String? {
-        if session.isJobActive || session.jobId != nil {
-            return "Finish or stop the current scan before changing projects."
+        if let reason = session.projectChangeDisabledReason {
+            return reason
         }
         if purpose == .saveRollAndScan, selectedFrameCount == 0 {
             return "Select at least one frame before saving and scanning."
@@ -294,12 +315,21 @@ struct ProjectLauncherView: View {
 
     private var openRecentSection: some View {
         Group {
-            if session.recentProjects.isEmpty {
-                ContentUnavailableView("No projects yet", systemImage: "tray")
+            if isLoadingRecentProjects {
+                ProgressView("Loading projects…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if session.recentProjects.isEmpty {
+                ContentUnavailableView(
+                    openRecentAttemptError == nil ? "No projects yet" : "Couldn’t load projects",
+                    systemImage: "tray"
+                )
             } else {
                 List(session.recentProjects) { summary in
                     Button {
                         Task {
+                            guard !isSubmitting else { return }
+                            isSubmitting = true
+                            defer { isSubmitting = false }
                             openRecentAttemptError = nil
                             await session.openProject(directory: summary.directory)
                             if session.lastErrorMessage == nil {
@@ -320,8 +350,17 @@ struct ProjectLauncherView: View {
                         recentProjectRow(summary)
                     }
                     .buttonStyle(.plain)
-                    .disabled(session.isJobActive || session.jobId != nil)
+                    .disabled(isSubmitting || session.projectChangeDisabledReason != nil)
                 }
+            }
+
+            if isSubmitting {
+                ProgressView("Opening project…")
+            } else if let reason = session.projectChangeDisabledReason {
+                Text(reason)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color.scanStudioSecondaryText)
+                    .padding(.horizontal)
             }
 
             if let error = openRecentAttemptError {
@@ -334,20 +373,39 @@ struct ProjectLauncherView: View {
                     .foregroundStyle(Color.scanStudioRed)
                     .fixedSize(horizontal: false, vertical: true)
                     .padding(.horizontal)
+                Button("Reload Projects") {
+                    Task { await loadRecentProjects() }
+                }
+                .disabled(isSubmitting || isLoadingRecentProjects)
             }
         }
-        .task { await session.refreshRecentProjects() }
+        .task { await loadRecentProjects() }
+    }
+
+    private func loadRecentProjects() async {
+        isLoadingRecentProjects = true
+        openRecentAttemptError = nil
+        await session.refreshRecentProjects()
+        if let error = session.errorPresentation {
+            openRecentAttemptError = LauncherAttemptError(title: error.title, guidance: error.guidance)
+        }
+        isLoadingRecentProjects = false
     }
 
     private func recentProjectRow(_ summary: ProjectSummary) -> some View {
         VStack(alignment: .leading, spacing: 3) {
             Text(summary.name)
                 .font(.system(size: 12, weight: .semibold))
-            Text("\(summary.carrier.displayName) · \(summary.filmProcess.rawValue) · \(summary.createdAt)")
+            Text("\(summary.carrier.displayName) · \(filmProcessLabel(summary.filmProcess)) · \(projectDate(summary.createdAt))")
                 .font(.system(size: 10))
                 .foregroundStyle(Color.scanStudioSecondaryText)
         }
         .padding(.vertical, 2)
+    }
+
+    private func projectDate(_ value: String) -> String {
+        guard let date = ISO8601DateFormatter().date(from: value) else { return value }
+        return date.formatted(date: .abbreviated, time: .shortened)
     }
 
     private func framePluralized(_ count: Int) -> String {

--- a/app/ScanStudio/Sources/ScanStudio/ScanPanelView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ScanPanelView.swift
@@ -214,10 +214,14 @@ struct ScanPanelView: View {
             Button {
                 Task { await sessionModel.stopAfterCurrentFrame() }
             } label: {
-                Label("Pause after frame", systemImage: "pause.circle")
+                Label(
+                    sessionModel.device?.kind == "real" ? "Stop after frame" : "Pause after frame",
+                    systemImage: "pause.circle"
+                )
             }
             .buttonStyle(.bordered)
             .disabled(sessionModel.jobState == .stoppingAfterCurrentFrame || sessionModel.jobState == .stoppingImmediately)
+            .help("Finish the current frame, then stop the batch. Remaining frames can be resumed later.")
 
             Button {
                 Task { await sessionModel.skipCurrentFrame() }
@@ -228,14 +232,18 @@ struct ScanPanelView: View {
             .disabled(sessionModel.jobState == .stoppingAfterCurrentFrame || sessionModel.jobState == .stoppingImmediately || sessionModel.device?.kind == "real")
             .help(skipFrameHelpText)
 
-            Button(role: .destructive) {
-                Task { await sessionModel.stopImmediately() }
-            } label: {
-                Label("Stop Scan", systemImage: "stop.circle.fill")
+            // Real hardware always stops after the current frame; an immediate
+            // stop control would promise an abort the scanner cannot perform.
+            if sessionModel.device?.kind == "simulated" {
+                Button(role: .destructive) {
+                    Task { await sessionModel.stopImmediately() }
+                } label: {
+                    Label("Stop Scan", systemImage: "stop.circle.fill")
+                }
+                .buttonStyle(.bordered)
+                .tint(.scanStudioRed)
+                .disabled(sessionModel.jobState == .stoppingImmediately)
             }
-            .buttonStyle(.bordered)
-            .tint(.scanStudioRed)
-            .disabled(sessionModel.jobState == .stoppingImmediately)
         }
     }
 

--- a/app/ScanStudio/Sources/ScanStudio/ScanStudioApp.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ScanStudioApp.swift
@@ -41,7 +41,10 @@ struct ScanStudioApp: App {
             }
             .launchUpdateOfferAlert(appDelegate.updateFlowModel)
         }
-        .defaultSize(width: 1_500, height: 920)
+        .defaultSize(
+            width: min(1_500, NSScreen.main?.visibleFrame.width ?? 1_500),
+            height: min(920, (NSScreen.main?.visibleFrame.height ?? 948) - 28)
+        )
         .windowResizability(.contentMinSize)
         .commands {
             if case .ready(_, let model) = appDelegate.launchState {

--- a/app/ScanStudio/Sources/ScanStudio/SessionSidebarView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/SessionSidebarView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct SessionSidebarView: View {
     @Environment(SessionModel.self) private var sessionModel
-    @State private var isShowingProjectLauncher = false
+    let onManageProjects: () -> Void
 
     private var isConnected: Bool { sessionModel.status?.connected == true }
     private var isRealDevice: Bool { sessionModel.device?.kind == "real" }
@@ -27,9 +27,6 @@ struct SessionSidebarView: View {
 
         }
         .background(Color.scanStudioSidebar)
-        .sheet(isPresented: $isShowingProjectLauncher) {
-            ProjectLauncherView(session: sessionModel)
-        }
     }
 
     private var projectSection: some View {
@@ -47,22 +44,25 @@ struct SessionSidebarView: View {
                 SidebarRow(icon: "camera.filters", title: "Film process", trailing: project.filmProcess.rawValue)
 
                 Button("Switch Project…") {
-                    isShowingProjectLauncher = true
+                    onManageProjects()
                 }
                 .buttonStyle(.borderless)
                 .font(.system(size: 11))
                 .foregroundStyle(Color.scanStudioSecondaryText)
-                .disabled(sessionModel.isJobActive || sessionModel.jobId != nil)
+                .disabled(sessionModel.projectChangeDisabledReason != nil)
+                .help(sessionModel.projectChangeDisabledReason ?? "Open or save a project")
                 .padding(.leading, 30)
             } else {
                 Button {
-                    isShowingProjectLauncher = true
+                    onManageProjects()
                 } label: {
                     Label("New / Open Project…", systemImage: "folder.badge.plus")
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.scanStudioAmber)
+                .disabled(sessionModel.projectChangeDisabledReason != nil)
+                .help(sessionModel.projectChangeDisabledReason ?? "Open or save a project")
             }
         }
     }

--- a/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
@@ -117,7 +117,7 @@ struct UpdateSettingsView: View {
             VStack(alignment: .leading, spacing: 10) {
                 Label("Update available: \(candidate.version.raw)", systemImage: "arrow.down.circle.fill")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(Color.scanStudioAmber)
+                    .foregroundStyle(.primary)
 
                 if model.pendingInstallURL != nil {
                     // The prominent next action once install() has already

--- a/app/ScanStudio/Sources/ScanStudioKit/FrameDetailZoomState.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/FrameDetailZoomState.swift
@@ -12,6 +12,7 @@ public struct FrameDetailZoomState: Equatable, Sendable {
 
     private var steadyScale: CGFloat = minimumScale
     private var steadyPanOffset: CGSize = .zero
+    private var viewportSize: CGSize = .zero
 
     public init() {}
 
@@ -27,10 +28,12 @@ public struct FrameDetailZoomState: Equatable, Sendable {
         if scale == Self.minimumScale {
             reset()
         }
+        constrainPan()
     }
 
     public mutating func updateMagnification(_ gestureScale: CGFloat) {
         scale = Self.clamp(steadyScale * gestureScale)
+        constrainPan()
     }
 
     public mutating func finishMagnification() {
@@ -42,10 +45,22 @@ public struct FrameDetailZoomState: Equatable, Sendable {
 
     public mutating func updatePan(translation: CGSize) {
         guard scale > Self.minimumScale else { return }
-        panOffset = CGSize(
+        panOffset = boundedPan(CGSize(
             width: steadyPanOffset.width + translation.width,
             height: steadyPanOffset.height + translation.height
-        )
+        ))
+    }
+
+    public mutating func updateViewportSize(_ size: CGSize) {
+        guard size.width.isFinite, size.height.isFinite else { return }
+        viewportSize = CGSize(width: max(0, size.width), height: max(0, size.height))
+        constrainPan()
+    }
+
+    /// Discrete movement shared by keyboard and accessibility actions.
+    public mutating func pan(by delta: CGSize) {
+        updatePan(translation: delta)
+        finishPan()
     }
 
     public mutating func finishPan() {
@@ -61,5 +76,19 @@ public struct FrameDetailZoomState: Equatable, Sendable {
 
     private static func clamp(_ scale: CGFloat) -> CGFloat {
         min(Self.maximumScale, max(Self.minimumScale, scale))
+    }
+
+    private func boundedPan(_ offset: CGSize) -> CGSize {
+        let horizontalLimit = viewportSize.width * (scale - 1) / 2
+        let verticalLimit = viewportSize.height * (scale - 1) / 2
+        return CGSize(
+            width: min(horizontalLimit, max(-horizontalLimit, offset.width)),
+            height: min(verticalLimit, max(-verticalLimit, offset.height))
+        )
+    }
+
+    private mutating func constrainPan() {
+        panOffset = boundedPan(panOffset)
+        steadyPanOffset = boundedPan(steadyPanOffset)
     }
 }

--- a/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
@@ -1479,6 +1479,10 @@ public final class SessionModel {
     /// token owned by that concrete UI presentation.
     @discardableResult
     public func requestPreview(_ intent: PreviewIntent) async -> PreviewRequestOutcome {
+        guard !isChangingProject else {
+            lastErrorMessage = "Wait for the project to finish opening or saving before previewing the film."
+            return .rejected
+        }
         let context = PreviewIntentStateMachine.Context(
             hasProject: project != nil,
             isAcquiring: isAcquiringThumbnails,
@@ -2736,23 +2740,28 @@ public final class SessionModel {
         activeOperationStartedAt = nil
     }
 
+    /// Shared by project actions and their controls so a disabled action explains
+    /// the same conflict the model enforces, including a preview still in flight.
+    public var projectChangeDisabledReason: String? {
+        if isChangingProject {
+            return "Another project action is still in progress. Wait for it to finish and try again."
+        }
+        if pendingScanStart != nil || jobId != nil || isJobActive {
+            return "A scan is still in progress. Wait for it to finish or stop it before changing projects."
+        }
+        if pendingFrameAlignmentAdjustment != nil || pendingFrameAlignmentRestore != nil
+            || isRestoringFrameAlignments {
+            return "A frame alignment is still in progress. Wait for it to finish before changing projects."
+        }
+        if isAcquiringThumbnails {
+            return "Wait for the current preview to finish before changing projects."
+        }
+        return nil
+    }
+
     private func beginProjectLifecycleChange() -> Bool {
-        guard !isChangingProject else {
-            lastErrorMessage =
-                "Another project action is still in progress. Wait for it to finish and try again."
-            return false
-        }
-        guard pendingScanStart == nil, jobId == nil, !isJobActive else {
-            lastErrorMessage =
-                "A scan is still in progress. Wait for it to finish or stop it before changing projects."
-            return false
-        }
-        guard pendingFrameAlignmentAdjustment == nil,
-              pendingFrameAlignmentRestore == nil,
-              !isRestoringFrameAlignments
-        else {
-            lastErrorMessage =
-                "A frame alignment is still in progress. Wait for it to finish before changing projects."
+        if let reason = projectChangeDisabledReason {
+            lastErrorMessage = reason
             return false
         }
         isChangingProject = true

--- a/app/ScanStudio/Tests/ScanStudioKitTests/FrameDetailZoomStateTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/FrameDetailZoomStateTests.swift
@@ -27,6 +27,7 @@ struct FrameDetailZoomStateTests {
     @Test("Zoom Out returning to fit resets both live and accumulated pan")
     func zoomOutToFitResetsPan() {
         var state = FrameDetailZoomState()
+        state.updateViewportSize(CGSize(width: 400, height: 300))
         state.step(by: FrameDetailZoomState.controlStep)
         state.updatePan(translation: CGSize(width: 24, height: -12))
         state.finishPan()
@@ -43,6 +44,7 @@ struct FrameDetailZoomStateTests {
     @Test("pinch magnification and panning share the same clamped viewport state")
     func gestureStateSharesLimits() {
         var state = FrameDetailZoomState()
+        state.updateViewportSize(CGSize(width: 400, height: 300))
         state.updateMagnification(8)
         state.finishMagnification()
 
@@ -59,5 +61,45 @@ struct FrameDetailZoomStateTests {
         #expect(state.scale == 1)
         #expect(state.panOffset == .zero)
         #expect(state.isFitted)
+    }
+
+    @Test("discrete pan clamps at every edge and the next drag starts from that position")
+    func discretePanClampsAndAccumulates() {
+        var state = FrameDetailZoomState()
+        state.updateViewportSize(CGSize(width: 400, height: 300))
+        state.pan(by: CGSize(width: 40, height: 40))
+        #expect(state.panOffset == .zero)
+
+        state.step(by: 1)
+        state.pan(by: CGSize(width: 1_000, height: -1_000))
+        #expect(state.panOffset == CGSize(width: 200, height: -150))
+        state.updatePan(translation: CGSize(width: -40, height: 40))
+        state.finishPan()
+        #expect(state.panOffset == CGSize(width: 160, height: -110))
+        state.pan(by: CGSize(width: -1_000, height: 1_000))
+        #expect(state.panOffset == CGSize(width: -200, height: 150))
+    }
+
+    @Test("zooming out and resizing constrain both current and accumulated pan")
+    func viewportChangesConstrainPan() {
+        var state = FrameDetailZoomState()
+        state.updateViewportSize(CGSize(width: 400, height: 300))
+        state.step(by: 3)
+        state.pan(by: CGSize(width: 1_000, height: 1_000))
+        state.step(by: -2)
+        #expect(state.panOffset == CGSize(width: 200, height: 150))
+
+        state.updateViewportSize(CGSize(width: 200, height: 100))
+        #expect(state.panOffset == CGSize(width: 100, height: 50))
+        state.pan(by: CGSize(width: -40, height: -40))
+        #expect(state.panOffset == CGSize(width: 60, height: 10))
+
+        state.updateMagnification(0.75)
+        state.finishMagnification()
+        #expect(state.panOffset == CGSize(width: 50, height: 10))
+        state.reset()
+        state.step(by: 1)
+        state.pan(by: CGSize(width: 40, height: 40))
+        #expect(state.panOffset == CGSize(width: 40, height: 40))
     }
 }

--- a/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/SessionEventPolicyTests.swift
@@ -23,9 +23,12 @@ private actor ProjectFlowEngineStub: EngineClientProtocol {
     nonisolated let events: AsyncStream<EngineEvent>
     var engineVersion: String? = "project-flow-stub"
     private let project: ScanProject
+    private let suspendProjectOpen: Bool
+    private var openContinuation: CheckedContinuation<Void, Never>?
 
-    init(project: ScanProject) {
+    init(project: ScanProject, suspendProjectOpen: Bool = false) {
         self.project = project
+        self.suspendProjectOpen = suspendProjectOpen
         self.events = AsyncStream { _ in }
     }
 
@@ -37,7 +40,11 @@ private actor ProjectFlowEngineStub: EngineClientProtocol {
         switch method {
         case "scanner.list": value = ScannerListResult(devices: [])
         case "project.create": value = ProjectCreateResult(project: project, directory: "/tmp/positive-roll")
-        case "project.open": value = ProjectOpenResult(project: project, directory: "/tmp/positive-roll")
+        case "project.open":
+            if suspendProjectOpen {
+                await withCheckedContinuation { openContinuation = $0 }
+            }
+            value = ProjectOpenResult(project: project, directory: "/tmp/positive-roll")
         case "sim.loadMedia":
             value = ScannerStatus(
                 connected: true,
@@ -61,6 +68,12 @@ private actor ProjectFlowEngineStub: EngineClientProtocol {
         }
         return result
     }
+    func isOpenSuspended() -> Bool { openContinuation != nil }
+    func resumeOpen() {
+        openContinuation?.resume()
+        openContinuation = nil
+    }
+
 }
 
 private actor SequencedProjectFlowEngineStub: EngineClientProtocol {
@@ -1163,6 +1176,43 @@ struct SessionEventPolicyTests {
             createdAt: "2026-07-27T21:36:49Z",
             frames: [ProjectFrame(index: 1, excluded: false, receipts: [])]
         )
+    }
+
+    @Test("project changes cannot discard an active preview", arguments: [false, true])
+    @MainActor
+    func projectChangeDuringPreviewIsRefused(create: Bool) async throws {
+        let project = try projectLifecycleFixture(id: "preview-in-flight", completedFrames: [])
+        let model = SessionModel(engineClient: ProjectFlowEngineStub(project: project))
+        await model.loadCarrier(.strip6)
+        #expect(await model.requestPreview(.initial(token: PreviewIntentToken())) == .started)
+        #expect(model.isAcquiringThumbnails)
+        if create {
+            await model.createProject(name: "Other roll", carrier: .strip6,
+                                      frameCount: 6, filmProcess: .c41ColorNegative)
+        } else {
+            await model.openProject(directory: "/tmp/other-roll")
+        }
+        #expect(model.project == nil)
+        #expect(model.isAcquiringThumbnails)
+        #expect(model.lastErrorMessage?.contains("preview") == true)
+    }
+
+    @Test("preview cannot start while an existing project is opening")
+    @MainActor
+    func previewDuringProjectOpenIsRefused() async throws {
+        let project = try projectLifecycleFixture(id: "opening-project", completedFrames: [])
+        let client = ProjectFlowEngineStub(project: project, suspendProjectOpen: true)
+        let model = SessionModel(engineClient: client)
+        await model.loadCarrier(.strip6)
+        let opening = Task { await model.openProject(directory: "/tmp/opening-project") }
+        while !(await client.isOpenSuspended()) { await Task.yield() }
+        #expect(model.isChangingProject)
+        #expect(await model.requestPreview(.initial(token: PreviewIntentToken())) == .rejected)
+        #expect(!model.isAcquiringThumbnails)
+        await client.resumeOpen()
+        await opening.value
+        #expect(model.project?.id == "opening-project")
+        #expect(!model.isChangingProject)
     }
 
     private func projectLifecycleFixture(

--- a/app/ScanStudio/engine/src/evidence_package.rs
+++ b/app/ScanStudio/engine/src/evidence_package.rs
@@ -811,7 +811,7 @@ fn create_package_file(
 fn cleanup_staged_manifest(
     package: &crate::render::ReservedEvidencePackage,
     temporary_name: &std::ffi::OsStr,
-    staged: &std::fs::File,
+    staged: std::fs::File,
 ) -> Result<(), String> {
     package
         .retire_exact_root_file(temporary_name, staged)
@@ -820,7 +820,7 @@ fn cleanup_staged_manifest(
 
 fn rollback_committed_manifest(
     package: &crate::render::ReservedEvidencePackage,
-    manifest_file: &std::fs::File,
+    manifest_file: std::fs::File,
 ) -> Result<(), String> {
     package
         .retire_exact_root_file(std::ffi::OsStr::new("manifest.json"), manifest_file)
@@ -878,7 +878,7 @@ where
         Ok(())
     })();
     if let Err(error) = staged {
-        return match cleanup_staged_manifest(package, &temporary_name, &manifest_file) {
+        return match cleanup_staged_manifest(package, &temporary_name, manifest_file) {
             Ok(()) => Err(error),
             Err(cleanup) => Err(format!(
                 "{error}; HOLD: staged evidence manifest cleanup could not be proven: {cleanup}"
@@ -893,7 +893,7 @@ where
         std::ffi::OsStr::new("manifest.json"),
     ) {
         let primary = format!("create-only authoritative evidence manifest commit: {error}");
-        return match cleanup_staged_manifest(package, &temporary_name, &manifest_file) {
+        return match cleanup_staged_manifest(package, &temporary_name, manifest_file) {
             Ok(()) => Err(primary),
             Err(cleanup) => Err(format!(
                 "{primary}; HOLD: staged evidence manifest cleanup could not be proven: {cleanup}"
@@ -919,7 +919,7 @@ where
     })();
     match post_commit {
         Ok(()) => Ok(()),
-        Err(primary) => match rollback_committed_manifest(package, &manifest_file) {
+        Err(primary) => match rollback_committed_manifest(package, manifest_file) {
             Ok(()) => Err(format!(
                 "{primary}; authoritative manifest was rolled back and completion was not reported"
             )),
@@ -1042,7 +1042,7 @@ where
     Ok((
         FileDigest {
             path: source.display().to_string(),
-            package_path: destination.to_string_lossy().to_string(),
+            package_path: destination.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/"),
             sha256: source_hash,
         },
         PackageFileProof {
@@ -1504,7 +1504,7 @@ mod tests {
         })
         .expect_err("post-commit ambiguity must never return successful completion");
         assert!(error.contains("ordering ambiguity"));
-        assert!(error.contains("rolled back"));
+        assert!(error.contains("rolled back"), "{error}");
         assert!(!package.final_path().join("manifest.json").exists());
 
         let _ = std::fs::remove_dir_all(root);

--- a/app/ScanStudio/engine/src/exiftool.rs
+++ b/app/ScanStudio/engine/src/exiftool.rs
@@ -3198,6 +3198,11 @@ pub(crate) mod metadata_publish_sys {
     }
 
     pub fn open_regular(parent: &File, name: &OsStr) -> io::Result<File> {
+        // Readers must coexist with publication handles that deny deletion.
+        relative_file(parent, name, false, false, false, false, true)
+    }
+
+    fn open_regular_for_delete(parent: &File, name: &OsStr) -> io::Result<File> {
         relative_file(parent, name, false, false, false, true, true)
     }
 
@@ -3265,8 +3270,8 @@ pub(crate) mod metadata_publish_sys {
         to_directory: &File,
         to_name: &OsStr,
     ) -> io::Result<()> {
-        let source = open_regular(from_directory, from_name)?;
-        let target = open_regular(to_directory, to_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
+        let target = open_regular_for_delete(to_directory, to_name)?;
         let parking = from_name
             .to_str()
             .and_then(|name| name.strip_prefix(".swap-"))
@@ -3319,7 +3324,7 @@ pub(crate) mod metadata_publish_sys {
                 ))
             }
         }
-        let source = open_regular(from_directory, from_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
         rename_handle(&source, to_directory, to_name, false)
     }
 
@@ -3345,7 +3350,7 @@ pub(crate) mod metadata_publish_sys {
         to_directory: &File,
         to_name: &OsStr,
     ) -> io::Result<()> {
-        let source = open_regular(from_directory, from_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
         rename_handle(&source, to_directory, to_name, true)
     }
 
@@ -3371,7 +3376,7 @@ pub(crate) mod metadata_publish_sys {
     }
 
     pub fn unlink(parent: &File, name: &OsStr) -> io::Result<()> {
-        let file = open_regular(parent, name)?;
+        let file = open_regular_for_delete(parent, name)?;
         delete_handle(&file)
     }
 

--- a/app/ScanStudio/engine/src/exiftool.rs
+++ b/app/ScanStudio/engine/src/exiftool.rs
@@ -2592,7 +2592,7 @@ pub(crate) mod metadata_publish_sys {
     const FILE_OPEN: u32 = 0x0000_0001;
     const FILE_CREATE: u32 = 0x0000_0002;
     const FILE_NAMES_INFORMATION_CLASS: u32 = 12;
-    const FILE_RENAME_INFO_EX_CLASS: u32 = 22;
+    const FILE_RENAME_INFORMATION_CLASS: u32 = 10;
     const FILE_DISPOSITION_INFO_EX_CLASS: u32 = 21;
     const FILE_DISPOSITION_FLAG_DELETE: u32 = 0x0000_0001;
     const FILE_DISPOSITION_FLAG_POSIX_SEMANTICS: u32 = 0x0000_0002;
@@ -2612,8 +2612,8 @@ pub(crate) mod metadata_publish_sys {
     const ACL_SIZE_INFORMATION_CLASS: u32 = 2;
 
     #[repr(C)]
-    struct FileRenameInfoEx {
-        flags: u32,
+    struct FileRenameInformation {
+        replace_if_exists: u8,
         root_directory: Handle,
         file_name_length: u32,
         file_name: [u16; 1],
@@ -2781,6 +2781,13 @@ pub(crate) mod metadata_publish_sys {
 
     #[link(name = "ntdll")]
     extern "system" {
+        fn NtSetInformationFile(
+            file: Handle,
+            io_status_block: *mut IoStatusBlock,
+            information: *mut std::ffi::c_void,
+            information_size: u32,
+            information_class: u32,
+        ) -> i32;
         fn NtCreateFile(
             file: *mut Handle,
             desired_access: u32,
@@ -3205,14 +3212,14 @@ pub(crate) mod metadata_publish_sys {
         replace: bool,
     ) -> io::Result<()> {
         let name = component(destination_name)?;
-        let header_size = offset_of!(FileRenameInfoEx, file_name);
+        let header_size = offset_of!(FileRenameInformation, file_name);
         let byte_len = name.len().checked_mul(size_of::<u16>()).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Windows rename name is too long",
             )
         })?;
-        let total = header_size.checked_add(byte_len).ok_or_else(|| {
+        let total = size_of::<FileRenameInformation>().checked_add(byte_len).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Windows rename buffer overflow",
@@ -3220,9 +3227,9 @@ pub(crate) mod metadata_publish_sys {
         })?;
         let words = total.div_ceil(size_of::<usize>());
         let mut storage = vec![0_usize; words];
-        let info = storage.as_mut_ptr().cast::<FileRenameInfoEx>();
+        let info = storage.as_mut_ptr().cast::<FileRenameInformation>();
         unsafe {
-            (*info).flags = u32::from(replace);
+            (*info).replace_if_exists = u8::from(replace);
             (*info).root_directory = destination_directory.as_raw_handle();
             (*info).file_name_length = byte_len as u32;
             std::ptr::copy_nonoverlapping(
@@ -3231,17 +3238,22 @@ pub(crate) mod metadata_publish_sys {
                 byte_len,
             );
         }
-        let result = unsafe {
-            SetFileInformationByHandle(
+        // Use the native handle-relative operation, matching NtCreateFile above.
+        // The Win32 rename wrapper rejects this directory-relative request with
+        // ERROR_INVALID_PARAMETER on supported Windows hosts.
+        let mut status_block = IoStatusBlock { status_or_pointer: 0, information: 0 };
+        let status = unsafe {
+            NtSetInformationFile(
                 source.as_raw_handle(),
-                FILE_RENAME_INFO_EX_CLASS,
+                &mut status_block,
                 info.cast(),
                 total as u32,
+                FILE_RENAME_INFORMATION_CLASS,
             )
         };
-        if result == 0 {
-            let error = io::Error::last_os_error();
-            Err(io::Error::new(error.kind(), format!("SetFileInformationByHandle rename: {error}")))
+        if status < 0 {
+            let error = io::Error::from_raw_os_error(unsafe { RtlNtStatusToDosError(status) } as i32);
+            Err(io::Error::new(error.kind(), format!("NtSetInformationFile rename: {error}")))
         } else {
             Ok(())
         }

--- a/app/ScanStudio/engine/src/exiftool.rs
+++ b/app/ScanStudio/engine/src/exiftool.rs
@@ -3205,7 +3205,7 @@ pub(crate) mod metadata_publish_sys {
         relative_file(parent, name, false, false, true, false, false)
     }
 
-    fn rename_handle(
+    pub(crate) fn rename_handle(
         source: &File,
         destination_directory: &File,
         destination_name: &OsStr,
@@ -7101,7 +7101,12 @@ mod tests {
     fn windows_runner_assigns_and_resumes_a_normal_process() {
         let command =
             std::env::var("ComSpec").unwrap_or_else(|_| r"C:\Windows\System32\cmd.exe".to_string());
-        let command = bind_executable(Path::new(&command)).expect("bind Windows command");
+        // System binaries may have servicing hard links; the executable binder
+        // intentionally requires a unique file identity.
+        let root = temp_root("windows-runner");
+        let executable = root.join("cmd.exe");
+        std::fs::copy(&command, &executable).expect("copy Windows command fixture");
+        let command = bind_executable(&executable).expect("bind Windows command");
         let output = run_bounded_command(
             &command,
             &["/D".into(), "/C".into(), "exit /B 0".into()],
@@ -7110,6 +7115,8 @@ mod tests {
         )
         .expect("run a Job-contained Windows process");
         assert!(output.status.success());
+        drop(command);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[cfg(windows)]

--- a/app/ScanStudio/engine/src/exiftool.rs
+++ b/app/ScanStudio/engine/src/exiftool.rs
@@ -2043,7 +2043,8 @@ pub(crate) fn ensure_supported_metadata_filesystem(file: &File) -> std::io::Resu
         )
     };
     if result == 0 {
-        return Err(std::io::Error::last_os_error());
+        let error = std::io::Error::last_os_error();
+        return Err(std::io::Error::new(error.kind(), format!("GetVolumeInformationByHandleW: {error}")));
     }
     if !windows_metadata_filesystem_name_is_supported(&filesystem_name) {
         let name = String::from_utf16_lossy(&filesystem_name)
@@ -3158,7 +3159,8 @@ pub(crate) mod metadata_publish_sys {
         };
         if status < 0 {
             let windows_error = unsafe { RtlNtStatusToDosError(status) };
-            return Err(io::Error::from_raw_os_error(windows_error as i32));
+            let error = io::Error::from_raw_os_error(windows_error as i32);
+            return Err(io::Error::new(error.kind(), format!("NtCreateFile metadata entry: {error}")));
         }
         if handle.is_null() || handle as isize == -1 {
             return Err(io::Error::other(
@@ -3238,7 +3240,8 @@ pub(crate) mod metadata_publish_sys {
             )
         };
         if result == 0 {
-            Err(io::Error::last_os_error())
+            let error = io::Error::last_os_error();
+            Err(io::Error::new(error.kind(), format!("SetFileInformationByHandle rename: {error}")))
         } else {
             Ok(())
         }
@@ -3485,7 +3488,9 @@ pub(crate) mod metadata_publish_sys {
         // File::sync_all maps to FlushFileBuffers on Windows. Directory
         // capabilities are opened with write access so this ordering barrier
         // is enforced instead of silently assuming a rename is durable.
-        directory.sync_all()
+        directory.sync_all().map_err(|error| {
+            io::Error::new(error.kind(), format!("FlushFileBuffers directory: {error}"))
+        })
     }
 }
 

--- a/app/ScanStudio/engine/src/manifest.rs
+++ b/app/ScanStudio/engine/src/manifest.rs
@@ -1779,6 +1779,9 @@ mod tests {
             let dir = temp_project_dir();
             fs::create_dir_all(&dir).unwrap();
             fs::write(dir.join(MANIFEST_FILE_NAME), corruption).unwrap();
+            // Windows keeps its transaction-lock inode for all later opens.
+            #[cfg(windows)]
+            fs::write(dir.join(".scanstudio-manifest.lock"), b"").unwrap();
 
             let before = snapshot_regular_files(&dir);
             let err = create_project(

--- a/app/ScanStudio/engine/src/real_backend.rs
+++ b/app/ScanStudio/engine/src/real_backend.rs
@@ -1444,6 +1444,7 @@ mod private_workspace_sys {
     ) -> io::Result<std::fs::File> {
         let marker_path = root_path.join(marker_name);
         let mut file = std::fs::OpenOptions::new()
+            .write(true)
             .access_mode(GENERIC_READ | GENERIC_WRITE | DELETE_ACCESS)
             .create_new(true)
             .share_mode(FILE_SHARE_READ)
@@ -8234,6 +8235,17 @@ mod tests {
         assert!(admit_evidence_frame_slot(
             &requested, &remaining, 2, &mut error
         ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_private_workspace_creates_and_verifies_its_marker() {
+        let working = PrivateCaptureWorkingDirectory::create().expect("create Windows workspace");
+        working.verify_namespace().expect("verify held workspace authority");
+        let root = working.root.clone();
+        assert!(std::fs::metadata(root.join(PRIVATE_CAPTURE_MARKER)).unwrap().len() > 0);
+        drop(working);
+        std::fs::remove_dir_all(root).expect("remove private test workspace");
     }
 
     #[cfg(unix)]

--- a/app/ScanStudio/engine/src/render.rs
+++ b/app/ScanStudio/engine/src/render.rs
@@ -1275,7 +1275,6 @@ mod destination_sys {
     const GENERIC_READ: u32 = 0x8000_0000;
     const GENERIC_WRITE: u32 = 0x4000_0000;
     const DELETE_ACCESS: u32 = 0x0001_0000;
-    const FILE_RENAME_INFO_CLASS: u32 = 3;
     const FILE_DISPOSITION_INFO_CLASS: u32 = 4;
 
     #[link(name = "Kernel32")]
@@ -1286,14 +1285,6 @@ mod destination_sys {
             information: *mut std::ffi::c_void,
             buffer_size: u32,
         ) -> i32;
-    }
-
-    #[repr(C)]
-    struct FileRenameInfoHeader {
-        replace_if_exists: u8,
-        root_directory: *mut std::ffi::c_void,
-        file_name_length: u32,
-        file_name: [u16; 1],
     }
 
     #[repr(C)]
@@ -1625,6 +1616,7 @@ mod destination_sys {
             ));
             let path = held.display_path.join(&candidate);
             match std::fs::OpenOptions::new()
+                .write(true)
                 .access_mode(GENERIC_READ | GENERIC_WRITE | DELETE_ACCESS)
                 .share_mode(FILE_SHARE_READ)
                 .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
@@ -1701,53 +1693,12 @@ mod destination_sys {
         role: &str,
     ) -> Result<(), domain::EngineError> {
         verify_namespace(held)?;
-        let wide: Vec<u16> = final_name.encode_wide().collect();
-        let file_name_offset = std::mem::offset_of!(FileRenameInfoHeader, file_name);
-        let byte_length = wide
-            .len()
-            .checked_mul(std::mem::size_of::<u16>())
-            .ok_or_else(|| output_authority_error("final output leaf is too long"))?;
-        let total = file_name_offset
-            .checked_add(byte_length)
-            .ok_or_else(|| output_authority_error("final output rename buffer is too large"))?;
-        // `Vec<u8>` only guarantees byte alignment; casting its pointer to
-        // FILE_RENAME_INFO would be undefined behaviour on Windows. Back the
-        // variable-sized record with pointer-aligned words while still
-        // passing the exact byte length required by the API.
-        let word = std::mem::size_of::<usize>();
-        let word_count = total
-            .checked_add(word - 1)
-            .ok_or_else(|| output_authority_error("final output rename buffer is too large"))?
-            / word;
-        let mut buffer = vec![0_usize; word_count];
-        let buffer_bytes = buffer.as_mut_ptr().cast::<u8>();
-        let header = buffer_bytes.cast::<FileRenameInfoHeader>();
-        unsafe {
-            std::ptr::write(
-                header,
-                FileRenameInfoHeader {
-                    replace_if_exists: (!create_only) as u8,
-                    root_directory: held.directory.as_raw_handle().cast(),
-                    file_name_length: byte_length as u32,
-                    file_name: [0],
-                },
-            );
-            std::ptr::copy_nonoverlapping(
-                wide.as_ptr().cast::<u8>(),
-                buffer_bytes.add(file_name_offset),
-                byte_length,
-            );
-        }
-        let result = unsafe {
-            SetFileInformationByHandle(
-                temporary_file.as_raw_handle().cast(),
-                FILE_RENAME_INFO_CLASS,
-                buffer_bytes.cast(),
-                total as u32,
-            )
-        };
-        if result == 0 {
-            let error = std::io::Error::last_os_error();
+        if let Err(error) = crate::exiftool::metadata_publish_sys::rename_handle(
+            temporary_file,
+            &held.directory,
+            final_name,
+            !create_only,
+        ) {
             let code = if create_only && error.kind() == std::io::ErrorKind::AlreadyExists {
                 protocol::ErrorCode::ArchiveCollision
             } else {
@@ -2800,6 +2751,9 @@ fn validate_filesystem_output_leaf_collation(
                 ))
             })?;
         }
+        // Windows delete dispositions finish when the last held file closes.
+        // Close our exact probe handles before checking for foreign entries.
+        created.clear();
         crate::exiftool::metadata_publish_sys::sync_directory(&probe).map_err(|error| {
             output_authority_error(format!("sync emptied output-name alias probe: {error}"))
         })?;
@@ -6782,6 +6736,7 @@ fn sync_output_directory(directory: &Path) -> std::io::Result<()> {
     const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
     std::fs::OpenOptions::new()
         .read(true)
+        .write(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .open(directory)?
         .sync_all()

--- a/app/ScanStudio/engine/src/render.rs
+++ b/app/ScanStudio/engine/src/render.rs
@@ -378,7 +378,7 @@ impl ReservedEvidencePackage {
     pub(crate) fn retire_exact_root_file(
         &self,
         name: &std::ffi::OsStr,
-        expected: &std::fs::File,
+        expected: std::fs::File,
     ) -> Result<(), domain::EngineError> {
         let relative = Path::new(name);
         if relative.components().count() != 1
@@ -391,8 +391,9 @@ impl ReservedEvidencePackage {
                 "exact evidence cleanup requires one normal root-file component",
             ));
         }
-        self.verify_regular_file(relative, expected)?;
-        destination_sys::delete_exact_regular_file(expected)?;
+        self.verify_regular_file(relative, &expected)?;
+        destination_sys::delete_exact_regular_file(&expected)?;
+        drop(expected);
         crate::exiftool::metadata_publish_sys::sync_directory(self.directory_handle()).map_err(
             |error| {
                 output_authority_error(format!(
@@ -10278,17 +10279,34 @@ mod tests {
         output.preview.enabled = false;
         output.raw_export.enabled = false;
 
-        let error = acquire_job_output_authorities(
+        // NTFS upcase tables vary by volume generation. Derive the expected
+        // answer from actual ordinary Windows file creation on this volume.
+        let first = project.join("Σ_0001.tif");
+        let second = project.join("ς_0001.tif");
+        std::fs::write(&first, b"oracle").unwrap();
+        let oracle = std::fs::OpenOptions::new().write(true).create_new(true).open(&second);
+        let collision = match oracle {
+            Ok(file) => { drop(file); false }
+            Err(error) => {
+                assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+                true
+            }
+        };
+        let result = acquire_job_output_authorities(
             Some(&project),
             &[1],
             &domain::CaptureRecipe::default(),
             &output,
             &std::collections::HashMap::new(),
         )
-        .expect_err("NTFS-upcase aliases must collide before capture");
-
-        assert_eq!(error.code, protocol::ErrorCode::InvalidParams);
-        assert!(error.message.contains("filename collation"), "{error}");
+        ;
+        if collision {
+            let error = result.expect_err("filesystem aliases must collide before capture");
+            assert_eq!(error.code, protocol::ErrorCode::InvalidParams);
+            assert!(error.message.contains("filename collation"), "{error}");
+        } else {
+            result.expect("distinct filesystem names must remain usable");
+        }
         let _ = std::fs::remove_dir_all(&project);
     }
 
@@ -11886,7 +11904,16 @@ mod tests {
 
         let positive = written.positive_path.as_ref().unwrap();
         let displaced = root.join("engine-authored-positive.tif");
-        std::fs::rename(positive, &displaced).unwrap();
+        let renamed = std::fs::rename(positive, &displaced);
+        if cfg!(windows) {
+            assert!(renamed.is_err(), "held Windows output must deny replacement");
+            crate::exiftool::bind_metadata_output_publications(&root, &written.metadata_publications)
+                .expect("denied replacement retains the original binding");
+            drop(written);
+            let _ = std::fs::remove_dir_all(root);
+            return;
+        }
+        renamed.unwrap();
         std::fs::write(positive, b"attacker replacement").unwrap();
 
         let error = crate::exiftool::bind_metadata_output_publications(

--- a/app/ScanStudio/engine/src/server.rs
+++ b/app/ScanStudio/engine/src/server.rs
@@ -4831,6 +4831,7 @@ mod tests {
                 .recv_timeout(std::time::Duration::from_secs(10))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.completed" {
                 break;
             }

--- a/app/ScanStudio/engine/src/sim.rs
+++ b/app/ScanStudio/engine/src/sim.rs
@@ -1976,7 +1976,18 @@ mod tests {
         )
         .unwrap();
         let positive = written.positive_path.as_ref().unwrap();
-        std::fs::rename(positive, root.join("engine-positive.tif")).unwrap();
+        let renamed = std::fs::rename(positive, root.join("engine-positive.tif"));
+        if cfg!(windows) {
+            assert!(renamed.is_err(), "held Windows output must deny replacement");
+            build_receipt(
+                "job-binding-replacement", 1, 1000, &recipe, &processing, &output,
+                DEVICE_ID, &written, Some(&project_root),
+            ).expect("denied replacement retains valid receipt evidence");
+            drop((written, project_root));
+            let _ = std::fs::remove_dir_all(root);
+            return;
+        }
+        renamed.unwrap();
         std::fs::write(positive, b"unrelated replacement").unwrap();
 
         let error = build_receipt(
@@ -2606,6 +2617,7 @@ mod tests {
                 .recv_timeout(Duration::from_secs(30))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.completed" {
                 break;
             }
@@ -2691,6 +2703,7 @@ mod tests {
                 .recv_timeout(Duration::from_secs(30))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.frameState" && value["payload"]["frameIndex"] == 1 {
                 match value["payload"]["state"].as_str() {
                     Some("completed") => {

--- a/app/ScanStudio/scripts/test_packaged_bridge.sh
+++ b/app/ScanStudio/scripts/test_packaged_bridge.sh
@@ -166,6 +166,7 @@ output="$workdir/bridge.ndjson"
 bridge="$relocated_app/Contents/MacOS/scanstudio-bridge"
 engine="$relocated_app/Contents/MacOS/scanstudio-engine"
 runtime_python="$relocated_app/Contents/Resources/BridgeRuntime/python/bin/python3.13"
+"$runtime_python" -I -S -B "$package_root/../../scripts/smoke_project_persistence.py" "$engine"
 runtime_sysconfig="$relocated_app/Contents/Resources/BridgeRuntime/python/lib/python3.13/_sysconfigdata__darwin_darwin.py"
 coolscanpy_pyproject="$relocated_app/Contents/Resources/CorrespondingSource/coolscanpy/pyproject.toml"
 if [[ ! -f "$runtime_sysconfig" || -L "$runtime_sysconfig" ]] \

--- a/bridge/uv.lock
+++ b/bridge/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/coolscanpy/CHANGELOG.md
+++ b/coolscanpy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.7.5 - 2026-09-06
+
+- Accept the observed EBDE-prefixed LS-5000 padding counter dialect only when the entire padding block matches its exact counter train. Offline and streaming decoding retain strict corruption rejection and identical sample output.
+
 ## 0.7.4 - 2026-08-23
 
 - Linear DNG and raw-export infrared markers moved from private tag

--- a/coolscanpy/pyproject.toml
+++ b/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -53,7 +53,9 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     "manual_frames.py": "8fc4ba82c177e1b7ecd6943354db33930b468ef3b4b82c712202b8caea54c9bb",
     "usb_backend.py": "afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62",
     "density.py": "c2c47de2886bc4b60197d2721b6d72050a76f1095760590fa7bb34a728b9da76",
-    "packed.py": "856315714e4f7e81f42e1ca93917e4cc0feb03b24915c2ad604302bfdca46f87",
+    # Resealed 2026-08-12 after a complete 2,980-record LS-5000 capture
+    # established the strict EBDE-prefixed padding-counter dialect.
+    "packed.py": "abff893d6ec5ff36aa33be86ef401a28ffbd6054e2279129e8fb88d7f650b435",
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "b03b3212d1ff1f8e3ad8ca7b512765ad6a115d4766e3f3eb5a86de3573076d4e",

--- a/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/packed.py
+++ b/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/packed.py
@@ -112,11 +112,11 @@ def _counter_train_ok(
 def _padding_counter_dialect(block: np.ndarray) -> str | None:
     """Identify any complete padding counter dialect observed live.
 
-    The original captures begin with the canonical ``AA55,D893`` pair.  Four
+    The original captures begin with the canonical ``AA55,D893`` pair.  Five
     further stable LS-5000 states, each observed identically in both long
     padding blocks across every record of its captured stream, replace only
     the first three words with a repeated sentinel — ``E9EA``, ``E004``,
-    ``DC4C``, or ``F6B1``.
+    ``DC4C``, ``F6B1``, or ``EBDE``.
     The fourth word remains ``D894`` and the canonical ``AA55,D895...`` train
     resumes immediately afterward.  Accept only those exact whole-block forms.
     """
@@ -130,6 +130,7 @@ def _padding_counter_dialect(block: np.ndarray) -> str | None:
         (0xE004, "e004-prefixed"),
         (0xDC4C, "dc4c-prefixed"),
         (0xF6B1, "f6b1-prefixed"),
+        (0xEBDE, "ebde-prefixed"),
     ):
         sentinel_prefix = np.array(
             [sentinel, sentinel, sentinel, 0xD894],

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_packed.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_packed.py
@@ -33,6 +33,11 @@ def _e004_prefixed_counter_train(words: np.ndarray) -> None:
     _counter_train(words[4:], 0xD895)
 
 
+def _ebde_prefixed_counter_train(words: np.ndarray) -> None:
+    words[:4] = (0xEBDE, 0xEBDE, 0xEBDE, 0xD894)
+    _counter_train(words[4:], 0xD895)
+
+
 def _synthetic_full_records(height: int = 3) -> tuple[np.ndarray, np.ndarray]:
     records = (height + 1) // 2
     base = (np.arange(records * 2 * WIDTH * 4, dtype=np.uint32).reshape(records * 2, WIDTH, 4) % 20_000).astype(np.uint16)
@@ -211,6 +216,67 @@ def test_full_decoder_rejects_e004_padding_1_with_e9ea_padding_3(tmp_path: Path)
     path.write_bytes(full.astype(">u2").tobytes())
 
     with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_accepts_ebde_prefixed_padding_counter_dialect(tmp_path: Path) -> None:
+    base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    path = tmp_path / "ebde-prefixed.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    decoded, report = decode_full_records(path, height=3)
+
+    expected = base.copy()
+    expected[..., :3] += 2
+    np.testing.assert_array_equal(expected, decoded)
+    assert report["padding_1_3_counter_dialect"] == "ebde-prefixed"
+
+
+@pytest.mark.parametrize(
+    "corrupt_word_offset",
+    [110_840 // 2, 110_840 // 2 + 3, 110_840 // 2 + 4, 111_616 // 2 - 1],
+    ids=["sentinel", "d894", "train-head", "train-tail"],
+)
+def test_full_decoder_rejects_corrupt_ebde_prefixed_padding(
+    tmp_path: Path, corrupt_word_offset: int
+) -> None:
+    _base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    full[1, corrupt_word_offset] ^= 1
+    path = tmp_path / "corrupt-ebde-prefixed.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 1 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_rejects_ebde_padding_1_with_canonical_padding_3(
+    tmp_path: Path,
+) -> None:
+    _base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+    path = tmp_path / "mixed-ebde-canonical.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_rejects_cross_record_ebde_dialect_change(tmp_path: Path) -> None:
+    _base, full = _synthetic_full_records()
+    record = full[1]
+    _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+    _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    path = tmp_path / "cross-record-ebde-dialect-change.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 1 counter train mismatch"):
         decode_full_records(path, height=3)
 
 

--- a/coolscanpy/tests/protocol/ls5000_single_pass/test_streaming.py
+++ b/coolscanpy/tests/protocol/ls5000_single_pass/test_streaming.py
@@ -65,6 +65,11 @@ def _f6b1_prefixed_counter_train(words: np.ndarray) -> None:
     _counter_train(words[4:], 0xD895)
 
 
+def _ebde_prefixed_counter_train(words: np.ndarray) -> None:
+    words[:4] = (0xEBDE, 0xEBDE, 0xEBDE, 0xD894)
+    _counter_train(words[4:], 0xD895)
+
+
 def _synthetic_full_records(height: int = 3) -> tuple[np.ndarray, np.ndarray]:
     records = (height + 1) // 2
     base = (
@@ -250,6 +255,69 @@ class TestStreamingFrameDecoder:
 
         np.testing.assert_array_equal(offline, decoded)
         assert offline_report["padding_1_3_counter_dialect"] == "f6b1-prefixed"
+
+    def test_ebde_prefixed_stream_matches_offline_decode_byte_for_byte(
+        self, tmp_path: Path
+    ) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+            _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        stream = full.astype(">u2").tobytes()
+        path = tmp_path / "ebde-capture.bin"
+        path.write_bytes(stream)
+        offline, offline_report = decode_full_records(path, height=3)
+
+        decoder = StreamingFrameDecoder(height=3)
+        _feed(decoder, stream, 4_096)
+        decoded, _ = decoder.finish()
+
+        np.testing.assert_array_equal(offline, decoded)
+        assert offline_report["padding_1_3_counter_dialect"] == "ebde-prefixed"
+
+    @pytest.mark.parametrize(
+        "corrupt_word_offset,match",
+        [
+            (110_840 // 2, "padding 1 counter train mismatch"),
+            (110_840 // 2 + 4, "padding 1 counter train mismatch"),
+            (207_096 // 2, "padding 3 counter train mismatch"),
+            (207_872 // 2 - 1, "padding 3 counter train mismatch"),
+        ],
+        ids=["pad1-sentinel", "pad1-train-head", "pad3-sentinel", "pad3-train-tail"],
+    )
+    def test_corrupt_ebde_prefixed_padding_fails_closed(
+        self, corrupt_word_offset: int, match: str
+    ) -> None:
+        _base, full = _synthetic_full_records(height=5)  # 3 records
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+            _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        full[1, corrupt_word_offset] ^= 1
+        decoder = StreamingFrameDecoder(height=5)
+
+        with pytest.raises(ValueError, match=match):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
+
+    def test_mixed_ebde_and_canonical_padding_dialects_fail_closed(self) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        decoder = StreamingFrameDecoder(height=3)
+
+        with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
+
+    def test_cross_record_ebde_dialect_change_fails_closed(self) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        record = full[1]
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        decoder = StreamingFrameDecoder(height=3)
+
+        with pytest.raises(
+            ValueError, match="dialect changed at record 1: canonical -> ebde-prefixed"
+        ):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
 
     @pytest.mark.parametrize(
         "corrupt_word_offset,match",

--- a/coolscanpy/uv.lock
+++ b/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/docs/HARDWARE-SUPPORT.md
+++ b/docs/HARDWARE-SUPPORT.md
@@ -4,7 +4,7 @@ This is the canonical ScanStudio hardware-support matrix. It records what the
 project has actually observed at four separate boundaries; a built package or
 an enumerated USB device is not evidence that preview or capture works.
 
-Current published release: [v0.7.0-beta.12](releases/v0.7.0-beta.12.md).
+Latest release notes: [v0.7.0-beta.13](releases/v0.7.0-beta.13.md).
 
 | Host and scanner | Package built | Device enumerated | Preview exercised | One-frame capture validated | Support / next evidence |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/releases/v0.7.0-beta.13.md
+++ b/docs/releases/v0.7.0-beta.13.md
@@ -10,6 +10,11 @@ verification around real project persistence.
   This fixes the `The parameter is incorrect` failure reproduced on NTFS
   during project creation (#100), while retaining locked directory authority
   and create-only publication. Native Windows persistence now runs in CI.
+- Windows output publication shares the native rename helper with manifests.
+  Private output files request creation access, directory flushes request
+  write access, and filename-collision probes close their deleted handles
+  before checking for unexpected entries. WSL infrared and meter sidecar
+  names retain Linux separators when validated by the Windows engine.
 - Project creation is strictly create-only. An existing manifest is refused
   with `PROJECT_ALREADY_EXISTS`, preserving projects with or without scan
   receipts instead of silently overwriting them (#99).

--- a/docs/releases/v0.7.0-beta.13.md
+++ b/docs/releases/v0.7.0-beta.13.md
@@ -6,6 +6,10 @@ verification around real project persistence.
 
 ## Everything that changed
 
+- Windows project publication uses the native handle-relative rename API.
+  This fixes the `The parameter is incorrect` failure reproduced on NTFS
+  during project creation (#100), while retaining locked directory authority
+  and create-only publication. Native Windows persistence now runs in CI.
 - Project creation is strictly create-only. An existing manifest is refused
   with `PROJECT_ALREADY_EXISTS`, preserving projects with or without scan
   receipts instead of silently overwriting them (#99).
@@ -78,9 +82,9 @@ the GPL bridge/driver corresponding source and applicable license notices.
 Physical validation on additional scanners, firmware, adapters, and operating
 systems remains outstanding. USB LS-40/LS-50 and FireWire models do not gain
 full scanning support in this release. No unattended hardware test was run
-for this audit. The Windows storage report in #100 and the post-preview film
-status report in #77 require comparison against the verified current build;
-this release does not claim to reproduce every affected field setup.
+for this audit. The post-preview film-status report in #77 still requires
+physical reproduction. The NTFS failure in #100 was reproduced and fixed;
+other storage configurations have not been exhaustively validated.
 
 Raw negative export remains unavailable on the Windows/WSL path. Real
 black-and-white fine scanning and optional host-SANE operations retain their

--- a/docs/releases/v0.7.0-beta.13.md
+++ b/docs/releases/v0.7.0-beta.13.md
@@ -1,0 +1,88 @@
+# ScanStudio v0.7.0-beta.13
+
+This prerelease brings the completed issue-audit fixes into the release line,
+adds the observed EBDE scanner-padding dialect, and strengthens package
+verification around real project persistence.
+
+## Everything that changed
+
+- Project creation is strictly create-only. An existing manifest is refused
+  with `PROJECT_ALREADY_EXISTS`, preserving projects with or without scan
+  receipts instead of silently overwriting them (#99).
+- Failed scans retain bounded transport witnesses and per-frame attempt
+  evidence. Both clients can explain the failure using that evidence;
+  diagnostic exports redact private fields and bound evidence references
+  (#76, #98, #106).
+- Meter-controller failures have typed, journaled refusal details, and
+  unknown SANE scanner identities cannot enter a supported motion path
+  (#101, #103).
+- Windows hardware-session ownership and process cleanup are hardened;
+  ordinary launches retain their separate unarmed behavior (#75).
+- Linear DNG infrared SubIFDs use the TIFF/EP LONG pointer type and a
+  standard image-description marker. TIFF infrared markers use tag 65010;
+  readers still accept legacy tag 65001. Stored image samples are unchanged
+  (#105).
+- Scanner-contract documentation, recovery guidance, and the hardware/OS
+  support matrix agree with the implemented capabilities (#29, #102).
+- Publication requires successful same-run verification of the exact tagged
+  commit and rechecks the remote tag object before publishing (#104).
+- CoolscanPy 0.7.5 accepts the exact EBDE-prefixed LS-5000 padding-counter
+  dialect in offline and streaming decoding, while rejecting malformed
+  padding. ScanStudio's driver generation matches the standalone package.
+- The relocated Mac package and both Windows package layouts exercise
+  project creation, mutation, reopening, and overwrite refusal using paths
+  containing spaces and #. Windows also runs this check before packaging.
+- Tauri build-tool downloads use hash-verified release URLs instead of
+  rate-limited unauthenticated API endpoints. The AppImage plugin is pinned
+  to a versioned release instead of a deleted continuous-build asset.
+- The DNG plan's TIFF marker references and the Mac developer README's
+  support-stage description match the implementation and support matrix.
+- The signing rehearsal's runtime probe disables Python bytecode writes,
+  uses an absolute library path, and re-verifies the signature afterward.
+  This prevents the check itself from modifying a notarized app bundle.
+- The hardware matrix labels its version link as release notes, so preparing
+  the next release does not incorrectly claim it is already published.
+
+## Validation
+
+- Apple Silicon local validation passed the Rust engine suite (529 unit
+  tests plus integration suites), 78 XCTest tests and 502 Swift Testing
+  tests, the bridge and CoolscanPy suites, 464 Tauri UI tests, the Tauri
+  production build, and Tauri Rust unit/integration tests.
+- The Developer ID-signed Mac app passed relocation, bundled-runtime,
+  launcher, project-persistence, and seeded updater verification. A manual
+  simulator session acquired six previews, saved a project, scanned one
+  frame, and persisted all three output files with matching SHA-256 receipts.
+- The tagged release workflow independently gates publication on native
+  Mac architecture builds, the macOS 14 runtime floor, updater checks, and
+  Windows/Linux package verification. A failed or skipped prerequisite
+  prevents publication.
+
+## Platform support and installation
+
+- Apple Silicon macOS: Beta, with real-film validation limited to the
+  documented LS-5000 setup. This audit's interactive scan was simulated.
+- Intel macOS: Preview; package checks do not establish real-scanner support.
+- Windows x64: Preview through WSL2 Ubuntu 24.04 and usbipd-win. Use the
+  documented Hardware Session launcher for explicit hardware operations.
+- Linux x64: Preview; requires the documented runtime packages and device
+  permissions. Real-scanner validation remains limited.
+
+macOS requires version 14 or later. Release DMGs are Developer ID signed,
+notarized, and stapled by the release workflow. Choose the DMG matching the
+Mac architecture. Windows and Linux packages remain unsigned. Bundles include
+the GPL bridge/driver corresponding source and applicable license notices.
+
+## Known limitations
+
+Physical validation on additional scanners, firmware, adapters, and operating
+systems remains outstanding. USB LS-40/LS-50 and FireWire models do not gain
+full scanning support in this release. No unattended hardware test was run
+for this audit. The Windows storage report in #100 and the post-preview film
+status report in #77 require comparison against the verified current build;
+this release does not claim to reproduce every affected field setup.
+
+Raw negative export remains unavailable on the Windows/WSL path. Real
+black-and-white fine scanning and optional host-SANE operations retain their
+documented limits. A simulator result is not evidence of physical scanner
+operation.

--- a/docs/reviews/2026-09-06-adversarial-ux.md
+++ b/docs/reviews/2026-09-06-adversarial-ux.md
@@ -1,0 +1,65 @@
+# Adversarial desktop UX review — 2026-09-06
+
+Method: independent native source assessment (Feynman), Tauri assessment and detector (Boyle), and parent-led native interaction/state-machine testing. The baseline is ScanStudio v0.7.0-beta.13. This report describes subsequent fixes on `codex/adversarial-ux-review`; those fixes are not part of the published beta.13 assets.
+
+## Findings and disposition
+
+| Priority | Finding and triggering scenario | Correction |
+| --- | --- | --- |
+| P1 | Open or create a project while preview acquisition is active: the project changes, and opening clears the UI's active preview state before the operation finishes. | Shared model/UI project-change guard preserves active preview ownership. The reverse overlap, starting preview while opening a project, is rejected too. |
+| P1 | On a 1,024-point Mac desktop, fixed sidebar + workspace + inspector widths put most Batch Settings offscreen. | Compact layouts move the sidebar into a labeled popover, retain the inspector, and allow the scan footer to scroll. Project dialogs are presented from the window, keeping them onscreen. |
+| P1 | Native frame detail offers Final and Before Repair, but both load the same scanner thumbnail. | Remove the false comparison. Label the available image Scanner Preview and retain the separate defect overlay. |
+| P1 | Tauri Capture selected has no return action; a new project can retain the previous local scan panel. | Add Back to film when the session is idle and reset capture state at project/job boundaries. |
+| P1 | Tauri inspection without a thumbnail shows Loading preview forever and omits Close, though no preview was requested. | Keep Close in every state. Show loading only for an active preview; otherwise explain how to acquire one. |
+| P1 | A failed Tauri Stop request rejects a discarded promise and gives the operator no feedback. | Show pending, acknowledged, and error states; prevent duplicate pending requests and retain retry access. |
+| P1 | Navigate away, change the store, and return: module-level snapshot caches can display the previous session state because their listeners were absent. | Invalidate every affected snapshot cache on subscription so React's post-subscription check sees current state. |
+| P2 | After a partial scan, Check remaining frames fetches and discards its result; a separate panel asks users to load data already requested by its parent. | One pending-frames panel owns loading, visible errors, refresh, and resume. Its state resets for a new job. |
+| P2 | Tauri frame tiles expose visual selection only, leaving assistive technology unable to identify included frames. | Expose each tile's state through `aria-pressed`. |
+| P2 | Mac New/Open Project before previewing repeats prerequisites and has no visible Cancel. Open Recent exposes internal process identifiers and UTC timestamps without loading/submission feedback. | Present one prerequisite explanation, a visible Cancel, readable film/date labels, loading/opening feedback, and a reload action. Prevent duplicate submissions. Escape already worked in the baseline, so this was not a complete modal trap. |
+| P2 | Opening an unsaved native preview automatically requests project-only defect analysis and shows an error even though preview editing is allowed. | Run analysis and expose project-only editing only after saving; retain preview zoom, pan, and transforms before saving. |
+| P2 | Native keyboard users can zoom but cannot pan to off-center image details. | Add focus-scoped arrow-key panning, named accessibility actions, and viewport bounds. |
+| P2 | The native update heading uses fixed amber text over a pale amber background in Light appearance. Token arithmetic gives about 1.95:1 contrast over white. | Use semantic primary text, preserving amber for decoration. The baseline estimate was calculated, not sampled from native pixels. |
+| P2 | Native Stop Scan suggests an immediate real-scanner abort, but the real backend always translates it to stopping after the current frame. | Label real-device behavior Stop after frame. Immediate Stop remains simulator-only. |
+
+The native state-machine regression failed before the fix for both create and open, including proof that opening set `isAcquiringThumbnails` to false. Tauri characterization/regression checks reproduced navigation, missing-preview, stop, resume, and remount failures. Fixes preserve explicit physical-motion authorization and do not add a new rendering or repair pipeline.
+
+## Native design assessment
+
+The interface is specific to film scanning: the contact sheet, holder identity, frame overrides, and hardware readiness provide useful structure. Preserve the explicit simulator label, honest indeterminate hardware progress, preview-versus-output distinction, contextual error guidance, and existing adaptive contact-sheet header.
+
+Baseline heuristic scores (0–4, before fixes):
+
+| Heuristic | Score |
+| --- | ---: |
+| Visibility of system status | 3 |
+| Match with the real world | 2 |
+| User control and freedom | 2 |
+| Consistency and standards | 3 |
+| Error prevention | 3 |
+| Recognition rather than recall | 2 |
+| Flexibility and efficiency | 2 |
+| Aesthetic and minimalist design | 2 |
+| Error recovery | 3 |
+| Help and documentation | 2 |
+| Total | 24/40 |
+
+This is a baseline qualitative assessment, not a measured post-fix score. Scan Settings remains dense; presets and grouped sections reduce that load. No additional redesign was justified by the bounded review.
+
+## Detector and verification scope
+
+The Tauri detector scanned the actual frontend source and reported zero errors and one warning: the setup checker's three-pixel status border. This is a literal style match without a demonstrated usability failure, so it was retained. Browser inspection reached the frontend shell; native Tauri APIs were unavailable in that browser. No browser overlay was claimed.
+
+Native checks used the released DMG to establish baseline behavior and a locally built development app to verify corrections. The corrected compact layout, sidebar access, centered project dialog, visible Cancel, recent-project labels, project opening, and scan footer were inspected on the 1,024-point display.
+
+Final automated and interaction results are recorded below after integration. Hardware motion was not performed. Existing hardware-validation issues #77, #23, #25, #27, and #28 remain dependent on physical scanner evidence. Displays narrower than 980 points remain outside the native app's supported minimum.
+
+## Final results
+
+- Swift: 78 XCTest tests and 506 Swift Testing tests passed. Final native executable builds successfully.
+- Tauri: 473 frontend tests passed with six environment-gated tests skipped in the full run. All six were then enabled against the bundled simulator-only engine: all 17 tests across the three subprocess test files passed.
+- Tauri typecheck and production build passed.
+- Vendor synchronization and diff-integrity checks passed.
+- Live Mac verification confirmed the compact layout, window-owned project sheet, readable recent list, visible cancellation, accessible scan footer, honest Scanner Preview label, unsaved preview without the automatic error, and actual arrow-key pan in both directions. Named accessibility pan actions also moved the image. The native move-command handler was used after live key delivery exposed that the initial key-press approach did not pan.
+- The unsaved-project defect selector is disabled until a project exists. Per-frame project settings and metadata actions remain available after saving.
+
+No claim is made that this finite review proves the absence of every bug. No physical scanner behavior or Light-appearance update announcement was exercised live in this pass; those fixes were checked against their backend contract and semantic appearance behavior respectively. Original uncommitted changes in the separate ScanStudio checkout were preserved.

--- a/ports/tauri/app/src/App.tsx
+++ b/ports/tauri/app/src/App.tsx
@@ -14,6 +14,7 @@ let cachedStore: unknown = null;
 let cachedSnapshot: Readonly<SessionState> | null = null;
 
 function stableSubscribe(listener: () => void): () => void {
+  cachedSnapshot = null;
   const unsubscribe = sessionStore.subscribe(() => {
     cachedSnapshot = null;
     listener();
@@ -92,6 +93,8 @@ function App() {
           )}
           {workspace.kind === "capture" && (
             <CaptureWorkflowView
+              key={state.project?.id ?? "no-project"}
+              onBack={() => setWorkspace({ kind: "contact" })}
               selectedFrames={selectedFrames}
               onRequestConnect={() => setWorkspace({ kind: "contact" })}
               onOpenFrameDetail={(frameIndex) => setWorkspace({ kind: "frame-detail", frameIndex })}

--- a/ports/tauri/app/src/__tests__/App.test.tsx
+++ b/ports/tauri/app/src/__tests__/App.test.tsx
@@ -138,6 +138,9 @@ describe("App release surfaces", () => {
           return { result: { project: PROJECT, directory: "/tmp/app-real" } };
         }
         if (method === "scan.start") return { result: { jobId: "job-real-1" } };
+        if (method === "project.pendingFrames") {
+          return {result: {frames: [], totalFrames: 36, completedCount: 36, excludedCount: 0}};
+        }
         if (method === "scan.stop") {
           return { result: { acknowledged: true, mode: "afterCurrentFrame" } };
         }
@@ -172,10 +175,27 @@ describe("App release surfaces", () => {
     const scanStartCall = calls.find((call) => call.method === "scan.start");
     expect((scanStartCall?.params.recipe as { multisamplePasses?: number })?.multisamplePasses).toBe(4);
     const setup = screen.getByTestId("windows-setup-action");
+    const back = screen.getByRole("button", { name: "Back to film" });
+    expect(back).toBeDisabled();
+    await user.click(back);
+    expect(calls.filter((call) => call.method === "scan.start")).toHaveLength(1);
+    expect(calls.filter((call) => call.method === "scan.stop")).toHaveLength(0);
     expect(setup).toBeDisabled();
     await user.click(setup);
     expect(screen.queryByTestId("setup-checker")).toBeNull();
     expect(screen.getByTestId("stop-after-current")).toBeVisible();
+    act(() => {
+      handle.emitEvent({
+        event: "scan.completed",
+        payload: {jobId: "job-real-1", summary: {completed: [1], failed: [], skipped: [], stopped: false}},
+      });
+    });
+    await user.click(screen.getByRole("button", {name: "Back to film"}));
+    expect(screen.getByTestId("contact-grid")).toBeInTheDocument();
+    await user.click(screen.getByTestId("capture-action"));
+    expect(screen.getByTestId("scan-setup-view")).toBeInTheDocument();
+    expect(calls.filter((call) => call.method === "scan.start")).toHaveLength(1);
+    expect(calls.filter((call) => call.method === "scan.stop")).toHaveLength(0);
   });
 
   it("leaves Windows setup if a real-hardware job becomes active while setup is open", async () => {
@@ -312,5 +332,9 @@ describe("App shell reachability (06-03 Task 2)", () => {
     const captureButton = await screen.findByTestId("capture-action");
     await user.click(captureButton);
     expect(await screen.findByTestId("capture-workflow-view")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Back to film" }));
+    expect(screen.getByTestId("contact-grid")).toBeInTheDocument();
+    expect(store.getState().selectedFrameIndices).toHaveLength(36);
+    expect(parseCalls.filter((call) => ["scan.start", "scan.stop"].includes(call.method))).toEqual([]);
   });
 });

--- a/ports/tauri/app/src/views/Capture/CaptureWorkflowView.tsx
+++ b/ports/tauri/app/src/views/Capture/CaptureWorkflowView.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { useSyncExternalStore } from "react";
 import { sessionStore, type SessionState } from "../../session";
-import type { ResolvedCaptureRecipe } from "../../session/store/session";
+import { sessionOperationBusy, type ResolvedCaptureRecipe } from "../../session/store/session";
 import type {
   OutputRecipe,
-  PendingFramesResult,
   ProcessingRecipe,
 } from "../../session/wire/types";
 import ScanSetupView from "../ScanSetup/ScanSetupView";
@@ -43,17 +42,18 @@ const TERMINAL_JOB_STATES = ["completed", "stopped", "failed"];
 export interface CaptureWorkflowViewProps {
   selectedFrames: number[];
   onRequestConnect: () => void;
+  onBack?: () => void;
   onOpenFrameDetail?: (frameIndex: number) => void;
 }
 
 export default function CaptureWorkflowView({
   selectedFrames,
   onRequestConnect,
+  onBack,
   onOpenFrameDetail,
 }: CaptureWorkflowViewProps) {
   const state = useSyncExternalStore(stableSubscribe, stableGetSnapshot);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
-  const [pending, setPending] = useState<PendingFramesResult | null>(null);
   const [lastRecipes, setLastRecipes] = useState<
     | { capture: ResolvedCaptureRecipe; processing?: ProcessingRecipe; output?: OutputRecipe }
     | undefined
@@ -71,44 +71,42 @@ export default function CaptureWorkflowView({
     [],
   );
 
-  // After a terminal job, surface the pending-frames panel with the engine's
-  // authoritative remaining set.
   useEffect(() => {
-    if (!jobTerminal) return;
-    void sessionStore
-      .pendingFrames()
-      .then((result) => setPending(result))
-      .catch(() => setPending(null));
-  }, [jobTerminal]);
-
-  // A job already active in the store (e.g. restored session) drives the run
-  // view directly.
-  useEffect(() => {
-    if (state.jobId !== null && state.jobState !== null && !jobTerminal) {
+    if (state.jobId === null) {
+      setActiveJobId(null);
+      setLastRecipes(undefined);
+    } else if (state.jobState !== null && !TERMINAL_JOB_STATES.includes(state.jobState)) {
       setActiveJobId(state.jobId);
     }
-  }, [state.jobId, state.jobState, jobTerminal]);
+  }, [state.jobId, state.jobState]);
+
+  const back = onBack === undefined ? null : (
+    <button
+      type="button"
+      className={styles.controlButton}
+      disabled={sessionOperationBusy(state)}
+      onClick={() => {
+        if (!sessionOperationBusy(sessionStore.getState())) onBack();
+      }}
+    >
+      Back to film
+    </button>
+  );
 
   // Once a job has started, keep the run panel mounted (even at a terminal
   // state — the terminal summary drives the skipped badging and the pending
   // panel appears beneath it).
-  if (activeJobId !== null) {
+  if (activeJobId !== null && activeJobId === state.jobId) {
     return (
       <div className={styles.shell} data-testid="capture-workflow-run">
-        <ScanRunView jobId={activeJobId} />
-        {jobTerminal && pending !== null && pending.frames.length > 0 && (
+        {back}
+        <ScanRunView key={`run-${activeJobId}`} jobId={activeJobId} />
+        {jobTerminal && (
           <PendingFramesPanel
+            key={`pending-${activeJobId}`}
             recipes={lastRecipes}
-            onResumed={(jobId) => {
-              setActiveJobId(jobId);
-              setPending(null);
-            }}
+            onResumed={setActiveJobId}
           />
-        )}
-        {jobTerminal && pending !== null && pending.frames.length === 0 && (
-          <p className={styles.doneNote} data-testid="capture-workflow-done">
-            All frames captured.
-          </p>
         )}
       </div>
     );
@@ -116,6 +114,7 @@ export default function CaptureWorkflowView({
 
   return (
     <div className={styles.shell} data-testid="capture-workflow-view">
+      {back}
       <ScanSetupView
         selectedFrames={selectedFrames}
         onScanStarted={onScanStarted}
@@ -125,7 +124,7 @@ export default function CaptureWorkflowView({
         type="button"
         className={styles.controlButton}
         data-testid="open-frame-detail"
-        disabled={selectedFrames.length !== 1}
+        disabled={selectedFrames.length !== 1 || sessionOperationBusy(state)}
         onClick={() => {
           if (onOpenFrameDetail !== undefined && selectedFrames.length === 1) {
             onOpenFrameDetail(selectedFrames[0]);

--- a/ports/tauri/app/src/views/Capture/__tests__/CaptureWorkflowView.gates.test.tsx
+++ b/ports/tauri/app/src/views/Capture/__tests__/CaptureWorkflowView.gates.test.tsx
@@ -298,3 +298,25 @@ describe("CaptureWorkflowView gates", () => {
     expect(screen.getByTestId("scan-run-ticker-list").textContent).toContain("FEED_JAM");
   });
 });
+
+
+it("loads remaining frames once, refreshes visibly, and clears the run on project creation", async () => {
+  const fixture = await gatesFixture();
+  completePreview(fixture, {1:false,2:false,3:false});
+  mocks.sessionStore = fixture.store;
+  const user = userEvent.setup();
+  render(<CaptureWorkflowView selectedFrames={[1,2,3]} onRequestConnect={() => undefined} />);
+  await user.click(screen.getByTestId("start-scan"));
+  act(() => fixture.emitEvent({event:"scan.completed",payload:{jobId:"job-1",summary:{completed:[1],failed:[],skipped:[2,3],stopped:true}}}));
+  expect(await screen.findByRole("button", {name:"Scan remaining (2)"})).toBeEnabled();
+  expect(fixture.calls.filter(c => c.method === "project.pendingFrames")).toHaveLength(1);
+  vi.spyOn(fixture.store, "pendingFrames").mockResolvedValue({frames:[],totalFrames:36,completedCount:36,excludedCount:0});
+  await user.click(screen.getByRole("button", {name:"Check remaining frames"}));
+  expect(await screen.findByText("All frames captured.")).toBeInTheDocument();
+  expect(screen.queryByRole("button", {name:/Scan remaining/})).toBeNull();
+  await act(async () => { await fixture.store.createProject("Gate Roll","roll36",36,"c41ColorNegative"); });
+  expect(screen.queryByTestId("scan-run-view")).toBeNull();
+  expect(screen.getByTestId("scan-setup-view")).toBeInTheDocument();
+  expect(fixture.calls.filter(c => c.method === "scan.start")).toHaveLength(1);
+  expect(fixture.calls.filter(c => c.method === "scan.stop")).toHaveLength(0);
+});

--- a/ports/tauri/app/src/views/ContactSheet.tsx
+++ b/ports/tauri/app/src/views/ContactSheet.tsx
@@ -19,6 +19,7 @@ let cachedStore: unknown = null;
 let cachedSnapshot: Readonly<SessionState> | null = null;
 
 function stableSubscribe(listener: () => void): () => void {
+  cachedSnapshot = null;
   const unsubscribe = sessionStore.subscribe(() => {
     cachedSnapshot = null;
     listener();
@@ -589,6 +590,7 @@ export default function ContactSheet({ onInspectFrame, onCapture }: ContactSheet
                 key={frameIndex}
                 type="button"
                 className={tileClass}
+                aria-pressed={selected}
                 data-testid={`contact-tile-${frameIndex}`}
                 data-rotation={derivativeTransform.rotationDegrees}
                 data-horizontal-mirror={derivativeTransform.horizontalMirror}

--- a/ports/tauri/app/src/views/DeviceBar.tsx
+++ b/ports/tauri/app/src/views/DeviceBar.tsx
@@ -17,6 +17,7 @@ let cachedStore: unknown = null;
 let cachedSnapshot: Readonly<SessionState> | null = null;
 
 function stableSubscribe(listener: () => void): () => void {
+  cachedSnapshot = null;
   const unsubscribe = sessionStore.subscribe(() => {
     cachedSnapshot = null;
     listener();

--- a/ports/tauri/app/src/views/FrameDetail/ApprovalPanel.tsx
+++ b/ports/tauri/app/src/views/FrameDetail/ApprovalPanel.tsx
@@ -10,6 +10,7 @@ let cachedStore: unknown = null;
 let cachedSnapshot: Readonly<SessionState> | null = null;
 
 function stableSubscribe(listener: () => void): () => void {
+  cachedSnapshot = null;
   const unsubscribe = sessionStore.subscribe(() => {
     cachedSnapshot = null;
     listener();

--- a/ports/tauri/app/src/views/FrameDetail/FrameDetailView.tsx
+++ b/ports/tauri/app/src/views/FrameDetail/FrameDetailView.tsx
@@ -22,6 +22,7 @@ let cachedStore: unknown = null;
 let cachedSnapshot: Readonly<SessionState> | null = null;
 
 function stableSubscribe(listener: () => void): () => void {
+  cachedSnapshot = null;
   const unsubscribe = sessionStore.subscribe(() => {
     cachedSnapshot = null;
     listener();
@@ -143,29 +144,38 @@ export default function FrameDetailView({
       .catch(() => setDefectResult(null));
   }, [frameIndex, defectRecipeKey]);
 
+  const header = (
+    <header className={styles.header}>
+      <h2 className={styles.heading}>Frame {frameIndex}</h2>
+      {onClose !== undefined && (
+        <button
+          type="button"
+          className={styles.controlButton}
+          data-testid="frame-detail-close"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      )}
+    </header>
+  );
+
   if (thumbnail === undefined) {
     return (
       <div className={styles.frameDetail} data-testid="frame-detail-loading">
-        <p className={styles.loadingText}>Loading preview for frame {frameIndex}…</p>
+        {header}
+        <p className={styles.loadingText} role="status">
+          {state.previewOutcome === "active"
+            ? `Loading preview for frame ${frameIndex}…`
+            : `No preview for frame ${frameIndex}. Close this view and choose Preview from the film view.`}
+        </p>
       </div>
     );
   }
 
   return (
     <div className={styles.frameDetail} data-testid="frame-detail-view">
-      <header className={styles.header}>
-        <h2 className={styles.heading}>Frame {frameIndex}</h2>
-        {onClose !== undefined && (
-          <button
-            type="button"
-            className={styles.controlButton}
-            data-testid="frame-detail-close"
-            onClick={onClose}
-          >
-            Close
-          </button>
-        )}
-      </header>
+      {header}
       <div className={styles.previewStack} data-testid="preview-stack">
         <ZoomPanViewer
           imagePath={thumbnail.imagePath}

--- a/ports/tauri/app/src/views/FrameDetail/SpacingOffsetControl.tsx
+++ b/ports/tauri/app/src/views/FrameDetail/SpacingOffsetControl.tsx
@@ -12,6 +12,7 @@ let cachedStore: unknown = null;
 let cachedSnapshot: Readonly<SessionState> | null = null;
 
 function stableSubscribe(listener: () => void): () => void {
+  cachedSnapshot = null;
   const unsubscribe = sessionStore.subscribe(() => {
     cachedSnapshot = null;
     listener();

--- a/ports/tauri/app/src/views/FrameDetail/__tests__/ApprovalPanel.test.tsx
+++ b/ports/tauri/app/src/views/FrameDetail/__tests__/ApprovalPanel.test.tsx
@@ -182,3 +182,17 @@ describe("ApprovalPanel", () => {
     expect(items.map((item) => item.textContent)).toEqual(warnings);
   });
 });
+
+
+it("refreshes approval after a same-store remount with missed notifications", async () => {
+  const fixture = await approvalFixture();
+  previewThumbnail(fixture, 2, { brightness: 0.5, needsApproval: true });
+  mocks.sessionStore = fixture.store;
+  const view = render(<ApprovalPanel frameIndex={2} />);
+  expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled();
+  view.unmount();
+  await fixture.store.approveFrame(2);
+  render(<ApprovalPanel frameIndex={2} />);
+  expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
+  expect(screen.queryByTestId("approval-needs-badge")).toBeNull();
+});

--- a/ports/tauri/app/src/views/FrameDetail/__tests__/FrameDetailView.test.tsx
+++ b/ports/tauri/app/src/views/FrameDetail/__tests__/FrameDetailView.test.tsx
@@ -211,3 +211,31 @@ describe("FrameDetailView", () => {
     expect(screen.getByTestId("defect-marker-7")).toBeInTheDocument();
   });
 });
+
+
+it("keeps Close available for missing previews without requesting hardware motion", async () => {
+  const fixture = await detailFixture();
+  mocks.sessionStore = fixture.store;
+  const onClose = vi.fn();
+  const user = userEvent.setup();
+  const before = fixture.calls.filter(c => c.method === "scanner.acquireThumbnails").length;
+  render(<FrameDetailView frameIndex={5} onClose={onClose} />);
+  await user.click(screen.getByRole("button", { name: "Close" }));
+  expect(onClose).toHaveBeenCalledOnce();
+  expect(fixture.calls.filter(c => c.method === "scanner.acquireThumbnails")).toHaveLength(before);
+});
+
+
+it("does not call a failed preview loading while its operation token awaits completion", async () => {
+  const fixture = await detailFixture();
+  mocks.sessionStore = fixture.store;
+  render(<FrameDetailView frameIndex={5} onClose={() => undefined} />);
+  expect(screen.getByRole("status")).toHaveTextContent("Loading preview for frame 5");
+  act(() => fixture.emitEvent({
+    event: "scanner.thumbnailsFailed",
+    payload: { operationId: fixture.operationId, code: "FEED_JAM", message: "Film did not advance" },
+  }));
+  expect(fixture.store.getState().activeOperationId).toBe(fixture.operationId);
+  expect(screen.getByRole("status")).toHaveTextContent("No preview for frame 5");
+  expect(screen.getByRole("button", { name: "Close" })).toBeEnabled();
+});

--- a/ports/tauri/app/src/views/FrameDetail/__tests__/SpacingOffsetControl.test.tsx
+++ b/ports/tauri/app/src/views/FrameDetail/__tests__/SpacingOffsetControl.test.tsx
@@ -280,3 +280,16 @@ describe("SpacingOffsetControl", () => {
     );
   });
 });
+
+
+it("refreshes the confirmed offset after a same-store remount with missed notifications", async () => {
+  const fixture = await offsetFixture();
+  previewThumbnail(fixture, 2, { brightness: 0.5, spacingOffset: 0 });
+  mocks.sessionStore = fixture.store;
+  const view = render(<SpacingOffsetControl frameIndex={2} />);
+  expect(screen.getByTestId("spacing-offset-input")).toHaveValue(0);
+  view.unmount();
+  await fixture.store.setSpacingOffset(2, 25);
+  render(<SpacingOffsetControl frameIndex={2} />);
+  expect(screen.getByTestId("spacing-offset-input")).toHaveValue(25);
+});

--- a/ports/tauri/app/src/views/ProjectPanel.tsx
+++ b/ports/tauri/app/src/views/ProjectPanel.tsx
@@ -17,6 +17,7 @@ let cachedStore: unknown = null;
 let cachedSnapshot: Readonly<SessionState> | null = null;
 
 function stableSubscribe(listener: () => void): () => void {
+  cachedSnapshot = null;
   const unsubscribe = sessionStore.subscribe(() => {
     cachedSnapshot = null;
     listener();

--- a/ports/tauri/app/src/views/ScanRun/PendingFramesPanel.tsx
+++ b/ports/tauri/app/src/views/ScanRun/PendingFramesPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { ResolvedCaptureRecipe } from "../../session/store/session";
 import type {
   CaptureRecipe,
@@ -26,18 +26,24 @@ export default function PendingFramesPanel({ onResumed, recipes }: PendingFrames
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const refresh = async (): Promise<void> => {
+  const [refreshCount, setRefreshCount] = useState(0);
+  const [checking, setChecking] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setChecking(true);
     setError(null);
-    try {
-      const result = await sessionStore.pendingFrames();
-      setPending(result);
-    } catch (reason) {
-      setError((reason as { message?: string })?.message ?? "failed to load pending frames");
-    }
-  };
+    void sessionStore.pendingFrames()
+      .then((result) => { if (!cancelled) setPending(result); })
+      .catch((reason) => {
+        if (!cancelled) setError(reason?.message ?? "Failed to load remaining frames. Try checking again.");
+      })
+      .finally(() => { if (!cancelled) setChecking(false); });
+    return () => { cancelled = true; };
+  }, [refreshCount]);
 
   const resume = async (): Promise<void> => {
-    if (pending === null || pending.frames.length === 0) return;
+    if (pending === null || pending.frames.length === 0 || checking || busy || error !== null) return;
     setError(null);
     setBusy(true);
     try {
@@ -70,16 +76,20 @@ export default function PendingFramesPanel({ onResumed, recipes }: PendingFrames
       <div className={styles.pendingRow}>
         <div className={styles.pendingStats} data-testid="pending-frames-stats">
           {pending === null
-            ? "No pending-frames data loaded."
+            ? checking ? "Checking remaining frames…" : "Remaining frames unavailable."
             : `${pending.frames.length} of ${pending.totalFrames} pending · ${pending.completedCount} complete · ${pending.excludedCount} excluded`}
         </div>
         <button
           type="button"
           className={styles.controlButton}
           data-testid="load-pending-frames"
-          onClick={() => void refresh()}
+          disabled={checking || busy}
+          onClick={() => {
+            setChecking(true);
+            setRefreshCount((count) => count + 1);
+          }}
         >
-          Load pending
+          {checking ? "Checking…" : "Check remaining frames"}
         </button>
       </div>
       {pending !== null && pending.frames.length > 0 && (
@@ -87,14 +97,19 @@ export default function PendingFramesPanel({ onResumed, recipes }: PendingFrames
           type="button"
           className={styles.resumeButton}
           data-testid="scan-remaining"
-          disabled={busy}
+          disabled={busy || checking || error !== null}
           onClick={() => void resume()}
         >
           Scan remaining ({pending.frames.length})
         </button>
       )}
+      {pending !== null && pending.frames.length === 0 && !checking && error === null && (
+        <p className={styles.hint} role="status" data-testid="capture-workflow-done">
+          {pending.completedCount === pending.totalFrames ? "All frames captured." : "No frames remaining."}
+        </p>
+      )}
       {error !== null && (
-        <p className={styles.hint} data-testid="pending-frames-error">
+        <p className={styles.hint} role="alert" data-testid="pending-frames-error">
           {error}
         </p>
       )}

--- a/ports/tauri/app/src/views/ScanRun/ScanRunView.tsx
+++ b/ports/tauri/app/src/views/ScanRun/ScanRunView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSyncExternalStore } from "react";
 import { sessionStore, type SessionState } from "../../session";
-import type { JobState, PendingFramesResult } from "../../session/wire/types";
+import type { JobState } from "../../session/wire/types";
 import type { StopMode } from "../../session/store/session";
 import type { EngineError, FrameState } from "../../session/wire/types";
 import type { ScanReceipt } from "../../session/wire/types";
@@ -11,6 +11,7 @@ let cachedStore: unknown = null;
 let cachedSnapshot: Readonly<SessionState> | null = null;
 
 function stableSubscribe(listener: () => void): () => void {
+  cachedSnapshot = null;
   const unsubscribe = sessionStore.subscribe(() => {
     cachedSnapshot = null;
     listener();
@@ -34,7 +35,6 @@ const TICKER_LIMIT = 200;
 
 export interface ScanRunViewProps {
   jobId: string;
-  onResume?: (pending: PendingFramesResult) => void;
 }
 
 interface ProgressTick {
@@ -75,7 +75,7 @@ function receiptDetails(receipt: ScanReceipt): string[] {
   return details;
 }
 
-export default function ScanRunView({ jobId, onResume }: ScanRunViewProps) {
+export default function ScanRunView({ jobId }: ScanRunViewProps) {
   const state = useSyncExternalStore(stableSubscribe, stableGetSnapshot);
   const jobState = state.jobState;
   const frameIndices = useMemo(
@@ -99,6 +99,9 @@ export default function ScanRunView({ jobId, onResume }: ScanRunViewProps) {
   // only when simulated).
   const supportsImmediateStop = state.connection.device?.kind === "simulated";
   const mediaLoaded = state.connection.connected && state.connection.status?.mediaLoaded === true;
+  const [stopPending, setStopPending] = useState(false);
+  const [stopError, setStopError] = useState<string | null>(null);
+  const [stopAcknowledged, setStopAcknowledged] = useState(false);
   const [ejectPending, setEjectPending] = useState(false);
   const [ejectResult, setEjectResult] = useState<"succeeded" | EngineError | null>(null);
   const [recoveryActionError, setRecoveryActionError] = useState<string | null>(null);
@@ -146,12 +149,19 @@ export default function ScanRunView({ jobId, onResume }: ScanRunViewProps) {
   }, [frameIndices, state.frameStates, state.frameErrors]);
 
   const stop = async (mode: StopMode): Promise<void> => {
-    await sessionStore.stopJob(jobId, mode);
-  };
-
-  const loadPending = async (): Promise<void> => {
-    const pending = await sessionStore.pendingFrames();
-    if (onResume !== undefined) onResume(pending);
+    if (stopPending || !jobActive) return;
+    setStopPending(true);
+    setStopError(null);
+    setStopAcknowledged(false);
+    try {
+      const result = await sessionStore.stopJob(jobId, mode);
+      if (!result.acknowledged) throw new Error("Stop was not acknowledged. Try again.");
+      setStopAcknowledged(true);
+    } catch (reason) {
+      setStopError((reason as { message?: string })?.message ?? "Stop request failed. Try again.");
+    } finally {
+      setStopPending(false);
+    }
   };
 
   const retryWithAttendedApproval = async (): Promise<void> => {
@@ -246,11 +256,14 @@ export default function ScanRunView({ jobId, onResume }: ScanRunViewProps) {
       )}
 
       <div className={styles.controls}>
+        {stopPending && <p role="status">Sending stop request…</p>}
+        {stopError !== null && <p className={styles.frameError} role="alert">{stopError}</p>}
+        {!stopPending && stopAcknowledged && <p role="status">Stop request acknowledged.</p>}
         <button
           type="button"
           className={styles.primaryButton}
           data-testid="stop-after-current"
-          disabled={!jobActive}
+          disabled={!jobActive || stopPending}
           onClick={() => void stop("afterCurrentFrame")}
         >
           Stop after current frame
@@ -263,7 +276,7 @@ export default function ScanRunView({ jobId, onResume }: ScanRunViewProps) {
             type="button"
             className={styles.dangerButton}
             data-testid="stop-now"
-            disabled={!jobActive}
+            disabled={!jobActive || stopPending}
             onClick={() => void stop("immediate")}
           >
             Stop now
@@ -288,14 +301,6 @@ export default function ScanRunView({ jobId, onResume }: ScanRunViewProps) {
             {ejectResult.code} — {ejectResult.message}
           </p>
         )}
-        <button
-          type="button"
-          className={styles.controlButton}
-          data-testid="refresh-pending"
-          onClick={() => void loadPending()}
-        >
-          Check remaining frames
-        </button>
       </div>
 
       <div className={styles.frameTable} data-testid="scan-run-frames">

--- a/ports/tauri/app/src/views/ScanRun/__tests__/ScanRunView.test.tsx
+++ b/ports/tauri/app/src/views/ScanRun/__tests__/ScanRunView.test.tsx
@@ -10,6 +10,7 @@ import {
 import { createScriptedTransport } from "../../../session/testing/harness";
 import type { DeviceInfo, EngineError, ScanProject } from "../../../session/wire/types";
 import ScanRunView from "../ScanRunView";
+import PendingFramesPanel from "../PendingFramesPanel";
 import { captureDurationLabel } from "../ScanRunView";
 
 afterEach(cleanup);
@@ -345,17 +346,19 @@ describe("ScanRunView", () => {
     expect(screen.getByTestId("frame-row-3").textContent).not.toContain("failed");
   });
 
-  it("calls pendingFrames and loads remaining frames from the exact returned set", async () => {
+  it("shows a remaining-frame lookup failure and allows a visible retry", async () => {
     const fixture = await runFixture();
     mocks.sessionStore = fixture.store;
+    const pending = vi.spyOn(fixture.store, "pendingFrames")
+      .mockRejectedValueOnce(new Error("Project is unavailable"))
+      .mockResolvedValueOnce({frames:[3,4],totalFrames:36,completedCount:2,excludedCount:0});
     const user = userEvent.setup();
-    render(<ScanRunView jobId="job-1" onResume={vi.fn()} />);
-    await act(async () => {
-      await user.click(screen.getByTestId("refresh-pending"));
-    });
-    const pendingCall = fixture.calls.find((c) => c.method === "project.pendingFrames");
-    expect(pendingCall).toBeDefined();
-    expect(fixture.store.getState().jobId).toBe("job-1");
+    render(<PendingFramesPanel />);
+    expect(await screen.findByRole("alert")).toHaveTextContent("Project is unavailable");
+    await user.click(screen.getByRole("button", {name:"Check remaining frames"}));
+    expect(await screen.findByRole("button", {name:"Scan remaining (2)"})).toBeEnabled();
+    expect(pending).toHaveBeenCalledTimes(2);
+    expect(fixture.calls.filter(c => c.method === "scan.start")).toHaveLength(1);
   });
 
   it("counts scanned frames rather than receipt file types and surfaces alpha.11 provenance", async () => {
@@ -461,4 +464,58 @@ describe("ScanRunView", () => {
     expect(fixture.calls.filter((call) => call.method === "roll.approve")).toHaveLength(5);
     expect(fixture.calls.filter((call) => call.method === "scan.start")).toHaveLength(2);
   });
+});
+
+
+it("reports a rejected stop and allows an acknowledged retry", async () => {
+  const fixture = await runFixture();
+  mocks.sessionStore = fixture.store;
+  const stop = vi.spyOn(fixture.store, "stopJob")
+    .mockRejectedValueOnce({code:"SCANNER_BUSY",message:"Transport unavailable",recoverable:true})
+    .mockResolvedValueOnce({acknowledged:true,mode:"afterCurrentFrame"});
+  const user = userEvent.setup();
+  render(<ScanRunView jobId="job-1" />);
+  await user.click(screen.getByTestId("stop-after-current"));
+  expect(await screen.findByRole("alert")).toHaveTextContent("Transport unavailable");
+  expect(screen.getByTestId("stop-after-current")).toBeEnabled();
+  await user.click(screen.getByTestId("stop-after-current"));
+  expect(await screen.findByRole("status")).toHaveTextContent("Stop request acknowledged");
+  expect(screen.queryByRole("alert")).toBeNull();
+  expect(stop).toHaveBeenCalledTimes(2);
+  expect(stop).toHaveBeenLastCalledWith("job-1", "afterCurrentFrame");
+});
+
+
+it("keeps Stop pending until the request settles and prevents duplicate requests", async () => {
+  const fixture = await runFixture();
+  mocks.sessionStore = fixture.store;
+  let resolveStop!: (result: {acknowledged: boolean; mode: "afterCurrentFrame"}) => void;
+  const stop = vi.spyOn(fixture.store, "stopJob").mockImplementation(() =>
+    new Promise((resolve) => { resolveStop = resolve; }),
+  );
+  const user = userEvent.setup();
+  render(<ScanRunView jobId="job-1" />);
+  const button = screen.getByTestId("stop-after-current");
+  await user.click(button);
+  expect(screen.getByRole("status")).toHaveTextContent("Sending stop request");
+  expect(button).toBeDisabled();
+  await user.click(button);
+  expect(stop).toHaveBeenCalledOnce();
+  await act(async () => { resolveStop({acknowledged: true, mode: "afterCurrentFrame"}); });
+  expect(screen.getByRole("status")).toHaveTextContent("Stop request acknowledged");
+});
+
+
+it("refreshes progress after a same-store remount with missed notifications", async () => {
+  const fixture = await runFixture();
+  mocks.sessionStore = fixture.store;
+  const view = render(<ScanRunView jobId="job-1" />);
+  expect(screen.queryByTestId("scan-run-progress")).toBeNull();
+  view.unmount();
+  fixture.emitEvent({
+    event: "scan.progress",
+    payload: { jobId: "job-1", frameIndex: 1, jobPercent: 75, etaSeconds: 4 },
+  });
+  render(<ScanRunView jobId="job-1" />);
+  expect(screen.getByTestId("scan-run-job-percent")).toHaveTextContent("75%");
 });

--- a/ports/tauri/app/src/views/ScanSetup/ScanSetupView.tsx
+++ b/ports/tauri/app/src/views/ScanSetup/ScanSetupView.tsx
@@ -39,6 +39,7 @@ function stableGetSnapshot(): ReturnType<typeof sessionStore.getState> {
   return cachedSnapshot;
 }
 function stableSubscribe(listener: () => void): () => void {
+  cachedSnapshot = null;
   const unsubscribe = sessionStore.subscribe(() => {
     cachedSnapshot = null;
     listener();

--- a/ports/tauri/app/src/views/__tests__/ContactSheet.test.tsx
+++ b/ports/tauri/app/src/views/__tests__/ContactSheet.test.tsx
@@ -767,3 +767,19 @@ describe("ContactSheet", () => {
     expect(screen.queryByTestId("preview-complete")).toBeNull();
   });
 });
+
+
+it("exposes keyboard selection state for each frame", async () => {
+  const fixture = contactFixture();
+  await fixture.store.loadMedia("roll36");
+  mocks.sessionStore = fixture.store;
+  const user = userEvent.setup();
+  render(<ContactSheet />);
+  const tile = screen.getByTestId("contact-tile-1");
+  expect(tile).toHaveAttribute("aria-pressed", "false");
+  act(() => tile.focus());
+  await user.keyboard(" ");
+  expect(tile).toHaveAttribute("aria-pressed", "true");
+  await user.keyboard(" ");
+  expect(tile).toHaveAttribute("aria-pressed", "false");
+});

--- a/ports/tauri/packaging/install_pinned_tauri_tools.py
+++ b/ports/tauri/packaging/install_pinned_tauri_tools.py
@@ -116,16 +116,10 @@ NSIS_PLUGIN = {
     "sha256": "5ba143b5db4a87d32d6e7802e033330aae56cbceabe0d1e3ba41948385ad4709",
 }
 
-# 2026-08-24: Microsoft rotated the fwlink 2124701 delivery GUID again
-# (previous: 22ced09c-d6bd-4427-a658-f1dc48f3a440, itself a 2026-08-23
-# rotation of eb04ea38-69c8-4b86-b65b-fd4c8469ae59, itself a 2026-08-14
-# rotation of e4dd9b83-b7e3-4d17-8d7c-e14cdd7c3a51); Tauri's bundler
-# resolved the new GUID during the eleven-issue PR's Windows package job,
-# ignored the pinned copy staged under the old path, downloaded a fresh
-# installer into its own cache directory, and the pin gate failed closed
-# on the unexpected directory exactly as designed. New artifact
-# re-verified via the official fwlink redirect before re-pinning.
-WEBVIEW2_GUID = "89620190-81af-46a2-bb59-6228918a312e"
+# 2026-09-06: verified the official fwlink 2124701 redirect and repinned its
+# current installer. Tauri resolves that redirect to choose its cache path;
+# an unexpected rotation must still fail the exact-tree and Authenticode gates.
+WEBVIEW2_GUID = "a8f5ad97-0b01-41e5-9245-e8fc9ba9b311"
 WEBVIEW2_ASSET = {
     "name": "MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
     "url": (
@@ -133,8 +127,8 @@ WEBVIEW2_ASSET = {
         "filestreamingservice/files/"
         f"{WEBVIEW2_GUID}/MicrosoftEdgeWebView2RuntimeInstallerX64.exe"
     ),
-    "size": 213_044_432,
-    "sha256": "358a11cff88ce519301c3b60bcefe848f922688ab0a333fc0f18ddf83bb3b4f3",
+    "size": 258_614_480,
+    "sha256": "e7fa35755196ad9223596ef021a1ce6799509142eaa40ba35f634026be50b831",
 }
 
 WINDOWS_RESERVED_NAMES = {

--- a/ports/tauri/packaging/install_pinned_tauri_tools.py
+++ b/ports/tauri/packaging/install_pinned_tauri_tools.py
@@ -37,8 +37,8 @@ LINUX_ASSETS = (
     {
         "name": "AppRun-x86_64",
         "url": (
-            "https://api.github.com/repos/tauri-apps/binary-releases/"
-            "releases/assets/274691722"
+            "https://github.com/tauri-apps/binary-releases/"
+            "releases/download/apprun-old/AppRun-x86_64"
         ),
         "size": 31_552,
         "sha256": "f30140a43a0a59e46db21bdefdf749b9e9f2c6946e92afabbacf98b8ae73fb4f",
@@ -46,8 +46,8 @@ LINUX_ASSETS = (
     {
         "name": "linuxdeploy-x86_64.AppImage",
         "url": (
-            "https://api.github.com/repos/tauri-apps/binary-releases/"
-            "releases/assets/182515537"
+            "https://github.com/tauri-apps/binary-releases/"
+            "releases/download/linuxdeploy/linuxdeploy-x86_64.AppImage"
         ),
         "size": 13_264_064,
         "sha256": "e762bea85c8eb0d4b3508d46e5c1f037f717d0f9303ae3b4aafc8b04991fa1ef",
@@ -81,19 +81,20 @@ LINUX_ASSETS = (
     {
         "name": "linuxdeploy-plugin-appimage.AppImage",
         "url": (
-            "https://api.github.com/repos/linuxdeploy/"
-            "linuxdeploy-plugin-appimage/releases/assets/497460911"
+            "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/"
+            "releases/download/1-alpha-20250213-1/linuxdeploy-plugin-appimage-x86_64.AppImage"
         ),
-        "size": 16_484_856,
-        "sha256": "a45d3e227bc7f397e9cf6bfa4c9507494efa2293357b6e86690a3de2ca992e79",
+        # Use a versioned release: continuous assets are deleted on replacement.
+        "size": 15_889_136,
+        "sha256": "992d502a248e14ab185448ddf6f6e7d25558cb84d4623c354c3af350c25fccb3",
     },
 )
 
 NSIS_ARCHIVE = {
     "name": "nsis-3.11.zip",
     "url": (
-        "https://api.github.com/repos/tauri-apps/binary-releases/"
-        "releases/assets/317051073"
+        "https://github.com/tauri-apps/binary-releases/"
+        "releases/download/nsis-3.11/nsis-3.11.zip"
     ),
     "size": 2_361_546,
     "sha256": "c7d27f780ddb6cffb4730138cd1591e841f4b7edb155856901cdf5f214394fa1",
@@ -108,8 +109,8 @@ NSIS_BASE_TREE_SHA256 = (
 NSIS_PLUGIN = {
     "name": "nsis_tauri_utils.dll",
     "url": (
-        "https://api.github.com/repos/tauri-apps/nsis-tauri-utils/"
-        "releases/assets/345882097"
+        "https://github.com/tauri-apps/nsis-tauri-utils/"
+        "releases/download/nsis_tauri_utils-v0.5.3/nsis_tauri_utils.dll"
     ),
     "size": 34_304,
     "sha256": "5ba143b5db4a87d32d6e7802e033330aae56cbceabe0d1e3ba41948385ad4709",

--- a/ports/tauri/packaging/linux/build-and-verify.sh
+++ b/ports/tauri/packaging/linux/build-and-verify.sh
@@ -129,6 +129,7 @@ PY
         exit 1
     fi
     npm run sync-engine
+    cargo test --locked --manifest-path ../vendor/engine/Cargo.toml --lib
     npm test
     npx tsc --noEmit
     npm run build

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -815,6 +815,7 @@ try {
     }
     npm run sync-engine
     Invoke-EngineSmoke -Tree (Join-Path $appRoot 'src-tauri\binaries')
+    cargo test --locked --manifest-path ..\vendor\engine\Cargo.toml --lib
     npm test
     npx tsc --noEmit
     npm run build

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -28,13 +28,12 @@ $windowsPowerShell = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\
 $pinnedToolsInstaller = Join-Path $portRoot 'packaging\install_pinned_tauri_tools.py'
 $cargoTarget = Join-Path $appRoot 'src-tauri\target'
 $tauriToolsRoot = Join-Path $cargoTarget '.tauri'
-# 2026-08-24: Microsoft rotated the fwlink 2124701 delivery GUID again
-# (previous: 22ced09c-d6bd-4427-a658-f1dc48f3a440); re-verified via the
-# official fwlink redirect before re-pinning. Moves in lockstep with
-# install_pinned_tauri_tools.py.
-$webViewGuid = '89620190-81af-46a2-bb59-6228918a312e'
+# 2026-09-06: verified the current official fwlink 2124701 redirect.
+# Moves in lockstep with install_pinned_tauri_tools.py; verify Microsoft
+# Authenticode before the bundler or installer consumes these pinned bytes.
+$webViewGuid = 'a8f5ad97-0b01-41e5-9245-e8fc9ba9b311'
 $webViewFileName = 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe'
-$webViewSha256 = '358a11cff88ce519301c3b60bcefe848f922688ab0a333fc0f18ddf83bb3b4f3'
+$webViewSha256 = 'e7fa35755196ad9223596ef021a1ce6799509142eaa40ba35f634026be50b831'
 $nsisPluginSha256 = '5ba143b5db4a87d32d6e7802e033330aae56cbceabe0d1e3ba41948385ad4709'
 $pinnedWebView = Join-Path $tauriToolsRoot "x64\$webViewGuid\$webViewFileName"
 $pinnedMakensis = Join-Path $tauriToolsRoot 'NSIS\makensis.exe'

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -714,6 +714,11 @@ function Invoke-EngineSmoke {
         throw "Expected exactly one engine sidecar under $Tree, found $($engines.Count): $engines"
     }
 
+    # Exercise filesystem operations in both the installed and portable builds
+    # (#100); a hello/list handshake never touches project persistence.
+    & python -I -S -B (Join-Path $portRoot '..\..\scripts\smoke_project_persistence.py') $engines[0].FullName
+    if ($LASTEXITCODE -ne 0) { throw 'Packaged engine project persistence failed' }
+
     $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
     $startInfo.FileName = $engines[0].FullName
     $startInfo.UseShellExecute = $false

--- a/ports/tauri/packaging/windows/build-and-verify.ps1
+++ b/ports/tauri/packaging/windows/build-and-verify.ps1
@@ -814,6 +814,7 @@ try {
         throw "Unexpected Tauri CLI version: $tauriCliVersion"
     }
     npm run sync-engine
+    Invoke-EngineSmoke -Tree (Join-Path $appRoot 'src-tauri\binaries')
     npm test
     npx tsc --noEmit
     npm run build

--- a/ports/tauri/vendor/coolscanpy/CHANGELOG.md
+++ b/ports/tauri/vendor/coolscanpy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.7.5 - 2026-09-06
+
+- Accept the observed EBDE-prefixed LS-5000 padding counter dialect only when the entire padding block matches its exact counter train. Offline and streaming decoding retain strict corruption rejection and identical sample output.
+
 ## 0.7.4 - 2026-08-23
 
 - Linear DNG and raw-export infrared markers moved from private tag

--- a/ports/tauri/vendor/coolscanpy/pyproject.toml
+++ b/ports/tauri/vendor/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py
@@ -57,7 +57,9 @@ CAPTURE_BUNDLE_COMPONENT_SHA256 = {
     # source snapshot, so this cannot silently drift again.
     "usb_backend.py": "77499a606dc48049521d2fd0359a0405cb55525242843d61165b642c78841208",
     "density.py": "c2c47de2886bc4b60197d2721b6d72050a76f1095760590fa7bb34a728b9da76",
-    "packed.py": "856315714e4f7e81f42e1ca93917e4cc0feb03b24915c2ad604302bfdca46f87",
+    # Resealed 2026-08-12 after a complete 2,980-record LS-5000 capture
+    # established the strict EBDE-prefixed padding-counter dialect.
+    "packed.py": "abff893d6ec5ff36aa33be86ef401a28ffbd6054e2279129e8fb88d7f650b435",
     "streaming_sidecar.py": "81ca79a72b37dee579d57be07bd00f59f6e7843a43710bab1811d8b9a94dffb7",
     "continuation_plan.py": "bfdebfaa28075c708f3e8ef070083edce36a28b497bba622173cbb6d1466a282",
     "meter.py": "b03b3212d1ff1f8e3ad8ca7b512765ad6a115d4766e3f3eb5a86de3573076d4e",

--- a/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/packed.py
+++ b/ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/packed.py
@@ -112,11 +112,11 @@ def _counter_train_ok(
 def _padding_counter_dialect(block: np.ndarray) -> str | None:
     """Identify any complete padding counter dialect observed live.
 
-    The original captures begin with the canonical ``AA55,D893`` pair.  Four
+    The original captures begin with the canonical ``AA55,D893`` pair.  Five
     further stable LS-5000 states, each observed identically in both long
     padding blocks across every record of its captured stream, replace only
     the first three words with a repeated sentinel — ``E9EA``, ``E004``,
-    ``DC4C``, or ``F6B1``.
+    ``DC4C``, ``F6B1``, or ``EBDE``.
     The fourth word remains ``D894`` and the canonical ``AA55,D895...`` train
     resumes immediately afterward.  Accept only those exact whole-block forms.
     """
@@ -130,6 +130,7 @@ def _padding_counter_dialect(block: np.ndarray) -> str | None:
         (0xE004, "e004-prefixed"),
         (0xDC4C, "dc4c-prefixed"),
         (0xF6B1, "f6b1-prefixed"),
+        (0xEBDE, "ebde-prefixed"),
     ):
         sentinel_prefix = np.array(
             [sentinel, sentinel, sentinel, 0xD894],

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_packed.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_packed.py
@@ -33,6 +33,11 @@ def _e004_prefixed_counter_train(words: np.ndarray) -> None:
     _counter_train(words[4:], 0xD895)
 
 
+def _ebde_prefixed_counter_train(words: np.ndarray) -> None:
+    words[:4] = (0xEBDE, 0xEBDE, 0xEBDE, 0xD894)
+    _counter_train(words[4:], 0xD895)
+
+
 def _synthetic_full_records(height: int = 3) -> tuple[np.ndarray, np.ndarray]:
     records = (height + 1) // 2
     base = (np.arange(records * 2 * WIDTH * 4, dtype=np.uint32).reshape(records * 2, WIDTH, 4) % 20_000).astype(np.uint16)
@@ -211,6 +216,67 @@ def test_full_decoder_rejects_e004_padding_1_with_e9ea_padding_3(tmp_path: Path)
     path.write_bytes(full.astype(">u2").tobytes())
 
     with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_accepts_ebde_prefixed_padding_counter_dialect(tmp_path: Path) -> None:
+    base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    path = tmp_path / "ebde-prefixed.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    decoded, report = decode_full_records(path, height=3)
+
+    expected = base.copy()
+    expected[..., :3] += 2
+    np.testing.assert_array_equal(expected, decoded)
+    assert report["padding_1_3_counter_dialect"] == "ebde-prefixed"
+
+
+@pytest.mark.parametrize(
+    "corrupt_word_offset",
+    [110_840 // 2, 110_840 // 2 + 3, 110_840 // 2 + 4, 111_616 // 2 - 1],
+    ids=["sentinel", "d894", "train-head", "train-tail"],
+)
+def test_full_decoder_rejects_corrupt_ebde_prefixed_padding(
+    tmp_path: Path, corrupt_word_offset: int
+) -> None:
+    _base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    full[1, corrupt_word_offset] ^= 1
+    path = tmp_path / "corrupt-ebde-prefixed.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 1 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_rejects_ebde_padding_1_with_canonical_padding_3(
+    tmp_path: Path,
+) -> None:
+    _base, full = _synthetic_full_records()
+    for record in full:
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+    path = tmp_path / "mixed-ebde-canonical.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+        decode_full_records(path, height=3)
+
+
+def test_full_decoder_rejects_cross_record_ebde_dialect_change(tmp_path: Path) -> None:
+    _base, full = _synthetic_full_records()
+    record = full[1]
+    _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+    _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+    path = tmp_path / "cross-record-ebde-dialect-change.bin"
+    path.write_bytes(full.astype(">u2").tobytes())
+
+    with pytest.raises(ValueError, match="padding 1 counter train mismatch"):
         decode_full_records(path, height=3)
 
 

--- a/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_streaming.py
+++ b/ports/tauri/vendor/coolscanpy/tests/protocol/ls5000_single_pass/test_streaming.py
@@ -65,6 +65,11 @@ def _f6b1_prefixed_counter_train(words: np.ndarray) -> None:
     _counter_train(words[4:], 0xD895)
 
 
+def _ebde_prefixed_counter_train(words: np.ndarray) -> None:
+    words[:4] = (0xEBDE, 0xEBDE, 0xEBDE, 0xD894)
+    _counter_train(words[4:], 0xD895)
+
+
 def _synthetic_full_records(height: int = 3) -> tuple[np.ndarray, np.ndarray]:
     records = (height + 1) // 2
     base = (
@@ -250,6 +255,69 @@ class TestStreamingFrameDecoder:
 
         np.testing.assert_array_equal(offline, decoded)
         assert offline_report["padding_1_3_counter_dialect"] == "f6b1-prefixed"
+
+    def test_ebde_prefixed_stream_matches_offline_decode_byte_for_byte(
+        self, tmp_path: Path
+    ) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+            _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        stream = full.astype(">u2").tobytes()
+        path = tmp_path / "ebde-capture.bin"
+        path.write_bytes(stream)
+        offline, offline_report = decode_full_records(path, height=3)
+
+        decoder = StreamingFrameDecoder(height=3)
+        _feed(decoder, stream, 4_096)
+        decoded, _ = decoder.finish()
+
+        np.testing.assert_array_equal(offline, decoded)
+        assert offline_report["padding_1_3_counter_dialect"] == "ebde-prefixed"
+
+    @pytest.mark.parametrize(
+        "corrupt_word_offset,match",
+        [
+            (110_840 // 2, "padding 1 counter train mismatch"),
+            (110_840 // 2 + 4, "padding 1 counter train mismatch"),
+            (207_096 // 2, "padding 3 counter train mismatch"),
+            (207_872 // 2 - 1, "padding 3 counter train mismatch"),
+        ],
+        ids=["pad1-sentinel", "pad1-train-head", "pad3-sentinel", "pad3-train-tail"],
+    )
+    def test_corrupt_ebde_prefixed_padding_fails_closed(
+        self, corrupt_word_offset: int, match: str
+    ) -> None:
+        _base, full = _synthetic_full_records(height=5)  # 3 records
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+            _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        full[1, corrupt_word_offset] ^= 1
+        decoder = StreamingFrameDecoder(height=5)
+
+        with pytest.raises(ValueError, match=match):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
+
+    def test_mixed_ebde_and_canonical_padding_dialects_fail_closed(self) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        for record in full:
+            _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        decoder = StreamingFrameDecoder(height=3)
+
+        with pytest.raises(ValueError, match="padding 3 counter train mismatch"):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
+
+    def test_cross_record_ebde_dialect_change_fails_closed(self) -> None:
+        _base, full = _synthetic_full_records(height=3)
+        record = full[1]
+        _ebde_prefixed_counter_train(record[110_840 // 2 : 111_616 // 2])
+        _ebde_prefixed_counter_train(record[207_096 // 2 : 207_872 // 2])
+        decoder = StreamingFrameDecoder(height=3)
+
+        with pytest.raises(
+            ValueError, match="dialect changed at record 1: canonical -> ebde-prefixed"
+        ):
+            _feed(decoder, full.astype(">u2").tobytes(), 65_535)
 
     @pytest.mark.parametrize(
         "corrupt_word_offset,match",

--- a/ports/tauri/vendor/coolscanpy/uv.lock
+++ b/ports/tauri/vendor/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/ports/tauri/vendor/engine/src/evidence_package.rs
+++ b/ports/tauri/vendor/engine/src/evidence_package.rs
@@ -1056,7 +1056,7 @@ fn create_package_file(
 fn cleanup_staged_manifest(
     package: &crate::render::ReservedEvidencePackage,
     temporary_name: &std::ffi::OsStr,
-    staged: &std::fs::File,
+    staged: std::fs::File,
 ) -> Result<(), String> {
     package
         .retire_exact_root_file(temporary_name, staged)
@@ -1065,7 +1065,7 @@ fn cleanup_staged_manifest(
 
 fn rollback_committed_manifest(
     package: &crate::render::ReservedEvidencePackage,
-    manifest_file: &std::fs::File,
+    manifest_file: std::fs::File,
 ) -> Result<(), String> {
     package
         .retire_exact_root_file(std::ffi::OsStr::new("manifest.json"), manifest_file)
@@ -1123,7 +1123,7 @@ where
         Ok(())
     })();
     if let Err(error) = staged {
-        return match cleanup_staged_manifest(package, &temporary_name, &manifest_file) {
+        return match cleanup_staged_manifest(package, &temporary_name, manifest_file) {
             Ok(()) => Err(error),
             Err(cleanup) => Err(format!(
                 "{error}; HOLD: staged evidence manifest cleanup could not be proven: {cleanup}"
@@ -1138,7 +1138,7 @@ where
         std::ffi::OsStr::new("manifest.json"),
     ) {
         let primary = format!("create-only authoritative evidence manifest commit: {error}");
-        return match cleanup_staged_manifest(package, &temporary_name, &manifest_file) {
+        return match cleanup_staged_manifest(package, &temporary_name, manifest_file) {
             Ok(()) => Err(primary),
             Err(cleanup) => Err(format!(
                 "{primary}; HOLD: staged evidence manifest cleanup could not be proven: {cleanup}"
@@ -1164,7 +1164,7 @@ where
     })();
     match post_commit {
         Ok(()) => Ok(()),
-        Err(primary) => match rollback_committed_manifest(package, &manifest_file) {
+        Err(primary) => match rollback_committed_manifest(package, manifest_file) {
             Ok(()) => Err(format!(
                 "{primary}; authoritative manifest was rolled back and completion was not reported"
             )),
@@ -1287,7 +1287,7 @@ where
     Ok((
         FileDigest {
             path: source.display().to_string(),
-            package_path: destination.to_string_lossy().to_string(),
+            package_path: destination.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/"),
             sha256: source_hash,
         },
         PackageFileProof {
@@ -1837,7 +1837,7 @@ mod tests {
         })
         .expect_err("post-commit ambiguity must never return successful completion");
         assert!(error.contains("ordering ambiguity"));
-        assert!(error.contains("rolled back"));
+        assert!(error.contains("rolled back"), "{error}");
         assert!(!package.final_path().join("manifest.json").exists());
 
         let _ = std::fs::remove_dir_all(root);

--- a/ports/tauri/vendor/engine/src/exiftool.rs
+++ b/ports/tauri/vendor/engine/src/exiftool.rs
@@ -3198,6 +3198,11 @@ pub(crate) mod metadata_publish_sys {
     }
 
     pub fn open_regular(parent: &File, name: &OsStr) -> io::Result<File> {
+        // Readers must coexist with publication handles that deny deletion.
+        relative_file(parent, name, false, false, false, false, true)
+    }
+
+    fn open_regular_for_delete(parent: &File, name: &OsStr) -> io::Result<File> {
         relative_file(parent, name, false, false, false, true, true)
     }
 
@@ -3265,8 +3270,8 @@ pub(crate) mod metadata_publish_sys {
         to_directory: &File,
         to_name: &OsStr,
     ) -> io::Result<()> {
-        let source = open_regular(from_directory, from_name)?;
-        let target = open_regular(to_directory, to_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
+        let target = open_regular_for_delete(to_directory, to_name)?;
         let parking = from_name
             .to_str()
             .and_then(|name| name.strip_prefix(".swap-"))
@@ -3319,7 +3324,7 @@ pub(crate) mod metadata_publish_sys {
                 ))
             }
         }
-        let source = open_regular(from_directory, from_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
         rename_handle(&source, to_directory, to_name, false)
     }
 
@@ -3345,7 +3350,7 @@ pub(crate) mod metadata_publish_sys {
         to_directory: &File,
         to_name: &OsStr,
     ) -> io::Result<()> {
-        let source = open_regular(from_directory, from_name)?;
+        let source = open_regular_for_delete(from_directory, from_name)?;
         rename_handle(&source, to_directory, to_name, true)
     }
 
@@ -3371,7 +3376,7 @@ pub(crate) mod metadata_publish_sys {
     }
 
     pub fn unlink(parent: &File, name: &OsStr) -> io::Result<()> {
-        let file = open_regular(parent, name)?;
+        let file = open_regular_for_delete(parent, name)?;
         delete_handle(&file)
     }
 

--- a/ports/tauri/vendor/engine/src/exiftool.rs
+++ b/ports/tauri/vendor/engine/src/exiftool.rs
@@ -2592,7 +2592,7 @@ pub(crate) mod metadata_publish_sys {
     const FILE_OPEN: u32 = 0x0000_0001;
     const FILE_CREATE: u32 = 0x0000_0002;
     const FILE_NAMES_INFORMATION_CLASS: u32 = 12;
-    const FILE_RENAME_INFO_EX_CLASS: u32 = 22;
+    const FILE_RENAME_INFORMATION_CLASS: u32 = 10;
     const FILE_DISPOSITION_INFO_EX_CLASS: u32 = 21;
     const FILE_DISPOSITION_FLAG_DELETE: u32 = 0x0000_0001;
     const FILE_DISPOSITION_FLAG_POSIX_SEMANTICS: u32 = 0x0000_0002;
@@ -2612,8 +2612,8 @@ pub(crate) mod metadata_publish_sys {
     const ACL_SIZE_INFORMATION_CLASS: u32 = 2;
 
     #[repr(C)]
-    struct FileRenameInfoEx {
-        flags: u32,
+    struct FileRenameInformation {
+        replace_if_exists: u8,
         root_directory: Handle,
         file_name_length: u32,
         file_name: [u16; 1],
@@ -2781,6 +2781,13 @@ pub(crate) mod metadata_publish_sys {
 
     #[link(name = "ntdll")]
     extern "system" {
+        fn NtSetInformationFile(
+            file: Handle,
+            io_status_block: *mut IoStatusBlock,
+            information: *mut std::ffi::c_void,
+            information_size: u32,
+            information_class: u32,
+        ) -> i32;
         fn NtCreateFile(
             file: *mut Handle,
             desired_access: u32,
@@ -3205,14 +3212,14 @@ pub(crate) mod metadata_publish_sys {
         replace: bool,
     ) -> io::Result<()> {
         let name = component(destination_name)?;
-        let header_size = offset_of!(FileRenameInfoEx, file_name);
+        let header_size = offset_of!(FileRenameInformation, file_name);
         let byte_len = name.len().checked_mul(size_of::<u16>()).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Windows rename name is too long",
             )
         })?;
-        let total = header_size.checked_add(byte_len).ok_or_else(|| {
+        let total = size_of::<FileRenameInformation>().checked_add(byte_len).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Windows rename buffer overflow",
@@ -3220,9 +3227,9 @@ pub(crate) mod metadata_publish_sys {
         })?;
         let words = total.div_ceil(size_of::<usize>());
         let mut storage = vec![0_usize; words];
-        let info = storage.as_mut_ptr().cast::<FileRenameInfoEx>();
+        let info = storage.as_mut_ptr().cast::<FileRenameInformation>();
         unsafe {
-            (*info).flags = u32::from(replace);
+            (*info).replace_if_exists = u8::from(replace);
             (*info).root_directory = destination_directory.as_raw_handle();
             (*info).file_name_length = byte_len as u32;
             std::ptr::copy_nonoverlapping(
@@ -3231,17 +3238,22 @@ pub(crate) mod metadata_publish_sys {
                 byte_len,
             );
         }
-        let result = unsafe {
-            SetFileInformationByHandle(
+        // Use the native handle-relative operation, matching NtCreateFile above.
+        // The Win32 rename wrapper rejects this directory-relative request with
+        // ERROR_INVALID_PARAMETER on supported Windows hosts.
+        let mut status_block = IoStatusBlock { status_or_pointer: 0, information: 0 };
+        let status = unsafe {
+            NtSetInformationFile(
                 source.as_raw_handle(),
-                FILE_RENAME_INFO_EX_CLASS,
+                &mut status_block,
                 info.cast(),
                 total as u32,
+                FILE_RENAME_INFORMATION_CLASS,
             )
         };
-        if result == 0 {
-            let error = io::Error::last_os_error();
-            Err(io::Error::new(error.kind(), format!("SetFileInformationByHandle rename: {error}")))
+        if status < 0 {
+            let error = io::Error::from_raw_os_error(unsafe { RtlNtStatusToDosError(status) } as i32);
+            Err(io::Error::new(error.kind(), format!("NtSetInformationFile rename: {error}")))
         } else {
             Ok(())
         }

--- a/ports/tauri/vendor/engine/src/exiftool.rs
+++ b/ports/tauri/vendor/engine/src/exiftool.rs
@@ -3205,7 +3205,7 @@ pub(crate) mod metadata_publish_sys {
         relative_file(parent, name, false, false, true, false, false)
     }
 
-    fn rename_handle(
+    pub(crate) fn rename_handle(
         source: &File,
         destination_directory: &File,
         destination_name: &OsStr,
@@ -7101,7 +7101,12 @@ mod tests {
     fn windows_runner_assigns_and_resumes_a_normal_process() {
         let command =
             std::env::var("ComSpec").unwrap_or_else(|_| r"C:\Windows\System32\cmd.exe".to_string());
-        let command = bind_executable(Path::new(&command)).expect("bind Windows command");
+        // System binaries may have servicing hard links; the executable binder
+        // intentionally requires a unique file identity.
+        let root = temp_root("windows-runner");
+        let executable = root.join("cmd.exe");
+        std::fs::copy(&command, &executable).expect("copy Windows command fixture");
+        let command = bind_executable(&executable).expect("bind Windows command");
         let output = run_bounded_command(
             &command,
             &["/D".into(), "/C".into(), "exit /B 0".into()],
@@ -7110,6 +7115,8 @@ mod tests {
         )
         .expect("run a Job-contained Windows process");
         assert!(output.status.success());
+        drop(command);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[cfg(windows)]

--- a/ports/tauri/vendor/engine/src/exiftool.rs
+++ b/ports/tauri/vendor/engine/src/exiftool.rs
@@ -2043,7 +2043,8 @@ pub(crate) fn ensure_supported_metadata_filesystem(file: &File) -> std::io::Resu
         )
     };
     if result == 0 {
-        return Err(std::io::Error::last_os_error());
+        let error = std::io::Error::last_os_error();
+        return Err(std::io::Error::new(error.kind(), format!("GetVolumeInformationByHandleW: {error}")));
     }
     if !windows_metadata_filesystem_name_is_supported(&filesystem_name) {
         let name = String::from_utf16_lossy(&filesystem_name)
@@ -3158,7 +3159,8 @@ pub(crate) mod metadata_publish_sys {
         };
         if status < 0 {
             let windows_error = unsafe { RtlNtStatusToDosError(status) };
-            return Err(io::Error::from_raw_os_error(windows_error as i32));
+            let error = io::Error::from_raw_os_error(windows_error as i32);
+            return Err(io::Error::new(error.kind(), format!("NtCreateFile metadata entry: {error}")));
         }
         if handle.is_null() || handle as isize == -1 {
             return Err(io::Error::other(
@@ -3238,7 +3240,8 @@ pub(crate) mod metadata_publish_sys {
             )
         };
         if result == 0 {
-            Err(io::Error::last_os_error())
+            let error = io::Error::last_os_error();
+            Err(io::Error::new(error.kind(), format!("SetFileInformationByHandle rename: {error}")))
         } else {
             Ok(())
         }
@@ -3485,7 +3488,9 @@ pub(crate) mod metadata_publish_sys {
         // File::sync_all maps to FlushFileBuffers on Windows. Directory
         // capabilities are opened with write access so this ordering barrier
         // is enforced instead of silently assuming a rename is durable.
-        directory.sync_all()
+        directory.sync_all().map_err(|error| {
+            io::Error::new(error.kind(), format!("FlushFileBuffers directory: {error}"))
+        })
     }
 }
 

--- a/ports/tauri/vendor/engine/src/manifest.rs
+++ b/ports/tauri/vendor/engine/src/manifest.rs
@@ -1787,6 +1787,9 @@ mod tests {
             let dir = temp_project_dir();
             fs::create_dir_all(&dir).unwrap();
             fs::write(dir.join(MANIFEST_FILE_NAME), corruption).unwrap();
+            // Windows keeps its transaction-lock inode for all later opens.
+            #[cfg(windows)]
+            fs::write(dir.join(".scanstudio-manifest.lock"), b"").unwrap();
 
             let before = snapshot_regular_files(&dir);
             let err = create_project(

--- a/ports/tauri/vendor/engine/src/real_backend.rs
+++ b/ports/tauri/vendor/engine/src/real_backend.rs
@@ -1452,6 +1452,7 @@ mod private_workspace_sys {
     ) -> io::Result<std::fs::File> {
         let marker_path = root_path.join(marker_name);
         let mut file = std::fs::OpenOptions::new()
+            .write(true)
             .access_mode(GENERIC_READ | GENERIC_WRITE | DELETE_ACCESS)
             .create_new(true)
             .share_mode(FILE_SHARE_READ)
@@ -8785,6 +8786,17 @@ mod tests {
         drop(working);
         std::fs::remove_dir_all(workspace_root).unwrap();
         std::fs::remove_dir_all(test_root).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_private_workspace_creates_and_verifies_its_marker() {
+        let working = PrivateCaptureWorkingDirectory::create().expect("create Windows workspace");
+        working.verify_namespace().expect("verify held workspace authority");
+        let root = working.root.clone();
+        assert!(std::fs::metadata(root.join(PRIVATE_CAPTURE_MARKER)).unwrap().len() > 0);
+        drop(working);
+        std::fs::remove_dir_all(root).expect("remove private test workspace");
     }
 
     #[cfg(unix)]

--- a/ports/tauri/vendor/engine/src/render.rs
+++ b/ports/tauri/vendor/engine/src/render.rs
@@ -378,7 +378,7 @@ impl ReservedEvidencePackage {
     pub(crate) fn retire_exact_root_file(
         &self,
         name: &std::ffi::OsStr,
-        expected: &std::fs::File,
+        expected: std::fs::File,
     ) -> Result<(), domain::EngineError> {
         let relative = Path::new(name);
         if relative.components().count() != 1
@@ -391,8 +391,9 @@ impl ReservedEvidencePackage {
                 "exact evidence cleanup requires one normal root-file component",
             ));
         }
-        self.verify_regular_file(relative, expected)?;
-        destination_sys::delete_exact_regular_file(expected)?;
+        self.verify_regular_file(relative, &expected)?;
+        destination_sys::delete_exact_regular_file(&expected)?;
+        drop(expected);
         crate::exiftool::metadata_publish_sys::sync_directory(self.directory_handle()).map_err(
             |error| {
                 output_authority_error(format!(
@@ -10302,17 +10303,34 @@ mod tests {
         output.preview.enabled = false;
         output.raw_export.enabled = false;
 
-        let error = acquire_job_output_authorities(
+        // NTFS upcase tables vary by volume generation. Derive the expected
+        // answer from actual ordinary Windows file creation on this volume.
+        let first = project.join("Σ_0001.tif");
+        let second = project.join("ς_0001.tif");
+        std::fs::write(&first, b"oracle").unwrap();
+        let oracle = std::fs::OpenOptions::new().write(true).create_new(true).open(&second);
+        let collision = match oracle {
+            Ok(file) => { drop(file); false }
+            Err(error) => {
+                assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+                true
+            }
+        };
+        let result = acquire_job_output_authorities(
             Some(&project),
             &[1],
             &domain::CaptureRecipe::default(),
             &output,
             &std::collections::HashMap::new(),
         )
-        .expect_err("NTFS-upcase aliases must collide before capture");
-
-        assert_eq!(error.code, protocol::ErrorCode::InvalidParams);
-        assert!(error.message.contains("filename collation"), "{error}");
+        ;
+        if collision {
+            let error = result.expect_err("filesystem aliases must collide before capture");
+            assert_eq!(error.code, protocol::ErrorCode::InvalidParams);
+            assert!(error.message.contains("filename collation"), "{error}");
+        } else {
+            result.expect("distinct filesystem names must remain usable");
+        }
         let _ = std::fs::remove_dir_all(&project);
     }
 
@@ -11985,7 +12003,16 @@ mod tests {
 
         let positive = written.positive_path.as_ref().unwrap();
         let displaced = root.join("engine-authored-positive.tif");
-        std::fs::rename(positive, &displaced).unwrap();
+        let renamed = std::fs::rename(positive, &displaced);
+        if cfg!(windows) {
+            assert!(renamed.is_err(), "held Windows output must deny replacement");
+            crate::exiftool::bind_metadata_output_publications(&root, &written.metadata_publications)
+                .expect("denied replacement retains the original binding");
+            drop(written);
+            let _ = std::fs::remove_dir_all(root);
+            return;
+        }
+        renamed.unwrap();
         std::fs::write(positive, b"attacker replacement").unwrap();
 
         let error = crate::exiftool::bind_metadata_output_publications(

--- a/ports/tauri/vendor/engine/src/render.rs
+++ b/ports/tauri/vendor/engine/src/render.rs
@@ -1275,7 +1275,6 @@ mod destination_sys {
     const GENERIC_READ: u32 = 0x8000_0000;
     const GENERIC_WRITE: u32 = 0x4000_0000;
     const DELETE_ACCESS: u32 = 0x0001_0000;
-    const FILE_RENAME_INFO_CLASS: u32 = 3;
     const FILE_DISPOSITION_INFO_CLASS: u32 = 4;
 
     #[link(name = "Kernel32")]
@@ -1286,14 +1285,6 @@ mod destination_sys {
             information: *mut std::ffi::c_void,
             buffer_size: u32,
         ) -> i32;
-    }
-
-    #[repr(C)]
-    struct FileRenameInfoHeader {
-        replace_if_exists: u8,
-        root_directory: *mut std::ffi::c_void,
-        file_name_length: u32,
-        file_name: [u16; 1],
     }
 
     #[repr(C)]
@@ -1625,6 +1616,7 @@ mod destination_sys {
             ));
             let path = held.display_path.join(&candidate);
             match std::fs::OpenOptions::new()
+                .write(true)
                 .access_mode(GENERIC_READ | GENERIC_WRITE | DELETE_ACCESS)
                 .share_mode(FILE_SHARE_READ)
                 .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
@@ -1701,53 +1693,12 @@ mod destination_sys {
         role: &str,
     ) -> Result<(), domain::EngineError> {
         verify_namespace(held)?;
-        let wide: Vec<u16> = final_name.encode_wide().collect();
-        let file_name_offset = std::mem::offset_of!(FileRenameInfoHeader, file_name);
-        let byte_length = wide
-            .len()
-            .checked_mul(std::mem::size_of::<u16>())
-            .ok_or_else(|| output_authority_error("final output leaf is too long"))?;
-        let total = file_name_offset
-            .checked_add(byte_length)
-            .ok_or_else(|| output_authority_error("final output rename buffer is too large"))?;
-        // `Vec<u8>` only guarantees byte alignment; casting its pointer to
-        // FILE_RENAME_INFO would be undefined behaviour on Windows. Back the
-        // variable-sized record with pointer-aligned words while still
-        // passing the exact byte length required by the API.
-        let word = std::mem::size_of::<usize>();
-        let word_count = total
-            .checked_add(word - 1)
-            .ok_or_else(|| output_authority_error("final output rename buffer is too large"))?
-            / word;
-        let mut buffer = vec![0_usize; word_count];
-        let buffer_bytes = buffer.as_mut_ptr().cast::<u8>();
-        let header = buffer_bytes.cast::<FileRenameInfoHeader>();
-        unsafe {
-            std::ptr::write(
-                header,
-                FileRenameInfoHeader {
-                    replace_if_exists: (!create_only) as u8,
-                    root_directory: held.directory.as_raw_handle().cast(),
-                    file_name_length: byte_length as u32,
-                    file_name: [0],
-                },
-            );
-            std::ptr::copy_nonoverlapping(
-                wide.as_ptr().cast::<u8>(),
-                buffer_bytes.add(file_name_offset),
-                byte_length,
-            );
-        }
-        let result = unsafe {
-            SetFileInformationByHandle(
-                temporary_file.as_raw_handle().cast(),
-                FILE_RENAME_INFO_CLASS,
-                buffer_bytes.cast(),
-                total as u32,
-            )
-        };
-        if result == 0 {
-            let error = std::io::Error::last_os_error();
+        if let Err(error) = crate::exiftool::metadata_publish_sys::rename_handle(
+            temporary_file,
+            &held.directory,
+            final_name,
+            !create_only,
+        ) {
             let code = if create_only && error.kind() == std::io::ErrorKind::AlreadyExists {
                 protocol::ErrorCode::ArchiveCollision
             } else {
@@ -2800,6 +2751,9 @@ fn validate_filesystem_output_leaf_collation(
                 ))
             })?;
         }
+        // Windows delete dispositions finish when the last held file closes.
+        // Close our exact probe handles before checking for foreign entries.
+        created.clear();
         crate::exiftool::metadata_publish_sys::sync_directory(&probe).map_err(|error| {
             output_authority_error(format!("sync emptied output-name alias probe: {error}"))
         })?;
@@ -6783,6 +6737,7 @@ fn sync_output_directory(directory: &Path) -> std::io::Result<()> {
     const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
     std::fs::OpenOptions::new()
         .read(true)
+        .write(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .open(directory)?
         .sync_all()

--- a/ports/tauri/vendor/engine/src/server.rs
+++ b/ports/tauri/vendor/engine/src/server.rs
@@ -4831,6 +4831,7 @@ mod tests {
                 .recv_timeout(std::time::Duration::from_secs(10))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.completed" {
                 break;
             }

--- a/ports/tauri/vendor/engine/src/sim.rs
+++ b/ports/tauri/vendor/engine/src/sim.rs
@@ -1976,7 +1976,18 @@ mod tests {
         )
         .unwrap();
         let positive = written.positive_path.as_ref().unwrap();
-        std::fs::rename(positive, root.join("engine-positive.tif")).unwrap();
+        let renamed = std::fs::rename(positive, root.join("engine-positive.tif"));
+        if cfg!(windows) {
+            assert!(renamed.is_err(), "held Windows output must deny replacement");
+            build_receipt(
+                "job-binding-replacement", 1, 1000, &recipe, &processing, &output,
+                DEVICE_ID, &written, Some(&project_root),
+            ).expect("denied replacement retains valid receipt evidence");
+            drop((written, project_root));
+            let _ = std::fs::remove_dir_all(root);
+            return;
+        }
+        renamed.unwrap();
         std::fs::write(positive, b"unrelated replacement").unwrap();
 
         let error = build_receipt(
@@ -2606,6 +2617,7 @@ mod tests {
                 .recv_timeout(Duration::from_secs(30))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.completed" {
                 break;
             }
@@ -2691,6 +2703,7 @@ mod tests {
                 .recv_timeout(Duration::from_secs(30))
                 .expect("scan.completed event");
             let value: serde_json::Value = serde_json::from_str(&line).expect("event json");
+            eprintln!("{value}");
             if value["event"] == "scan.frameState" && value["payload"]["frameIndex"] == 1 {
                 match value["payload"]["state"].as_str() {
                     Some("completed") => {

--- a/ports/tauri/vendor/engine/src/wsl_io.rs
+++ b/ports/tauri/vendor/engine/src/wsl_io.rs
@@ -242,10 +242,8 @@ fn sidecar_path(rgb: &str, label: &str) -> Result<String, String> {
     let parent = path
         .parent()
         .ok_or_else(|| format!("capture path has no parent: {rgb:?}"))?;
-    Ok(parent
-        .join(format!("{stem}_{label}.tif"))
-        .to_string_lossy()
-        .to_string())
+    // These names belong to Linux even when this engine runs on Windows.
+    Ok(format!("{}/{stem}_{label}.tif", parent.display()))
 }
 
 pub fn validate_staged_receipt_paths(

--- a/ports/tauri/vendor/scanstudio-bridge/uv.lock
+++ b/ports/tauri/vendor/scanstudio-bridge/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/scripts/check_coolscanpy_pypi_sync.sh
+++ b/scripts/check_coolscanpy_pypi_sync.sh
@@ -6,7 +6,7 @@
 # debugging confusion the instrumented-refusal work exists to prevent
 # (owner policy, 2026-08-08: "keep them in sync so there's no delta").
 #
-# Mechanics: download the exact authenticated coolscanpy 0.7.4 sdist and compare its
+# Mechanics: download the exact authenticated coolscanpy 0.7.5 sdist and compare its
 # src/coolscanpy tree byte-for-byte against this repo's vendored
 # coolscanpy/src/coolscanpy. Version strings are NOT trusted as the primary
 # signal (an unbumped version with changed code is precisely the failure
@@ -30,19 +30,19 @@ VENDORED_DIR="coolscanpy/src/coolscanpy"
 # Re-pin: shasum -a 256 <both files>, update the entry in the same change
 # that alters the file.
 KNOWN_VENDORED_DIVERGENCE=(
-  # required scanner_identity + capture-timing feature; re-pinned for 0.7.4
+  # required scanner_identity + capture-timing feature; re-pinned for 0.7.5
   # (meter-controller refusal + transport-failure witness landed upstream)
   "protocol/ls5000_single_pass/worker.py|773d9915cf68fd5f6d0937a3f26cdee488f257a584ff8bfe4950b33b96678777|22ba191b7f9d313d80aeec195db648bc686f631849145b620851d0961dcbc5cf"
-  # LeadingFrameClippedError + confident-clear-film gate; re-pinned for 0.7.4
+  # LeadingFrameClippedError + confident-clear-film gate; re-pinned for 0.7.5
   # (failure witness replay landed upstream)
   "protocol/ls5000_single_pass/roll_index.py|c99c54a434d0d53e94e51ed503f0289709b5f20365e16606f365264a617c8b17|38013a1e942c3d1d1798ca0e718fb7ccdc3bc605277ca729e9891fa53bcde311"
   # its export surface for the class above
   "protocol/ls5000_single_pass/__init__.py|ce8aa97b707f5ef83f96128b378722191f7280bd41c1f3acbb04c75e3ea7523e|1f0f324034a95e2c8ca772ce52a78a800b0bf215d3ae4ec77422b08b1376856c"
-  # pins differ because the two files above differ; re-pinned for 0.7.4
-  "protocol/ls5000_single_pass/bundle.py|7167c9cd7cbc50d1d641b3847fc1f71e6d37a06d6d8c4d90f2199443d1d5e812|a3a3e7bd307806c6c1b022dac59295525a3d8644e8059069864180fedb40167f"
+  # pins differ because the two files above differ; re-pinned for 0.7.5
+  "protocol/ls5000_single_pass/bundle.py|538dced76ea84c12d9c73c566da6a79955a717ca4a6a7d6b1857aeca02dbc9f6|b6e983319feaa37fbe67263fccc317c7844d81280986a34d15fed0d43b397175"
   # packaged-app libusb resolution (app bundles its own signed binary)
   "protocol/ls5000_single_pass/usb_backend.py|afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62|666a476ce706a4a854aac50116575e7143f5a1a7c1b1085125347696d89348d1"
-  # capture-timing receipt fields (started_at/duration); re-pinned for 0.7.4
+  # capture-timing receipt fields (started_at/duration); re-pinned for 0.7.5
   "_roll.py|29903307ce3c0e6f76785b437857450de1d35783fc01c2df9705f03f94fa3df3|61850c5da59b625dd1ce5dc854fe5be01a5a4f687c81fad0f589c9b1c865d094"
   "capture/single_pass_workflow.py|a5a01b15ff50df9a6f78d1c2c4f39d10548e7651cf3365e8698d479b633b5914|c8d93dce3c7de3b585c2d051b7d09054802a130797c590c97b36b78889def15c"
   "types.py|1343c93c03ade64f0927602fe8e8e25353bada6b1b8a919ce9084c5cbcb321de|f853b8dde9c4a6c3b7ce96195d320c7ba9c88839019bed9ce55fe444ea08e54a"
@@ -51,12 +51,12 @@ KNOWN_VENDORED_DIVERGENCE=(
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
-echo "fetching authenticated coolscanpy 0.7.4 source from PyPI..."
+echo "fetching authenticated coolscanpy 0.7.5 source from PyPI..."
 published_root="$(python3 -I -S -B scripts/fetch_pinned_coolscanpy_sdist.py \
   --destination "$workdir/published")"
 published_src="$published_root/src/coolscanpy"
 test -d "$published_src"
-pypi_version="0.7.4"
+pypi_version="0.7.5"
 
 printf '%s\n' "${KNOWN_VENDORED_DIVERGENCE[@]}" > "$workdir/exemptions"
 if PUBLISHED_SRC="$published_src" VENDORED_DIR="$VENDORED_DIR" \

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -296,7 +296,7 @@ EOF
 check_pair "protocol" "app/ScanStudio/protocol" "ports/tauri/vendor/protocol" "55577442d8b6a23ddcd3cc191ebf41a8258004047bc075511a241fa72adb0b65" <<'EOF'
 EOF
 
-check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "228c9c43e13a1e817cfb7e7c84f501d14b9e6af89d659ce2a1c828ec2474ca56" <<'EOF'
+check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "8bc07be47b3396d32f518b1fd7e89746492cefdbad086a0b931ee76efbecffab" <<'EOF'
 Files app/ScanStudio/engine/Cargo.lock and ports/tauri/vendor/engine/Cargo.lock differ
 Files app/ScanStudio/engine/Cargo.toml and ports/tauri/vendor/engine/Cargo.toml differ
 Files app/ScanStudio/engine/src/evidence_package.rs and ports/tauri/vendor/engine/src/evidence_package.rs differ

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -307,7 +307,7 @@ Files app/ScanStudio/engine/src/render.rs and ports/tauri/vendor/engine/src/rend
 Only in ports/tauri/vendor/engine/src: wsl_io.rs
 EOF
 
-check_pair "bridge" "bridge" "ports/tauri/vendor/scanstudio-bridge" "bc7676818b08648d47753255783e3b06105feed0aa4cf41d50174c98f7ab37aa" <<'EOF'
+check_pair "bridge" "bridge" "ports/tauri/vendor/scanstudio-bridge" "c6522e45b972ae719ab8f8e1b2fc8526e0842ebbe137395b0d543425f87cb3df" <<'EOF'
 Only in ports/tauri/vendor/scanstudio-bridge: .github
 Only in ports/tauri/vendor/scanstudio-bridge/scripts: probe-linux-env.py
 Only in ports/tauri/vendor/scanstudio-bridge/scripts: verify-bridge.sh

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -321,7 +321,7 @@ Only in ports/tauri/vendor/scanstudio-bridge/tests: test_stdout_byte_discipline.
 Files bridge/uv.lock and ports/tauri/vendor/scanstudio-bridge/uv.lock differ
 EOF
 
-check_pair "coolscanpy" "coolscanpy" "ports/tauri/vendor/coolscanpy" "63d4ce49d4e1977cb5a38b1fb99992d2f844de15dd39cb85fe2ec04c34920140" <<'EOF'
+check_pair "coolscanpy" "coolscanpy" "ports/tauri/vendor/coolscanpy" "cfd8b1e25cef049742e683a31a658e7ee37017e930200e51d94c246bca46dc31" <<'EOF'
 Files coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py and ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/bundle.py differ
 Files coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/usb_backend.py and ports/tauri/vendor/coolscanpy/src/coolscanpy/protocol/ls5000_single_pass/usb_backend.py differ
 Files coolscanpy/tests/test_usb_backend.py and ports/tauri/vendor/coolscanpy/tests/test_usb_backend.py differ

--- a/scripts/check_ports_vendor_sync.sh
+++ b/scripts/check_ports_vendor_sync.sh
@@ -296,7 +296,7 @@ EOF
 check_pair "protocol" "app/ScanStudio/protocol" "ports/tauri/vendor/protocol" "55577442d8b6a23ddcd3cc191ebf41a8258004047bc075511a241fa72adb0b65" <<'EOF'
 EOF
 
-check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "8bc07be47b3396d32f518b1fd7e89746492cefdbad086a0b931ee76efbecffab" <<'EOF'
+check_pair "engine" "app/ScanStudio/engine" "ports/tauri/vendor/engine" "2291ca17e46fe03540e79678d08551c21fb487a3418f9732acca417d00b18c30" <<'EOF'
 Files app/ScanStudio/engine/Cargo.lock and ports/tauri/vendor/engine/Cargo.lock differ
 Files app/ScanStudio/engine/Cargo.toml and ports/tauri/vendor/engine/Cargo.toml differ
 Files app/ScanStudio/engine/src/evidence_package.rs and ports/tauri/vendor/engine/src/evidence_package.rs differ

--- a/scripts/fetch_pinned_coolscanpy_sdist.py
+++ b/scripts/fetch_pinned_coolscanpy_sdist.py
@@ -16,20 +16,20 @@ import unicodedata
 import urllib.request
 
 
-VERSION = "0.7.4"
+VERSION = "0.7.5"
 FILENAME = f"coolscanpy-{VERSION}.tar.gz"
 URL = (
-    "https://files.pythonhosted.org/packages/f9/98/"
-    "4e60eb52655d5579cf7b25631509c287f7c3b8c75a69abfeb1fac0e71d01/"
+    "https://files.pythonhosted.org/packages/08/c9/"
+    "7a27d8fd2149d33b9f3514c2b6c54611c48c30a12b07b816ca7aeca9911b/"
     f"{FILENAME}"
 )
-SIZE = 556_523
-SHA256 = "e60b7b4a5464c9ace6b2f3002e7a2c7c8d0d6cd917e4d74bad98bb36ae573bab"
+SIZE = 556_532
+SHA256 = "7adee250d325b6f4b9872a9e7fef1199349558f87d673a3b48a46890c9d141f6"
 ROOT = f"coolscanpy-{VERSION}"
 ENTRY_COUNT = 104
 FILE_COUNT = 89
 DIRECTORY_COUNT = 15
-EXPANDED_FILE_BYTES = 2_447_475
+EXPANDED_FILE_BYTES = 2_447_520
 
 
 class FetchError(RuntimeError):

--- a/scripts/smoke_project_persistence.py
+++ b/scripts/smoke_project_persistence.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Exercise real project persistence through a packaged engine, without hardware."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def main(engine):
+    with tempfile.TemporaryDirectory(prefix="ScanStudio # project ") as root:
+        directory = str(Path(root) / "Saved roll # 1")
+        create = {"name": "Package check", "carrier": "strip6", "frameCount": 2,
+                  "filmProcess": "c41ColorNegative", "directory": directory}
+        commands = [
+            ("engine.hello", {"clientName": "persistence-smoke", "protocolVersion": 1}),
+            ("project.create", create),
+            ("project.setFrameExcluded", {"frameIndex": 1, "excluded": True}),
+            ("project.open", {"directory": directory}),
+            ("project.create", create),
+            ("project.open", {"directory": directory}),
+            ("engine.shutdown", {}),
+        ]
+        environment = {key: value for key, value in os.environ.items()
+                       if not key.startswith("SCANSTUDIO_")}
+        result = subprocess.run(
+            [engine], input="".join(json.dumps({"id": index, "method": method,
+                                               "params": params}) + "\n"
+                                    for index, (method, params) in enumerate(commands, 1)),
+            text=True, capture_output=True, timeout=30, env=environment, check=True,
+        )
+        responses = {}
+        for line in result.stdout.splitlines():
+            message = json.loads(line)
+            if "id" in message:
+                assert message["id"] not in responses, message
+                responses[message["id"]] = message
+        assert set(responses) == set(range(1, 8)), result.stdout
+        for index, response in responses.items():
+            if index == 5:
+                assert response.get("error", {}).get("code") == "PROJECT_ALREADY_EXISTS", response
+            else:
+                assert "result" in response and not response.get("error"), response
+        original_id = responses[2]["result"]["project"]["id"]
+        for index in (4, 6):
+            project = responses[index]["result"]["project"]
+            assert project["id"] == original_id, project
+            assert project["frames"][0]["excluded"] is True, project
+        manifest = json.loads((Path(directory) / "manifest.json").read_text())
+        assert manifest == responses[6]["result"]["project"], manifest
+        assert not list(Path(directory).glob(".manifest.json.*")), directory
+    print("Project create, mutate, reopen, and overwrite refusal passed (spaces and # in path)")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/scripts/tests/test_verify_hardware_support_docs.py
+++ b/scripts/tests/test_verify_hardware_support_docs.py
@@ -26,7 +26,7 @@ class HardwareSupportDocsTests(unittest.TestCase):
         (root / "docs" / "releases" / "v0.7.0-beta.11.md").write_text("old\n")
         (root / "docs" / "releases" / "v0.7.0-beta.12.md").write_text("new\n")
         (root / "docs" / "HARDWARE-SUPPORT.md").write_text(
-            "Current published release: [v0.7.0-beta.12]\n"
+            "Latest release notes: [v0.7.0-beta.12]\n"
             "Package built | Device enumerated | Preview exercised | One-frame capture validated\n"
             "closed evidence #24\nclosed evidence #26\nissues/101\nissues/104\n"
         )

--- a/scripts/verify_hardware_support_docs.py
+++ b/scripts/verify_hardware_support_docs.py
@@ -49,7 +49,7 @@ def verify_hardware_support_docs(root: Path = REPOSITORY_ROOT) -> None:
         raise HardwareSupportDocsError(f"cannot read {CANONICAL_MATRIX}: {error}") from error
 
     latest = _latest_release_note(root)
-    if f"Current published release: [{latest}]" not in matrix:
+    if f"Latest release notes: [{latest}]" not in matrix:
         raise HardwareSupportDocsError(
             f"{CANONICAL_MATRIX} does not name the newest documented release {latest}"
         )


### PR DESCRIPTION
Fix desktop workflows that could discard active preview state, strand users away from the contact sheet, or show misleading scan/repair status. The Mac layout now fits a 1,024-point display, project dialogs have explicit cancellation and progress, and unsaved frame previews no longer trigger project-only analysis errors. Frame detail identifies scanner imagery honestly and supports keyboard/accessibility panning.

The Tauri interface now provides safe return navigation, current state after remount, a closeable missing-preview state, visible Stop acknowledgements/errors, one working remaining-frame/resume panel, and accessible frame selection. The native real-device Stop label now matches the backend's after-current-frame behavior.

The full adversarial report records 14 findings, evidence, fixes, baseline heuristic scores, and remaining verification limits in `docs/reviews/2026-09-06-adversarial-ux.md`.

Validation: 78 XCTest + 506 Swift Testing tests; 473 Tauri tests plus all six previously skipped engine-backed tests (17 passing tests across the three subprocess files); Tauri typecheck/production build; native build; vendor-sync and diff checks. Live Mac simulator checks covered compact layout, project dialogs, unsaved detail, accurate image modes, and bidirectional keyboard/accessibility pan. No physical scanner motion was performed.
