### PR TITLE
Fix real scanner connection and preserve stop ownership

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         # standalone `pip install coolscanpy` users would not have -- version
         # skew between the two makes field reports for the same film
         # incomparable. Content is compared against the exact authenticated
-        # 0.7.1 sdist (version strings are checked second; an unbumped version
+        # pinned sdist (version strings are checked second; an unbumped version
         # with changed code is exactly the failure mode). Publish the matching
         # coolscanpy release from the canonical repo before tagging ScanStudio.
         run: bash scripts/check_coolscanpy_pypi_sync.sh

--- a/README.md
+++ b/README.md
@@ -2,166 +2,127 @@
 
 <img src="assets/scanstudio-app-icon.png" alt="ScanStudio app icon" width="128" height="128">
 
-<img src="assets/scanstudio-ls5000-offline.jpeg" alt="ScanStudio running on macOS with an LS-5000 ED offered by the bridge as a Connect target. No scanner is selected, the status is OFFLINE, the simulator is absent, and no media or preview data is shown." width="1000">
+ScanStudio is a free, open-source film-scanning app for **Apple Silicon
+(M-series, arm64) Macs running macOS 14 (Sonoma) or newer**. Its supported
+Beta workflow is C-41 color-roll scanning with the Nikon SUPER COOLSCAN 5000 ED
+(LS-5000): preview the film, choose frames, scan, and review saved images.
 
-ScanStudio is a free, open-source film-scanning app for Nikon Coolscan
-scanners on Apple Silicon (M-series) Macs, built first around the SUPER COOLSCAN 5000 ED (LS-5000). It covers
-the practical Nikon Scan workflow on macOS 14 (Sonoma) or newer: identify the loaded
-holder, preview the film, choose frames, set the recipe and outputs, scan, and
-stop safely when needed. When detection cannot find your frames, it works with
-you -- an automatic wider retry, a plain-English explanation of what the film
-measures, and full manual frame placement -- instead of just refusing.
+## Install and start
 
-The screenshot above is the installed app with an LS-5000 ED detected through
-the bridge and offered as a Connect target: not connected, status OFFLINE,
-simulator absent, no media or preview shown.
+1. Open [GitHub Releases](https://github.com/rohanpandula/ScanStudio/releases)
+   and choose a published Apple Silicon Beta:
+   `ScanStudio-<version>-macOS-arm64.dmg`.
+2. Open the DMG, copy **ScanStudio** to **Applications**, and launch it.
+3. Connect your LS-5000 over USB and select the real scanner in the app.
+   Being listed is discovery evidence; a successful connection and preview
+   are separate steps.
 
-## Scanner compatibility
+The release workflow Developer ID-signs, notarizes, and staples both the app
+and DMG. The app includes the hardware bridge, Python runtime, libusb, license
+notices, and corresponding GPL source. The supported color-roll workflow and
+software eject use direct USB: no Homebrew, SANE, or Nikon driver is required.
+The separate legacy plain-scan path needs a compatible system SANE backend;
+SANE may also be used for discovery when available.
 
-| Scanner | Connection | Status today |
-| --- | --- | --- |
-| SUPER COOLSCAN 5000 ED (LS-5000) | USB | Full workflow. Real-film validated on Apple Silicon macOS (Beta). |
-| Coolscan IV ED (LS-40) / Coolscan V ED (LS-50) | USB | Detected and named, not yet driven. Triage in [#27](https://github.com/rohanpandula/ScanStudio/issues/27). |
-| LS-4000 ED, LS-8000 ED, SUPER COOLSCAN 9000 ED | FireWire | Discovery, identity, and a motion-free probe on modern macOS through the [ASFireWire](https://github.com/mrmidi/ASFireWire) driver. Scanning is not wired up yet; probe output from real hardware is what unlocks it -- see [#28](https://github.com/rohanpandula/ScanStudio/issues/28) and the driver's [FIREWIRE.md](coolscanpy/FIREWIRE.md). |
+Intel Macs, Windows, and Linux are **retired ScanStudio platforms**, with no
+current builds, updates, or port support. NegPy offers an independent
+nkscan-backed Coolscan workflow. Consult [NegPy downloads](https://github.com/marcinz606/NegPy/releases)
+and [upstream setup and compatibility guidance](https://github.com/marcinz606/NegPy#readme)
+for those systems. Check your scanner, holder, and OS against upstream guidance;
+a download alone is not proof of compatibility. Older ScanStudio assets retain
+only the support and evidence recorded at their release dates.
 
-Real scanning has been validated end-to-end on one Apple Silicon Mac and one
-LS-5000. Treat everything else as narrow results rather than a promise for
-every scanner, adapter, computer, or film holder. The hardware bridge can move
-film, so stay nearby and supervise any real job. The canonical [hardware and
-platform evidence matrix](docs/HARDWARE-SUPPORT.md) separates package,
-enumeration, preview, and capture evidence. Reports from setups unlike the
-tested one are the most useful thing you can send.
+<img src="assets/scanstudio-ls5000-offline.jpeg" alt="ScanStudio on macOS with an LS-5000 offered as a Connect target; status OFFLINE, no scanner selected, no simulator or preview shown." width="1000">
 
-## Platform support
+## Scan and find your images
 
-ScanStudio is **Apple Silicon only** (M-series, arm64), on **macOS 14
-(Sonoma) or newer**. The LS-5000 color-roll workflow is Beta, with real-film
-evidence from one Apple Silicon Mac and one scanner configuration.
+1. **Create or open a roll** and choose a writable save folder with enough free
+   space for the selected frames and formats. Confirm the real device and holder.
+2. **Preview** the film. Check frame count, order, and boundaries before capture.
+   Detection can retry with wider limits and offer manual placement; recovered
+   or manually placed frames require your approval. Panoramic frames beyond
+   the 38.7 mm single-pass capture window are refused rather than cropped.
+3. **Choose frames and outputs.** Set the film stock, recipe, orientation,
+   naming, and resolution. Retain a Master TIFF, positive TIFF/JPEG, or both.
+   Optional raw negative exports include Linear DNG and linear TIFF with infrared options.
+4. **Scan** and stay nearby while film moves. Follow the app's progress and any
+   readiness or review prompts.
+5. **Review saved files.** In the inspector's **Saved roll** section, use
+   **Show Roll Folder in Finder** or **Frame N Saved Files** to reveal a
+   recorded output. Missing or moved files are reported explicitly. Completion
+   counts follow saved receipts; inspect the images as well as the count.
 
-Intel Macs, Windows, and Linux are retired ScanStudio platforms: no current
-builds, downloads, updates, or ongoing port support. For those systems, see
-[NegPy downloads](https://github.com/marcinz606/NegPy/releases) and the
-[upstream setup and compatibility documentation](https://github.com/marcinz606/NegPy#readme).
-NegPy's [0.55.0 release notes](https://github.com/marcinz606/NegPy/releases/tag/0.55.0)
-introduced Nikon Coolscan scanning through nkscan. As checked on 2026-09-06,
-[NegPy 0.57.0](https://github.com/marcinz606/NegPy/releases/tag/0.57.0) provides
-Intel and Apple Silicon DMGs, a Windows installer, and a Linux AppImage.
-Available downloads do not establish compatibility with your scanner, holder,
-or OS; follow upstream guidance for your setup.
+Scanner preview establishes frame placement. Capture reads the selected film
+at scan resolution. Positive TIFF/JPEG and generated Preview files are
+processed exports; the optional Master TIFF retains the archival capture.
+Settings apply to **future scans**: changing a recipe, color style, or crop
+does not rewrite existing files or make the scanner preview a live color proof.
+Keep a master if you will need it for later rendering work.
 
-Older ScanStudio assets and [release notes](docs/releases/README.md) preserve
-the platforms and evidence from their release dates. They are historical
-records, not the current support promise.
+The optional **Full Capture Package** adds available settings, receipts,
+checksums, and capture evidence alongside the master. Missing evidence is
+identified; capture files are not rewritten. See the [app guide](app/ScanStudio/README.md)
+and [color guide](app/ScanStudio/COLOR.md) for output and rendering details.
 
-## Download
+## Stop and recover
 
-Get the **Apple Silicon (M-series) Beta** from
-[GitHub Releases](https://github.com/rohanpandula/ScanStudio/releases):
-`ScanStudio-<version>-macOS-arm64.dmg`. Choose this arm64 DMG; older Intel,
-Windows, and Linux assets are historical only.
+- Press **Stop after frame** once and wait for the current frame to finish
+  safely and the batch to report stopped. Eject is unavailable during capture.
+- Preserve the saved roll, completed images, receipts, and attempt journals.
+  For a failure or lost connection, save the technical details or choose
+  **Save Diagnostic Bundle…** before following the app's recovery instructions.
+- Reopen the same roll when safe. A stopped batch needs a fresh preview;
+  refeed first if the app reports shifted or interrupted film. Reconnection
+  alone does not restore film position.
+- Resolve the current readiness and approval prompts, then use **Resume Batch
+  (N remaining)** when enabled. It reads pending frames from the saved project
+  and omits completed and excluded frames. Resolve a disabled action's reason
+  instead of restarting the whole roll or deleting receipts.
 
-Current release DMGs are Developer ID signed, notarized, and stapled. The
-updater uses the arm64 feed entry and verifies the download and publisher
-identity; release provenance must bind the assets to the same run and exact
-tag. See [update verification](docs/AUTO-UPDATE.md). There is no release-schedule
-promise.
+Launching the app does not move film. Preview, Scan, and Eject are explicit
+physical operations. Follow [Mac acceptance and recovery](docs/MAC-ACCEPTANCE.md)
+for attended operation, diagnostics, and the final full-roll acceptance record.
+Simulator stop/reopen/interruption/resume checks do not prove real transport,
+focus, framing, color, or dust-removal quality.
 
-A release DMG contains the app, the GPL hardware bridge and CoolscanPy source
-required for redistribution, and the applicable dependency notices. The
-supported LS-5000 color-roll workflow uses the signed libusb copy inside the
-app, so installing ScanStudio does not require Homebrew, SANE, or a Nikon
-driver. Software eject is likewise direct over USB (the traced unload
-sequence, with typed failures and presence confirmation) and needs no SANE.
-Only the legacy plain-scan path still requires a system SANE backend, which
-also remains how SANE-based discovery lists scanners.
+## Scanner support
 
-For scripting, or for running the FireWire probe without the app, the bundled
-driver is also published on its own:
-[`pip install coolscanpy`](https://pypi.org/project/coolscanpy/). Every
-ScanStudio release ships in lockstep with the matching coolscanpy release --
-the pipeline refuses to build until the exact bundled driver is on PyPI -- so
-the app and the package always carry the same driver code.
+| Scanner | Current scope |
+| --- | --- |
+| LS-5000 / SUPER COOLSCAN 5000 ED, USB | C-41 color-roll workflow in Beta; retained real preview/capture evidence from one Apple Silicon Mac and one scanner configuration. |
+| LS-40 / Coolscan IV ED and LS-50 / Coolscan V ED, USB | Identity recognition only; unsupported for scanning. |
+| LS-4000, LS-8000, LS-9000, FireWire | Discovery and a motion-free driver probe through ASFireWire; unsupported for scanning. See [FireWire guidance](coolscanpy/FIREWIRE.md). |
 
-## What it does
+The [hardware evidence matrix](docs/HARDWARE-SUPPORT.md) separates package,
+discovery, preview, and capture results. Final attended full-roll hardware
+acceptance for beta.15 is **NOT RUN**. Real black-and-white fine scanning
+remains blocked; infrared ICE is unsuitable for traditional silver B&W film.
+The clearly labeled simulator is for software exploration, not hardware evidence.
 
-- Detects the reported carrier and media when the scanner can provide them, keeping simulator and real hardware visibly distinct.
-- Previews the roll or strip, presents a contact sheet, and supports selected-frame or batch scanning with a Stop control.
-- When frame detection fails, retries with wider limits, explains in plain English what the film actually measures (half-frame, narrow gaps, fogged or dense base, blocked film window), and offers manual frame placement -- dragged boundaries flow through the same physical checks as automatic detection, and anything recovered or hand-placed always requires your approval before scanning.
-- Keeps scan settings, film stock, recipes, camera and lens metadata, naming, and save location together.
-- Writes positive TIFF or JPEG outputs, an optional high-bit-depth master TIFF for archival work, and optional raw negative exports: a Linear DNG (one file, untouched 16-bit negative, infrared dust plane embedded as a marked sub-image) or a linear TIFF with the infrared plane as a fourth channel, a sidecar file, or omitted.
-- Renders C-41 color through named styles: **Nikon Scan** (the default -- with matching builder inputs its output replays Nikon's own rendering byte-for-byte) plus experimental alternates (a gentler Noritsu-style look and a Flextight-style look). Styles only change the positive rendering; the archival scan is never touched.
-- Uses Digital ICE only where a suitable infrared channel is available. For traditional silver black-and-white film, infrared ICE stays disabled and software dust cleanup is a separate option.
-- Records receipts -- including authoritative per-frame timing -- so a finished scan can be reviewed after the job completes.
+## Develop and report problems
 
-## Preview, capture, and processed exports
+See [build, test, and packaging instructions](app/ScanStudio/README.md) and
+[release notes and policy](docs/releases/README.md). CoolscanPy is also available for
+scripting as `pip install coolscanpy`; see its [driver guide](coolscanpy/README.md).
+The release pipeline checks the bundled driver against the authenticated PyPI
+source, allowing only explicitly reviewed, hash-pinned differences.
 
-**Scanner preview** reads the film for a contact sheet and frame registration;
-it is not the finished positive. **Capture** acquires the selected frames at
-scan resolution. **Processed exports** render positive TIFF/JPEG files from
-that capture using the job's recipe; an optional Master TIFF remains separate.
-A generated Preview file is a rendered derivative, distinct from the scanner
-preview used to place frames.
+Report problems in [GitHub Issues](https://github.com/rohanpandula/ScanStudio/issues)
+with the app version, Mac/macOS, scanner/holder, failed step, and typed error.
+Review diagnostic bundles before sharing; keep film images, private paths,
+serial numbers, and raw capture journals out of public reports.
 
-Settings apply to **future scans**. Changing a recipe, color style, or output
-setting does not reprocess existing exports or turn the scanner preview into
-a live proof of the finished image. Review the saved outputs after capture.
+## Licenses and references
 
-## What is a Coolscan?
+The app, engine, and documentation are MIT unless a file says otherwise.
+The separate `scanstudio-bridge` process and CoolscanPy are **GPL-3.0-only**.
+A bundle containing them is a mixed-license distribution: preserve its
+licenses, corresponding source, and dependency notices.
 
-A Coolscan is a dedicated film scanner. It reads a negative or slide directly
-instead of photographing it with a camera. The LS-5000 is older hardware, but
-its 4000 dpi film scans and infrared capability on many color films still make
-it useful. ScanStudio supplies a current workflow around that hardware; the
-compatibility table above is the honest statement of what is driven today.
+NegPy is independent upstream software. ScanStudio's nkscan references are
+**documentation-only cleanroom references** to identity and behavioral facts;
+no nkscan implementation code or profiles are copied. ASFireWire is likewise
+an interface reference, with no source vendored. See [third-party notices](THIRD_PARTY_NOTICES.md).
 
-## The 1:1 archive bundle
-
-ScanStudio can create an optional archive bundle for a completed frame. It is
-a record of the capture, not a substitute for the image. Depending on what the
-job actually produced, it can include the separate RGB master, conditional
-infrared and meter or prepass evidence, effective settings and alignment,
-engine and bridge receipts, bridge attempt journals only when their exact
-evidence root is reported, and a manifest with checksums.
-
-The bundle names missing evidence instead of inventing it. It does not replace
-or rewrite the capture files.
-
-## Safety and limits
-
-See [Mac acceptance and recovery](docs/MAC-ACCEPTANCE.md) for the packaged
-software gate and attended hardware checks. Simulator acceptance is not
-evidence of a successful real scan.
-
-- Preview establishes the current registration. Preview again after a refeed or ejection.
-- If Capture reports that the film shifted, physically refeed it and acquire a fresh preview; ScanStudio discards the old frame registration so it cannot be retried accidentally.
-- Confirm that the app identifies a real scanner before treating it as hardware. The built-in simulator is for safe workflow exploration only.
-- Keep physical film transport under supervision. Stop and inspect the scanner if the physical state is uncertain.
-- Opening ScanStudio does not move film. Only explicit Preview, Scan, and Eject actions can move film; developer bridge sessions require the documented hardware authorization.
-- Manual placement caps frames at the scanner's single-pass capture window (38.7 mm); panoramic frames refuse with an explanation instead of silently cropping.
-- Do not post scans, private paths, device serial numbers, or raw capture journals in a public issue.
-
-## Source and feedback
-
-Source: <https://github.com/rohanpandula/ScanStudio>
-
-Issues: <https://github.com/rohanpandula/ScanStudio/issues>
-
-## License boundary
-
-The ScanStudio app, engine, site, and documentation in this repository are
-offered under MIT unless a file says otherwise. Real scanner access uses a
-separate `scanstudio-bridge` program and its CoolscanPy dependency, both
-GPL-3.0-only. The bridge is not part of the MIT-only app boundary.
-
-Any distribution that includes the bridge must keep its GPL-3.0-only license,
-corresponding source, and applicable dependency notices with that
-distribution. Do not describe such a bundle as MIT-only.
-
-Third-party behavioral references (the nkscan identity facts and the
-ASFireWire interface facts) are documented in
-[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md); no source code from either
-project is vendored.
-
-ScanStudio is independent software. Nikon, Coolscan, SUPER COOLSCAN, Nikon
-Scan, and Digital ICE are trademarks or registered trademarks of their
-respective owners. No affiliation or endorsement is claimed.
+ScanStudio is not affiliated with Nikon. Nikon, Coolscan, SUPER COOLSCAN,
+Nikon Scan, and Digital ICE belong to their respective trademark owners.

--- a/app/ScanStudio/README.md
+++ b/app/ScanStudio/README.md
@@ -1,178 +1,190 @@
-# ScanStudio
+# ScanStudio for macOS
 
-ScanStudio is an Apple Silicon (M-series, arm64) macOS 14+ app for scanning 35 mm film with a Nikon Coolscan
-LS-5000. It keeps the scan workflow in one place: identify the film that is
-loaded, preview the roll, select frames, choose the capture settings, scan,
-and stop safely when needed.
+ScanStudio is a SwiftUI film-scanning app for **Apple Silicon (M-series,
+arm64), macOS 14 (Sonoma) or newer**. Its supported hardware workflow is
+LS-5000 C-41 color-roll scanning in Beta. This guide covers source builds;
+use the [install and scan guide](../../README.md) for the packaged app and
+[GitHub Releases](https://github.com/rohanpandula/ScanStudio/releases) for
+published downloads.
 
-Developer runs without a hardware bridge offer a clearly labeled
-**SIMULATED** LS-5000 for exploring the interface safely. The release DMG
-already includes the CoolscanPy bridge and its direct-USB runtime; source
-builds can instead configure a separate compatible bridge. The app never
-presents the simulator as hardware.
+## Run from source
 
-Apple Silicon support is Beta. Intel Macs, Windows, and Linux are retired;
-see [NegPy downloads](https://github.com/marcinz606/NegPy/releases) and its
-[setup and compatibility documentation](https://github.com/marcinz606/NegPy#readme)
-for alternatives, subject to upstream device and OS support. Real scanning has
-been tested on one Apple Silicon Mac and one LS-5000 setup. Treat
-each real scan as a new operation: confirm the detected carrier and the
-preview before starting capture. Real black-and-white fine scanning remains
-blocked rather than pretending that infrared dust removal is available for
-film where it is not appropriate.
-
-See the [hardware evidence matrix](../../docs/HARDWARE-SUPPORT.md) for the
-separate package, enumeration, preview, and capture results.
-[Mac acceptance and recovery](../../docs/MAC-ACCEPTANCE.md) documents the
-packaged software gate separately from attended hardware checks.
-
-## Use the app
-
-1. **Choose a device.** Connect the simulator for a safe walkthrough, or
-   connect the LS-5000 reported by the bridge.
-2. **Preview the roll.** The app detects the loaded carrier when the scanner
-   reports it, then obtains a preview and a contact sheet. The simulator uses
-   generated previews and labels them accordingly.
-3. **Select the frames to capture.** Choose one or more tiles, review their
-   preview, and adjust orientation, mirroring, crop, or alignment where those
-   controls are available. Rotation and mirroring are saved into the finished
-   Positive/Preview files; the archival Master TIFF and its RGB, IR, and meter
-   capture layers remain untouched. On an already-saved project, a new
-   transform remains a session draft until the next scan starts; existing
-   files are never silently rewritten.
-4. **Set up the scan.** Choose negative or positive handling, film stock,
-   recipe, output formats, naming, and destination. Keep the archival master
-   TIFF, positive TIFF, positive JPEG, or any combination, but retain at
-   least one output. Without a retained master, real capture uses a private
-   temporary workspace only while derivatives render and keeps it only if
-   recovery is needed.
-5. **Scan or stop.** Start the selected frames and follow the in-app progress.
-   The Stop button asks the current frame to finish safely, then prevents the
-   next frame from starting. Eject stays unavailable during active capture.
-
-**Scanner preview, capture, and exports are different stages.** The scanner
-preview establishes frame placement; Capture acquires the selected frames;
-Positive and generated Preview files are processed derivatives of that capture.
-Settings apply to **future scans**. Recipe, color, and output changes do not
-reprocess saved exports or provide a live color proof in the scanner preview.
-
-When a master is retained, a Full Capture Package keeps the master image together with
-the available capture context: per-frame effective settings, receipts,
-checksums, and optional infrared or meter material. Attempt journals are
-included only when the bridge supplies exact journal roots.
-
-For a plain-language guide to the Nikon Scan, Noritsu Lab, and Flextight
-color choices, see [COLOR.md](COLOR.md).
-
-## Architecture
-
-```
-ScanStudio (SwiftUI app)  <-- NDJSON over stdin/stdout -->  scanstudio-engine (Rust subprocess)
-```
-
-- The SwiftUI app (`Sources/ScanStudio`) spawns `scanstudio-engine` as a
-  child process and talks to it exclusively over stdin/stdout, one JSON object
-  per line (NDJSON). It is a projection of the state and capabilities the
-  engine reports.
-- `ScanStudioKit` (`Sources/ScanStudioKit`) contains the wire protocol,
-  engine location and client plumbing, and the observable session state used
-  by the UI.
-- The Rust engine (`engine/`) owns scanner/session state and is the sole
-  implementation of the wire contract.
-- The contract, fixtures, and state machines are documented in
-  [`protocol/PROTOCOL.md`](protocol/PROTOCOL.md). The bridge boundary is
-  documented in [`protocol/BRIDGE.md`](protocol/BRIDGE.md).
-
-## Prerequisites
-
-- Apple Silicon (M-series) Mac running macOS 14 or newer
-- Xcode / Swift toolchain (Swift 6, macOS 14+ SDK)
-- Rust via Homebrew (`brew install rust`), or any `cargo` on `PATH`
-
-## Build, run, test
+Use an Apple Silicon Mac with Swift 6 and the macOS SDK, plus Rust Cargo on
+`PATH`. From the **repository root**:
 
 ```sh
-make run     # builds the engine (release) and launches the app
-make test    # runs both suites: cargo test (engine) + swift test (app)
-make smoke   # scripted end-to-end NDJSON session against the release binary
-make app     # swift build only
-make engine  # cargo build --release only
-make clean   # removes build artifacts for both the engine and the app
+make -C app/ScanStudio run
 ```
 
-`make run` sets `SCANSTUDIO_ENGINE_PATH` to the freshly built release binary.
-Without that variable, `EngineLocator` searches the engine build locations
-relative to the package root and reports a clear in-app error if it cannot
-find one.
-
-### Manual run
+This builds the release engine, sets `SCANSTUDIO_ENGINE_PATH`, and launches
+the SwiftUI app. Without a hardware bridge, choose the clearly labeled
+**SIMULATED** LS-5000 for a software walkthrough. To shorten simulated delays:
 
 ```sh
-SCANSTUDIO_ENGINE_PATH="$(pwd)/engine/target/release/scanstudio-engine" swift run ScanStudio
+SCANSTUDIO_TIMESCALE=0.05 make -C app/ScanStudio run
 ```
 
-### Speeding up the simulator for demos
-
-Set `SCANSTUDIO_TIMESCALE` (default `1.0`) to multiply simulated delays. For
-example, `SCANSTUDIO_TIMESCALE=0.05 make run` provides a fast walkthrough.
-
-## Real hardware: LS-5000 through the CoolscanPy bridge
-
-The real-device backend speaks the NDJSON contract in
-[`protocol/BRIDGE.md`](protocol/BRIDGE.md) to `scanstudio-bridge`, the
-GPL-3.0-only CoolscanPy helper. `make package` includes that helper, a
-relocatable CPython 3.13 runtime, production Python dependencies (including
-`python-sane` 2.9.2 built from its exact locked sdist), a signed app-owned
-libusb built from pinned source for the app's macOS 14 deployment target, and
-visible license/source material inside `ScanStudio.app`. The python-sane C
-extension is compiled against a private, source-pinned SANE 1.4.0 link SDK;
-the packager proves the SDK-only Mach-O identity before rewriting it to the
-architecture's canonical host `libsane.1.dylib` path. The private SDK and SANE
-runtime are never shipped. The app also does not include Nikon software.
-
-The package launcher resolves a bridge in this order: `SCANSTUDIO_BRIDGE_CMD`,
-the user bridge-command file, the bundled helper, then `PATH`. Set
-`SCANSTUDIO_BRIDGE_CMD` to use a different compatible bridge:
+The default timescale is `1.0`. From **app/ScanStudio**, after building the
+engine, the equivalent manual launch is:
 
 ```sh
-SCANSTUDIO_BRIDGE_CMD=/path/to/scanstudio-bridge make run
+SCANSTUDIO_ENGINE_PATH="$PWD/engine/target/release/scanstudio-engine" swift run ScanStudio
 ```
 
-- **Unset or empty:** only the labeled simulator is available.
-- **Working bridge:** the real scanner is offered for connection; while real
-  hardware is available, the simulator is hidden from device choice.
-- **Broken or incompatible bridge:** the engine reports the startup problem
-  and remains simulator-only; it does not create a half-connected device.
+## Test and build scopes
 
-When the packaged launcher selects any working bridge, it automatically
-prepares that app session for film movement. Launch itself performs no scanner
-operation; only explicit Preview, Scan, and Eject actions can move film. Direct
-bridge and developer launches still need to provide the two-part authorization
-described in `protocol/BRIDGE.md`.
+Bridge and driver tests also need `uv` and Python 3.13+. All commands below
+run from the **repository root**:
 
-The supported color-roll path does not require SANE. On a clean Mac, device
-discovery and connection fall back to the app-owned direct-USB route;
-film-status checks, whole-roll preview, and color fine scanning use direct USB
-and the exact signed libusb copy inside the app. A recipient does not need
-Homebrew, SANE, or a Nikon driver for that workflow. If a working host SANE
-installation already exists, discovery may use it, but capture remains direct
-USB. The bridge still includes `python-sane` for its separate plain-scan path;
-that optional path needs a compatible system SANE backend (`brew install
-sane-backends` on the tested Apple Silicon setup). Eject replays the traced
-Unload sequence over direct USB and confirms film absence; it needs neither
-SANE nor `scanimage`. If an unavailable optional path is requested, it fails
-rather than pretending it succeeded; it does not turn a real scanner into the
-simulator.
+```sh
+make test                       # Swift + Rust + bridge + CoolscanPy suites
+make -C app/ScanStudio test      # Swift and Rust only
+make -C app/ScanStudio smoke     # scripted simulator NDJSON session
+make -C app/ScanStudio app       # Swift build only
+make -C app/ScanStudio engine    # cargo build --release only
+make bridge-test                # locked bridge sync, then pytest
+make coolscanpy-test             # driver pytest
+make -C app/ScanStudio launcher-check
+```
 
-Release and CI packaging do not install Homebrew SANE as a build input. Use
-`make sane-link-sdk` only to inspect the create-only private SDK generated from
-the exact sane-backends 1.4.0 archive (SHA-256
-`f99205c903dfe2fb8990f0c531232c9a00ec9c2c66ac7cb0ce50b4af9f407a72`).
-`make package` performs the same source build in private staging, compiles the
-exact python-sane 2.9.2 sdist from the bridge lock, and rejects mismatched
-architecture, macOS 14 minimum, ABI, RPATHs, build paths, extra extensions,
-or accidental SDK/runtime files before signing.
+There is no root `run` target. Root `make test` covers all four components,
+but does not replace the packaging, macOS 14, policy, and updater release gates.
+`make -C app/ScanStudio clean` removes both engine and Swift build artifacts.
 
-The device bar identifies a connected real device as `real` and the simulator
-as `simulated`. Selecting a device is separate from confirming that film is
-present and previewed.
+## Connect real hardware in a source run
+
+From the repository root:
+
+```sh
+make bridge-sync
+SCANSTUDIO_BRIDGE_CMD="$PWD/bridge/.venv/bin/scanstudio-bridge" make -C app/ScanStudio run
+```
+
+Developer sessions must also satisfy the two-part hardware authorization in
+[BRIDGE.md](protocol/BRIDGE.md) before motion. For the normal attended workflow,
+use the packaged app and follow [Mac acceptance and recovery](../../docs/MAC-ACCEPTANCE.md).
+
+The packaged launcher resolves the bridge in this order: `SCANSTUDIO_BRIDGE_CMD`,
+`~/Library/Application Support/ScanStudio/bridge-command`, bundled helper,
+then `PATH`. It prepares session authorization; launch itself does not move
+film. Preview, Scan, and Eject are explicit operations with readiness and
+approval checks. A working bridge offers real hardware and hides the simulator
+when hardware is available. A broken bridge reports its startup error and
+leaves the simulator labeled; failed hardware operations never become
+simulated successes.
+
+## Build a local app or DMG
+
+Packaging requires native arm64 macOS; Intel/Rosetta and other architecture
+requests are rejected. Match CI with Rust **1.97.1**, **uv 0.11.30**, and
+relocatable managed **CPython 3.13.14, build 20260718**. See the
+[pinned installer](../../scripts/install_pinned_uv_python.py) and its
+[CI bootstrap sequence](../../.github/workflows/ci.yml). A Homebrew/framework
+Python is not a relocatable package runtime.
+
+With those tools available, run this **from the repository root**:
+
+```sh
+export UV_PYTHON=3.13.14
+export UV_PYTHON_PREFERENCE=only-managed
+export UV_PYTHON_CPYTHON_BUILD=20260718
+(cd bridge && uv sync --locked --no-dev --no-install-package python-sane)
+make -C app/ScanStudio package
+```
+
+This follows CI's dependency path. It creates
+`app/ScanStudio/.build/ScanStudio.app` and runs the relocated bridge and
+simulator acceptance checks. These commands rerun the existing app's gate or
+build a version-stamped local DMG:
+
+```sh
+make -C app/ScanStudio package-check
+SCANSTUDIO_RELEASE_VERSION=0.7.0-beta.15 make -C app/ScanStudio dmg
+```
+
+`dmg` rebuilds/checks the app, creates
+`app/ScanStudio/.build/ScanStudio-0.7.0-beta.15-macOS-arm64.dmg`, mounts it
+read-only, and checks the app inside. It refuses an existing DMG at that path.
+Local builds default to an ad-hoc app signature; these commands do not notarize
+or publish a release. The [release workflow](../../.github/workflows/release.yml)
+signs, notarizes, and staples both app and DMG after its exact-tag, same-run
+gates. See [release policy](../../docs/releases/README.md).
+
+Root `make package` and `make dmg` first run `bridge-sync-scanner`, asking uv
+to install the scanner extra. The app-directory path above instead lets the
+packager compile locked python-sane 2.9.2 against a private, pinned SANE 1.4.0
+link SDK, without host SANE as a build input. Neither that SDK nor a SANE
+runtime ships. For standalone SDK inspection, use
+`make -C app/ScanStudio sane-link-sdk` (create-only output).
+
+The app bundles its own signed libusb. LS-5000 color-roll status, preview,
+capture, and eject use direct USB; discovery/connection fall back to direct
+USB without SANE. Only the legacy plain-scan path needs a compatible host SANE
+backend. Eject confirms film absence without SANE or `scanimage`.
+
+## Scan, inspect saved files, and recover
+
+Create or open a roll, explicitly preview the film, review frame placement,
+choose outputs and a writable destination, then scan. A saved project does not
+establish physical registration. Recovered/manual boundaries need approval.
+
+Scanner preview locates frames; capture reads them at scan resolution.
+Positive TIFF/JPEG and generated Preview files are processed exports, separate
+from the optional archival Master TIFF. Settings apply to **future scans**:
+recipe, crop, color, and output changes do not rewrite saved files or update
+scanner previews. Rotation/mirroring affect processed exports, leaving the
+Master and its RGB/infrared/meter capture material untouched. Project edits
+can remain drafts until the next scan starts.
+
+Retain a Master TIFF, positive TIFF/JPEG, or both. With no retained master,
+capture uses temporary storage during rendering and preserves it if recovery
+is needed. Optional raw exports include Linear DNG and linear TIFF with
+infrared options. A **Full Capture Package** adds available settings, receipts,
+checksums, and evidence to the master; attempt journals require exact reported
+roots. See [COLOR.md](COLOR.md) for rendering choices.
+
+In **Saved roll**, use **Show Roll Folder in Finder** or **Frame N Saved Files**
+to reveal recorded outputs. Missing files are reported explicitly. Completion
+counts follow receipts; inspect saved images too.
+
+For hardware, choose **Stop after frame**; in the simulator, **Pause after
+frame**. Wait for the batch to stop and preserve files, receipts, and journals.
+Early Stop remains latched through batch setup; eject is unavailable during
+capture. Save failure details with **Save Diagnostic Bundle…**.
+
+Reopen the same roll when safe, follow any refeed instruction, and obtain a
+fresh preview after stopping. Resolve readiness/attendance prompts, then use
+**Resume Batch (N remaining)**. It requires a successful current pending-frame
+read and omits completed/excluded frames. Reconnection alone cannot restore
+film position or authorize a stale selection. Follow the
+[recovery procedure](../../docs/MAC-ACCEPTANCE.md) instead of restarting the
+whole roll or deleting receipts.
+
+Final attended full-roll hardware acceptance for beta.15 is **NOT RUN**. Simulator
+acceptance covers stop, reopen, process interruption, destination refusal,
+resume, and saved-file integrity; it cannot prove physical image quality or
+transport. The [hardware matrix](../../docs/HARDWARE-SUPPORT.md) distinguishes
+LS-5000 evidence from recognition/probing of unsupported models. Real B&W
+fine scanning remains blocked; infrared ICE is unsuitable for silver B&W film.
+
+## Contracts, platforms, and licenses
+
+```text
+SwiftUI app → scanstudio-engine (Rust) → scanstudio-bridge (Python) → CoolscanPy → scanner
+```
+
+The app/engine and engine/bridge each use a separate NDJSON stdin/stdout
+connection. The engine owns scanner/session state; `Sources/ScanStudioKit`
+contains app wire types, client plumbing, and observable state. See
+[PROTOCOL.md](protocol/PROTOCOL.md) and [BRIDGE.md](protocol/BRIDGE.md).
+
+Intel Macs, Windows, and Linux are retired. Consult [NegPy downloads](https://github.com/marcinz606/NegPy/releases)
+and [upstream compatibility guidance](https://github.com/marcinz606/NegPy#readme)
+for those platforms. nkscan is a documentation-only cleanroom reference;
+no implementation code or profiles are copied.
+
+The app/engine are MIT; the separate bridge and CoolscanPy are GPL-3.0-only.
+Packaged apps are mixed-license distributions. Preserve
+`Contents/Resources/Licenses` and `Contents/Resources/CorrespondingSource`,
+including dependency notices and rebuild material. See
+[third-party notices](../../THIRD_PARTY_NOTICES.md).

--- a/app/ScanStudio/protocol/BRIDGE.md
+++ b/app/ScanStudio/protocol/BRIDGE.md
@@ -1,6 +1,10 @@
 # Scan Studio Bridge Protocol v1
 
-Contract between the external `scanstudio-bridge` sidecar (GPL-3.0, wraps CoolscanPy, lives outside this repo) and its client (Phase 9's `RealLs5000` backend). This is a second, independent NDJSON-over-stdio boundary that mirrors PROTOCOL.md's style — it is not an extension of PROTOCOL.md and the two protocols never share a wire connection. No GPL code exists in this repo; this file is the wire contract only, read by anyone implementing either side without opening a bridge source file.
+Contract between the GPL-3.0-only [`scanstudio-bridge`](../../../bridge/README.md)
+service and the Rust engine’s real LS-5000 backend. The bridge and CoolscanPy
+source are included in this repository and in the packaged app’s corresponding
+source. This is a separate NDJSON-over-stdio boundary from PROTOCOL.md; the
+app/engine and engine/bridge protocols do not share a wire connection.
 
 ## Transport
 
@@ -16,7 +20,7 @@ Contract between the external `scanstudio-bridge` sidecar (GPL-3.0, wraps Coolsc
 
 ## Error codes
 
-`UNKNOWN_METHOD`, `INVALID_PARAMS`, `NOT_CONNECTED`, `ALREADY_CONNECTED`, `DEVICE_NOT_FOUND`, `DEVICE_BUSY`, `NO_PREVIEW`, `UNKNOWN_JOB`, `HW_MOTION_NOT_ARMED`, `HARDWARE_LANE_BUSY`, `EJECT_FAILED`, `FEEDER_PARKED`, `ADAPTER_UNSUPPORTED`, `FINGERPRINT_REFUSED`, `MANUAL_REVIEW_REQUIRED`, `REFEED_REQUIRED`, `FILM_FEED_INTERRUPTED`, `ROLL_MISMATCH`, `TRANSPORT_SMEAR_DETECTED`, `GEOMETRY_VALIDATION_ERROR`, `SPLIT_ALIGNMENT_ERROR`, `BATCH_INTEGRITY_ERROR`, `NOT_IMPLEMENTED`, `INTERNAL` — 24 total.
+`UNKNOWN_METHOD`, `INVALID_PARAMS`, `NOT_CONNECTED`, `ALREADY_CONNECTED`, `DEVICE_NOT_FOUND`, `DEVICE_BUSY`, `NO_PREVIEW`, `UNKNOWN_JOB`, `HW_MOTION_NOT_ARMED`, `HARDWARE_LANE_BUSY`, `EJECT_FAILED`, `FEEDER_PARKED`, `ADAPTER_UNSUPPORTED`, `FINGERPRINT_REFUSED`, `MANUAL_REVIEW_REQUIRED`, `REFEED_REQUIRED`, `FILM_FEED_INTERRUPTED`, `ROLL_MISMATCH`, `TRANSPORT_SMEAR_DETECTED`, `GEOMETRY_VALIDATION_ERROR`, `SPLIT_ALIGNMENT_ERROR`, `BATCH_INTEGRITY_ERROR`, `METER_UNUSABLE`, `METER_CONTROLLER_REFUSED`, `NOT_IMPLEMENTED`, `INTERNAL`.
 
 `recoverable` is `true` only for `HARDWARE_LANE_BUSY`: retrying the identical request once the lane frees can succeed with no other action. Every other code needs a *different* action first — re-arm the latch, call `roll.approve`, physically refeed the strip, power-cycle the transport — so every other code is `recoverable: false`.
 
@@ -38,6 +42,8 @@ Contract between the external `scanstudio-bridge` sidecar (GPL-3.0, wraps Coolsc
 | `GeometryValidationError` | `GEOMETRY_VALIDATION_ERROR` |
 | `SplitAlignmentError` | `SPLIT_ALIGNMENT_ERROR` |
 | `BatchIntegrityError` | `BATCH_INTEGRITY_ERROR` |
+| `MeterUnusableError` | `METER_UNUSABLE` |
+| `MeterControllerRefused` | `METER_CONTROLLER_REFUSED` |
 | `NotImplementedError` | `NOT_IMPLEMENTED` |
 
 ## Methods
@@ -135,7 +141,13 @@ The engine may supply a private, job-owned `output` route when the user has elec
 
 ### `scan.stop`
 
-Stops **between transfers** only (mirrors CoolscanPy's `Roll.safe_stop()`): the in-flight slot always finishes and is reported via `scan.frameCompleted`, the next slot is skipped, no other slots are attempted. There is no `"immediate"` mode — no safe immediate abort exists against real hardware (see "Differences from PROTOCOL.md"). `acknowledged: false` if the job already reached a terminal state.
+Requests a stop **between transfers**. An in-flight slot is allowed to finish
+and is reported via `scan.frameCompleted` if successful; later slots are skipped.
+An acknowledged Stop before worker startup or batch reservation remains latched
+and can finish the job without starting a frame. Driver reservation and retry
+must not erase it. Wait for `scan.completed`; acknowledgement alone is not proof
+that the scanner is idle. There is no `"immediate"` mode. A terminal job returns
+`acknowledged: false`.
 
 ### `device.eject` (MOTION-CAPABLE)
 
@@ -143,7 +155,7 @@ Returns `HARDWARE_LANE_BUSY` while a scan job holds the lane — mirrors PROTOCO
 
 **`{}` means confirmed ejected, never anything less (2026-07-26).** A transport that reports the film did not come out, a capability-gated no-op, or any accepted-without-progress outcome surfaces as a typed error, never as `{}`. This rule exists because an LS-5000 can acknowledge an eject command while the parked mechanism does not actuate.
 
-- `EJECT_FAILED` — the direct-USB unload could not run, returned an unconfirmed result, or the post-unload presence check did not prove the film clear. Eject does not require SANE or `scanimage`. The typed error preserves the underlying refusal; callers must not infer success or auto-retry it.
+- `EJECT_FAILED` — the direct-USB unload could not run, returned an unconfirmed result, or the post-unload presence check did not prove the film clear. Eject does not require SANE or `scanimage`. The driver performs that confirmation; the bridge uses its confirmed result without a second presence probe. The typed error preserves the underlying refusal; callers must not infer success or auto-retry it.
 - `FEEDER_PARKED` — the typed stalled outcome: the driver's traced eject reported accepted-without-confirmed-clear (CoolscanPy `FeederParked`). The film state is unknown-but-likely-inside, the session is left untouched, and a power cycle is the only demonstrated recovery. A client must NEVER auto-retry this (or any) eject outcome — retry decisions belong to the operator at the machine.
 
 SANE remains a host/runtime requirement on lanes that use it for discovery,

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -6,7 +6,7 @@ responses and asynchronous scan events share that connection. It has no GUI.
 
 The released ScanStudio app includes the bridge, its Python runtime, libusb,
 licenses, and corresponding source. App users should follow the
-[ScanStudio installation guide](../README.md) instead of installing a second
+[ScanStudio installation guide](https://github.com/rohanpandula/ScanStudio/blob/main/README.md) instead of installing a second
 bridge. ScanStudio supports Apple Silicon Macs running macOS 14 or newer.
 The standalone [CoolscanPy driver](../coolscanpy/README.md) has its own platform
 and scanner support boundaries.
@@ -23,9 +23,9 @@ Eject does not require SANE or `scanimage`; the optional `scanner` extra is for
 CoolscanPy’s legacy SANE plain-scan path. The Rust engine and native app own
 project persistence, user-facing recovery, and processed output presentation.
 
-Read the [bridge wire protocol](../app/ScanStudio/protocol/BRIDGE.md) for
+Read the [bridge wire protocol](https://github.com/rohanpandula/ScanStudio/blob/main/app/ScanStudio/protocol/BRIDGE.md) for
 methods, events, field names, and errors. The separate
-[app/engine protocol](../app/ScanStudio/protocol/PROTOCOL.md) is not a bridge
+[app/engine protocol](https://github.com/rohanpandula/ScanStudio/blob/main/app/ScanStudio/protocol/PROTOCOL.md) is not a bridge
 connection.
 
 ## Develop and test
@@ -68,7 +68,7 @@ from the driver; the bridge does not issue a second confirmation probe.
 The bridge records session provenance, call/phase outcomes, and anomalies under
 `~/.scanstudio/hw-telemetry/` by default. Capture journals and durable project
 receipts provide different evidence; no single log contains every UI progress
-update. Follow the [Mac acceptance and full-roll guide](../docs/MAC-ACCEPTANCE.md)
+update. Follow the [Mac acceptance and full-roll guide](https://github.com/rohanpandula/ScanStudio/blob/main/docs/MAC-ACCEPTANCE.md)
 for exact paths, continuous observation, stop/reopen/resume, and image checks.
 Preserve live receipts and originals. Monitoring is not an automatic retry loop.
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,25 +1,84 @@
-# scanstudio-bridge
+# ScanStudio bridge
 
-A headless NDJSON-over-stdio service that wraps CoolscanPy's LS-5000 roll-feeder
-engine so the Scan Studio Rust engine can drive real Nikon SUPER COOLSCAN 5000 ED
-hardware. The canonical wire-protocol spec is in this repository at
-`app/ScanStudio/protocol/BRIDGE.md` — read that file for every method, error
-code, type, and event this service implements.
+`scanstudio-bridge` is the headless Python service between ScanStudio’s Rust
+engine and CoolscanPy. It exchanges newline-delimited JSON over stdin/stdout;
+responses and asynchronous scan events share that connection. It has no GUI.
 
-License: GPL-3.0-only
+The released ScanStudio app includes the bridge, its Python runtime, libusb,
+licenses, and corresponding source. App users should follow the
+[ScanStudio installation guide](../README.md) instead of installing a second
+bridge. ScanStudio supports Apple Silicon Macs running macOS 14 or newer.
+The standalone [CoolscanPy driver](../coolscanpy/README.md) has its own platform
+and scanner support boundaries.
 
-## Development
+## What it owns
 
+The bridge discovers and opens positively identified supported LS-5000 units,
+requests roll previews, handles frame review and capture, writes output and
+receipt evidence, and reports typed failures. Discovery alone is not evidence
+that a scanner, holder, or film process can complete a capture.
+
+The supported roll path uses direct USB for color-negative capture and eject.
+Eject does not require SANE or `scanimage`; the optional `scanner` extra is for
+CoolscanPy’s legacy SANE plain-scan path. The Rust engine and native app own
+project persistence, user-facing recovery, and processed output presentation.
+
+Read the [bridge wire protocol](../app/ScanStudio/protocol/BRIDGE.md) for
+methods, events, field names, and errors. The separate
+[app/engine protocol](../app/ScanStudio/protocol/PROTOCOL.md) is not a bridge
+connection.
+
+## Develop and test
+
+Use Python 3.13 or newer and the repository’s pinned uv toolchain. From the
+repository root:
+
+```sh
+cd bridge
+uv sync --locked
+uv run --locked pytest
+bash scripts/smoke_bridge.sh
 ```
-uv sync
-uv run pytest
-```
 
-This project uses the checkout-local `../coolscanpy` source through the locked
-`uv` configuration. It does not require a sibling archaeology checkout.
+The lockfile uses checkout-local `../coolscanpy`; no archaeology checkout or
+separate installed driver is needed. Unit tests substitute hardware dispatch.
+The smoke script launches the actual console entry point with the mock
+transport and a temporary state directory, and checks that unarmed preview is
+refused. These checks do not move a scanner or establish hardware acceptance.
 
-Motion is refused unless both `SCANSTUDIO_HW_MOTION=1` is set and a non-empty
-regular authorization-latch file is present. The packaged ScanStudio launcher
-prepares both for its own app session; direct bridge/developer launches must do
-so themselves. Opening the app sends no motion command. See BRIDGE.md's SAFE-02
-guardrails section for the full policy.
+The console entry point is `scanstudio-bridge`. Production defaults to the
+CoolscanPy transport. `SCANSTUDIO_BRIDGE_TRANSPORT=mock` selects the mock;
+`SCANSTUDIO_BRIDGE_BASE_DIR` isolates process ownership and telemetry storage
+for a development run. Use the packaged app for attended hardware work.
+
+## Stop, recovery, and monitoring
+
+Motion requires both `SCANSTUDIO_HW_MOTION=1` and a valid nonempty authorization
+latch. The packaged launcher prepares these for its owned app session. Starting
+the app does not itself request scanner movement. A process-ownership lock and
+one hardware lane prevent competing bridge sessions from controlling the unit.
+
+`scan.stop` is a request to stop safely, not an immediate physical abort. Its
+acknowledgement is not a completed-job event: wait for `scan.completed` and the
+app’s recovery instructions. An early acknowledged Stop remains bound to the
+accepted job through worker startup and batch reservation. Shutdown refuses to
+claim completion while an owned worker remains active. Confirmed eject comes
+from the driver; the bridge does not issue a second confirmation probe.
+
+The bridge records session provenance, call/phase outcomes, and anomalies under
+`~/.scanstudio/hw-telemetry/` by default. Capture journals and durable project
+receipts provide different evidence; no single log contains every UI progress
+update. Follow the [Mac acceptance and full-roll guide](../docs/MAC-ACCEPTANCE.md)
+for exact paths, continuous observation, stop/reopen/resume, and image checks.
+Preserve live receipts and originals. Monitoring is not an automatic retry loop.
+
+## Distribution and license
+
+The bridge and CoolscanPy are GPL-3.0-only; see [LICENSE](LICENSE). Their source
+and notices accompany packaged distributions. The app/engine’s MIT license
+does not make the combined bundle MIT-only.
+
+ScanStudio releases verify the bridge suite, exact packaged runtime, and
+matching published CoolscanPy source before publishing a signed app. Driver
+changes must reach the canonical driver release first; a version string alone
+is not proof of parity.

--- a/bridge/pyproject.toml
+++ b/bridge/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # of the base dependency set: the bridge's test suite doesn't touch
     # hardware, and python-sane needs OS SANE headers to build, which the
     # test/CI environment doesn't have. Package builds install the `scanner`
-    # extra below so the optional plain-scan/eject compatibility path remains
+    # extra below so the optional legacy plain-scan compatibility path remains
     # available when a host SANE backend exists; color-roll capture does not
     # use it.
     "coolscanpy",
@@ -31,7 +31,7 @@ dependencies = [
 [project.optional-dependencies]
 # The production hardware bridge is installed with `uv sync --extra scanner`.
 # python-sane is packaged as part of this extra, and a compatible OS SANE
-# backend remains a host prerequisite only for plain scan and software eject.
+# backend remains a host prerequisite only for the legacy plain-scan path.
 # ScanStudio packages its own libusb for CoolscanPy's direct color-roll path.
 scanner = ["coolscanpy[scanner]"]
 
@@ -48,8 +48,6 @@ dev = [
 coolscanpy = { path = "../coolscanpy", editable = true }
 
 [project.scripts]
-# cli.py doesn't exist until Plan 08-03; fine, `uv sync` only needs this
-# string to resolve when the console script actually runs.
 scanstudio-bridge = "scanstudio_bridge.cli:main"
 
 [tool.setuptools.packages.find]

--- a/bridge/src/scanstudio_bridge/service.py
+++ b/bridge/src/scanstudio_bridge/service.py
@@ -944,6 +944,11 @@ class BridgeService:
         self._lane_held = True
         self._motion_op_active = True
 
+        # The real transport must arm its job stop latch before the worker
+        # starts: scan.stop/shutdown can arrive before start_scan() enters.
+        prepare_scan = getattr(self._transport, "prepare_scan", None)
+        if callable(prepare_scan):
+            prepare_scan()
         self._seen_job_ids.add(job_id)
         job_record: dict = {"job_id": job_id, "terminal": False}
         self._last_job = job_record

--- a/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -760,8 +760,7 @@ class CoolscanPyTransport:
     def _failed_attempt_evidence(
         self, error: IndexDecodeError
     ) -> tuple[dict[str, object] | None, str | None]:
-        info = getattr(self._device, "info", None)
-        capabilities = getattr(info, "capabilities", None)
+        capabilities = getattr(self._device, "capabilities", None)
         capacity = getattr(capabilities, "adapter_frame_capacity", 40)
         try:
             return (
@@ -784,22 +783,29 @@ class CoolscanPyTransport:
         if self._device is not None:
             raise BridgeError(ErrorCode.ALREADY_CONNECTED, "a device is already open")
         try:
-            opened_device = coolscanpy.open(device_id)
+            # Device exposes capabilities, not DeviceInfo. Resolve the public
+            # discovery record, then open that exact ID (never the alias again).
+            # open() independently revalidates attachment and support.
+            infos = coolscanpy.get_devices()
+            matches = [
+                info for info in infos
+                if isinstance(info, coolscanpy.DeviceInfo)
+                and (info.supported if device_id == "ls5000" else info.id == device_id)
+            ]
+            if len(matches) != 1:
+                raise coolscanpy.DeviceNotFound(
+                    f"expected one attached Coolscan matching {device_id!r}; found {len(matches)}"
+                )
+            info = matches[0]
+            if not info.supported:
+                raise coolscanpy.DeviceNotFound(
+                    f"{info.model} is not a positively identified supported LS-5000"
+                )
+            opened_device = coolscanpy.open(info.id)
         except coolscanpy.DeviceNotFound as exc:
             raise BridgeError(ErrorCode.DEVICE_NOT_FOUND, str(exc)) from exc
         except coolscanpy.DeviceBusy as exc:
             raise BridgeError(ErrorCode.DEVICE_BUSY, str(exc)) from exc
-        info = getattr(opened_device, "info", None)
-        if not isinstance(info, coolscanpy.DeviceInfo) or not info.supported:
-            try:
-                opened_device.close()
-            except Exception:
-                pass
-            model = getattr(info, "model", "unverified scanner identity")
-            raise BridgeError(
-                ErrorCode.DEVICE_NOT_FOUND,
-                f"{model} is not a positively identified supported LS-5000",
-            )
         self._device = opened_device
         self._device_id = info.id
         return _device_info_from_coolscanpy(info)

--- a/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
+++ b/bridge/src/scanstudio_bridge/transport/coolscanpy_transport.py
@@ -12,10 +12,10 @@ level -- every other module stays hardware-library-free.
 from __future__ import annotations
 
 import json
-import math
 import os
 import re
 import subprocess
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -105,93 +105,6 @@ from scanstudio_bridge.transport.output_reservation import (
 # absent" -- provenance reporting must never be able to hang bridge
 # startup.
 _GIT_HEAD_SHA_TIMEOUT_SECONDS = 5.0
-
-# `_require_vendor_eject_confirmed`'s settle-and-retry loop calls these two
-# module-level names instead of `time.sleep`/`time.monotonic` directly
-# (2026-08-13 adversarial review of PR #88, P2-5): a test that needs to
-# fake the clock swaps THESE names (`monkeypatch.setattr(<this module>,
-# "_sleep", ...)` / `"_monotonic"`), never the real stdlib `time` module.
-# Mutating the actual `time.sleep`/`time.monotonic` for a test's duration
-# would be process-visible to any other live thread in the same test run
-# (e.g. service.py's scan soft-timeout watchdog, which really does sleep
-# in real time), not just this one call.
-_sleep = time.sleep
-_monotonic = time.monotonic
-
-# LV-2 (2026-08-13 live validation, shortstrip-lab/live-attempts/
-# 20260813-beta8-linux-validation/RESULT.md +
-# vm-logs/eject-nopreview-194010.log): on a real LS-5000, a genuinely
-# successful vendor eject's confirmation probe (Device.film_present(), see
-# _require_vendor_eject_confirmed) can land inside the scanner's
-# post-motion UNIT ATTENTION drain (sense 063f04/062800 before it settles
-# to 023a00) and read back an indeterminate None -- not because the film
-# is still loaded, but because the drain hasn't cleared yet. Motion-free
-# probes ~15-20s later returned a definitive film_present=False.
-#
-# 2026-08-13 adversarial review of PR #88, P1-1: `Device.film_present()`
-# is not a cheap, instantaneous read. It calls coolscanpy's own
-# `coolscanpy.transport.adapter_status.probe_adapter_status()`, which
-# ALREADY drains these same startup unit-attention senses internally --
-# polling for up to its own `_SETTLE_DEADLINE_SECONDS` (10.0s, present
-# since before beta.8) before it gives up and returns None. So a single
-# `film_present()` call that comes back None can itself have already cost
-# up to ~10s of wall time; the original 15.0s OUTER window (sized as if
-# each call were free) bought only about two such calls, ending around
-# ~21s -- barely past RESULT.md's own observed 15-20s clearing, not the
-# "well inside" margin its comment claimed.
-#
-# `_VENDOR_EJECT_CONFIRM_SETTLE_SECONDS` below is total OUTER wall time
-# across every retry, not a per-call budget: each retry can itself cost up
-# to that inner ~10s, so 40.0s budgets roughly four such attempts (worst-
-# case realized time landing a bit past 40s once the triggering attempt's
-# own ~10s is counted -- the same shape as the old 15s/~21s relationship,
-# just with far more headroom): at least 2x RESULT.md's observed 15-20s
-# clearing, and about 4x its own ~10s typical estimate.
-#
-# `SCANSTUDIO_EJECT_CONFIRM_SETTLE_SECS` lets an out-of-process harness
-# drive a shorter window without a rebuild, on the same env-tunable idiom
-# as this bridge's own `service._scan_timeout_seconds` and the engine's
-# own `SCANSTUDIO_EJECT_DEADLINE_SECS`
-# (`real_backend.rs::eject_call_deadline_from_env`, PR #89, not yet
-# merged). That engine-side eject RPC deadline (300s default) wraps this
-# whole bridge call plus everything else the eject path does, and
-# dominates the worst-case end-to-end time even with this window at 40s.
-#
-# A definite True or False verdict at ANY attempt still resolves
-# immediately -- these constants only bound how long a persistently
-# INDETERMINATE probe is retried. That includes the pathological case of a
-# probe that never resolves at all (a permanently wedged interface, a
-# device that always times out): before this settle window existed, that
-# failed EJECT_FAILED instantly; now it burns the full window first. This
-# is a deliberate trade, not an oversight -- still bounded (40s, never
-# unbounded) and still typed EJECT_FAILED, in exchange for no longer
-# misreporting LV-2's transient-drain shape as a failure.
-_VENDOR_EJECT_CONFIRM_SETTLE_ENV_VAR = "SCANSTUDIO_EJECT_CONFIRM_SETTLE_SECS"
-_VENDOR_EJECT_CONFIRM_SETTLE_SECONDS = 40.0
-_VENDOR_EJECT_CONFIRM_POLL_INTERVAL_SECONDS = 1.0
-
-
-def _vendor_eject_confirm_settle_seconds() -> float:
-    """`SCANSTUDIO_EJECT_CONFIRM_SETTLE_SECS`, read once per
-    `_require_vendor_eject_confirmed` call -- the same unset-or-unparseable-
-    falls-back-to-default idiom as this bridge's own
-    `service._scan_timeout_seconds`, plus the strictness of the engine's
-    own `real_backend.rs::eject_call_deadline_from_env`
-    (`SCANSTUDIO_EJECT_DEADLINE_SECS`): a non-positive or non-finite value
-    is rejected too, since zero (or a negative, NaN, or infinite value)
-    would either expire before a single probe could return or never
-    expire at all. Never raises."""
-    raw = os.environ.get(_VENDOR_EJECT_CONFIRM_SETTLE_ENV_VAR)
-    if raw is None:
-        return _VENDOR_EJECT_CONFIRM_SETTLE_SECONDS
-    try:
-        value = float(raw)
-    except ValueError:
-        return _VENDOR_EJECT_CONFIRM_SETTLE_SECONDS
-    if not math.isfinite(value) or value <= 0:
-        return _VENDOR_EJECT_CONFIRM_SETTLE_SECONDS
-    return value
-
 
 # The wire and CoolscanPy enum string VALUES do not match (see BRIDGE.md's
 # Types note) -- never assume they do, always translate explicitly.
@@ -738,6 +651,9 @@ class CoolscanPyTransport:
         self._material: domain.Material | None = None
         self._preview_established = False
         self._scanning = False
+        self._stop_lock = threading.RLock()
+        self._scan_prepared = False
+        self._stop_requested = False
         # Plan 10-09 (attempts-root persistence): the exact `attempts_root`
         # passed to `Device.roll()` below, kept here purely for our own
         # reporting -- service.py reads this (via getattr, since
@@ -761,7 +677,11 @@ class CoolscanPyTransport:
         self, error: IndexDecodeError
     ) -> tuple[dict[str, object] | None, str | None]:
         capabilities = getattr(self._device, "capabilities", None)
-        capacity = getattr(capabilities, "adapter_frame_capacity", 40)
+        capacity = getattr(capabilities, "adapter_frame_capacity", None)
+        if capacity is None:
+            # Direct USB has no negotiated holder capacity. Use the existing
+            # 40-anchor diagnostic bound, never as authority for scan motion.
+            capacity = 40
         try:
             return (
                 publish_index_failure(
@@ -1414,6 +1334,12 @@ class CoolscanPyTransport:
 
     # -- scanning -----------------------------------------------------------------
 
+    def prepare_scan(self) -> None:
+        """Arm cancellation at job acceptance, before the worker can be stopped."""
+        with self._stop_lock:
+            self._stop_requested = False
+            self._scan_prepared = True
+
     def start_scan(
         self,
         slots: list[int],
@@ -1451,7 +1377,12 @@ class CoolscanPyTransport:
         # _trim_out_of_table_slots' recovery to exactly one attempt per
         # start_scan call -- see the RollMismatch handler below.
         table_trim_retried = False
-        self._scanning = True
+        with self._stop_lock:
+            # Direct callers have no service acceptance hook. An already
+            # prepared job may have been stopped before this worker entered.
+            if not self._scan_prepared:
+                self.prepare_scan()
+            self._scanning = True
         reservations: OutputReservations | None = None
         try:
             # scan_many requires unique, strictly-increasing slots.
@@ -1500,7 +1431,14 @@ class CoolscanPyTransport:
                 batch_iterator: Iterator[coolscanpy.Frame] | None = None
                 try:
                     with _ScanPhase(on_call):
-                        batch_iterator = self._roll.scan_many(remaining, on_progress=None)
+                        with self._stop_lock:
+                            if self._stop_requested:
+                                raise coolscanpy.SafeStopRequested("scan job stopped before batch reservation")
+                            batch_iterator = self._roll.scan_many(remaining, on_progress=None)
+                            # Real Roll reservation resets its own stop event.
+                            # Preserve a reentrant stop during that call too.
+                            if self._stop_requested:
+                                self._roll.safe_stop()
                         try:
                             for frame in batch_iterator:
                                 slot = frame.slot
@@ -1745,11 +1683,16 @@ class CoolscanPyTransport:
                 reservations.release_unused()
             raise
         finally:
-            self._scanning = False
+            with self._stop_lock:
+                self._scanning = False
+                self._scan_prepared = False
 
     def request_stop(self) -> None:
-        if self._roll is not None:
-            self._roll.safe_stop()
+        with self._stop_lock:
+            if self._scan_prepared:
+                self._stop_requested = True
+                if self._roll is not None:
+                    self._roll.safe_stop()
 
     def eject(self) -> bool:
         if self._device is None:
@@ -1766,11 +1709,8 @@ class CoolscanPyTransport:
             target = roll
         else:
             target = self._device
-        # True whenever the eject that produced `ejected` ran through the
-        # vendor Device route (directly, or as the fallback below) -- that
-        # route reports acceptance, not actuation, so its success must be
-        # confirmed before it is reported (see _require_vendor_eject_confirmed).
-        vendor_route = target is self._device
+        # Both pinned driver routes report confirmed absence, not mere command
+        # acceptance. A second presence probe can only lose that evidence.
         # Roll.eject() with no held reservation raises EjectNotAvailable,
         # which is NOT an EjectFailed subclass. Exported by the pinned
         # coolscanpy since 2026-08-07; still resolved per call so a pin
@@ -1786,7 +1726,7 @@ class CoolscanPyTransport:
         except ImportError as exc:
             raise BridgeError(
                 ErrorCode.EJECT_FAILED,
-                "real eject requires the coolscanpy[scanner] extra and SANE installed -- see README",
+                "a scanner runtime dependency could not load; repair or reinstall the scanner runtime",
             ) from exc
         except coolscanpy.FeederParked as exc:
             # The typed accepted-without-progress outcome
@@ -1812,15 +1752,14 @@ class CoolscanPyTransport:
             # back to the capability-gated vendor eject on Device before
             # giving up. Every fallback outcome keeps the direct device
             # route's typed mapping, and success below still requires a
-            # confirmed ejected=True -- the fallback adds a second attempt,
-            # never a weaker acceptance.
-            vendor_route = True
+            # confirmed ejected=True. Roll sent no eject command, so this
+            # is the first physical eject attempt.
             try:
                 ejected = bool(self._device.eject())
             except ImportError as fallback_exc:
                 raise BridgeError(
                     ErrorCode.EJECT_FAILED,
-                    "real eject requires the coolscanpy[scanner] extra and SANE installed -- see README",
+                    "a scanner runtime dependency could not load; repair or reinstall the scanner runtime",
                 ) from fallback_exc
             except coolscanpy.DeviceBusy as fallback_exc:
                 raise BridgeError(
@@ -1834,8 +1773,6 @@ class CoolscanPyTransport:
                 raise BridgeError(
                     ErrorCode.EJECT_FAILED, str(fallback_exc)
                 ) from fallback_exc
-        if ejected and vendor_route:
-            self._require_vendor_eject_confirmed()
         if not ejected:
             # A capability-gated no-op is NOT an eject: the film is still
             # inside the feeder. Returning success here would be exactly
@@ -1866,72 +1803,3 @@ class CoolscanPyTransport:
         self._material = None
         self._preview_established = False
         return True
-
-    def _require_vendor_eject_confirmed(self) -> None:
-        # The vendor eject reports acceptance, not actuation: the LS-5000
-        # can accept the eject CDB with clean sense and never move
-        # (INCIDENT-20260719-eject-from-park, reconfirmed 2026-07-24 from
-        # the 022b4b wedge). The Roll route confirms actuation through the
-        # worker journal; the Device route must confirm through the
-        # motion-free film-presence probe before any success is reported.
-        # The probe's None means "could not determine" -- per its own
-        # contract it must never be read as film-absent -- so anything
-        # short of a definite False fails closed.
-        #
-        # LV-2 (see _VENDOR_EJECT_CONFIRM_SETTLE_SECONDS above for the full
-        # evidence citation, including why a None call can itself already
-        # cost ~10s): a None straight after the eject call returns can just
-        # be the scanner's post-motion UNIT ATTENTION drain, not a failed
-        # eject. Retry a None verdict with short sleeps up to the bounded
-        # settle window below before giving up. A definite verdict at any
-        # attempt -- True or False -- resolves immediately and is never
-        # retried further: False confirms the eject (below); True is the
-        # accepted-without-progress wedge
-        # (INCIDENT-20260719-eject-from-park) reaching its own typed
-        # outcome, not a draining attention, and burning the rest of the
-        # settle window on a park that will never clear on its own would
-        # only delay reporting it -- this exact shape fired live on the
-        # MA-21 today (vm-logs/ma21-201040.log) and must keep surfacing
-        # FEEDER_PARKED without delay.
-        #
-        # This method holds no lock of its own, and sleeping here is safe
-        # for a structural reason, not a lock-scoping one (2026-08-13
-        # adversarial review of PR #88, P2-1): cli.py's dispatch loop is
-        # single-threaded -- one blocking `for raw_line in sys.stdin` loop
-        # on the main thread, and device.eject is dispatched INLINE via
-        # service.py's `_handle_device_eject` (unlike roll.preview/
-        # scan.start, which run on their own worker thread). No other
-        # request -- device.status included -- can even be READ off stdin,
-        # let alone dispatched, until this whole call returns. (The
-        # caller's HardwareLane also happens not to gate device.status, but
-        # that is incidental, not the reason this is safe: a future
-        # architecture that dispatches requests from a thread pool would
-        # have to re-examine dispatch concurrency itself, not read this
-        # comment as already having done so.)
-        probe = getattr(self._device, "film_present", None)
-        probe_callable = callable(probe)
-        deadline = _monotonic() + _vendor_eject_confirm_settle_seconds()
-        present: bool | None = None
-        while True:
-            if probe_callable:
-                try:
-                    present = probe()
-                except Exception:
-                    present = None
-            if present is True:
-                raise BridgeError(
-                    ErrorCode.FEEDER_PARKED,
-                    "the vendor eject was accepted but the film is still "
-                    "present; the transport did not actuate -- a power cycle "
-                    "is the only demonstrated recovery",
-                )
-            if present is False:
-                return
-            if not probe_callable or _monotonic() >= deadline:
-                break
-            _sleep(_VENDOR_EJECT_CONFIRM_POLL_INTERVAL_SECONDS)
-        raise BridgeError(
-            ErrorCode.EJECT_FAILED,
-            "the vendor eject was accepted but film presence could "
-            "not be confirmed clear; treat the film as still loaded",
-        )

--- a/bridge/tests/test_transport_coolscanpy.py
+++ b/bridge/tests/test_transport_coolscanpy.py
@@ -36,14 +36,6 @@ from coolscanpy.protocol.ls5000_single_pass.density import (
 )
 from coolscanpy.protocol.ls5000_single_pass.plan import CANONICAL_PLAN_SHA256
 from coolscanpy.roll.preview_session import _preview_binding_contract
-# LV-2 settle-window realism (2026-08-13 adversarial review of PR #88,
-# P2-3): the real inner cost a `None` verdict from `Device.film_present()`
-# can carry -- see coolscanpy_transport_module's own settle-window
-# rationale comment. Imported by name, not hand-copied as a bare literal,
-# so this test file cannot silently drift from coolscanpy's own constant.
-from coolscanpy.transport.adapter_status import (
-    _SETTLE_DEADLINE_SECONDS as _COOLSCANPY_INNER_PROBE_SETTLE_SECONDS,
-)
 
 from scanstudio_bridge import domain, safety, service
 from scanstudio_bridge.protocol import BridgeError, ErrorCode
@@ -221,37 +213,10 @@ class _FakeDevice:
         self._roll = roll
         self._info = info or _fake_device_info()
         self.eject_effect: object = True
-        # The vendor-eject confirmation probe (Device.film_present): None
-        # (undetermined) mirrors the pre-probe default; vendor-route eject
-        # success tests set False (confirmed-out) explicitly, and the
-        # accepted-without-progress / unconfirmable shapes set True/None.
-        #
-        # LV-2 settle-window coverage: this also accepts a `list` of
-        # per-call values (each element a bool/None verdict, or an
-        # exception instance to raise for that call), exercising
-        # _require_vendor_eject_confirmed's retry loop one scripted probe
-        # at a time -- e.g. `[None, None, False]` for "settles clear after
-        # two indeterminate reads" or `[None, True]` for "settles into the
-        # accepted-without-progress wedge". While more than one element
-        # remains, each call POPS the next one; once only one element is
-        # left (including a plain single-item list), that element is
-        # returned/raised on every further call instead of raising
-        # IndexError -- a test scripting the exhausted-retries shape can
-        # therefore just write a bare scalar (or a one-item list) for
-        # "returns None forever" without having to predict the fix's exact
-        # retry count. A bare (non-list) value keeps its original meaning
-        # unchanged: return/raise that one value on every call.
+        # Current Device.eject() confirms absence internally; film_present is
+        # the separate status query and can legitimately return unknown.
         self.film_present_result: object = None
-        # Counts every film_present() call, list-scripted or scalar --
-        # lets a test assert exactly how many times the settle loop probed
-        # (e.g. ==1 for an immediate definite verdict, >1 for a settle
-        # retry) without inferring it indirectly from elapsed fake time.
         self.film_present_calls = 0
-        # P2-3 (2026-08-13 adversarial review of PR #88): a `_FakeEjectConfirmClock`
-        # a test wants charged with the real inner probe cost -- see
-        # film_present() below. `None` (the default) means "free", matching
-        # every OTHER test in this file that never touches this attribute.
-        self.film_present_settle_clock: "_FakeEjectConfirmClock | None" = None
         self.closed = False
         self.capabilities = self._info.capabilities
         # Plan 10-09 (attempts-root persistence): records exactly what
@@ -277,21 +242,6 @@ class _FakeDevice:
             value = result.pop(0) if len(result) > 1 else (result[0] if result else None)
         else:
             value = result
-        # P2-3: a None verdict from the REAL Device.film_present() is never
-        # free -- coolscanpy's own probe_adapter_status() already drains
-        # the same startup unit-attention senses internally for up to
-        # _COOLSCANPY_INNER_PROBE_SETTLE_SECONDS before it gives up and
-        # returns None (see that import's own comment above). Charge that
-        # cost to the SAME fake clock the outer settle-and-retry loop
-        # reads, via `.advance()` (not `.sleep()` -- see
-        # _FakeEjectConfirmClock's own docstring for why those stay
-        # separate), so a test's accounting reflects the true multi-probe/
-        # multi-second shape instead of getting free (zero-cost) probes. A
-        # definite True/False costs nothing, exactly like the real probe:
-        # the first TEST UNIT READY reply was already conclusive, so no
-        # internal drain was needed.
-        if value is None and self.film_present_settle_clock is not None:
-            self.film_present_settle_clock.advance(_COOLSCANPY_INNER_PROBE_SETTLE_SECONDS)
         if isinstance(value, BaseException):
             raise value
         return value
@@ -3524,6 +3474,7 @@ def test_request_stop_calls_roll_safe_stop(monkeypatch: pytest.MonkeyPatch) -> N
     transport, _device = _opened_transport(monkeypatch, roll)
     transport.preview(domain.Material.COLOR_NEGATIVE, None, lambda _t: None)
 
+    transport.prepare_scan()
     transport.request_stop()
 
     assert roll.safe_stop_calls == 1
@@ -3738,195 +3689,6 @@ def test_eject_fallback_device_busy_maps_typed(
 
     assert excinfo.value.code == ErrorCode.DEVICE_BUSY
     assert roll.closed is False
-
-
-class _FakeEjectConfirmClock:
-    """Deterministic stand-in for `_require_vendor_eject_confirmed`'s own
-    `_monotonic`/`_sleep` module-level indirection points (2026-08-13
-    adversarial review of PR #88, P2-5) -- patched in via
-    `_patch_eject_confirm_clock`, which swaps THOSE two names
-    (`coolscanpy_transport_module._monotonic` / `._sleep`), never the real
-    stdlib `time` module: mutating the actual `time.sleep`/`time.monotonic`
-    for a test's duration would be process-visible to any other live
-    thread in the same test run (e.g. a scan soft-timeout watchdog), not
-    just this one call.
-
-    `sleep()` is what the code under test actually calls (via the patched
-    `_sleep` name): it advances `now` AND is recorded in `sleep_calls`, a
-    pure record of the settle loop's own outer-poll sleeps. `advance()` is
-    a separate, unrecorded way to move `now` forward, used by
-    `_FakeDevice.film_present()` (P2-3) to charge its own simulated inner
-    probe cost onto this SAME clock without polluting `sleep_calls` --
-    keeping that list an honest record of only the production retry loop's
-    own behavior."""
-
-    def __init__(self) -> None:
-        self.now = 0.0
-        self.sleep_calls: list[float] = []
-
-    def monotonic(self) -> float:
-        return self.now
-
-    def sleep(self, seconds: float) -> None:
-        self.sleep_calls.append(seconds)
-        self.now += seconds
-
-    def advance(self, seconds: float) -> None:
-        self.now += seconds
-
-
-def _patch_eject_confirm_clock(
-    monkeypatch: pytest.MonkeyPatch, device: "_FakeDevice"
-) -> _FakeEjectConfirmClock:
-    """Patches both halves of LV-2's settle-window determinism in one call:
-    `coolscanpy_transport_module`'s own `_monotonic`/`_sleep` indirection
-    points (P2-5), and wires `device.film_present_settle_clock` (P2-3) so
-    an indeterminate probe charges its simulated inner cost onto the same
-    clock the retry loop reads. Takes `device` rather than returning
-    something each caller must remember to wire up itself."""
-    clock = _FakeEjectConfirmClock()
-    monkeypatch.setattr(coolscanpy_transport_module, "_monotonic", clock.monotonic)
-    monkeypatch.setattr(coolscanpy_transport_module, "_sleep", clock.sleep)
-    device.film_present_settle_clock = clock
-    return clock
-
-
-def test_vendor_eject_still_present_after_accept_is_feeder_parked(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The vendor eject reports acceptance, not actuation
-    (INCIDENT-20260719-eject-from-park): a clean scanimage exit with film
-    still present is the accepted-without-progress wedge and must surface
-    as FEEDER_PARKED, never as success -- immediately, on the very first
-    probe, spending none of LV-2's settle window: that window is for a
-    genuinely INDETERMINATE None, never for waiting out a definite True.
-
-    This IS the live MA-21 shape (2026-08-13 adversarial review of PR #88,
-    P2-2, correcting the earlier mislabeled synthetic test below):
-    vm-logs/ma21-201040.log shows a single FEEDER_PARKED with no preceding
-    retry. The MA-21's eject was accepted-but-inert -- no transport motion
-    occurred at all -- so no post-motion UNIT ATTENTION was ever posted for
-    a probe to drain; the very first TEST UNIT READY reply was already a
-    definite True, with no preceding None."""
-    transport, device = _opened_transport(monkeypatch, _FakeRoll())
-    clock = _patch_eject_confirm_clock(monkeypatch, device)
-    device.eject_effect = True
-    device.film_present_result = True
-
-    with pytest.raises(BridgeError) as excinfo:
-        transport.eject()
-
-    assert excinfo.value.code == ErrorCode.FEEDER_PARKED
-    assert "still present" in str(excinfo.value)
-    assert device.film_present_calls == 1
-    assert clock.sleep_calls == []
-    assert clock.now == 0.0
-
-
-def test_vendor_eject_present_during_settle_window_is_feeder_parked_without_further_retry(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """SYNTHETIC coverage, NOT the literal live MA-21 log shape (2026-08-13
-    adversarial review of PR #88, P2-2 -- see the adjacent immediate-True
-    test above for that one): defensive coverage for a stall that first
-    reads as an indeterminate settling probe (one settle-retry sleep fires,
-    after the real inner probe cost -- P2-3) before a SECOND probe resolves
-    to a definite True -- the accepted-without-progress wedge, not a drain.
-    Proves the "True is final, never retried further" rule holds even when
-    it is the settle window's own retry path that surfaces the True, not
-    just an immediate first read."""
-    transport, device = _opened_transport(monkeypatch, _FakeRoll())
-    clock = _patch_eject_confirm_clock(monkeypatch, device)
-    device.eject_effect = True
-    device.film_present_result = [None, True]
-
-    with pytest.raises(BridgeError) as excinfo:
-        transport.eject()
-
-    assert excinfo.value.code == ErrorCode.FEEDER_PARKED
-    assert "still present" in str(excinfo.value)
-    assert device.film_present_calls == 2
-    assert clock.sleep_calls == [
-        coolscanpy_transport_module._VENDOR_EJECT_CONFIRM_POLL_INTERVAL_SECONDS
-    ]
-    # P2-3: the first (None) call charges the real inner-probe cost too --
-    # accounting now reflects ~11s of simulated wall time (10s inner + 1s
-    # outer poll), not the old free-probe ~1s.
-    assert clock.now == pytest.approx(
-        _COOLSCANPY_INNER_PROBE_SETTLE_SECONDS
-        + coolscanpy_transport_module._VENDOR_EJECT_CONFIRM_POLL_INTERVAL_SECONDS
-    )
-    assert clock.now < coolscanpy_transport_module._VENDOR_EJECT_CONFIRM_SETTLE_SECONDS
-
-
-def test_vendor_eject_confirms_clear_after_settle_retry(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """LV-2's actual fix, direct coverage (2026-08-13,
-    shortstrip-lab/live-attempts/20260813-beta8-linux-validation/RESULT.md
-    + vm-logs/eject-nopreview-194010.log): two indeterminate probes (the
-    post-motion UNIT ATTENTION drain, each carrying its own real inner
-    settle cost -- P2-3) followed by a definite False must confirm the
-    eject as a SUCCESS -- the exact shape that used to fail closed with
-    EJECT_FAILED from a single immediate probe."""
-    transport, device = _opened_transport(monkeypatch, _FakeRoll())
-    clock = _patch_eject_confirm_clock(monkeypatch, device)
-    device.eject_effect = True
-    device.film_present_result = [None, None, False]
-
-    assert transport.eject() is True
-
-    assert device.film_present_calls == 3
-    assert clock.sleep_calls == [
-        coolscanpy_transport_module._VENDOR_EJECT_CONFIRM_POLL_INTERVAL_SECONDS
-    ] * 2
-    # ~22s of simulated wall time (2x10s inner + 2x1s outer), comfortably
-    # inside the 40s bound -- this is the "settles well inside the window"
-    # shape RESULT.md's own evidence describes.
-    assert clock.now == pytest.approx(
-        2 * _COOLSCANPY_INNER_PROBE_SETTLE_SECONDS
-        + 2 * coolscanpy_transport_module._VENDOR_EJECT_CONFIRM_POLL_INTERVAL_SECONDS
-    )
-    assert clock.now < coolscanpy_transport_module._VENDOR_EJECT_CONFIRM_SETTLE_SECONDS
-
-
-def test_vendor_eject_unconfirmable_presence_fails_closed(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """film_present() -> None means undetermined -- per its contract it
-    must never be read as film-absent. LV-2 gives a persistently
-    indeterminate probe a bounded settle-and-retry window
-    (_VENDOR_EJECT_CONFIRM_SETTLE_SECONDS) before this still fails closed
-    as EJECT_FAILED, exactly as it did before that window existed -- only
-    the timing changed, not the verdict for a probe that never resolves.
-
-    P2-3 (2026-08-13 adversarial review of PR #88): each probe now charges
-    its own real inner settle cost too, so this reflects the true
-    ~4-probe/~40s accounting the fix actually produces, not the old
-    free-probe count."""
-    transport, device = _opened_transport(monkeypatch, _FakeRoll())
-    clock = _patch_eject_confirm_clock(monkeypatch, device)
-    device.eject_effect = True
-    device.film_present_result = None
-
-    with pytest.raises(BridgeError) as excinfo:
-        transport.eject()
-
-    assert excinfo.value.code == ErrorCode.EJECT_FAILED
-    assert "could not be confirmed" in str(excinfo.value)
-    # Proves the settle window actually ran to its bound instead of
-    # failing closed on the first indeterminate read: one more probe than
-    # outer sleep (the final probe that hits the deadline does not sleep
-    # again), and the fake clock advanced to at least the settle bound.
-    assert device.film_present_calls == len(clock.sleep_calls) + 1
-    assert device.film_present_calls > 1
-    assert clock.now >= coolscanpy_transport_module._VENDOR_EJECT_CONFIRM_SETTLE_SECONDS
-    # With each probe costing ~10s (P2-3) and the outer bound at 40s, the
-    # window should exhaust in roughly four probes, not the sixteen
-    # free-probe calls the old (unrealistic) fake produced -- a loose
-    # upper bound that stays true across small constant tuning rather than
-    # hardcoding an exact count.
-    assert device.film_present_calls <= 6
 
 
 def test_eject_roll_close_failure_reports_film_out_not_eject_failed(
@@ -4169,13 +3931,19 @@ def test_real_open_rechecks_disappeared_device(monkeypatch):
     assert transport._device is None
 
 
-def test_failed_preview_evidence_uses_real_device_capacity(monkeypatch):
+@pytest.mark.parametrize("capacity", [6, None])
+def test_failed_preview_evidence_uses_real_device_capacity(monkeypatch, capacity):
     from coolscanpy.protocol.ls5000_single_pass.roll_index import IndexDecodeError
 
     info = _fake_device_info()
-    info = dataclasses.replace(
-        info, capabilities=dataclasses.replace(info.capabilities, adapter_frame_capacity=6)
+    from coolscanpy._device import _usb_fallback_capabilities
+
+    capabilities = (
+        _usb_fallback_capabilities() if capacity is None else
+        dataclasses.replace(info.capabilities, adapter_frame_capacity=capacity)
     )
+    info = dataclasses.replace(info, capabilities=capabilities)
+    expected_bound = 40 if capacity is None else capacity
     device = coolscanpy.Device(info, object())
     transport = CoolscanPyTransport()
     transport._device = device
@@ -4188,7 +3956,22 @@ def test_failed_preview_evidence_uses_real_device_capacity(monkeypatch):
     monkeypatch.setattr(coolscanpy_transport_module, "publish_index_failure", publish)
     try:
         evidence, error = transport._failed_attempt_evidence(IndexDecodeError("bad preview"))
-        assert (evidence, error) == ({"capacity": 6}, None)
-        assert capacities == [6]
+        assert (evidence, error) == ({"capacity": expected_bound}, None)
+        assert capacities == [expected_bound]
+    finally:
+        device.close()
+
+
+def test_confirmed_real_device_eject_needs_no_second_probe(monkeypatch):
+    from types import SimpleNamespace
+    from coolscanpy.transport import medium_unload
+
+    device = coolscanpy.Device(_fake_device_info(), object())
+    monkeypatch.setattr(medium_unload, "unload_medium", lambda **_: SimpleNamespace(ejected=True))
+    monkeypatch.setattr(device, "film_present", lambda: pytest.fail("eject already confirmed absence"))
+    transport = CoolscanPyTransport()
+    transport._device = device
+    try:
+        assert transport.eject() is True
     finally:
         device.close()

--- a/bridge/tests/test_transport_coolscanpy.py
+++ b/bridge/tests/test_transport_coolscanpy.py
@@ -4,11 +4,11 @@ API. See BRIDGE.md (nikon-coolscan4-software-archaeology,
 app/ScanStudio/protocol/BRIDGE.md) for the wire-level contract and the
 CoolscanPy-exception-to-error-code rename table this module implements.
 
-Per this task's own instructions, these tests mock the `coolscanpy` module
-boundary directly (`coolscanpy.open`/`coolscanpy.get_devices`, plus
+Most tests mock the `coolscanpy` module boundary directly (`coolscanpy.open`/`coolscanpy.get_devices`, plus
 lightweight fake `Device`/`Roll` doubles implementing only the methods
-`CoolscanPyTransport` calls) -- never coolscanpy's own internal
-adapter/workflow injection seams. No hardware is touched by any test here.
+`CoolscanPyTransport` calls). A real-facade regression also substitutes
+enumeration and service creation while exercising the actual Device/open
+implementation. No hardware is touched.
 """
 
 from __future__ import annotations
@@ -219,7 +219,7 @@ class _FakeDevice:
         info: "coolscanpy.DeviceInfo | None" = None,
     ) -> None:
         self._roll = roll
-        self.info = info or _fake_device_info()
+        self._info = info or _fake_device_info()
         self.eject_effect: object = True
         # The vendor-eject confirmation probe (Device.film_present): None
         # (undetermined) mirrors the pre-probe default; vendor-route eject
@@ -253,7 +253,7 @@ class _FakeDevice:
         # every OTHER test in this file that never touches this attribute.
         self.film_present_settle_clock: "_FakeEjectConfirmClock | None" = None
         self.closed = False
-        self.capabilities = _fake_capabilities()
+        self.capabilities = self._info.capabilities
         # Plan 10-09 (attempts-root persistence): records exactly what
         # CoolscanPyTransport.preview() passed, so a test can assert on it
         # -- mirrors the real Device.roll()'s own attempts_root kwarg.
@@ -812,6 +812,8 @@ def test_open_device_raises_device_not_found(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_open_device_raises_device_busy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(coolscanpy, "get_devices", lambda: [_fake_device_info()])
+
     def _raise_busy(devname: str) -> None:
         raise coolscanpy.DeviceBusy(f"device {devname!r} already open")
 
@@ -839,7 +841,13 @@ def test_open_device_reports_the_exact_identity_validated_by_coolscanpy(
         model="LS-5000 ED",
     )
     device = _FakeDevice(info=info)
-    monkeypatch.setattr(coolscanpy, "open", lambda _device_id: device)
+    monkeypatch.setattr(coolscanpy, "get_devices", lambda: [info])
+
+    def open_exact(device_id):
+        assert device_id == info.id
+        return device
+
+    monkeypatch.setattr(coolscanpy, "open", open_exact)
 
     opened = CoolscanPyTransport().open_device("ls5000")
 
@@ -857,15 +865,14 @@ def test_open_device_refuses_an_unverified_identity_without_synthesizing_ls5000(
         model="Coolscan Mystery Model",
         supported=False,
     )
-    device = _FakeDevice(info=info)
-    monkeypatch.setattr(coolscanpy, "open", lambda _device_id: device)
+    monkeypatch.setattr(coolscanpy, "get_devices", lambda: [info])
+    monkeypatch.setattr(coolscanpy, "open", lambda _: pytest.fail("must refuse before open"))
 
     with pytest.raises(BridgeError) as excinfo:
         CoolscanPyTransport().open_device(info.id)
 
     assert excinfo.value.code == ErrorCode.DEVICE_NOT_FOUND
     assert "Coolscan Mystery Model" in str(excinfo.value)
-    assert device.closed is True
 
 
 # -- preview -----------------------------------------------------------------------
@@ -4120,3 +4127,68 @@ def test_status_adapter_is_none_when_probe_is_absent_or_failing(
     # the defensive callable() check keeps the identity honestly unknown.
     device.adapter_identity = "Mount"
     assert transport.status().adapter is None
+
+
+def test_transport_opens_real_driver_device(monkeypatch):
+    from coolscanpy import _device
+
+    info = _fake_device_info()
+    monkeypatch.setattr(coolscanpy, "get_devices", lambda: [info])
+    monkeypatch.setattr(_device, "get_devices", lambda: [info])
+    monkeypatch.setattr(_device, "_service_factory", lambda: object())
+    transport = CoolscanPyTransport()
+    try:
+        opened = transport.open_device("ls5000")
+        assert isinstance(transport._device, coolscanpy.Device)
+        assert opened.device_id == info.id
+        assert opened.supported is True
+    finally:
+        if transport._device is not None:
+            transport._device.close()
+
+
+@pytest.mark.parametrize("infos", [[], [_fake_device_info(), _fake_device_info("other")]])
+def test_open_alias_requires_one_supported_device(monkeypatch, infos):
+    monkeypatch.setattr(coolscanpy, "get_devices", lambda: infos)
+    monkeypatch.setattr(coolscanpy, "open", lambda _: pytest.fail("ambiguous open"))
+    with pytest.raises(BridgeError) as error:
+        CoolscanPyTransport().open_device("ls5000")
+    assert error.value.code == ErrorCode.DEVICE_NOT_FOUND
+
+
+def test_real_open_rechecks_disappeared_device(monkeypatch):
+    from coolscanpy import _device
+
+    monkeypatch.setattr(coolscanpy, "get_devices", lambda: [_fake_device_info()])
+    monkeypatch.setattr(_device, "get_devices", lambda: [])
+    monkeypatch.setattr(_device, "_service_factory", lambda: pytest.fail("device disappeared"))
+    transport = CoolscanPyTransport()
+    with pytest.raises(BridgeError) as error:
+        transport.open_device(_DEVICE_ID)
+    assert error.value.code == ErrorCode.DEVICE_NOT_FOUND
+    assert transport._device is None
+
+
+def test_failed_preview_evidence_uses_real_device_capacity(monkeypatch):
+    from coolscanpy.protocol.ls5000_single_pass.roll_index import IndexDecodeError
+
+    info = _fake_device_info()
+    info = dataclasses.replace(
+        info, capabilities=dataclasses.replace(info.capabilities, adapter_frame_capacity=6)
+    )
+    device = coolscanpy.Device(info, object())
+    transport = CoolscanPyTransport()
+    transport._device = device
+    capacities = []
+
+    def publish(error, *, base_dir, holder_capacity):
+        capacities.append(holder_capacity)
+        return {"capacity": holder_capacity}
+
+    monkeypatch.setattr(coolscanpy_transport_module, "publish_index_failure", publish)
+    try:
+        evidence, error = transport._failed_attempt_evidence(IndexDecodeError("bad preview"))
+        assert (evidence, error) == ({"capacity": 6}, None)
+        assert capacities == [6]
+    finally:
+        device.close()

--- a/bridge/tests/test_transport_stop.py
+++ b/bridge/tests/test_transport_stop.py
@@ -1,0 +1,133 @@
+"""Cancellation through real Device/Roll; only capture dispatch is substituted."""
+
+import threading
+from types import SimpleNamespace
+
+import coolscanpy
+import pytest
+from coolscanpy.roll.preview_session import build_roll_preview_session
+
+from scanstudio_bridge import domain, safety, service
+from scanstudio_bridge.protocol import BridgeError, ErrorCode, to_wire
+from scanstudio_bridge.transport.coolscanpy_transport import (
+    CoolscanPyTransport,
+    _reconstruct_preview_attempt,
+)
+from tests.test_transport_coolscanpy import _fake_device_info, _write_synthetic_preview_attempt
+from tests.test_service_dispatch import _arm
+
+
+@pytest.fixture
+def real_transport(tmp_path, monkeypatch):
+    monkeypatch.setattr("usb.core.find", lambda **_: pytest.fail("physical USB access"))
+    device = coolscanpy.Device(_fake_device_info(), object())
+    transport = CoolscanPyTransport()
+    transport._device = device
+    roll = device.roll(attempts_root=tmp_path / "attempts")
+    transport._roll = roll
+    attempt_dir = _write_synthetic_preview_attempt(tmp_path / "preview")
+    session = build_roll_preview_session(_reconstruct_preview_attempt(attempt_dir / "journal.json"))
+    roll.install_manual_session(session)
+    for slot in (1, 2):
+        if roll.needs_approval(slot):
+            roll.approve(slot)
+    transport._material = domain.Material.COLOR_NEGATIVE
+    transport._preview_established = True
+    dispatched = []
+    def capture(*args, **kwargs):
+        dispatched.append(True)
+        raise coolscanpy.SafeStopRequested("test capture boundary")
+    roll._adapter = SimpleNamespace(run_batch_session=capture)
+    yield transport, roll, dispatched
+    transport.close_device()
+
+
+def scan(transport, tmp_path, **callbacks):
+    return transport.start_scan(
+        [1, 2], domain.FIXED_COLOR_NEGATIVE_RECIPE,
+        domain.OutputSpec(destination=str(tmp_path / "out"), filename_template="frame-####.tif"),
+        on_progress=callbacks.get("on_progress", lambda _: None),
+        on_retry=lambda *a: None, on_frame=lambda *a: None,
+        on_call=callbacks.get("on_call"),
+    )
+
+
+@pytest.mark.parametrize("boundary", ["progress", "reservation"])
+def test_stop_survives_real_driver_reservation(real_transport, tmp_path, monkeypatch, boundary):
+    transport, roll, dispatched = real_transport
+    callbacks = {}
+    if boundary == "progress":
+        callbacks["on_progress"] = lambda _: transport.request_stop()
+    else:
+        reserve = roll._reserve_batch_locked
+        def stop_then_reserve(iterator):
+            transport.request_stop()
+            return reserve(iterator)
+        monkeypatch.setattr(roll, "_reserve_batch_locked", stop_then_reserve)
+    assert scan(transport, tmp_path, **callbacks).stopped
+    assert dispatched == []
+    assert not roll._device._lock.locked()
+
+
+@pytest.mark.parametrize("refusal", ["manual", "table"])
+def test_stop_prevents_retry_dispatch(real_transport, tmp_path, monkeypatch, refusal):
+    transport, roll, dispatched = real_transport
+    scan_many = roll.scan_many
+    calls = []
+    def refuse_once(*args, **kwargs):
+        calls.append(True)
+        if len(calls) == 1:
+            transport.request_stop()
+            if refusal == "manual":
+                raise coolscanpy.ManualReviewRequired("review slot 2", slot=2)
+            raise coolscanpy.RollMismatch("requested frame 2 is outside the scanner-addressable table 1..1")
+        return scan_many(*args, **kwargs)
+    monkeypatch.setattr(roll, "scan_many", refuse_once)
+    assert scan(transport, tmp_path).stopped
+    assert calls == [True]
+    assert dispatched == []
+
+
+def test_completed_job_stop_cannot_poison_next_job(real_transport, tmp_path):
+    transport, _, dispatched = real_transport
+    assert scan(transport, tmp_path, on_progress=lambda _: transport.request_stop()).stopped
+    transport.request_stop()  # Old job has finished; its terminal event may still be pending.
+    assert scan(transport, tmp_path).stopped
+    assert dispatched == [True]
+
+
+@pytest.mark.parametrize("ending", ["stop", "shutdown"])
+def test_service_cancels_before_transport_worker_entry(real_transport, tmp_path, monkeypatch, ending):
+    transport, _, dispatched = real_transport
+    _arm(monkeypatch, tmp_path)
+    svc = service.BridgeService(transport, safety.TelemetryLog(tmp_path), base_dir=tmp_path)
+    svc._device_open = True
+    svc._preview_material = domain.Material.COLOR_NEGATIVE
+    entered, proceed = threading.Event(), threading.Event()
+    start_scan = transport.start_scan
+    def delayed_start(*args, **kwargs):
+        entered.set()
+        assert proceed.wait(10)
+        return start_scan(*args, **kwargs)
+    monkeypatch.setattr(transport, "start_scan", delayed_start)
+    emitted = []
+    result = svc._handle_scan_start({"params": {
+        "slots": [1, 2], "recipe": to_wire(domain.FIXED_COLOR_NEGATIVE_RECIPE),
+        "output": {"destination": str(tmp_path / "out"), "filenameTemplate": "frame-####.tif"},
+    }}, lambda name, payload: emitted.append((name, payload)))
+    try:
+        assert entered.wait(10)
+        if ending == "stop":
+            assert svc._handle_scan_stop({"params": {"jobId": result["jobId"]}}) == {"acknowledged": True}
+        else:
+            with pytest.raises(BridgeError) as error:
+                svc._handle_shutdown(join_timeout=0)
+            assert error.value.code == ErrorCode.HARDWARE_LANE_BUSY
+    finally:
+        proceed.set()
+        svc._last_job["thread"].join(10)
+    assert not svc._last_job["thread"].is_alive()
+    assert dispatched == []
+    completed = [payload for name, payload in emitted if name == "scan.completed"]
+    assert len(completed) == 1
+    assert completed[0]["summary"]["stopped"] is True

--- a/bridge/uv.lock
+++ b/bridge/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "../coolscanpy" }
 dependencies = [
     { name = "imagecodecs" },

--- a/coolscanpy/README.md
+++ b/coolscanpy/README.md
@@ -1,406 +1,379 @@
-# coolscanpy
+# CoolscanPy
 
-coolscanpy is a direct-USB acquisition library for Nikon Coolscan film
-scanners. It exposes a python-sane-style API: open a device, read and set
-typed options, call `scan()` and get back an array. On top of that plain
-surface it adds a roll-feeder extension for whole-roll workflows. A roll can
-be previewed across all 40 addressable slots, each frame's transport spacing
-adjusted individually, then batch-scanned in one continuous reservation.
+CoolscanPy 0.7.6 is a standalone Python acquisition library for the Nikon
+Super Coolscan 5000 ED (LS-5000). Its main path previews a strip or roll,
+binds reviewed frame positions to that insertion, and captures color-negative
+frames over direct USB. It returns scanner-linear pixels and acquisition
+evidence for an application to save, repair, and render.
 
-Each scanned frame comes back as:
-- scanner-linear RGB (4000 dpi, 16-bit)
-- an aligned infrared plane
-- the 285 dpi RGBI meter pass the scanner captured for auto-exposure (see
-  `Frame.meter_rgbi`)
-- an in-memory receipt with exposure, clipping, focus, and transport-smear
-  telemetry
+There is no GUI. The package does not require ScanStudio or NegPy, and its
+public API does not depend on either application.
 
-## Status
+This directory is ScanStudio’s pinned driver source, with explicitly reviewed
+app integrations. Its release gate compares package source with the published
+canonical driver and pins both sides of each intentional difference. For the
+standalone repository, use [rohanpandula/coolscanpy](https://github.com/rohanpandula/coolscanpy/tree/port/cross-platform).
 
-This code was extracted from a working NegPy integration branch. On real
-hardware, an LS-5000 running firmware 1.03 with an SA-21 roll feeder
-converted to SA-30 wiring, that integration produced full-roll previews and
-4000 dpi 16-bit RGBI captures with receipts, and those captures fed the
-downstream dust-repair pipeline.
+## Scope and support
 
-The current source tree collects 911 hardware-free tests covering the
-transport protocol, roll engine, capture finalization, receipt assembly, and
-public facade against synthetic fixtures and replay data. CI runs that suite
-and Ruff on Ubuntu and macOS with Python 3.13 and 3.14. Windows is not in the
-CI matrix and has not run the direct-USB transport against real hardware.
+| Area | Contract in 0.7.6 |
+| --- | --- |
+| Scanner | LS-5000. Other recognized Coolscan models can appear in discovery with `supported=False`; `open()` refuses them. |
+| Roll adapter | Strip-feeder identities `6Strip` and `36Strip` are accepted. A positively identified mount adapter is refused by the roll path. This allowlist is not a hardware-validation matrix. |
+| Color negatives | `Material.COLOR_NEGATIVE`: direct-USB preview, review, batch fine capture, infrared, meter pass, and receipts. |
+| Black-and-white negatives | Preview and approval are available. Roll fine capture is not wired; `Roll.scan()` and `scan_many()` raise `NotImplementedError`. |
+| Fine-capture format | LS-5000 single-pass 4000 dpi, 16-bit RGBI acquisition. This is a fixed capture contract, not arbitrary resolution or scanner support. |
+| Plain `Device.scan()` | A separate, SANE-backed array API requiring the optional `scanner` extra and host SANE support. |
+| Platforms | Hardware-free CI runs on Ubuntu and macOS with Python 3.13 and 3.14. Windows has no CI or validated transport claim; concurrency tests assume POSIX locking. |
 
-Live validation ran on 2026-07-18 with the packaged wheel installed into a
-clean environment against a powered LS-5000, with no SANE installed: USB
-enumeration, `open()`, option introspection, and a full roll preview of a
-6-slot strip. The transport index read cleanly, slots 1 through 4 came
-back aligned with no manual spacing offset, slot 5 was flagged for manual
-review near the strip end, and slot 6 was correctly reported as a 2-row
-trailing sliver rather than a frame. That run exposed one real bug, fixed
-in 0.1.1: roll fingerprinting rejected strips with a trailing sliver.
+Tests use synthetic devices and protocol replays. They do not establish
+compatibility with every firmware or feeder modification. No live-scanner
+validation is claimed for 0.7.6; [CHANGELOG.md](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/CHANGELOG.md) records earlier changes.
 
-The 0.1.3 short-strip fixes allow preview and fine scanning of strips shorter
-than a full roll. The current source also accepts the normal end-of-roll case
-where a fresh transport table has fewer usable records than the reviewed
-preview; it still refuses a count above the reviewed table, a mismatched visual
-fingerprint, or a requested slot that is no longer addressable.
-
-The 285 dpi meter pass is now surfaced on every frame. The scanner already
-captures three of these per frame during auto-exposure; the third (settled
-exposure) is decoded and attached to the `Frame`. Downstream tools that
-need a dual-capture (prepass + main) can use it directly. See the
-[downstream pipeline](#downstream-pipeline) section.
-
-C-41 fine scans expose RGB to Nikon Scan's rendering intent by default.
-The auto-exposure loop still converges exactly as before, but the commanded
-fine-scan RGB exposures are now a guarded Nikon-like target derived from
-the settled meter pass. Live v3 validation used fine-scan fractions
-R 0.950337, G 0.987481, and B 0.983639. Across three matched physical
-frames, the Nikon-referenced full-scale channel biases were R +0.823…+2.086
-%, G +0.146…+1.033 %, and B -0.391…+0.822 %, with a 0.9129 % mean absolute
-bias. Under the explicitly defined complement statistic (100 % minus mean
-absolute full-scale channel bias), that is 99.0871 % average full-scale
-RGB-channel agreement. Mean 8x8-smoothed ΔE00 improved from 2.8469 to
-2.1413 (-24.8 %). These figures describe this three-frame validation set;
-they are neither a byte-identity claim nor a universal perceptual-accuracy
-percentage. Highlights are capped at a reviewed q99.99 threshold and the
-device exposure bounds, both journaled; infrared metering is unchanged; and
-each frame's journal carries an `active_exposure_authority` record binding
-the active solve, the guarded candidate, and the exact commanded contract,
-so the receipt trail proves which numbers reached the scanner and why.
-
-For the proven LS-5000 full-record geometry, fine-scan decoding now starts
-while the raw capture is still arriving. This is an advisory fast path: the
-raw capture remains the oracle, and an absent, slow, malformed, or failed
-streaming sidecar falls back to the normal offline decode without interrupting
-or blocking the scanner read. Set `COOLSCANPY_CAPTURE_STREAMING=0` to disable
-this optimization. The streaming path is covered by hardware-free tests; no
-additional live-hardware claim is made for it here.
-
-Coverage is uneven by material. `Material.COLOR_NEGATIVE` scans through a
-direct-USB single-pass path and is implemented end to end, preview through
-receipt. `Material.BLACK_AND_WHITE_NEGATIVE` previews and approves
-correctly, but its fine-scan path routes through SANE and that route is not
-yet wired into the roll batch engine; calling `scan()` or `scan_many()` on
-a black-and-white roll raises `NotImplementedError` with a message
-explaining the gap.
-
-## Downstream pipeline
-
-coolscanpy gets the raw data off the scanner. Three other projects turn it
-into a finished image:
-
-**[digital-fauxice](https://github.com/rohanpandula/digital-fauxice)** —
-infrared dust and scratch repair. A byte-exact, from-scratch
-reimplementation of Digital ICE (the Nikon/Applied Science Fiction process
-that uses the IR channel to find defects and reconstruct the RGB underneath).
-Validated against Nikon's own output: 68 million 16-bit values per frame,
-zero mismatches. It takes the 4000 dpi RGBI main scan plus the 285 dpi
-meter pass as its prepass, and produces the same repaired output Nikon
-would have. An optional hybrid mode routes the worst damage (where the
-exact repair leaves visible scars) to a LaMa inpainting model, disclosed
-and bounded. The meter pass coolscanpy now surfaces on `Frame` is exactly
-what fauxice's input contract expects — same physical frame, same focus,
-same transport position, captured milliseconds before the fine scan.
-
-**[cool-colors](https://github.com/rohanpandula/cool-colors)** — C-41
-color inversion. Turns the scanner-linear negative into a positive,
-reproducing Nikon Scan 4's CMS-off color pipeline bit-for-bit (the
-per-frame inversion LUT, fixed tone curve, and gamma 2.2). With a
-captured per-frame builder LUT, output matches Nikon Scan byte-for-byte.
-Without it, a principled density inversion (film-base estimation, log
-inversion, normalization) gets you a natural positive from any C-41 scan.
-
-**[NegPy](https://github.com/marcinz606/NegPy)** — the desktop
-application that ties capture, repair, and inversion together behind a
-GUI. It consumes coolscanpy as an optional scanner backend, digital-fauxice
-as an optional IR repair engine, and runs its own inversion pipeline for
-the final print rendering.
-
-The pipeline in order: coolscanpy captures → fauxice repairs dust →
-cool-colors (or NegPy) inverts to a positive. Each step is optional and
-independently installable.
+Version 0.7.6 fixes held-session cleanup before batch iteration and retains
+ownership when child shutdown is uncertain; see [cleanup contracts](#reservation-stop-and-cleanup-contracts).
 
 ## Install
 
-```
-pip install coolscanpy
-```
+Use Python 3.13 or later in a virtual environment:
 
-coolscanpy requires Python 3.13 or later. To use the current checkout rather
-than an index release, install it in editable mode:
-
-```
-python -m pip install -e .
+```sh
+python3.13 -m venv .venv
+source .venv/bin/activate
+python -m pip install 'coolscanpy==0.7.6'
 ```
 
-The base install covers `get_devices()`, `open()`, `Device.eject()`, and the
-roll preview, registration, and color-capture operations under
-`Device.roll()`. None of those needs SANE. `get_devices()`/`open()` fall back
-to direct USB enumeration when python-sane is not installed, the roll-feeder
-capture extension talks to the scanner over raw USB in a separate process
-regardless, and `Device.eject()` (and `Roll.eject()`, which delegates to it)
-replays the scanner's own traced unload sequence over that same raw-USB
-transport.
+Direct USB requires a host libusb 1.0 runtime that PyUSB can load. Typical
+package-manager commands are:
 
-Standalone/source installs still need a host libusb shared library for PyUSB.
-On macOS, install it with `brew install libusb`. ScanStudio's release DMG is a
-separate distribution shape that includes and pins its own signed libusb, so
-ScanStudio users do not need that Homebrew installation for color-roll work.
+```sh
+# macOS, with Homebrew
+brew install libusb
 
-SANE is needed only for the plain `Device.scan()` path:
-
-```
-pip install "coolscanpy[scanner]"
+# Debian / Ubuntu
+sudo apt install libusb-1.0-0
 ```
 
-On macOS, that build needs sane-backends' headers, and Homebrew does not put
-them on the default include path:
+The process needs USB access permission and exclusive interface ownership.
+Close competing scanner applications and resolve surviving workers before
+opening a replacement session. Frozen applications must bundle libusb; see
+the [loader contract](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/src/coolscanpy/protocol/ls5000_single_pass/usb_backend.py).
 
+Discovery, the color roll workflow, presence probing, and `Device.eject()`
+use the base installation. SANE is not required for those paths.
+
+### Optional SANE path
+
+Install the extra only when using the plain `Device.scan()` API or the
+SANE-based diagnostic workflows:
+
+```sh
+python -m pip install 'coolscanpy[scanner]==0.7.6'
 ```
+
+Building `python-sane` requires host SANE headers. On macOS:
+
+```sh
 brew install sane-backends
-CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib" pip install "coolscanpy[scanner]"
+CPPFLAGS="-I$(brew --prefix)/include" \
+LDFLAGS="-L$(brew --prefix)/lib" \
+python -m pip install 'coolscanpy[scanner]==0.7.6'
 ```
 
-On Linux, `sudo apt install libsane-dev` before the plain `pip install`
-above is usually enough.
+On Debian / Ubuntu, install `libsane-dev` before installing the extra.
+The extra does not expand scanner support or enable black-and-white roll capture.
 
-## Quickstart
-
-Plain scan, the python-sane-shaped path:
+## Discover and open a device
 
 ```python
 import coolscanpy
 
-dev = coolscanpy.open("ls5000")
-print(dev.option_names)
-print(dev["resolution"].constraint)
+for info in coolscanpy.get_devices():
+    print(info.id, info.model, info.supported, info.capabilities)
 
-dev.resolution = 4000
-dev.depth = 16
-rgb = dev.scan()  # uint16, shape (H, W, 3)
-dev.close()
+with coolscanpy.open("ls5000") as device:
+    print(device.capabilities)
+    print(device.option_names)
 ```
 
-Roll workflow:
+`get_devices()` returns `DeviceInfo` objects. It tries SANE enumeration and
+falls back to direct USB when SANE is unavailable, fails, or finds no
+Coolscan. There is no network transport. The `"ls5000"` alias requires one
+supported attached scanner; use an exact discovery ID to disambiguate.
+`open()` rechecks discovery and support.
+
+Read identity from the discovery result and capabilities from
+`device.capabilities`; there is no public `device.info` property. USB-only
+capabilities are conservative: an unknown `adapter_frame_capacity` can be
+`None`, and `can_eject=False` is not a gate on the direct-USB `eject()` method.
+
+## Preview, review, and scan color negatives
+
+The following interactive example writes preview TIFFs for review, asks for
+an explicit slot selection, and saves the selected frames. It performs real
+scanner I/O when run with a connected scanner. Use a new output directory
+for each insertion; the retained attempt directory contains the acquisition
+journals and intermediate evidence.
 
 ```python
-import coolscanpy
+from contextlib import closing
+from pathlib import Path
 
-with coolscanpy.open("ls5000") as dev:
-    with dev.roll(material=coolscanpy.Material.COLOR_NEGATIVE) as roll:
+import coolscanpy
+import tifffile
+
+output = Path("roll-capture").resolve()
+output.mkdir()  # Refuse to overwrite an earlier capture directory.
+
+with coolscanpy.open("ls5000") as device:
+    with device.roll(
+        material=coolscanpy.Material.COLOR_NEGATIVE,
+        attempts_root=output / "attempts",
+    ) as roll:
         thumbnails = roll.preview()
+        for thumbnail in thumbnails:
+            tifffile.imwrite(
+                output / f"preview-{thumbnail.slot:02d}.tif", thumbnail.image
+            )
+            print(thumbnail.slot, thumbnail.needs_approval, thumbnail.warnings)
 
-        for thumb in thumbnails:
-            if thumb.needs_approval:
-                roll.approve(thumb.slot)
+        selected = [
+            int(slot) for slot in input(
+                "Inspect the saved previews, then enter approved slots (e.g. 1,2): "
+            ).split(",")
+        ]
+        for slot in selected:
+            if roll.attended_binding_available:
+                roll.approve(slot, attended=True)
+            elif roll.needs_approval(slot):
+                roll.approve(slot)
 
-        selected = [thumb.slot for thumb in thumbnails[:36]]
-        for frame in roll.scan_many(selected, eject_after=True):
-            print(frame.slot, frame.rgb.shape, frame.receipt.transport_smear.verdict)
-            # The 285 dpi RGBI meter pass, if present:
-            if frame.meter_rgbi is not None:
-                print("  prepass for fauxice:", frame.meter_rgbi.shape)
+        try:
+            with closing(roll.scan_many(selected, eject_after=True)) as frames:
+                for frame in frames:
+                    tifffile.imwrite(output / f"frame-{frame.slot:02d}-rgb.tif", frame.rgb)
+                    if frame.ir is not None:
+                        tifffile.imwrite(output / f"frame-{frame.slot:02d}-ir.tif", frame.ir)
+                    print(frame.slot, frame.receipt.transport_smear.verdict)
+        except coolscanpy.SafeStopRequested:
+            print("Stopped after completing the frame already in flight.")
 ```
 
-`roll.scan_many()` opens one continuous transport reservation for the whole
-list of slots and yields a `Frame` as each completes. `roll.scan(slot)` is
-sugar for scanning one slot. Calling `roll.safe_stop()` from another thread
-lets the frame in flight finish normally; the next one raises
-`SafeStopRequested` instead of starting. The `preview()` call above leaves
-its reservation open, which is why this `scan_many()` resumes it directly
-instead of needing a refeed -- and, left to run without `eject_after`, a
-*further* `scan_many()`/`scan()` call would resume it again, any number of
-times, on the same feed; see Safety model below for the exact scope of that
-hold.
+`preview()` performs a whole-roll transport read at approximately 97 dpi.
+Its optional `slots` argument filters thumbnails, not the hardware read.
+Up to 40 slots can be represented; inspect warnings and partial crops rather
+than assuming all are complete, scanner-addressable frames.
 
-`eject_after=True` ends the batch, once the last requested slot's frame is
-finalized, by replaying the scanner's own traced end-of-session eject
-sequence -- still inside this batch's original reservation -- before
-releasing, instead of the plain release every batch without it already
-performs when it was never holding anything. Leave it off (the default) and
-a batch that resumed a held reservation keeps that same reservation held
-afterward too -- the strip stays parked inside for a later
-`preview()`/`scan_many()`/`scan()` on the same feed, or an explicit
-`roll.eject()` -- rather than releasing. The other way to eject is
-`roll.eject()`, for the "I'm not scanning anything else on this roll" case:
-valid whenever a reservation is currently held, whether that is `preview()`'s
-own (before the first `scan_many()`/`scan()` consumes it) or a later batch's
-(before the next one, or an explicit `release()`). Either path raises
-`FeederParked` instead of completing if the traced sequence does not finish
-as expected -- most often a suspected transport wedge, for which a power
-cycle is the only demonstrated recovery.
+A new preview replaces the fingerprint and clears approvals. To adjust a
+boundary, use `set_spacing_offset(slot, offset_rows)` in native preview rows;
+it returns a re-cropped thumbnail and invalidates that slot's approval.
+`spacing_offset(slot)` reads the offset. Review the changed crop before
+approving again.
 
-Both `scan_many()` and `scan()` also accept an `exposure_override_10ns=(red,
-green, blue)` keyword: raw 10 ns hardware exposure ticks that replace the AE
-meter's own proposal for every frame in the batch, without changing what the
-meter itself measures.
+When `attended_binding_available` is true, automatic detection has medium
+confidence: use `approve(slot, attended=True)` for **every requested slot**,
+not just flagged slots. Low-confidence detection is not rescued by this
+approval. Approvals bind to the reviewed content and geometry, not to a
+permanent slot number.
 
-For live diagnostics or acceptance runs, pass an absolute caller-owned
-directory as `dev.roll(attempts_root=...)`. Preview rasters, transport tables,
-journals, and capture scratch written there survive `Roll.close()` for offline
-verification. Omitting it retains the self-cleaning temporary default.
+`scan_many()` reserves its lazy iterator before returning it. It freezes the
+selected slots, approvals, and reviewed session against concurrent mutation.
+Fully consume the iterator, or explicitly close it with `contextlib.closing`
+as above. `scan(slot)` is the one-slot convenience API.
 
-## Hardware support
+### Frames and evidence
 
-Tested: Nikon Super Coolscan 5000 ED (LS-5000), firmware 1.03, with an SA-21
-roll feeder wired for SA-30 compatibility.
+A color-roll `Frame` contains scanner-linear `rgb`, an `ir` plane and
+`ir_validity` mask, the settled 285 dpi `meter_rgbi` pass, and a `receipt`
+with exposure, clipping, focus, transport-smear, and artifact evidence.
+Optional evidence fields must be checked before use. RGB and infrared use
+the package's Nikon Scan storage orientation; the meter has its own
+acquisition geometry. `frame.prepare_digital_ice()` validates and returns
+the scanner-native inputs for a repair call, or refuses incomplete evidence.
 
-Untested: every other Coolscan model, and any roll feeder other than the
-SA-21/SA-30 configuration above. Platforms: the suite runs on Linux and
-macOS in CI. Windows is untested; the transport layer has never run there
-and the concurrency tests assume POSIX file-lock semantics. The code does not assume LS-5000-only
-behavior where the protocol is generic, but nothing beyond the one
-combination above has run against real film. Reports and pull requests
-against other bodies are welcome, and an LS-50 test is particularly wanted:
-its transport and optics differ from the LS-5000, and none of those
-differences are covered here yet.
+Pixels are not inverted or rendered for display. Clipping is informational;
+stopped-transport smear can refuse a frame. The guarded color-negative
+exposure solve records its commanded authority rather than promising color
+equivalence with another scanner application.
 
-On the tested LS-5000/SA-21, startup `READ(0x8f)` can return a complete
-self-declared shorter frame-table envelope with the observed `022b4b`
-data-underrun status. coolscanpy accepts that status only when the envelope is
-valid and shorter than the requested 40-slot maximum. The observed exact
-37-record canonical prefix is also bound to a matching shorter preview window
-and read allocation; the canonical 40-record path is unchanged. Every other
-short count, changed record prefix, malformed envelope, full-length underrun,
-or differently failed response still refuses before motion. The later live
-`0x8e` index and preview independently validate roll identity and frame
-addressability before any fine scan. If the live transport table has already
-entered its terminal `0x81xx`/`0x83xx` suffix, affected trailing slots remain
-visible for review but are deliberately not scanner-addressable on that
-insertion.
+Both scan methods accept `exposure_override_10ns=(red, green, blue)`:
+validated per-channel fine-exposure ticks, each 10 ns, independent of the
+meter measurements. Advanced contracts live alongside the implementation:
 
-Strips shorter than a full roll work for preview and, as of 0.1.3, for fine
-scanning too. A preview traversal parks a short strip at the transport
-end-stop. `preview()` keeps its reservation open, and every
-`scan_many()`/`scan()` call afterward -- not just the first -- resumes it
-directly instead of re-reading the index, so the ordinary preview-then-scan
-sequence no longer needs a refeed for that reason, on a short strip or a
-full roll. `RefeedRequired` still applies if a held reservation cannot be
-resumed (the scanner may have auto-ejected, or the held child died), if
-`release()` was called first, or to a batch on a feed that was never held
-in the first place: pull the strip out, reinsert it until the feeder grips,
-and run the batch again. Treat that refeed as a new registration.
+| Contract | Reference |
+| --- | --- |
+| Frame arrays, receipts, density ownership and repair inputs | [Public types](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/src/coolscanpy/types.py) |
+| Validated manual placement and restored preview state | [Preview sessions](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/src/coolscanpy/roll/preview_session.py), [Roll API](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/src/coolscanpy/_roll.py) |
+| Short-strip geometry, terminal slots and fingerprint validation | [Transport index](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/src/coolscanpy/protocol/ls5000_single_pass/roll_index.py) |
+| Capture resource and implementation hashes | [Bundle integrity](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/src/coolscanpy/protocol/ls5000_single_pass/bundle.py) |
+| Strict EBDE padding validation and streaming/offline parity | [Packed decoder](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/src/coolscanpy/protocol/ls5000_single_pass/packed.py) |
+| Streaming artifact validation and raw-capture fallback | [Capture finalization](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/src/coolscanpy/capture/single_pass_workflow.py) |
 
-The converted SA-21 can park or eject a strip after an uncharacterized idle
-interval. Start the intended capture promptly after feeding. A transport-index
-stall or refusal is a stop condition: preserve the evidence, establish the
-physical media state, and do not retry the same insertion.
+Concurrent decoding is advisory: invalid or unavailable derived data falls
+back to the retained raw capture. `COOLSCANPY_CAPTURE_STREAMING=0` disables
+that optimization. It does not disable acquisition integrity checks.
 
-## Relationship to NegPy
+## Reservation, stop, and cleanup contracts
 
-coolscanpy is a dependency, the way NegPy already consumes python-sane or
-gphoto2. It does not import NegPy, and NegPy does not depend on it by
-default. A caller wires it in behind whatever extension seam their own
-application already uses for other scanner backends: open a device, run one
-roll to completion, close it.
+A successful preview leaves a child holding the scanner reservation. A
+batch resumes it without another frame-table traversal. A resumed batch
+that completes without stop or `eject_after=True` keeps the session held for
+the next batch. Without a held session, a batch starts a fresh reservation
+and releases it at completion. Repeating `preview()` supersedes the old hold
+and registration.
 
-## How this compares to SANE
+Use these operations according to the state you own:
 
-SANE's `coolscan3` backend is the mature, general route to these scanners:
-one API across many models, a daemon ecosystem, and a working eject. NegPy
-consumes it happily. coolscanpy exists for the narrower job SANE's frame
-API cannot express: archival capture with evidence. The honest split:
+| Operation | Meaning |
+| --- | --- |
+| `roll.safe_stop()` | Stop the current batch between frames. It does not abort a frame already being captured. The consumer receives completed frames followed by `SafeStopRequested`. |
+| Iterator `close()` | Stop and drain an active batch, or clean up an unstarted reservation, before relinquishing its ownership. |
+| `roll.release()` | Give up a still-held session between batches. This is not an eject. |
+| `roll.eject()` | Replay the held-session eject sequence within the existing reservation. Raises `EjectNotAvailable` when there is no held session. |
+| `scan_many(..., eject_after=True)` | Eject after the final requested frame. A safe stop takes priority and releases without ejecting. |
+| `roll.close()` | Close owned work and release the Roll reservation. Unconfirmed worker shutdown raises `DeviceBusy` and retains ownership. |
+| `device.eject()` | Direct-USB unload when the caller has no capture child owning the interface. It confirms absence before returning success; an already-empty transport is a no-op success. |
 
-| Capability | coolscanpy | SANE `coolscan3` |
-|---|---|---|
-| Single-pass 4000 dpi 16-bit RGBI contract | yes, fixed protocol | partial — RGB + separate IR handling, backend-dependent |
-| 285 dpi meter-pass surfaced per frame (`Frame.meter_rgbi`) | yes | no |
-| Density-calibration payloads exposed with hashes | yes | no |
-| Per-frame receipt telemetry (exposure vectors, clipping, focus, transport smear) | yes | no |
-| Per-frame + session journals on disk | yes | no |
-| Hash-pinned capture bundle provenance | yes | no |
-| Roll batch under one reservation with fingerprint identity checks | yes | no — per-frame `--frame n` |
-| Whole-roll preview with per-slot review states | yes | no |
-| Eject | direct-USB traced Unload plus presence confirmation | yes |
-| Scanner model breadth | one tested body (LS-5000/SA-30 wiring) | many Coolscan models |
-| Years in production | extracted 2026 | decades |
+Stop state is batch-scoped: creating a new batch resets the Roll stop event.
+An application that acknowledges cancellation for a larger job must keep
+its own job stop state across preparation, reservation, and retries. It
+must serialize that state with reservation and avoid starting another batch
+after acknowledging the stop. A pre-reservation call to `safe_stop()` alone
+does not cancel a future batch.
 
-They compose rather than compete: the direct-USB path owns color-roll capture,
-its evidence chain, and eject. A live LS-5000 color-roll preview, capture, and
-eject requires no SANE; discovery may use SANE when present, and the legacy
-plain-scan path still requires it.
+In 0.7.6, stopping before the first `next()`, closing an unstarted iterator,
+closing its Roll, or abandoning that iterator tears down its pending held
+child. A reservation failure leaves the original hold available for cleanup.
+If child exit cannot be confirmed, another batch or device close must not
+silently acquire ownership. The retained `DeviceBusy` state is a recovery
+condition, not an instruction to retry in a loop. Closing from an active
+progress callback is also refused; request a stop and let the owning caller
+complete cleanup instead.
 
-## Safety model
+`attempts_root` should be an absolute caller-owned directory when evidence
+must survive. Without it, CoolscanPy uses temporary storage that normal
+close removes; uncertain cleanup and other evidence-preserving failures
+retain it. Keep attempt journals and raw data until a failure is understood.
 
-A roll batch takes one reservation over the physical transport for its whole
-scan_many() call, not one per frame, and releases it exactly once on close.
-Requesting a safe stop never interrupts the frame currently being read; only
-the next one is affected.
+### Recovery
 
-`preview()` keeps its own reservation open rather than releasing
-immediately, so every `scan_many()`/`scan()` call that follows resumes it
-directly instead of reacquiring the transport, with no refeed needed, even
-on hardware that parks between reads. This is not limited to the first
-batch after a preview: a batch that completes without `eject_after=True`
-keeps the same reservation held for the next one too -- same child process,
-same reservation, same retained frame table, matching the vendor's own
-traced session shape (one `RESERVE_UNIT` from feed to eject, any number of
-fine scans in between, no repeated frame-table read, no intermediate
-`RELEASE_UNIT`) -- so a whole roll can be scanned across as many
-`scan_many()`/`scan()` calls as the caller wants without a refeed between
-them. `release()` gives up a still-held reservation explicitly at any point
-between batches, reverting to a fresh reservation on the next scan; calling
-`preview()` again always supersedes whatever reservation the one before it
-was holding, whether that was `preview()`'s own or a batch's. A cold batch
--- no preceding `preview()`, or one whose hold was already
-released/ejected/never established -- opens its own fresh reservation
-exactly as every batch always has, and can still raise `RefeedRequired` if
-the transport has parked by then; a batch resuming a held reservation whose
-child died in the meantime (auto-eject, crash) raises the same
-`RefeedRequired` rather than assuming the reservation is still good.
+| Result | What the caller should do |
+| --- | --- |
+| `ManualReviewRequired` | Review the current crop and geometry, then approve the requested slot. |
+| `FingerprintRefused` / `RollMismatch` | Do not capture using stale geometry; establish the media state and registration. |
+| `RefeedRequired` | The held reservation is unavailable. Treat a physical refeed as a new registration and preview again. |
+| `TransportIndexRefused` / `MeterControllerRefused` | Retain the typed failure evidence and investigate before retrying. |
+| `DeviceBusy` during shutdown | Keep ownership and evidence intact until the worker's state is resolved. |
+| `FeederParked` / `EjectFailed` | Establish whether film is still gripped; follow the reported physical remedy rather than automatically repeating unload. |
 
-Ejecting -- `scan_many(..., eject_after=True)` or `roll.eject()` on a
-still-held reservation -- replays the scanner's own traced end-of-session
-sequence inside the reservation already held, the same session shape a
-normal scan already uses, rather than releasing first and re-reserving to
-eject afterward. Every reply is checked against that trace; any deviation
-stops before another motion command is sent and raises `FeederParked`
-instead of reporting success, since a mid-motion failure with film still
-inside is exactly the case a power cycle, not a retry, is the documented
-recovery for. `EjectNotAvailable` is raised instead if nothing is currently
-held to eject -- no `preview()` has run yet, or the hold was already
-consumed by a `scan_many()`/`scan()` call that ended it with
-`eject_after=True`, or was released/ejected explicitly.
+`device.film_present()` returns `True`, `False`, or `None`. Unknown is not
+absent, and present is not proof that motion is safe. `Device.eject()` already
+confirms absence; a second presence probe should not turn its successful
+return into an error. A transport-index stall is a stop condition: preserve
+the attempt and do not repeatedly retry the same insertion.
 
-Before the first fine scan of a batch, the roll's fingerprint (bound at the
-last preview) is checked against a fresh read of the transport. If the
-comparison doesn't match, `FingerprintRefused` is raised instead of scanning
-under the wrong geometry. Separately, a slot whose transport origin was not
-confidently automatic must be approved against its current thumbnail before
-it can be fine-scanned; scanning an unapproved flagged slot raises
-`ManualReviewRequired`.
+For exact exception payloads and held-child teardown behavior, see
+[exceptions](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/src/coolscanpy/exceptions.py) and the
+[capture process adapter](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/src/coolscanpy/protocol/ls5000_single_pass/capture_process.py).
 
-Every returned frame carries transport-smear and clipping telemetry.
-Clipping is informational and never gates a capture. An abnormal repeated
-tail from a stopped transport does gate: that frame is refused rather than
-returned with smeared rows.
+## Plain scan and diagnostic commands
 
-The concurrent decoder used for proven full-record captures is deliberately
-non-authoritative. It submits work without blocking the USB loop, has a
-bounded completion wait, and records its terminal state in the frame journal.
-Finalization consumes its derived artifact only after revalidating its schema,
-raw-stream binding, hash, NPY layout, and file identities; otherwise it decodes
-the retained raw stream offline.
+With the optional SANE installation, the python-sane-shaped path returns
+an array directly:
 
-## What this package is not
+```python
+import coolscanpy
 
-There is no GUI. The RGB comes back scanner-linear and unmodified; color
-inversion and print rendering belong to the application above this library
-(see [cool-colors](https://github.com/rohanpandula/cool-colors) for a
-standalone C-41 inverter, or
-[NegPy](https://github.com/marcinz606/NegPy) for the full desktop app).
-The infrared plane comes back raw as well, and both arrays are stored in
-Nikon Scan's own orientation rather than the scanner's native portrait
-readout, so `frame.rgb`/`frame.ir` line up with what Nikon Scan renders for
-the same frame with no extra rotation downstream. Turning the infrared
-plane into a defect mask and healing the dust it reveals is the job of
-[digital-fauxice](https://github.com/rohanpandula/digital-fauxice), which
-consumes this package's RGBI output directly — the `Frame.meter_rgbi`
-field is the 285 dpi prepass its input contract requires.
+with coolscanpy.open("ls5000") as device:
+    print(device["resolution"].constraint)
+    device.resolution = 4000
+    device.depth = 16
+    rgb = device.scan()
+    print(rgb.shape, rgb.dtype)
+```
 
-## License
+Plain scan options describe that path. They do not change the color-roll
+engine's fixed acquisition contract. `Device.cancel()` is the plain-scan
+cancellation API; use `Roll.safe_stop()` for a roll batch.
 
-GPL-3.0-only. The code began life on a fork branch of
-[NegPy](https://github.com/marcinz606/NegPy), marcinz606's film-negative
-processing application, and is republished here as a standalone package
-under the same license.
+Installed command entry points and diagnostic modules expose their own help:
+
+```sh
+coolscanpy-roll-scan --help
+coolscanpy-practical-parity --help
+python -m coolscanpy.cli.vpd_dump --help
+python -m coolscanpy.cli.perforation_probe --help
+python -m coolscanpy.cli.unload_timer --help
+python -m coolscanpy.cli.wedge_recovery --help
+```
+
+`coolscanpy-roll-scan` is a separate plan/registration workflow, with
+`prepare`, `status`, `approve`, `fine`, `full-negative`, and `forward-roll`
+commands; it is not a CLI wrapper for the `Roll` example above. Its live
+commands require `--live` and `NEGPY_ROLL_LIVE=YES`.
+`coolscanpy-practical-parity` uses SANE and requires `--live` for capture;
+its default probe can still contact hardware. The diagnostic modules also
+have different motion contracts: VPD, perforation, and unload-timer probes
+are read-only; wedge recovery can command motion. Read their help before
+invoking them on a scanner.
+
+## Develop and test in ScanStudio
+
+From the ScanStudio repository root, use its pinned **uv 0.11.30** toolchain:
+
+```sh
+(cd coolscanpy && uv sync --locked --dev --python 3.13)
+(cd coolscanpy && uv run --locked pytest -q)
+make bridge-test
+```
+
+The bridge lockfile uses this checkout-local source. Run its integration tests
+when changing the Device/Roll API as well as the driver’s own tests; a fake
+that exposes a nonexistent property cannot establish compatibility with the
+real facade.
+
+The suite uses synthetic devices, replay fixtures, and substituted transport
+boundaries. Optional dependencies or external archived captures can cause
+explicit skips. Passing tests do not establish attached-scanner compatibility.
+Use [Mac acceptance and recovery](../docs/MAC-ACCEPTANCE.md) for ScanStudio’s
+separate packaged-software gate and attended hardware evidence.
+
+The canonical release branch is `port/cross-platform`. Standalone development,
+locked builds, linting, and trusted publishing are documented in the
+[canonical README](https://github.com/rohanpandula/coolscanpy/blob/port/cross-platform/README.md).
+The canonical project’s build settings and release workflow are separate from
+this vendored directory’s packaging configuration.
+
+### Releasing a driver change
+
+1. Review and test the canonical driver change, preserving ScanStudio-specific
+   differences rather than copying the entire vendored package over upstream.
+2. Merge the green canonical PR and publish the matching version through its
+   existing [trusted publishing workflow](https://github.com/rohanpandula/coolscanpy/blob/port/cross-platform/.github/workflows/publish.yml).
+3. Update ScanStudio’s project/lockfile version and authenticated sdist pins.
+   Re-review and pin both sides of any intentional source differences.
+4. Run the parity gate from the ScanStudio repository root:
+
+```sh
+bash scripts/check_coolscanpy_pypi_sync.sh
+```
+
+The gate compares source bytes; equal version strings alone do not pass.
+ScanStudio’s release workflow requires it before signing and publishing the
+app. See [release policy](../docs/releases/README.md). Changes to capture-bundle
+files also require their integrity checks; `_roll.py` is outside that manifest
+and does not require a bundle reseal.
+
+## Downstream processing and license
+
+Applications can consume CoolscanPy as an acquisition dependency:
+[digital-fauxice](https://github.com/rohanpandula/digital-fauxice) handles
+infrared-guided repair, [cool-colors](https://github.com/rohanpandula/cool-colors)
+handles color-negative rendering, and
+[NegPy](https://github.com/marcinz606/NegPy) provides a desktop processing
+application. These are separate projects; installing CoolscanPy does not
+install them or assert equivalence between their rendered output and a
+particular scanner application.
+
+CoolscanPy originated in a NegPy fork and is distributed independently under
+[GPL-3.0-only](https://github.com/rohanpandula/coolscanpy/blob/v0.7.6/LICENSE).

--- a/coolscanpy/README.md
+++ b/coolscanpy/README.md
@@ -335,7 +335,7 @@ real facade.
 The suite uses synthetic devices, replay fixtures, and substituted transport
 boundaries. Optional dependencies or external archived captures can cause
 explicit skips. Passing tests do not establish attached-scanner compatibility.
-Use [Mac acceptance and recovery](../docs/MAC-ACCEPTANCE.md) for ScanStudio’s
+Use [Mac acceptance and recovery](https://github.com/rohanpandula/ScanStudio/blob/main/docs/MAC-ACCEPTANCE.md) for ScanStudio’s
 separate packaged-software gate and attended hardware evidence.
 
 The canonical release branch is `port/cross-platform`. Standalone development,
@@ -360,7 +360,7 @@ bash scripts/check_coolscanpy_pypi_sync.sh
 
 The gate compares source bytes; equal version strings alone do not pass.
 ScanStudio’s release workflow requires it before signing and publishing the
-app. See [release policy](../docs/releases/README.md). Changes to capture-bundle
+app. See [release policy](https://github.com/rohanpandula/ScanStudio/blob/main/docs/releases/README.md). Changes to capture-bundle
 files also require their integrity checks; `_roll.py` is outside that manifest
 and does not require a bundle reseal.
 

--- a/coolscanpy/pyproject.toml
+++ b/coolscanpy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coolscanpy"
-version = "0.7.5"
+version = "0.7.6"
 description = "Direct-USB acquisition library for Nikon Coolscan film scanners with a python-sane-style API — roll scanning, RGBI capture, IR plane, scan receipts"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/coolscanpy/src/coolscanpy/_roll.py
+++ b/coolscanpy/src/coolscanpy/_roll.py
@@ -202,12 +202,10 @@ class _OwnedRollBatchIterator(Iterator[Frame]):
         finally:
             try:
                 if terminal:
-                    self._release_roll_once()
+                    self._finish_definite_close()
             finally:
                 with self._condition:
                     self._executing_thread = None
-                    if terminal:
-                        self._closed = True
                     self._condition.notify_all()
 
     def close(self) -> None:
@@ -281,7 +279,13 @@ class _OwnedRollBatchIterator(Iterator[Frame]):
 
         try:
             self._release_roll_once()
-        finally:
+        except _BatchWorkerStillActive:
+            self._mark_ownership_uncertain()
+            with self._condition:
+                self._closing_thread = None
+                self._condition.notify_all()
+            raise
+        else:
             with self._condition:
                 self._closed = True
                 self._closing_thread = None
@@ -296,8 +300,9 @@ class _OwnedRollBatchIterator(Iterator[Frame]):
         with self._condition:
             if self._released:
                 return
-            self._released = True
         self._roll._batch_finished(self)
+        with self._condition:
+            self._released = True
 
     def __del__(self) -> None:
         # Roll keeps only a weak reference, so abandoning a temporary iterator
@@ -359,6 +364,9 @@ class Roll:
         # Also None if released/ejected (by release()/eject()/close(), or
         # eject_after=True) or if no preview() has run yet.
         self._held_session: HeldPreviewSession | None = None
+        # Owned by the lazy batch until its worker actually dispatches it.
+        # An unstarted generator cannot run cleanup on close().
+        self._pending_held_session: HeldPreviewSession | None = None
         # When set, close() keeps self._attempts_root on disk instead of
         # deleting it: the journal/preview/table evidence in there is what
         # explains a refused preview or a held child that could not be
@@ -1227,7 +1235,6 @@ class Roll:
             # same lock as everything else above, rather than lazily
             # inside the generator below.
             held = self._held_session
-            self._held_session = None
             iterator = self._scan_many(
                 batch_request,
                 ordered_slots,
@@ -1236,7 +1243,10 @@ class Roll:
                 eject_after,
                 held,
             )
-            return self._reserve_batch_locked(iterator)
+            owned = self._reserve_batch_locked(iterator)
+            self._pending_held_session = held
+            self._held_session = None
+            return owned
 
     def _scan_many(
         self,
@@ -1359,6 +1369,8 @@ class Roll:
         def run_batch() -> None:
             try:
                 try:
+                    with self._state_condition:
+                        self._pending_held_session = None
                     if held is not None and held.usable:
                         result = adapter.resume_held_session(
                             held, batch_request, frame_handler=frame_handler
@@ -1693,6 +1705,23 @@ class Roll:
         with self._state_condition:
             if self._active_batch_id != id(batch):
                 return
+            pending = self._pending_held_session
+        if pending is not None and pending.usable:
+            error = SafeStopRequested("batch ended before dispatching its held session")
+            try:
+                clean = self._ensure_adapter().teardown_held_session(pending, error=error)
+                exited = pending.process.poll() is not None
+            except BaseException as cleanup_error:
+                clean = exited = False
+                error.add_note(f"held-session teardown failed: {cleanup_error}")
+            if not clean or not exited:
+                self._preserve_evidence(str(error))
+            if not exited:
+                raise _BatchWorkerStillActive(
+                    "held child shutdown was not confirmed; USB ownership is retained"
+                ) from error
+        with self._state_condition:
+            self._pending_held_session = None
             self._active_batch = None
             self._uncertain_batch = None
             self._active_batch_id = None

--- a/coolscanpy/tests/test_facade.py
+++ b/coolscanpy/tests/test_facade.py
@@ -3853,7 +3853,7 @@ class TestRollScanMany:
             roll.close()
 
             assert list(iterator) == []
-            assert events == ["preview-hold-ready"]
+            assert events == ["preview-hold-ready", "hold-ack-release"]
         finally:
             roll.close()
             dev.close()
@@ -6186,3 +6186,126 @@ def test_thumbnail_from_slot_carries_partial_through_to_the_public_thumbnail() -
 
     assert partial_thumbnail.partial is True
     assert full_thumbnail.partial is None
+
+
+@pytest.mark.parametrize("ending", ["stop", "iterator-close", "roll-close", "abandon"])
+def test_unstarted_batch_releases_held_child(fake_service_factory, tmp_path, ending):
+    events = []
+    dev = _open_device(fake_service_factory)
+    roll, _ = _make_roll(tmp_path, dev, batch_spawner=_success_spawner(events))
+    try:
+        roll.preview()
+        if roll.needs_approval(1):
+            roll.approve(1)
+        held = roll._held_session
+        iterator = roll.scan_many([1])
+        if ending == "stop":
+            roll.safe_stop()
+            with pytest.raises(coolscanpy.SafeStopRequested):
+                next(iterator)
+            iterator.close()
+        elif ending == "iterator-close":
+            iterator.close()
+        elif ending == "roll-close":
+            roll.close()
+        else:
+            del iterator
+            gc.collect()
+        assert events == ["preview-hold-ready", "hold-ack-release"]
+        assert held.process.poll() is not None
+        assert not dev._lock.locked()
+        roll.close()
+        assert events.count("hold-ack-release") == 1
+    finally:
+        roll.close()
+        dev.close()
+
+
+def test_failed_batch_reservation_retains_held_child(fake_service_factory, tmp_path):
+    events = []
+    dev = _open_device(fake_service_factory)
+    roll, _ = _make_roll(tmp_path, dev, batch_spawner=_success_spawner(events))
+    try:
+        roll.preview()
+        if roll.needs_approval(1):
+            roll.approve(1)
+        held = roll._held_session
+        dev._acquire_io_lock("competing operation")
+        try:
+            with pytest.raises(coolscanpy.DeviceBusy):
+                roll.scan_many([1])
+        finally:
+            dev._release_io_lock()
+        assert roll._held_session is held
+        roll.close()
+        assert events == ["preview-hold-ready", "hold-ack-release"]
+    finally:
+        roll.close()
+        dev.close()
+
+
+@pytest.mark.parametrize("ending", ["stop", "close"])
+@pytest.mark.parametrize("teardown_raises", [False, True])
+def test_unstarted_batch_retains_ownership_when_teardown_is_uncertain(
+    fake_service_factory, tmp_path, monkeypatch, ending, teardown_raises
+):
+    events = []
+    dev = _open_device(fake_service_factory)
+    roll, _ = _make_roll(tmp_path, dev, batch_spawner=_success_spawner(events))
+    roll.preview()
+    if roll.needs_approval(1):
+        roll.approve(1)
+    held = roll._held_session
+    iterator = roll.scan_many([1])
+    with monkeypatch.context() as patch:
+        def uncertain_teardown(*a, **k):
+            if teardown_raises:
+                raise RuntimeError("cleanup failed")
+            return False
+        patch.setattr(roll._adapter, "teardown_held_session", uncertain_teardown)
+        with pytest.raises(coolscanpy.DeviceBusy, match="shutdown was not confirmed"):
+            if ending == "stop":
+                roll.safe_stop()
+                next(iterator)
+            else:
+                iterator.close()
+        with pytest.raises(coolscanpy.DeviceBusy):
+            roll.close()
+        with pytest.raises(coolscanpy.DeviceBusy):
+            dev.close()
+        with pytest.raises(coolscanpy.DeviceBusy):
+            roll.scan_many([1])
+        assert roll._pending_held_session is held
+        assert dev._lock.locked()
+        assert roll._attempts_root.is_dir()
+    # Test-only resolution of the deliberately retained ownership token.
+    assert roll._adapter.teardown_held_session(held, error=RuntimeError("test cleanup"))
+    iterator._ownership_uncertain = False
+    iterator.close()
+    roll.close()
+    dev.close()
+
+
+def test_unstarted_batch_preserves_evidence_after_nonclean_confirmed_exit(
+    fake_service_factory, tmp_path, monkeypatch
+):
+    dev = _open_device(fake_service_factory)
+    roll, _ = _make_roll(tmp_path, dev, batch_spawner=_success_spawner([]), attempts_root=None)
+    try:
+        roll.preview()
+        if roll.needs_approval(1):
+            roll.approve(1)
+        teardown = roll._adapter.teardown_held_session
+        def nonclean_exit(*args, **kwargs):
+            assert teardown(*args, **kwargs)
+            return False
+        monkeypatch.setattr(roll._adapter, "teardown_held_session", nonclean_exit)
+        iterator = roll.scan_many([1])
+        iterator.close()
+        assert not dev._lock.locked()
+        roll.close()
+        assert roll._attempts_root.is_dir()
+        assert roll._evidence_preservation_reason is not None
+    finally:
+        roll.close()
+        dev.close()

--- a/coolscanpy/uv.lock
+++ b/coolscanpy/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "coolscanpy"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "imagecodecs" },

--- a/docs/HARDWARE-SUPPORT.md
+++ b/docs/HARDWARE-SUPPORT.md
@@ -11,7 +11,7 @@ use [NegPy downloads](https://github.com/marcinz606/NegPy/releases) and
 [upstream compatibility guidance](https://github.com/marcinz606/NegPy#readme),
 without assuming a download guarantees scanner support.
 
-Latest release notes: [v0.7.0-beta.14](releases/v0.7.0-beta.14.md).
+Latest release notes: [v0.7.0-beta.15](releases/v0.7.0-beta.15.md).
 
 | Host and scanner | Package built | Device enumerated | Preview exercised | One-frame capture validated | Support / next evidence |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,36 +1,122 @@
-# Release notes policy
+# ScanStudio releases
 
-Current ScanStudio releases target **Apple Silicon (M-series, arm64) only**,
-on macOS 14 (Sonoma) or newer. Intel macOS, Windows, and Linux are retired.
-For those systems, consult [NegPy downloads](https://github.com/marcinz606/NegPy/releases)
-and [upstream compatibility documentation](https://github.com/marcinz606/NegPy#readme).
+[v0.7.0-beta.15 release notes](v0.7.0-beta.15.md) describe the Mac-only
+release scope, scanner connection and Stop/recovery changes, saved-output
+controls, and validation evidence.
 
-Existing versioned notes and published assets are historical evidence. Preserve
-their original platform claims, test results, and signing state; do not rewrite
-them to imply that those releases were Apple Silicon only. Their old support
-statements do not extend to current releases. New notes must describe the
-arm64-only scope and distinguish automated checks from real hardware results.
+Use the [GitHub Releases listing](https://github.com/rohanpandula/ScanStudio/releases)
+to find published downloads. A versioned notes file or locally built DMG does
+not establish publication. Releases remain prereleases with `latest=false`;
+a stable `/latest` link is not the download entry point.
 
-Every ScanStudio release must publish a full changelog. The release body is a
-source-controlled artifact, not text generated from commit subjects or edited
-into GitHub after publication.
+## Current release scope
 
-Before creating a tag named `v<version>`:
+ScanStudio targets **Apple Silicon (M-series, arm64) only, macOS 14 (Sonoma)
+or newer**. The downloadable image is
+`ScanStudio-<version>-macOS-arm64.dmg`; copy the app to Applications.
+The release workflow Developer ID-signs, notarizes, and staples **both the
+app and DMG**. It publishes one arm64 DMG, `SHA256SUMS`, and `latest.json`.
 
-1. Add `docs/releases/v<version>.md` in the exact commit that will be tagged.
-2. Start it with `# ScanStudio v<version>`.
-3. Include, in order, one non-empty section with each exact heading:
-   `## Everything that changed`, `## Validation`,
-   `## Platform support and installation`, and `## Known limitations`.
-4. Replace draft language and placeholders with the final verified test counts,
-   support claims, installation instructions, and residual boundaries.
-5. Run `python3 -I -S -B scripts/verify_release_notes.py
-   docs/releases/v<version>.md v<version> <version>` and the complete
-   `scripts/tests` unittest suite before tagging.
+The supported LS-5000 C-41 color-roll workflow remains Beta, with limited
+retained hardware evidence. LS-40/LS-50 identity recognition and FireWire
+probing are not scanning support. Refer to the [hardware matrix](../HARDWARE-SUPPORT.md)
+and [Mac acceptance and recovery](../MAC-ACCEPTANCE.md) when describing results.
+Final attended full-roll hardware acceptance for beta.15 is **NOT RUN**.
+Software checks cannot establish real focus, framing, color, dust repair, or
+physical stop/resume behavior.
 
-The tag-triggered release workflow derives the filename from the validated tag,
-refuses symlinks, invalid UTF-8, abnormal sizes, placeholders, a tag/version
-mismatch, and missing or reordered sections. It passes that committed file to
-GitHub and requires the draft and published API bodies to equal it exactly.
-Publication remains a prerelease with `latest=false` until the release workflow
-is deliberately changed for a field-proven stable release.
+Intel Macs, Windows, and Linux are retired ScanStudio platforms. Direct those
+users to [NegPy downloads](https://github.com/marcinz606/NegPy/releases) and
+[upstream setup and compatibility guidance](https://github.com/marcinz606/NegPy#readme),
+without promising scanner or holder support. nkscan remains a documentation-only
+cleanroom reference; no implementation code or profiles are copied.
+
+Historical versioned notes and published assets retain the support, test, and
+signing facts that applied to them. Preserve those records without extending
+their platform promises to current releases. Keep live guidance concise;
+release-by-release history belongs in the versioned notes.
+
+## Prepare the release notes
+
+Before creating `v<version>`, include `docs/releases/v<version>.md` in the exact
+commit to be tagged. The release workflow requires that commit to be contained
+in reviewed `main` history. Write the complete changelog in that file; GitHub's
+release body must come from it, not generated commit subjects or later edits.
+
+The file must begin with `# ScanStudio v<version>` and contain each of these
+non-empty sections exactly once, in this order:
+
+1. `## Everything that changed`
+2. `## Validation`
+3. `## Platform support and installation`
+4. `## Known limitations`
+
+Use verified test results and precise hardware boundaries. Keep unperformed
+hardware acceptance explicitly **NOT RUN**. Resolve draft language and
+placeholders before tagging; a structurally valid file is not proof that its
+claims are true. The verifier requires a regular non-symlink UTF-8 file,
+LF line endings with a final newline, and a size of 1–128 KiB. It rejects
+placeholder tokens, wrong titles/paths, and mismatched tags or versions.
+
+From the **repository root**, for beta.15:
+
+```sh
+python3 -I -S -B scripts/verify_release_notes.py \
+  docs/releases/v0.7.0-beta.15.md v0.7.0-beta.15 0.7.0-beta.15
+python3 -I -S -B scripts/verify_hardware_support_docs.py
+python3 -I -S -B scripts/verify_scanner_contract_docs.py
+python3 -I -S -B scripts/verify_release_workflow.py
+python3 -I -S -B scripts/check_github_action_pins.py
+python3 -I -S -B -m unittest discover -s scripts/tests -p 'test_*.py'
+```
+
+These documentation and policy checks supplement the full application,
+bridge, driver, packaging, and updater gates. See the [developer build guide](../../app/ScanStudio/README.md)
+for current commands and their directory scopes.
+
+## Existing release pipeline
+
+[`.github/workflows/release.yml`](../../.github/workflows/release.yml) owns
+publication. Its reusable [verification workflow](../../.github/workflows/ci.yml)
+runs for the **exact tagged commit in the same release run**. Prior green PR
+runs, local checks, or artifacts from another run cannot substitute for it.
+
+1. **Authorize the tag.** Fetch and pin the remote tag object, verify its commit
+   and containment in `main`, and validate the committed release notes.
+2. **Require all verification families.** Run Swift/Rust, bridge, CoolscanPy,
+   supply-chain policy, arm64 package, macOS 14 runtime, and updater integration
+   checks. Failed, canceled, skipped, timed-out, or missing required results
+   block publication; the verified SHA must equal the tagged commit.
+3. **Check driver publication and build.** The PyPI synchronization gate compares
+   the bundled CoolscanPy tree with authenticated published source, permitting
+   only explicitly reviewed differences pinned by hashes on both sides. Publish
+   the required driver and reconcile those pins before tagging; matching version
+   strings alone are insufficient. Use the pinned toolchains and locked
+   dependencies. The app-directory `make package` builds and checks the app.
+4. **Sign and notarize in order.** Sign the app with Developer ID, verify it,
+   then notarize and staple it. Build the DMG from that already-stapled app using
+   `app/ScanStudio/scripts/package_dmg.sh`; sign, notarize, and staple the DMG.
+   Each artifact needs its own ticket. Emit checksums and updater metadata only
+   after DMG stapling, which changes its bytes.
+5. **Bind and verify the artifacts.** Provenance ties hashes to repository,
+   workflow run and attempt, commit, and tag. The final gate requires every
+   same-run job to succeed. Publication verifies provenance, asset names,
+   checksums, and the arm64 updater entry, and rechecks the pinned remote tag.
+6. **Publish the verified prerelease.** Create and verify a draft, then publish
+   it as a prerelease with `latest=false`. Both draft and published API bodies
+   must equal the committed notes exactly; downloaded assets and published
+   metadata are checked by the workflow.
+
+The central package check runs relocated bridge smoke and simulator acceptance
+before final signature verification. The macOS 14 job executes the exact app
+from the CI package job; signed release packages and mounted DMG contents also
+run the package gate. This covers software stop/reopen/interruption/resume and
+saved-output integrity, while the separate final hardware record remains
+**NOT RUN** until an attended run supplies evidence.
+
+[Signing dry runs](../../.github/workflows/signing-dry-run.yml) exercise signing
+without replacing release authorization or publishing a release. Local
+`make package`/`make dmg` are likewise build checks, not publication commands.
+See [update verification](../AUTO-UPDATE.md) for publisher trust and updater
+behavior. Preserve all bridge/CoolscanPy GPL source and dependency notices in
+both app and DMG distributions; see [third-party notices](../../THIRD_PARTY_NOTICES.md).

--- a/docs/releases/v0.7.0-beta.15.md
+++ b/docs/releases/v0.7.0-beta.15.md
@@ -10,8 +10,15 @@ rolls, saved output, and release verification easier to trust.
   It no longer requires a nonexistent `Device.info` property. Missing,
   ambiguous, unsupported, and disconnected devices still fail closed.
 - Diagnostic preview evidence reads the real public device capabilities, so
-  holder capacity is preserved. A regression exercises the real driver open
+  known holder capacity is preserved and unknown direct-USB capacity uses the
+  existing bounded diagnostic limit. A regression exercises the real driver open
   and Device implementation with only enumeration/service creation substituted.
+- Early Stop requests remain latched from job acceptance through batch
+  reservation and retry. CoolscanPy 0.7.6 releases a held preview session when
+  a lazy batch stops or closes before dispatch, retaining ownership if child
+  shutdown cannot be confirmed.
+- Device eject uses the pinned driver’s confirmed-absence result directly,
+  avoiding a redundant status probe that could turn success into a false error.
 - Beta.14 publication was cancelled after this integration defect was reported;
   beta.15 includes that unreleased work plus the connection correction.
 
@@ -52,6 +59,9 @@ rolls, saved output, and release verification easier to trust.
   PR verification replaces duplicate feature-branch push runs. Release
   publication still requires successful same-run verification of the exact
   tagged commit, pinned tag objects, signing, notarization, and provenance.
+- The root, app, bridge, driver, and release READMEs are fully rewritten
+  around working installation, scanning, recovery, development, and release
+  paths, with checked commands and links.
 - The Mac acceptance guide prepares a supervised full-roll run and continuous
   observation, with separate software and physical-image evidence.
 
@@ -62,6 +72,9 @@ rolls, saved output, and release verification easier to trust.
   explicitly ignored. No physical result is inferred from these tests.
 - All 78 XCTest tests and 518 Swift Testing tests passed, including recovery
   races and recorded-output presentation.
+- All 393 bridge tests passed, including seven real-facade cancellation
+  regressions. All 178 driver facade tests passed, including held-session
+  cleanup and retained ownership when child shutdown cannot be confirmed.
 - All 107 root policy/acceptance tests and two packaging-policy tests passed.
   GitHub Action pin, release structure, source identity, scanner-contract, and
   hardware-support documentation checks passed.

--- a/docs/releases/v0.7.0-beta.15.md
+++ b/docs/releases/v0.7.0-beta.15.md
@@ -1,12 +1,19 @@
-# ScanStudio v0.7.0-beta.14
-
-**Publication cancelled:** a real-device integration defect was found before
-publishing. Use [beta.15](v0.7.0-beta.15.md), which includes the fix and this work.
+# ScanStudio v0.7.0-beta.15
 
 This release focuses ScanStudio on Apple Silicon Macs and makes interrupted
 rolls, saved output, and release verification easier to trust.
 
 ## Everything that changed
+
+- Fix real scanner connection failure reported in #111: the bridge now resolves
+  identity through CoolscanPy's public discovery API and opens that exact ID.
+  It no longer requires a nonexistent `Device.info` property. Missing,
+  ambiguous, unsupported, and disconnected devices still fail closed.
+- Diagnostic preview evidence reads the real public device capabilities, so
+  holder capacity is preserved. A regression exercises the real driver open
+  and Device implementation with only enumeration/service creation substituted.
+- Beta.14 publication was cancelled after this integration defect was reported;
+  beta.15 includes that unreleased work plus the connection correction.
 
 - ScanStudio now targets Apple Silicon (M-series, arm64) only, on macOS 14 or
   newer. Windows/Linux app ports and their duplicated source, build tooling,
@@ -67,7 +74,7 @@ rolls, saved output, and release verification easier to trust.
 
 ## Platform support and installation
 
-Download `ScanStudio-0.7.0-beta.14-macOS-arm64.dmg` for an Apple Silicon Mac
+Download `ScanStudio-0.7.0-beta.15-macOS-arm64.dmg` for an Apple Silicon Mac
 running macOS 14 (Sonoma) or newer. The release workflow Developer ID-signs,
 notarizes, and staples both the app and DMG. Copy ScanStudio to Applications.
 The app contains the hardware bridge, bundled runtime and libusb, corresponding

--- a/docs/reviews/2026-09-06-mac-only-reliability.md
+++ b/docs/reviews/2026-09-06-mac-only-reliability.md
@@ -32,6 +32,19 @@ separate `codex/mac-only-reliability` checkout.
   artifact download. The download is restored before provenance verification;
   policy tests reject a missing, duplicate, wrong-root, or cross-run download.
 
+## Real-driver integration follow-up
+
+GitHub #111 revealed that the bridge expected `Device.info`, which only its
+fake exposed. Beta.14 publication was cancelled before any release assets were
+published. The beta.15 follow-up uses public discovery and exact-ID open, and
+adds a regression through the real driver facade with hardware dispatch blocked.
+
+The follow-up review also covers acknowledged Stop before worker startup,
+Stop around lazy batch reservation, held-child cleanup before first iteration,
+unknown direct-USB diagnostic capacity, and confirmed eject without a second
+presence probe. Matching driver fixes are released through canonical CoolscanPy
+before ScanStudio publication; the PyPI parity gate is retained.
+
 ## Verification boundaries
 
 The canonical engine suite, Swift suites, root policy tests, packaging guards,

--- a/scripts/check_coolscanpy_pypi_sync.sh
+++ b/scripts/check_coolscanpy_pypi_sync.sh
@@ -6,7 +6,7 @@
 # debugging confusion the instrumented-refusal work exists to prevent
 # (owner policy, 2026-08-08: "keep them in sync so there's no delta").
 #
-# Mechanics: download the exact authenticated coolscanpy 0.7.5 sdist and compare its
+# Mechanics: download the exact authenticated coolscanpy 0.7.6 sdist and compare its
 # src/coolscanpy tree byte-for-byte against this repo's vendored
 # coolscanpy/src/coolscanpy. Version strings are NOT trusted as the primary
 # signal (an unbumped version with changed code is precisely the failure
@@ -30,20 +30,20 @@ VENDORED_DIR="coolscanpy/src/coolscanpy"
 # Re-pin: shasum -a 256 <both files>, update the entry in the same change
 # that alters the file.
 KNOWN_VENDORED_DIVERGENCE=(
-  # required scanner_identity + capture-timing feature; re-pinned for 0.7.5
+  # required scanner_identity + capture-timing feature; re-pinned for 0.7.6
   # (meter-controller refusal + transport-failure witness landed upstream)
   "protocol/ls5000_single_pass/worker.py|773d9915cf68fd5f6d0937a3f26cdee488f257a584ff8bfe4950b33b96678777|22ba191b7f9d313d80aeec195db648bc686f631849145b620851d0961dcbc5cf"
-  # LeadingFrameClippedError + confident-clear-film gate; re-pinned for 0.7.5
+  # LeadingFrameClippedError + confident-clear-film gate; re-pinned for 0.7.6
   # (failure witness replay landed upstream)
   "protocol/ls5000_single_pass/roll_index.py|c99c54a434d0d53e94e51ed503f0289709b5f20365e16606f365264a617c8b17|38013a1e942c3d1d1798ca0e718fb7ccdc3bc605277ca729e9891fa53bcde311"
   # its export surface for the class above
   "protocol/ls5000_single_pass/__init__.py|ce8aa97b707f5ef83f96128b378722191f7280bd41c1f3acbb04c75e3ea7523e|1f0f324034a95e2c8ca772ce52a78a800b0bf215d3ae4ec77422b08b1376856c"
-  # pins differ because the two files above differ; re-pinned for 0.7.5
+  # pins differ because the two files above differ; re-pinned for 0.7.6
   "protocol/ls5000_single_pass/bundle.py|538dced76ea84c12d9c73c566da6a79955a717ca4a6a7d6b1857aeca02dbc9f6|b6e983319feaa37fbe67263fccc317c7844d81280986a34d15fed0d43b397175"
   # packaged-app libusb resolution (app bundles its own signed binary)
   "protocol/ls5000_single_pass/usb_backend.py|afb5b3cbb57404b758f4f8d8795f4307c07c8f6d01bbeccb3ced38026787fd62|666a476ce706a4a854aac50116575e7143f5a1a7c1b1085125347696d89348d1"
-  # capture-timing receipt fields (started_at/duration); re-pinned for 0.7.5
-  "_roll.py|29903307ce3c0e6f76785b437857450de1d35783fc01c2df9705f03f94fa3df3|61850c5da59b625dd1ce5dc854fe5be01a5a4f687c81fad0f589c9b1c865d094"
+  # capture-timing receipt fields (started_at/duration); re-pinned for 0.7.6
+  "_roll.py|596b2600188ef485d6148839c370895cc9440c8efb722e850e81afae88e11de2|b1aa5f2a6b7172dba635a93902bd9f2d021c5a5f21b8a3f3aa6834e559845b20"
   "capture/single_pass_workflow.py|a5a01b15ff50df9a6f78d1c2c4f39d10548e7651cf3365e8698d479b633b5914|c8d93dce3c7de3b585c2d051b7d09054802a130797c590c97b36b78889def15c"
   "types.py|1343c93c03ade64f0927602fe8e8e25353bada6b1b8a919ce9084c5cbcb321de|f853b8dde9c4a6c3b7ce96195d320c7ba9c88839019bed9ce55fe444ea08e54a"
 )
@@ -51,12 +51,12 @@ KNOWN_VENDORED_DIVERGENCE=(
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
-echo "fetching authenticated coolscanpy 0.7.5 source from PyPI..."
+echo "fetching authenticated coolscanpy 0.7.6 source from PyPI..."
 published_root="$(python3 -I -S -B scripts/fetch_pinned_coolscanpy_sdist.py \
   --destination "$workdir/published")"
 published_src="$published_root/src/coolscanpy"
 test -d "$published_src"
-pypi_version="0.7.5"
+pypi_version="0.7.6"
 
 printf '%s\n' "${KNOWN_VENDORED_DIVERGENCE[@]}" > "$workdir/exemptions"
 if PUBLISHED_SRC="$published_src" VENDORED_DIR="$VENDORED_DIR" \

--- a/scripts/fetch_pinned_coolscanpy_sdist.py
+++ b/scripts/fetch_pinned_coolscanpy_sdist.py
@@ -16,20 +16,20 @@ import unicodedata
 import urllib.request
 
 
-VERSION = "0.7.5"
+VERSION = "0.7.6"
 FILENAME = f"coolscanpy-{VERSION}.tar.gz"
 URL = (
-    "https://files.pythonhosted.org/packages/08/c9/"
-    "7a27d8fd2149d33b9f3514c2b6c54611c48c30a12b07b816ca7aeca9911b/"
+    "https://files.pythonhosted.org/packages/38/27/"
+    "6b2eac47ec9ce8dd86567409fcbb9089dfa7cf5c07ac91a422e95e5d3e5b/"
     f"{FILENAME}"
 )
-SIZE = 556_532
-SHA256 = "7adee250d325b6f4b9872a9e7fef1199349558f87d673a3b48a46890c9d141f6"
+SIZE = 555_426
+SHA256 = "8a5c50fa12c3eb06745cf670e5ac79339fd846c366acad1183849a6f0e375c3d"
 ROOT = f"coolscanpy-{VERSION}"
 ENTRY_COUNT = 104
 FILE_COUNT = 89
 DIRECTORY_COUNT = 15
-EXPANDED_FILE_BYTES = 2_447_520
+EXPANDED_FILE_BYTES = 2_448_646
 
 
 class FetchError(RuntimeError):


### PR DESCRIPTION
Real scanner connections failed because the bridge required a nonexistent `Device.info` property that its test double exposed. Resolve identity through public discovery and open the exact selected ID with the real driver’s revalidation. Also preserve acknowledged Stop from job acceptance through worker startup, batch reservation, and retries; clean up held sessions before first iteration and retain ownership when child exit is unconfirmed. Diagnostic evidence handles unknown USB holder capacity, and confirmed eject no longer triggers a redundant presence probe.

Publish the matching canonical CoolscanPy 0.7.6 first, then pin the official authenticated sdist and reviewed source differences. Fully rewrite the root, app, bridge, driver, and release READMEs around installation, scanning, recovery, development, and release; correct related protocol guidance. Beta.14 was cancelled before publication; beta.15 includes this correction and the merged Apple Silicon work. Windows/Linux/Intel remain retired.

Validation: 393 bridge tests, including seven real-facade stop regressions; 178 driver facade tests; 107 policy/acceptance tests; authenticated PyPI parity; documentation and command checks; Developer ID-signed local package and simulator recovery acceptance. Canonical 0.7.6 passed its macOS/Linux Python 3.13/3.14 matrix and publishing gate; both PyPI attestations and all 72 package files verified. Physical full-roll acceptance remains NOT RUN.

Fixes #111.
