### PR TITLE
Surface bridge startup and quarantine failures; fix amber button contrast

### DIFF
--- a/app/ScanStudio/Sources/ScanStudio/BatchInspectorView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/BatchInspectorView.swift
@@ -632,10 +632,14 @@ struct BatchInspectorView: View {
                 // Issue #76/#24: a whole-batch refusal (e.g. the unattended
                 // binding confidence gate) can fail every frame for the same
                 // one reason before any capture is attempted, leaving
-                // "Completed: 0" with nothing explaining why. Smallest
-                // honest surfacing of that reason, not a redesign.
+                // "Completed: 0" with nothing explaining why; a single
+                // refused frame after completed ones needs the same reason.
+                // Smallest honest surfacing of that reason, not a redesign.
                 if let batchFailureReason {
-                    Label(batchFailureReason.guidance, systemImage: "info.circle")
+                    Label(
+                        "\(batchFailureReason.title). \(batchFailureReason.guidance)",
+                        systemImage: "info.circle"
+                    )
                         .font(.system(size: 10))
                         .foregroundStyle(Color.scanStudioSecondaryText)
                         .fixedSize(horizontal: false, vertical: true)
@@ -657,14 +661,15 @@ struct BatchInspectorView: View {
         }
     }
 
-    /// The scanner's own explanation for a batch that finished without
-    /// completing a single frame -- distinct from `needsReviewFrames`/
-    /// `failedFrames` (which list WHICH frames failed): a whole-batch
-    /// refusal fails every frame for the same one reason before any capture
-    /// is attempted. `nil` whenever the batch completed at least one frame,
-    /// or no failed frame carries a real (non-review) error detail.
+    /// The scanner's own explanation for the first failed (non-review)
+    /// frame -- distinct from `needsReviewFrames`/`failedFrames` (which list
+    /// WHICH frames failed). Originally shown only for a whole-batch refusal
+    /// that left "Completed: 0"; live LS-5000 QA (2026-09-06) completed five
+    /// frames and had frame 6 refused by the exposure-meter controller with
+    /// nothing in the app saying why while Resume and Retry were offered.
+    /// `nil` only when no failed frame carries a real (non-review) detail.
     private var batchFailureReason: ErrorPresentation? {
-        guard let summary = sessionModel.scanSummary, summary.completed.isEmpty else {
+        guard let summary = sessionModel.scanSummary else {
             return nil
         }
         guard let error = summary.failed.lazy.compactMap({ sessionModel.frameErrors[$0] }).first(where: {

--- a/app/ScanStudio/Sources/ScanStudio/ContentView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ContentView.swift
@@ -323,7 +323,7 @@ private struct ManualReviewScanSheet: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.scanStudioAmber)
-                .foregroundStyle(.black)
+                .amberProminentLabel()
                 .disabled(isApproving)
                 .keyboardShortcut(.defaultAction)
             }
@@ -890,7 +890,7 @@ private struct DeviceConnectionWorkspaceView: View {
             case .noDevices:
                 Text("No scanner found")
                     .font(.system(size: 19, weight: .semibold))
-                Button("Look Again") { Task { await sessionModel.refreshAvailableDevices() } }
+                Button("Look Again") { Task { await sessionModel.refreshAvailableDevices(rescan: true) } }
                     .buttonStyle(.bordered)
             case .unsupported(let devices):
                 VStack(spacing: 8) {
@@ -977,7 +977,7 @@ private struct DeviceConnectionWorkspaceView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.scanStudioAmber)
-            .foregroundStyle(.black)
+            .amberProminentLabel()
         }
         .padding(16)
         .background(Color.scanStudioRaised, in: RoundedRectangle(cornerRadius: ScanStudioMetrics.cardCornerRadius))
@@ -1103,7 +1103,7 @@ private struct PreProjectPreviewWorkspaceView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.scanStudioAmber)
-            .foregroundStyle(.black)
+            .amberProminentLabel()
             .controlSize(.regular)
             .disabled(sessionModel.selectedFrameCount == 0)
             .help(
@@ -1217,7 +1217,7 @@ private struct PreviewGateWorkspaceView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.scanStudioAmber)
-            .foregroundStyle(.black)
+            .amberProminentLabel()
             .disabled(
                 sessionModel.status?.transport != "idle"
                     || !sessionModel.hardwareMotionReadiness.allowsMotion
@@ -1341,7 +1341,7 @@ private struct ProjectRegistrationMismatchWorkspaceView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.scanStudioAmber)
-            .foregroundStyle(.black)
+            .amberProminentLabel()
             .controlSize(.large)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/app/ScanStudio/Sources/ScanStudio/FrameAlignmentControl.swift
+++ b/app/ScanStudio/Sources/ScanStudio/FrameAlignmentControl.swift
@@ -128,7 +128,7 @@ struct FrameAlignmentControl: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .tint(.scanStudioAmber)
-                    .foregroundStyle(.black)
+                    .amberProminentLabel()
                     .disabled(isUpdating)
                     .help(
                         "Restore this frame’s chosen scanner position and save it to the current roll."

--- a/app/ScanStudio/Sources/ScanStudio/FrameDetailWorkspaceView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/FrameDetailWorkspaceView.swift
@@ -1793,7 +1793,7 @@ struct FrameDetailWorkspaceView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.scanStudioAmber)
-            .foregroundStyle(.black)
+            .amberProminentLabel()
             .disabled(!frameScanReadiness.isReady)
             .help(frameScanReadiness.reason ?? "Scan this frame")
             if let reason = frameScanReadiness.reason {

--- a/app/ScanStudio/Sources/ScanStudio/ManualFramePlacementView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ManualFramePlacementView.swift
@@ -363,7 +363,7 @@ struct ManualFramePlacementView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.scanStudioAmber)
-            .foregroundStyle(.black)
+            .amberProminentLabel()
             .disabled(!canConfirm)
             .help("Use these boundaries to scan the resulting frames")
             .keyboardShortcut(.defaultAction)

--- a/app/ScanStudio/Sources/ScanStudio/ScanPanelView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ScanPanelView.swift
@@ -326,16 +326,16 @@ struct ScanPanelView: View {
 
     /// Issue #76/#24: "Last batch: 0 completed" alone hid the driver's own
     /// refusal reason (e.g. the unattended-binding confidence gate failing
-    /// every frame before any capture). This footer label has no room for a
-    /// second line, so the reason surfaces as a tooltip instead --
-    /// `BatchInspectorView.batchResultSummary` shows the same reason inline
-    /// for the fuller Batch inspector. The reason is appended after the
-    /// visible label text, never substituted for it: a reason no curated
-    /// matcher recognizes still gets its generic guidance, and the count
-    /// stays visible either way.
+    /// every frame before any capture); live LS-5000 QA (2026-09-06) showed
+    /// "5 saved" hiding a meter refusal of frame 6 the same way. This footer
+    /// label has no room for a second line, so the reason surfaces as a
+    /// tooltip instead -- `BatchInspectorView.batchResultSummary` shows the
+    /// same reason inline for the fuller Batch inspector. The reason is
+    /// appended after the visible label text, never substituted for it: a
+    /// reason no curated matcher recognizes still gets its generic
+    /// guidance, and the count stays visible either way.
     private func batchSummaryHelp(_ summary: ScanSummary) -> String {
-        guard summary.completed.isEmpty,
-              let error = summary.failed.lazy.compactMap({ sessionModel.frameErrors[$0] }).first(where: {
+        guard let error = summary.failed.lazy.compactMap({ sessionModel.frameErrors[$0] }).first(where: {
                   $0.code != FrameFailureLabel.manualReviewCode
               })
         else {

--- a/app/ScanStudio/Sources/ScanStudio/ScanStudioTheme.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ScanStudioTheme.swift
@@ -30,6 +30,32 @@ enum ScanStudioMetrics {
     static let minimumInteractiveTarget: CGFloat = 40
 }
 
+/// Label color for the app's amber `.borderedProminent` buttons. The amber
+/// fill needs a black label for contrast, but macOS drops the tint on a
+/// disabled button and in an inactive window, leaving a gray fill where a
+/// forced black label is unreadable in dark appearance (live QA, 2026-09-06:
+/// "Use Frame Anyway" after acceptance and the Connect card). Fall back to
+/// the system label color whenever the fill is not actually amber.
+private struct AmberProminentLabel: ViewModifier {
+    @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.controlActiveState) private var controlActiveState
+
+    func body(content: Content) -> some View {
+        content.foregroundStyle(
+            isEnabled && controlActiveState != .inactive
+                ? AnyShapeStyle(Color.black)
+                : AnyShapeStyle(.primary)
+        )
+    }
+}
+
+extension View {
+    /// Pair with `.buttonStyle(.borderedProminent).tint(.scanStudioAmber)`.
+    func amberProminentLabel() -> some View {
+        modifier(AmberProminentLabel())
+    }
+}
+
 struct ScanStudioDivider: View {
     var body: some View {
         Rectangle()

--- a/app/ScanStudio/Sources/ScanStudio/SessionSidebarView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/SessionSidebarView.swift
@@ -107,7 +107,7 @@ struct SessionSidebarView: View {
                             .frame(maxWidth: .infinity)
                             .foregroundStyle(Color.scanStudioSecondaryText)
                         Button("Look Again") {
-                            Task { await sessionModel.refreshAvailableDevices() }
+                            Task { await sessionModel.refreshAvailableDevices(rescan: true) }
                         }
                         .buttonStyle(.borderless)
                         .font(.system(size: 11))

--- a/app/ScanStudio/Sources/ScanStudio/ThumbnailGridView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/ThumbnailGridView.swift
@@ -660,7 +660,7 @@ private struct ManualReviewFrameSheet: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.scanStudioAmber)
-                .foregroundStyle(.black)
+                .amberProminentLabel()
                 .disabled(!reviewIsCurrent || decision == .useFrameAnyway)
             }
 

--- a/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
+++ b/app/ScanStudio/Sources/ScanStudio/UpdateSettingsView.swift
@@ -131,7 +131,7 @@ struct UpdateSettingsView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .tint(.scanStudioAmber)
-                    .foregroundStyle(.black)
+                    .amberProminentLabel()
                     .disabled(model.jobActive)
                     .help(model.jobActive
                         ? "Relaunch is disabled while a scan is active."
@@ -147,7 +147,7 @@ struct UpdateSettingsView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .tint(.scanStudioAmber)
-                    .foregroundStyle(.black)
+                    .amberProminentLabel()
                     .disabled(model.jobActive)
                     .help(model.jobActive
                         ? "Install is disabled while a scan is active."

--- a/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
@@ -164,6 +164,12 @@ public enum ErrorPresentationPolicy {
 
     private static let knownCopy: [Copy] = [
         Copy(
+            code: "BRIDGE_STARTUP_FAILED",
+            title: "Scanner discovery failed",
+            guidance: "Check that the scanner is powered on and connected, then choose Look Again. "
+                + "If discovery keeps failing, quit and reopen ScanStudio, then report the issue with the technical details."
+        ),
+        Copy(
             code: "CAPTURE_WORKER_BOOTSTRAP_FAILED",
             title: "ScanStudio’s scanning components need repair",
             guidance: "The scanner was not moved. Update or reinstall ScanStudio, then try again."
@@ -198,7 +204,9 @@ public enum ErrorPresentationPolicy {
         Copy(
             code: "NOT_CONNECTED",
             title: "Scanner connection was lost",
-            guidance: "Reconnect ScanStudio to the scanner, then try again. You do not need to power-cycle it."
+            guidance: "Reconnect ScanStudio to the scanner, then try again. "
+                + "If the last failure asked for a scanner power-cycle, do that first. "
+                + "If reconnecting keeps failing, quit and reopen ScanStudio."
         ),
         Copy(
             code: "NO_MEDIA",

--- a/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/ErrorPresentation.swift
@@ -280,6 +280,7 @@ public enum ErrorPresentationPolicy {
             ?? filmTransportSlipCopy(in: lastErrorMessage)
             ?? unattendedBindingConfidenceCopy(in: lastErrorMessage)
             ?? previewReadinessTimeoutCopy(in: lastErrorMessage)
+            ?? meterControllerRefusalCopy(in: lastErrorMessage)
             ?? knownCopy.first {
                 $0.code != ScanFailureCode.attendedBindingRequired
                     && containsCode($0.code, in: normalizedMessage)
@@ -428,6 +429,20 @@ public enum ErrorPresentationPolicy {
                 + "binding requires. Refeeding the strip or previewing it again may raise "
                 + "that confidence."
         )
+    }
+
+    /// The driver's bounded exposure-meter controller refusal. CoolscanPy's
+    /// batch worker raises it wrapped in a generic `RollMismatch`, so it
+    /// reaches the app as `INTERNAL: bridge scan.frameFailed (ROLL_MISMATCH):
+    /// SynchronizedProtocolError: meter pass 3 final controller refused:
+    /// nonconverged` and never carries the METER_CONTROLLER_REFUSED code
+    /// (live LS-5000 QA, 2026-09-06, frame 6 of a six-frame strip). The
+    /// phrase is unique to the worker's `_raise_meter_controller_refusal`.
+    private static func meterControllerRefusalCopy(in message: String) -> Copy? {
+        guard message.range(of: "controller refused", options: .caseInsensitive) != nil else {
+            return nil
+        }
+        return knownCopy.first { $0.code == "METER_CONTROLLER_REFUSED" }
     }
 
     private static func previewReadinessTimeoutCopy(in message: String) -> Copy? {

--- a/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
+++ b/app/ScanStudio/Sources/ScanStudioKit/SessionModel.swift
@@ -1277,7 +1277,7 @@ public final class SessionModel {
     /// action. Called once from `init` (fire-and-forget); also called by
     /// `connect(deviceId:)` if `availableDevices` is still empty when a
     /// specific device is requested.
-    public func refreshAvailableDevices() async {
+    public func refreshAvailableDevices(rescan: Bool = false) async {
         deviceDiscoveryRequestsInFlight += 1
         isDiscoveringDevices = true
         defer {
@@ -1286,9 +1286,12 @@ public final class SessionModel {
         }
         do {
             let listResult: ScannerListResult = try await engineClient.request(
-                "scanner.list", params: EmptyParams()
+                rescan ? "scanner.rescan" : "scanner.list", params: EmptyParams()
             )
             availableDevices = listResult.devices
+            if lastErrorMessage?.contains("BRIDGE_STARTUP_FAILED") == true {
+                lastErrorMessage = nil
+            }
             recordDiagnostic(
                 event: "device.discovery.succeeded",
                 fields: ["count": String(listResult.devices.count)]

--- a/app/ScanStudio/Tests/ScanStudioKitTests/DeviceDiscoveryLifecycleTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/DeviceDiscoveryLifecycleTests.swift
@@ -13,6 +13,7 @@ private actor DiscoveryEngineStub: EngineClientProtocol {
     enum Mode: Sendable {
         case gatedSuccess
         case failure
+        case startupFailure
     }
 
     nonisolated let events: AsyncStream<EngineEvent>
@@ -33,6 +34,13 @@ private actor DiscoveryEngineStub: EngineClientProtocol {
     ) async throws -> Result {
         guard method == "scanner.list" else {
             throw DiscoveryStubError.unexpectedMethod(method)
+        }
+        if mode == .startupFailure {
+            throw EngineRequestError(
+                code: "INTERNAL",
+                message: "BRIDGE_STARTUP_FAILED: bridge spawn/handshake failed: bridge call timed out",
+                recoverable: true
+            )
         }
         guard mode == .gatedSuccess else {
             throw DiscoveryStubError.forcedFailure
@@ -87,6 +95,19 @@ private func waitForDiscoveryState(
 
 @Suite("Device discovery lifecycle")
 struct DeviceDiscoveryLifecycleTests {
+    @Test("Configured bridge startup failure is actionable and retains the cause")
+    @MainActor
+    func startupFailureIsVisible() async {
+        let stub = DiscoveryEngineStub(mode: .startupFailure)
+        let model = SessionModel(engineClient: stub)
+
+        #expect(await waitForDiscoveryState(false, model: model))
+        #expect(model.availableDevices.isEmpty)
+        #expect(model.errorPresentation?.title == "Scanner discovery failed")
+        #expect(model.errorPresentation?.guidance.contains("Look Again") == true)
+        #expect(model.errorPresentation?.technicalDetails.contains("bridge call timed out") == true)
+    }
+
     @Test("Overlapping refreshes stay discovering until both finish")
     @MainActor
     func overlappingRefreshes() async {

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
@@ -147,7 +147,9 @@ struct ErrorPresentationPolicyTests {
             (
                 "NOT_CONNECTED: no scanner session",
                 "Scanner connection was lost",
-                "Reconnect ScanStudio to the scanner, then try again. You do not need to power-cycle it."
+                "Reconnect ScanStudio to the scanner, then try again. "
+                    + "If the last failure asked for a scanner power-cycle, do that first. "
+                    + "If reconnecting keeps failing, quit and reopen ScanStudio."
             ),
             (
                 "NO_MEDIA: no film detected",

--- a/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
+++ b/app/ScanStudio/Tests/ScanStudioKitTests/ErrorPresentationPolicyTests.swift
@@ -21,6 +21,20 @@ struct ErrorPresentationPolicyTests {
         #expect(presentation.technicalDetails == rawMessage)
     }
 
+    @Test("a meter controller refusal wrapped as ROLL_MISMATCH keeps its exposure guidance")
+    func meterControllerRefusalWrappedAsRollMismatch() {
+        let rawMessage = "INTERNAL: bridge scan.frameFailed (ROLL_MISMATCH): "
+            + "SynchronizedProtocolError: meter pass 3 final controller refused: nonconverged"
+
+        let presentation = ErrorPresentationPolicy.make(lastErrorMessage: rawMessage)
+
+        #expect(presentation.title == "Exposure control stopped safely")
+        #expect(presentation.guidance.contains("will not retry automatically"))
+        #expect(presentation.technicalDetails == rawMessage)
+        #expect(presentation.canPlaceFramesManually == false)
+        #expect(presentation.canApproveEveryFrameAndScan == false)
+    }
+
     @Test("medium-not-present during batch positioning is a clear feed interruption")
     func filmFeedInterrupted() {
         let rawMessage = "FILM_FEED_INTERRUPTED: bridge scan.frameFailed "

--- a/app/ScanStudio/engine/src/real_backend.rs
+++ b/app/ScanStudio/engine/src/real_backend.rs
@@ -785,7 +785,23 @@ impl BridgeClient {
             self.restart();
         }
         if self.is_healthy() {
-            Ok(())
+            return Ok(());
+        }
+        // `restart()` replaces only a child the OS has proven exited. A child
+        // still running after a timed-out call stays quarantined because it
+        // may own an in-flight USB transaction; it is never killed or
+        // replaced from here. Name that state honestly instead of reporting
+        // an exit that did not happen (live LS-5000 QA, 2026-09-06: a
+        // FEEDER_PARKED batch failure left the bridge busy past the request
+        // timeout, and every later Connect reported "exited unexpectedly"
+        // while the process was visibly alive).
+        let still_running = matches!(self.child.lock().unwrap().try_wait(), Ok(None));
+        if still_running {
+            Err(BridgeCallError::Io(
+                "bridge process is still running but stopped answering after a timed-out call; \
+                 it stays quarantined until it exits, so quit and reopen ScanStudio to recover"
+                    .to_string(),
+            ))
         } else {
             Err(BridgeCallError::ProcessExited)
         }

--- a/app/ScanStudio/engine/src/server.rs
+++ b/app/ScanStudio/engine/src/server.rs
@@ -158,8 +158,8 @@ enum ActiveDevice {
 
 /// Backend registry/router: replaces the single hardcoded
 /// `Arc<SimulatedLs5000>` `run()` used to hold directly. `scanner.list`
-/// always reports the simulator, plus the real device when
-/// `SCANSTUDIO_BRIDGE_CMD` is configured and started successfully;
+/// reports the simulator, plus the real device when configured successfully.
+/// A configured bridge's startup failure is an error, not simulator mode;
 /// `scanner.connect` decides — from the requested device id alone, never
 /// from any other client input — which backend every subsequent request
 /// routes through.
@@ -171,40 +171,34 @@ struct Backends {
     /// re-attempt the real-backend startup that `from_env` performs exactly
     /// once. None when `SCANSTUDIO_BRIDGE_CMD` is unset/empty.
     bridge_cmd: Option<String>,
+    /// Retained until an explicit rescan succeeds; listing never retries hardware.
+    startup_error: Option<EngineError>,
 }
 
 impl Backends {
     /// Reads `SCANSTUDIO_BRIDGE_CMD` — the ONLY place in the engine this
-    /// environment variable is read. Unset/empty AND configured-but-broken
-    /// both resolve to the identical `real: None` sim-only state,
-    /// deliberately a superset of the literal "not configured" fallback: a
-    /// broken configuration must degrade exactly like no configuration,
-    /// never crash engine startup or leave a half-working device entry
-    /// (T-09-11).
+    /// environment variable is read. Unset/empty enables simulator-only mode.
+    /// A failed configured bridge leaves the engine alive, but discovery
+    /// reports the failure until the user explicitly retries.
     fn from_env() -> Self {
-        let sim = Arc::new(SimulatedLs5000::new());
         let bridge_cmd = match std::env::var("SCANSTUDIO_BRIDGE_CMD") {
             Ok(cmd) if !cmd.trim().is_empty() => Some(cmd),
             _ => None,
         };
-        let real = match &bridge_cmd {
-            Some(cmd) => match RealLs5000::new(cmd, DEFAULT_BRIDGE_TIMEOUT) {
-                Ok(backend) => Some(Arc::new(backend)),
-                Err(err) => {
-                    eprintln!(
-                        "scanstudio-engine: SCANSTUDIO_BRIDGE_CMD configured ('{cmd}') but the real backend could not start ({err}); falling back to simulator-only scanner.list"
-                    );
-                    None
-                }
-            },
-            None => None,
-        };
-        Backends {
-            sim,
-            real,
+        Self::from_bridge_cmd(bridge_cmd)
+    }
+
+    fn from_bridge_cmd(bridge_cmd: Option<String>) -> Self {
+        let mut backends = Backends {
+            sim: Arc::new(SimulatedLs5000::new()),
+            real: None,
             active: None,
             bridge_cmd,
-        }
+            startup_error: None,
+        };
+        // rescan retains the failure for scanner.list; engine.hello still works.
+        let _ = backends.rescan(None);
+        backends
     }
 
     /// `scanner.rescan`: one deliberate re-attempt of the real-backend
@@ -214,8 +208,7 @@ impl Backends {
     /// out, and the real device stays invisible until a full app restart.
     /// Idempotent by construction -- an already-running real backend and an
     /// unconfigured `SCANSTUDIO_BRIDGE_CMD` both return the current list
-    /// unchanged -- and a failed re-attempt degrades to the same sim-only
-    /// list as `from_env` (T-09-11), never an error. Refused while any
+    /// unchanged. A failed re-attempt remains visible to the client. Refused while any
     /// device is connected so an active session's backend can never be
     /// replaced underneath it (same invariant as T-09-12).
     fn rescan(
@@ -246,26 +239,36 @@ impl Backends {
                     Ok(backend) => {
                         backend.set_client_build(client_build.map(str::to_string));
                         self.real = Some(Arc::new(backend));
+                        self.startup_error = None;
                     }
                     Err(err) => {
-                        eprintln!(
-                            "scanstudio-engine: scanner.rescan could not start the real backend ({err}); the device list stays simulator-only"
-                        );
+                        let error = EngineError::new(
+                            ErrorCode::Internal,
+                            format!(
+                                "BRIDGE_STARTUP_FAILED: scanner discovery could not start: {err}"
+                            ),
+                        )
+                        .with_recoverable(true);
+                        eprintln!("scanstudio-engine: {error}");
+                        self.startup_error = Some(error);
                     }
                 }
             }
         }
-        Ok(self.list_devices())
+        self.list_devices()
     }
 
     /// `scanner.list`: the simulator always, plus the real device only if
     /// `SCANSTUDIO_BRIDGE_CMD` was configured and started successfully.
-    fn list_devices(&self) -> Vec<domain::DeviceInfo> {
+    fn list_devices(&self) -> Result<Vec<domain::DeviceInfo>, EngineError> {
+        if let Some(error) = &self.startup_error {
+            return Err(error.clone());
+        }
         let mut v = vec![self.sim.device_info()];
         if let Some(real) = &self.real {
             v.push(real.device_info());
         }
-        v
+        Ok(v)
     }
 
     fn set_client_build(&self, client_build: Option<String>) {
@@ -1050,7 +1053,7 @@ fn handle_request(
             })
         }
         "scanner.list" => to_json(&protocol::ScannerListResult {
-            devices: backends.list_devices(),
+            devices: backends.list_devices()?,
         }),
         "scanner.rescan" => to_json(&protocol::ScannerListResult {
             devices: backends.rescan(project_state.client_build.as_deref())?,
@@ -2146,6 +2149,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let devices = backends
             .rescan(None)
@@ -2155,17 +2159,20 @@ mod tests {
     }
 
     #[test]
-    fn rescan_with_a_broken_bridge_cmd_degrades_to_sim_only_like_startup() {
+    fn rescan_with_a_broken_bridge_cmd_reports_startup_failure() {
         let mut backends = Backends {
             sim: Arc::new(SimulatedLs5000::new()),
             real: None,
             active: None,
             bridge_cmd: Some("/nonexistent-wv2-rescan-bridge-cmd".to_string()),
+            startup_error: None,
         };
-        let devices = backends
+        let error = backends
             .rescan(None)
-            .expect("a broken bridge cmd must degrade exactly like from_env, never error");
-        assert_eq!(devices.len(), 1, "{devices:#?}");
+            .expect_err("a configured bridge failure must be visible to the client");
+        assert_eq!(error.code, ErrorCode::Internal);
+        assert!(error.message.contains("BRIDGE_STARTUP_FAILED"));
+        assert!(error.message.contains("bridge spawn/handshake failed"));
         assert!(backends.real.is_none());
     }
 
@@ -2176,6 +2183,7 @@ mod tests {
             real: None,
             active: Some(ActiveDevice::Sim),
             bridge_cmd: None,
+            startup_error: None,
         };
         let error = backends
             .rescan(None)
@@ -2190,6 +2198,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2245,6 +2254,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2301,6 +2311,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let request = Request {
@@ -2323,6 +2334,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2391,6 +2403,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2439,6 +2452,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2520,6 +2534,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2591,6 +2606,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2611,6 +2627,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2653,6 +2670,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2712,6 +2730,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2782,6 +2801,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2864,6 +2884,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2908,6 +2929,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2964,6 +2986,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -2997,6 +3020,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3040,6 +3064,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default(); // no project ever opened
@@ -3060,6 +3085,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3097,6 +3123,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3151,6 +3178,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3206,6 +3234,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3256,6 +3285,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3353,6 +3383,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3395,6 +3426,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default(); // no project.create call
@@ -3420,6 +3452,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3534,6 +3567,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3671,6 +3705,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3740,6 +3775,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3796,6 +3832,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3860,6 +3897,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3920,6 +3958,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -3987,6 +4026,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -4096,6 +4136,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -4242,6 +4283,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -4399,6 +4441,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -4429,6 +4472,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -4530,6 +4574,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -4605,6 +4650,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -4663,6 +4709,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let directory = temp_test_dir("all-off-effective-override");
@@ -4720,6 +4767,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -4756,6 +4804,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -4948,6 +4997,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -4991,6 +5041,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();
@@ -5090,6 +5141,7 @@ mod tests {
             real: None,
             active: None,
             bridge_cmd: None,
+            startup_error: None,
         };
         let (tx, _rx) = mpsc::channel();
         let mut project_state = ProjectState::default();

--- a/app/ScanStudio/engine/tests/end_to_end_real_backend.rs
+++ b/app/ScanStudio/engine/tests/end_to_end_real_backend.rs
@@ -2,8 +2,10 @@
 //! (Plan 09-04) dispatches through the correct backend based on
 //! `SCANSTUDIO_BRIDGE_CMD`: unset means sim-only (byte-identical to
 //! pre-Phase-9 behavior), a working bridge command adds the real device and
-//! makes it connectable, and a broken command degrades to the identical
-//! sim-only shape rather than crashing or half-registering a device.
+//! makes it connectable, and a broken command keeps the engine alive but
+//! reports a typed `BRIDGE_STARTUP_FAILED` discovery error until an explicit
+//! `scanner.rescan` succeeds -- never a silent simulator-only list and never
+//! a crash or a half-registered device.
 //!
 //! Mirrors `end_to_end_sim.rs`'s approach exactly (D-9d): real stdio pipes
 //! against the actual compiled binary, no in-process shortcuts. `send`,
@@ -1888,11 +1890,14 @@ fn real_device_listed_and_connectable_when_bridge_cmd_set() {
 }
 
 /// With `SCANSTUDIO_BRIDGE_CMD` pointing at a broken or nonexistent
-/// command, the engine still starts cleanly and behaves exactly like the
-/// unset case — graceful degradation, never a crash or a half-broken
-/// device entry.
+/// command, the engine still starts cleanly (`engine.hello` works), but
+/// discovery reports the startup failure as a typed, recoverable error
+/// instead of silently listing only the simulator (live LS-5000 QA,
+/// 2026-09-06: a cold first launch showed "simulator only" with the USB
+/// scanner attached and no hint why). `scanner.rescan` is the one
+/// deliberate retry; while it keeps failing the error stays visible.
 #[test]
-fn graceful_fallback_when_bridge_cmd_points_at_broken_command() {
+fn broken_bridge_cmd_reports_startup_failure_until_rescan_succeeds() {
     let bin = env!("CARGO_BIN_EXE_scanstudio-engine");
     let mut child = Command::new(bin)
         .env("SCANSTUDIO_BRIDGE_CMD", "/definitely/does/not/exist/xyz")
@@ -1932,22 +1937,38 @@ fn graceful_fallback_when_bridge_cmd_points_at_broken_command() {
 
     send(&mut stdin, 2, "scanner.list", json!({}));
     let list_resp = recv_response_for(&rx, 2, |_| {});
+    let list_error = list_resp
+        .get("error")
+        .unwrap_or_else(|| panic!("a broken SCANSTUDIO_BRIDGE_CMD must surface as a scanner.list error, not a simulator-only list: {list_resp:?}"));
+    assert_eq!(list_error["code"], json!("INTERNAL"), "{list_resp:?}");
+    assert_eq!(list_error["recoverable"], json!(true), "{list_resp:?}");
+    let list_message = list_error["message"].as_str().unwrap_or("");
     assert!(
-        list_resp.get("error").is_none(),
-        "scanner.list failed: {list_resp:?}"
+        list_message.contains("BRIDGE_STARTUP_FAILED"),
+        "the error must carry the typed startup-failure marker: {list_resp:?}"
     );
-    let devices = list_resp["result"]["devices"]
-        .as_array()
-        .expect("devices must be an array");
-    assert_eq!(
-        devices.len(),
-        1,
-        "a broken SCANSTUDIO_BRIDGE_CMD must degrade exactly like no configuration — one simulated device, never a crash or a half-working entry: {devices:?}"
+    assert!(
+        list_message.contains("bridge spawn/handshake failed"),
+        "the error must retain the actual cause: {list_resp:?}"
     );
-    assert_eq!(devices[0]["kind"], json!("simulated"));
 
-    send(&mut stdin, 3, "engine.shutdown", json!({}));
-    let shutdown_resp = recv_response_for(&rx, 3, |_| {});
+    // The explicit retry against the same broken command fails the same
+    // way -- visibly, never by degrading to a simulator-only list.
+    send(&mut stdin, 3, "scanner.rescan", json!({}));
+    let rescan_resp = recv_response_for(&rx, 3, |_| {});
+    let rescan_error = rescan_resp.get("error").unwrap_or_else(|| {
+        panic!("scanner.rescan against a broken command must still fail visibly: {rescan_resp:?}")
+    });
+    assert!(
+        rescan_error["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("BRIDGE_STARTUP_FAILED"),
+        "{rescan_resp:?}"
+    );
+
+    send(&mut stdin, 4, "engine.shutdown", json!({}));
+    let shutdown_resp = recv_response_for(&rx, 4, |_| {});
     assert!(
         shutdown_resp.get("error").is_none(),
         "shutdown failed: {shutdown_resp:?}"

--- a/app/ScanStudio/protocol/PROTOCOL.md
+++ b/app/ScanStudio/protocol/PROTOCOL.md
@@ -33,17 +33,21 @@ params `{clientName: string, protocolVersion: 1}` → result `{engineName: "scan
 params `{}` → result `{}`; then the engine cancels outstanding simulated work, flushes the response, and exits 0. Cancellation is bounded so an active operation cannot keep shutdown waiting on its normal simulated delay.
 
 ### `scanner.list`
-`{}` → `{devices: [DeviceInfo]}`. Always exactly one simulated device in M1.
+`{}` → `{devices: [DeviceInfo]}`. The simulated device, plus the real device
+when a configured bridge started successfully. When a configured bridge's
+startup failed, this returns a recoverable `INTERNAL` error whose message
+starts with `BRIDGE_STARTUP_FAILED:` and names the cause; it never silently
+degrades to a simulator-only list. The error stays until a `scanner.rescan`
+succeeds; listing itself never retries the bridge.
 
 ### `scanner.rescan`
 `{}` → `{devices: [DeviceInfo]}`. One deliberate re-attempt of the real
 backend's startup for the case where the engine started before the bridge
-stack was ready (the real device then stays invisible to `scanner.list`
-until rescan). Idempotent: an already-running real backend and an
-unconfigured bridge both return the current list unchanged, and a failed
-re-attempt degrades to the simulator-only list rather than erroring.
-Error: `ALREADY_CONNECTED` (rescan never replaces a connected session's
-backend).
+stack was ready, or the bridge process later exited. Idempotent: an
+already-running real backend and an unconfigured bridge both return the
+current list unchanged. A failed re-attempt returns the same recoverable
+`BRIDGE_STARTUP_FAILED` error as `scanner.list`. Error: `ALREADY_CONNECTED`
+(rescan never replaces a connected session's backend).
 
 ### `scanner.connect`
 `{deviceId: string, options?: {timeScale?: number, faultInjection?: "none"|"demo"}}` → `{device: DeviceInfo, status: ScannerStatus}` and emits a `scanner.status` event. `timeScale` (default `1.0`) multiplies every simulated delay — tests use ~`0.01`. Errors: `UNKNOWN_DEVICE`, `ALREADY_CONNECTED`.

--- a/docs/HARDWARE-SUPPORT.md
+++ b/docs/HARDWARE-SUPPORT.md
@@ -15,7 +15,7 @@ Latest release notes: [v0.7.0-beta.15](releases/v0.7.0-beta.15.md).
 
 | Host and scanner | Package built | Device enumerated | Preview exercised | One-frame capture validated | Support / next evidence |
 | --- | --- | --- | --- | --- | --- |
-| Apple Silicon macOS + LS-5000 USB | Yes | Yes | Yes | Yes, on one Mac/scanner configuration | **Beta.** More firmware, adapter, macOS, and media diversity is human-owned in [#23](https://github.com/rohanpandula/ScanStudio/issues/23). |
+| Apple Silicon macOS + LS-5000 USB | Yes | Yes | Yes | Yes, on one Mac/scanner configuration; five of six frames of a C-41 short strip on the 2026-09-06 beta.15 candidate (firmware 1.03, SA-30), the sixth refused by the exposure-meter controller | **Beta.** Full-roll attended run still pending. More firmware, adapter, macOS, and media diversity is human-owned in [#23](https://github.com/rohanpandula/ScanStudio/issues/23). |
 | LS-40 / Coolscan IV and LS-50 / Coolscan V USB | Packages contain identity recognition only | No retained packaged-app field result | No | No | **Unsupported for scanning.** Identification evidence is requested in [#27](https://github.com/rohanpandula/ScanStudio/issues/27). |
 | LS-4000, LS-8000, and LS-9000 FireWire | No scanning package | Yes, discovery and a motion-free probe on modern macOS | No | No | **Unsupported for scanning.** Driver-probe evidence and the remaining hardware work are tracked in [#28](https://github.com/rohanpandula/ScanStudio/issues/28). |
 

--- a/docs/releases/v0.7.0-beta.15.md
+++ b/docs/releases/v0.7.0-beta.15.md
@@ -21,6 +21,18 @@ rolls, saved output, and release verification easier to trust.
   avoiding a redundant status probe that could turn success into a false error.
 - Beta.14 publication was cancelled after this integration defect was reported;
   beta.15 includes that unreleased work plus the connection correction.
+- Live short-strip QA on 2026-09-06 (LS-5000 ED, firmware 1.03, SA-30, C-41)
+  found and fixed four app problems. A configured hardware bridge that fails
+  to start is now a visible "Scanner discovery failed" error whose "Look
+  Again" performs a real rescan, instead of a silent simulator-only list.
+  After a hardware failure left the bridge quarantined, "Connect" reported a
+  process exit that had not happened; it now names the quarantined state and
+  tells the operator to quit and reopen, and the connection-lost guidance no
+  longer promises that no power-cycle is needed. A refused frame after
+  completed frames now shows the scanner's own reason in the batch summary,
+  and a bounded exposure-meter refusal keeps its "Exposure control stopped
+  safely" guidance even when the driver reports it as a roll mismatch.
+  Amber buttons are readable when disabled or in an inactive window.
 
 - ScanStudio now targets Apple Silicon (M-series, arm64) only, on macOS 14 or
   newer. Windows/Linux app ports and their duplicated source, build tooling,
@@ -80,6 +92,18 @@ rolls, saved output, and release verification easier to trust.
   hardware-support documentation checks passed.
 - Packaged simulator acceptance decoded nine saved outputs and checked their
   receipts, partial-stop recovery, process interruption, and overwrite refusal.
+- Attended short-strip hardware run, 2026-09-06, on a Developer ID-signed local
+  build of commit 7b8dbe0 (this release's fixes minus the presentation-only
+  batch-summary change): Nikon LS-5000 ED firmware 1.03, SA-30, a six-frame
+  C-41 strip. Explicit preview found six frames in 19.4 s. Five frames were
+  captured at 4000 ppi, 16-bit RGB + infrared, 4× sampling, ICE Legacy, in
+  149–188 s each; every archive TIFF (5959×3946, 16-bit RGB), infrared TIFF,
+  positive TIFF, and preview JPEG decoded and matched its receipt's SHA-256,
+  byte length, inode, and volume. Frame 6 was refused by the driver's bounded
+  exposure-meter controller ("meter pass 3 final controller refused:
+  nonconverged") and produced no output; no automatic retry occurred. The
+  first cold launch timed out the bridge handshake and recovered through
+  "Look Again". Details are in `docs/reviews/next-improvements-2026-09-06.md`.
 - The tagged workflow independently requires the full Swift, Rust, bridge, and
   CoolscanPy suites; arm64 packaging; macOS 14 execution; and updater checks
   before producing and publishing the signed release. Any failed, cancelled,
@@ -101,6 +125,16 @@ A downloadable package does not guarantee a particular scanner configuration.
 ## Known limitations
 
 The final physical full-roll acceptance run is not part of this software audit.
+The 2026-09-06 short-strip run is not a full-roll pass: one of six frames was
+refused by the exposure-meter controller because its metering window stayed
+saturated after three bounded passes, and the driver reports that refusal as a
+roll mismatch. The first cold launch of a freshly signed build timed out the
+10-second bridge handshake and needed "Look Again". An earlier attempt on the
+same strip lost its idle USB handle after about sixteen minutes of holding the
+preview reservation, then failed a bulk read; both are recorded, not fixed.
+Positive renders use the default blind exposure estimator and showed a strong
+magenta cast and visible dust at 100% with ICE Legacy on this strip; no
+reference scan exists to grade them.
 The LS-5000 color-roll workflow remains Beta with limited retained hardware
 coverage. Additional firmware, holders, adapters, and macOS configurations need
 supervised evidence. LS-40/LS-50 and FireWire models remain unsupported for

--- a/docs/reviews/next-improvements-2026-09-06.md
+++ b/docs/reviews/next-improvements-2026-09-06.md
@@ -96,7 +96,63 @@ The re-run with candidate #2 (this fix set) is recorded below as it happens.
 
 ### Candidate #2 run
 
-Pending.
+Candidate #2 was a Developer ID-signed local package of commit `7b8dbe0`
+(this fix set minus the later presentation-only batch-summary change).
+
+- **Cold launch reproduced the startup timeout** (17:36:07–17:36:22 UTC):
+  the first bridge handshake exceeded the engine's 10 s deadline and the app
+  showed "Scanner discovery failed … bridge call timed out". "Look Again"
+  spawned a second bridge that listed the scanner 5 s later. Candidate #1's
+  first launch had failed the same way, silently. The cause of the slow first
+  handshake (first-run validation of a freshly signed bundle, cold Python
+  imports, or the scanner right after power-on) is not yet measured.
+- **Connect, preview:** connected at 17:37:58; explicit preview 17:38:37–
+  17:38:56 (19.4 s), six frames; boundaries for frames 1 and 6 reviewed and
+  accepted at zero offset.
+- **Capture:** batch started 17:42:33 with all six slots on the held
+  reservation. Frames 1–5 completed in 148.8, 186.9, 187.0, 186.1 and 187.5 s
+  (4 passes, 4000 ppi, 16-bit, RGB + infrared, ICE Legacy). Each archive TIFF
+  is 5959×3946 16-bit RGB (141,085,556 bytes) with a 16-bit infrared TIFF
+  (47,028,684 bytes) and a 281×425 four-channel meter TIFF; positive TIFFs are
+  5959×3946 16-bit and preview JPEGs 8-bit. All fifteen receipt bindings
+  matched SHA-256, byte length, inode and volume.
+- **Frame 6 refused** at 17:58:24 by the driver's bounded exposure-meter
+  controller: `meter pass 3 final controller refused: nonconverged`. The
+  metering window's central signal sat at the 65535 ceiling through three
+  passes (R 90000 → 76500 → 65025 raw 10 ns, the bounded 0.85 ratio each
+  time); the final update of 0.150 exceeded the 0.050 limit. The worker
+  released the scanner cleanly (`unit_released: true`, transport idle) and
+  no retry was attempted. The driver wrapped the refusal as `RollMismatch`,
+  the engine surfaced INTERNAL/ROLL_MISMATCH, and the app showed "Failed: 06"
+  with no reason while offering Resume and Retry; fixed in this PR at the
+  presentation layer (batch summary and footer show the reason for any
+  failed frame; the "controller refused" phrase keeps the exposure
+  guidance).
+- **Images (subjective, no reference):** frames 1–5 are complete scenes
+  matching their previews, sharp on the subject at 100%, with a strong
+  magenta/blue cast from the default blind render, clipped sky highlights in
+  frame 2, and visible dust specks at 100% with ICE Legacy on frame 1.
+  Orientation is as scanned (rotated, mirrored text); no per-frame rotation
+  or mirror was applied.
+
+Evidence: `/Users/rohan/ScanStudio-QA/short-strip-20260906/candidate-2/`
+(signature, hashes, log snapshots at preview start, capture start, frame-6
+failure and completion, inspection crops) and the roll under
+`~/ScanStudio Projects/qa-short-strip-20260906-c41-run2-proj-18d2cc3a47016f10`.
+
+Follow-ups recorded from this run, in addition to the two above:
+
+- The meter controller's three bounded passes at a 0.85 ratio can only cut
+  exposure by about 39% from the seed; a frame whose window is saturated
+  beyond that is always refused. Evaluate more passes or a wider first step
+  when linearity is confirmed, and carrying the previous frame's result as
+  the seed for an explicitly locked roll (step 5 below) — in CoolscanPy,
+  with a fixture from this frame's meter evidence.
+- CoolscanPy reports the meter refusal as `RollMismatch`; it should carry
+  `MeterControllerRefused` so no phrase matching is needed downstream.
+- Measure the cold bridge handshake on a freshly signed bundle before
+  changing the 10 s deadline; two cold launches failed it, two warm rescans
+  took about 5 s.
 
 ## Implementation order and acceptance
 

--- a/docs/reviews/next-improvements-2026-09-06.md
+++ b/docs/reviews/next-improvements-2026-09-06.md
@@ -1,0 +1,175 @@
+# What we learned and what to improve next
+
+Status: implementation plan, not a completed hardware acceptance report.
+Prepared on 2026-09-06 for the continuation of short-strip QA and beta.15.
+
+## What we learned from nkscan
+
+The [documentation review](nkscan-behavior-requirements-2026-09-06.md) gave us
+useful questions to test, rather than an implementation to transplant:
+
+- **Speed has several controls.** Its documentation describes resolution,
+  sampling, reuse of the first frame's exposure, and model-specific CCD modes.
+  These are candidates for experiments, not proof that ScanStudio can safely
+  enable them or that they will improve our image quality or throughput.
+- **Support depends on the whole setup.** A scanner model, holder, adapter,
+  transport and software version need their own evidence. Finding a device
+  over USB or FireWire does not establish that scanning works.
+- **Performance claims need measurements.** The reviewed release notes mention
+  two-line LS-5000 scanning. We did not benchmark it, establish a speedup, or
+  implement that mode in ScanStudio.
+- **Assets need separate provenance.** The reviewed metadata treats some
+  Nikon-derived profiles separately. This review transferred no profiles,
+  implementation code, or algorithms.
+
+The bounded review found no demonstrated feature gap requiring an immediate
+driver replacement. It did not establish that nkscan has stronger Stop or
+recovery guarantees. Read the linked resource audit for the exact research
+boundary; do not generalize that review's attestation to all historical work.
+
+## What we actually implemented
+
+ScanStudio still uses its own Rust engine, Python bridge and CoolscanPy driver.
+We did not switch the backend to nkscan. The comparison reinforced capability
+checks and honest support claims; most recent changes came from independent
+code review, issue reports and testing of our own app:
+
+- Fixed connection through CoolscanPy's real public discovery/open API.
+- Preserved early Stop requests and ownership of a held scanner session.
+- Made resume use the saved project's current unfinished-frame list, while
+  preserving completed images and requiring fresh registration when needed.
+- Distinguished saved files from settings for the next scan and made recorded
+  outputs accessible through Finder.
+- Restricted current app builds/releases to Apple Silicon macOS and retained
+  full packaging, signature, notarization and release checks.
+- Added executable simulator acceptance for interruption, resume, output
+  decoding and receipt integrity. These tests do not establish image quality.
+
+PR #112 merged as `4d4e05cb13b72d74df845f6920c5070f8072e768` after its full gate
+passed. Canonical CoolscanPy 0.7.6 was published and its source parity verified.
+Further startup-error and button-contrast fixes are in progress, not yet
+included in that merge or in the running local candidate.
+
+## What the 2026-09-06 hardware run established
+
+The user supplied a C-41 strip estimated at 5–7 shots. Local candidate #1
+(Developer ID-signed beta.15 build from `6622f260`, not notarized) connected
+to an LS-5000 ED reporting firmware 1.03 and an SA-30 holder. Its explicit
+preview found six frames (bridge telemetry: preview 16:58:41.594 to
+16:59:01.070 UTC, about 19.5 s for this one run). The first and last
+boundaries were reviewed and accepted at zero offset.
+
+The six-frame capture then failed before any frame completed. The operator
+started the batch by accident at 17:15:32 UTC; the held preview worker's
+first USB write returned `No such device` (its handle, open since 16:58,
+had become invalid while idle), the app reported FEEDER_PARKED, a fresh
+worker re-opened the scanner and failed 83 s later with a libusb bulk-read
+I/O error during `command 607 READ`, and the engine then quarantined its
+still-running bridge after a 10 s status timeout. "Connect" afterwards
+reported "bridge process exited unexpectedly" although the process was
+alive, while the banner said no power-cycle was needed. The operator
+power-cycled the scanner, quit the app and re-fed the film. Evidence:
+`/Users/rohan/ScanStudio-QA/short-strip-20260906/failure-20260906T1717Z/`.
+
+Fixes taken from that run, together with the earlier review items:
+
+- A configured bridge that fails to start is a visible, recoverable
+  `BRIDGE_STARTUP_FAILED` discovery error; "Look Again" performs the real
+  `scanner.rescan` instead of re-reading the cached list.
+- Explicit reconnect names a quarantined-but-running bridge honestly and
+  tells the operator to quit and reopen; the NOT_CONNECTED guidance no
+  longer promises that no power-cycle is needed.
+- Amber prominent buttons keep a black label only while the fill is amber;
+  disabled buttons and inactive windows fall back to the system label color.
+
+Still open after that run (recorded, not fixed here):
+
+- Why the held device handle became invalid after about 16 minutes idle, and
+  the later bulk-read failure. Both are below the app (scanner, hub or USB
+  power management); reproduce with the hub removed before changing code.
+- `scanner.rescan` drops an unhealthy backend on the assumption that its
+  child exited; after a timeout quarantine the child may still be running.
+  Align it with connect's proven-exit rule, or re-validate a live child with
+  `bridge.hello` before reusing it. Either needs a mock-bridge test first.
+
+The re-run with candidate #2 (this fix set) is recorded below as it happens.
+
+### Candidate #2 run
+
+Pending.
+
+## Implementation order and acceptance
+
+1. **Finish the current capture and remove release blockers.** Inspect outputs,
+   retain the master, save a new QA project and capture the six selected frames
+   using normal controls. Verify completed receipts and decode the actual files.
+   Inspect boundaries, grain/detail, color and IR treatment; record uncertainty
+   where no reference exists. Preserve diagnostics for any refusal. Integrate
+   the in-progress startup-error, real retry and contrast fixes, verify them,
+   merge through CI, then publish and verify the signed/notarized artifact.
+   Do not rebuild or replace the currently running app during its held session.
+
+2. **Measure where time and resources go.** Reuse phase telemetry and receipts
+   to separate preview, positioning, focus, metering, acquisition, rendering and
+   file publication. Record settings, dimensions, elapsed time, peak memory and
+   disk use alongside image evidence. Add only missing phase measurements needed
+   to distinguish a bottleneck. Establish a baseline before choosing an
+   optimization; report scanner time separately from computer processing time.
+
+3. **Remove measured computer-side waste.** Inspect the slowest measured phase
+   for repeated decoding, unnecessary full-image copies or redundant file I/O.
+   Reuse existing buffers and dependencies where appropriate. Change one cause
+   at a time and repeat the same fixture. Keep changes only when measurements
+   improve and bit depth, color behavior, receipt integrity, memory bounds and
+   Stop responsiveness remain correct. Do not remove integrity checks to save
+   time. Do not parallelize commands to the physical scanner.
+
+4. **Make everyday use clearer.** Complete the actionable startup error and
+   retry behavior; inspect prominent buttons in dark and light appearance.
+   Explain automatic adjustments such as the current supported 4× sampling
+   mode. Use measured phases to improve progress/ETA only if current estimates
+   prove misleading. Verify with the native app, including failure paths.
+
+5. **Evaluate faster acquisition as separate experiments.** Investigate
+   first-frame exposure reuse only for an explicitly locked, consistent roll;
+   compare it against per-frame metering on varied densities and scenes.
+   Independently investigate alternate sampling or CCD modes only when our
+   driver has a justified supported implementation and an attended test plan.
+   Keep experimental modes out of production capability advertisements until
+   geometry, color, focus, IR behavior, Stop and recovery are validated. No
+   promised speed multiplier and no copied command streams or profiles.
+
+6. **Prioritize features that avoid repeating physical scans.** Evaluate an
+   explicit offline re-render action using a retained master, reusing the
+   existing renderer. First verify that the retained data and settings are
+   sufficient. Write new derivative files, preserve the master and previous
+   outputs, and record which recipe produced each derivative. This is a future
+   feature proposal; changing current settings does not re-render saved files.
+
+7. **Expand evidence before expanding scope.** Finish the attended full-roll
+   test, including Stop/reopen/resume when the physical setup permits it.
+   Compare original completed-file hashes after resume. Add known reference
+   scans for image-quality comparisons. Retain Apple Silicon-only app scope;
+   other scanners, holders and film processes require their own test evidence.
+
+Steps 1–2 come first. Steps 3–4 can proceed in parallel on separate files once
+their evidence is available. Step 5 requires controlled hardware experiments;
+step 6 is independent of scanner transport. Each accepted change gets the
+smallest regression check that exercises its actual failure mode, followed by
+the required release gates. Avoid a new monitoring service or driver rewrite
+unless measurements demonstrate a need.
+
+## Required final explanation
+
+After QA and release work, give the user a plain-English report covering:
+
+1. What the other driver's published behavior taught us, with source links.
+2. Which ideas were implemented, which were already present, and which remain
+   proposals. Credit fixes found in our own code separately.
+3. What real hardware and software tests proved, including actual failures,
+   untested cases, performance measurements and the tested build identity.
+4. The next improvements in priority order, expected benefit, dependencies and
+   how each benefit will be measured. Do not state speculative savings as fact.
+
+Update this plan and the hardware record with actual results before calling the
+work complete. A six-frame preview is not a six-frame capture or a full-roll pass.


### PR DESCRIPTION
## Why

Live LS-5000 short-strip QA on 2026-09-06 (local Developer ID-signed beta.15 candidates) found four app problems around a failed capture and a refused frame. Evidence is preserved outside the repo under `~/ScanStudio-QA/short-strip-20260906/`; the run is summarized in `docs/reviews/next-improvements-2026-09-06.md` and the release notes.

## What changed

- **Configured bridge startup failure is visible.** `scanner.list` returns a recoverable `INTERNAL` error prefixed `BRIDGE_STARTUP_FAILED:` with the cause instead of silently listing only the simulator; the error stays until an explicit `scanner.rescan` succeeds. The app shows "Scanner discovery failed" with guidance and both "Look Again" buttons call `scanner.rescan`. `PROTOCOL.md` updated. Reproduced live: the first cold launch of candidate #2 timed out the handshake, showed the error, and "Look Again" listed the scanner 5 s later.
- **Honest reconnect after a quarantined bridge.** After a FEEDER_PARKED batch failure the engine quarantined its still-running bridge following a 10 s status timeout, and every later Connect reported "bridge process exited unexpectedly" although the process was alive. The explicit-reconnect path now names the quarantined-but-running state and tells the operator to quit and reopen. The `NOT_CONNECTED` guidance no longer claims that no power-cycle is needed.
- **Refused frames are explained after a partial batch.** Candidate #2 captured five of six frames; frame 6 was refused by CoolscanPy's bounded exposure-meter controller ("meter pass 3 final controller refused: nonconverged"), and the app showed "Failed: 06" with no reason while offering Resume and Retry. The batch summary and footer now show the driver's reason for any failed frame, and the "controller refused" phrase keeps the METER_CONTROLLER_REFUSED copy even though the driver wraps the refusal as ROLL_MISMATCH.
- **Amber prominent button contrast.** A shared `amberProminentLabel()` modifier keeps the black label only while the fill is amber and falls back to the system label color when disabled or in an inactive window. Applied to all eleven amber buttons.
- **Docs:** release notes (changes, validation, known limitations), hardware matrix row, and the improvements review with the full run record and follow-ups.

## Tests

- Engine: `cargo test` — 662 passed, 0 failed (rewritten `broken_bridge_cmd_reports_startup_failure_until_rescan_succeeds`; existing quarantine test still passes).
- App: `swift test` — 520 passed, 0 failed (new discovery-failure test, meter-refusal copy test, updated connection-lost copy test).
- Local policy checks: release notes, hardware docs, scanner-contract docs, release workflow, action pins, and the 107 root policy tests pass.

## Hardware evidence (attended, LS-5000 ED fw 1.03, SA-30, C-41 short strip)

- Candidate #2 (7b8dbe0): preview 6 frames in 19.4 s; frames 1–5 captured at 4000 ppi / 16-bit / RGB+IR / 4× / ICE Legacy in 149–188 s each; all 15 receipt bindings matched SHA-256, byte length, inode, volume; archive TIFFs 5959×3946 16-bit RGB with 16-bit IR TIFFs. Frame 6 refused by the meter controller (window saturated after three bounded passes); scanner released cleanly; no retry.
- Candidate #3 (this head, 232652d): cold launch listed the scanner in 7 s, connected (SA-30, film present); no film motion requested. Presentation-only delta from candidate #2.
- Not fixed, recorded: the earlier candidate #1 attempt lost its idle USB handle after ~16 min and then failed a bulk read; the cold-start handshake exceeded 10 s on two of three launches; the meter controller's 3×0.85 bound; CoolscanPy classifying the meter refusal as RollMismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
